### PR TITLE
feat(daemon): embeddable mode behind PITCHBOX_EMBED_DAEMON=1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5434/pitchbox
 PITCHBOX_ROOT=.
 ENCRYPTION_KEY=change-me-to-a-32-byte-hex-string-0000000000000000000000000000
 WEB_PORT=5180
+
+# Boot the daemon loops inside the web server instead of running a separate
+# `pitchbox daemon` process. Recommended for single-host self-hosters.
+# PITCHBOX_EMBED_DAEMON=1

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",
+  "exports": {
+    "./embed": "./src/embed.ts"
+  },
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",

--- a/daemon/src/embed.ts
+++ b/daemon/src/embed.ts
@@ -1,0 +1,157 @@
+/**
+ * Embeddable daemon: the same loops the standalone `pitchbox daemon` runs,
+ * exported as a `start()` factory the web server can invoke at boot when
+ * PITCHBOX_EMBED_DAEMON=1.
+ *
+ * The advisory lock around dispatch (#32) and `SELECT … FOR UPDATE SKIP LOCKED`
+ * on webhook deliveries (#36) already make these loops safe to run from
+ * multiple processes; embedding here removes the friction of supervising a
+ * second Node process on single-host installs.
+ */
+import { applyJitter } from '@pitchbox/shared/scheduler/jitter';
+import { config } from './config.js';
+import { logger } from './logger.js';
+import { beat } from './heartbeat.js';
+import { tick as schedulerTick } from './scheduler.js';
+import { tick as replyPollerTick } from './reply-poller.js';
+import { tick as webhookSenderTick } from './webhook-sender.js';
+import { tick as retentionTick } from './retention.js';
+import { tick as keywordWatcherTick } from './keyword-watcher.js';
+
+const log = logger('embed');
+
+type Loop = {
+  name: string;
+  intervalMs: number;
+  run: () => Promise<void>;
+};
+
+type LoopHandle = { cancel: () => void; settle: () => Promise<void> };
+
+function every(ms: number, fn: () => Promise<void>): LoopHandle {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let cancelled = false;
+  let inflight: Promise<void> | null = null;
+
+  const kick = async () => {
+    if (cancelled) return;
+    const run = (async () => {
+      try {
+        await fn();
+      } catch (err) {
+        log.error('loop iteration crashed', err);
+      }
+    })();
+    inflight = run;
+    try {
+      await run;
+    } finally {
+      inflight = null;
+      if (!cancelled) timer = setTimeout(kick, applyJitter(ms, config.jitterPct));
+    }
+  };
+
+  void kick();
+  return {
+    cancel() {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    },
+    async settle() {
+      if (inflight) await inflight;
+    },
+  };
+}
+
+export type StartOptions = {
+  /** Identifier for the heartbeat row. Use 'daemon' for standalone, 'web' for embedded. */
+  heartbeatModule?: string;
+};
+
+export type EmbeddedDaemon = {
+  /** Stop all loops; awaits in-flight iterations up to 10s before resolving. */
+  stop(): Promise<void>;
+};
+
+export function startEmbeddedDaemon(opts: StartOptions = {}): EmbeddedDaemon {
+  const heartbeatModule = opts.heartbeatModule ?? 'daemon';
+  log.info(`starting embedded daemon (web=${config.webUrl}, heartbeat=${heartbeatModule})`);
+
+  const loops: Loop[] = [
+    {
+      name: 'heartbeat',
+      intervalMs: config.heartbeatIntervalMs,
+      run: () => beat(heartbeatModule),
+    },
+    {
+      name: 'scheduler',
+      intervalMs: config.tickIntervalMs,
+      run: schedulerTick,
+    },
+    {
+      name: 'retention',
+      intervalMs: config.retentionIntervalMs,
+      run: async () => {
+        const res = await retentionTick();
+        if (res.runEventsDeleted + res.draftEventsDeleted + res.draftsDeleted > 0) {
+          logger('retention').info(
+            `pruned run_events=${res.runEventsDeleted} draft_events=${res.draftEventsDeleted} drafts=${res.draftsDeleted}`,
+          );
+        }
+      },
+    },
+    {
+      name: 'keyword-watcher',
+      intervalMs: config.keywordWatcherIntervalMs,
+      run: async () => {
+        const res = await keywordWatcherTick();
+        if (res.checked > 0) {
+          logger('keyword-watcher').info(
+            `checked ${res.checked} watches → ${res.dispatched} dispatched`,
+          );
+        }
+      },
+    },
+    {
+      name: 'webhook-sender',
+      intervalMs: config.webhookSenderIntervalMs,
+      run: async () => {
+        await webhookSenderTick();
+      },
+    },
+  ];
+
+  if (!config.repliesDisabled) {
+    loops.push({
+      name: 'reply-poller',
+      intervalMs: config.replyPollIntervalMs,
+      run: async () => {
+        const res = await replyPollerTick();
+        if (res.checked > 0) {
+          logger('reply-poller').info(
+            `checked ${res.checked} contacts → ${res.newReplies} new replies, ${res.skipped} skipped`,
+          );
+        }
+      },
+    });
+  }
+
+  const handles = loops.map((l) => {
+    log.info(`starting loop "${l.name}" every ${l.intervalMs}ms`);
+    return every(l.intervalMs, l.run);
+  });
+
+  let stopped = false;
+  return {
+    async stop() {
+      if (stopped) return;
+      stopped = true;
+      log.info('draining loops');
+      for (const h of handles) h.cancel();
+      const drain = Promise.all(handles.map((h) => h.settle()));
+      const timeout = new Promise<void>((resolve) => setTimeout(resolve, 10_000));
+      await Promise.race([drain, timeout]);
+      log.info('stopped');
+    },
+  };
+}

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -1,151 +1,22 @@
-import { applyJitter } from '@pitchbox/shared/scheduler/jitter';
-import { config } from './config.js';
+/**
+ * Standalone daemon entry point. Wraps the embeddable factory with process
+ * signal handlers so SIGINT/SIGTERM drain in-flight iterations before exit.
+ */
 import { logger } from './logger.js';
-import { beat } from './heartbeat.js';
-import { tick as schedulerTick } from './scheduler.js';
-import { tick as replyPollerTick } from './reply-poller.js';
-import { tick as webhookSenderTick } from './webhook-sender.js';
-import { tick as retentionTick } from './retention.js';
-import { tick as keywordWatcherTick } from './keyword-watcher.js';
+import { startEmbeddedDaemon } from './embed.js';
 
 const log = logger('main');
 
-let running = true;
+const daemon = startEmbeddedDaemon({ heartbeatModule: 'daemon' });
 
-type Loop = {
-  name: string;
-  intervalMs: number;
-  run: () => Promise<void>;
+let shuttingDown = false;
+const shutdown = async (sig: string) => {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  log.info(`received ${sig}`);
+  await daemon.stop();
+  process.exit(0);
 };
 
-type LoopHandle = { cancel: () => void; settle: () => Promise<void> };
-
-function every(ms: number, fn: () => Promise<void>): LoopHandle {
-  let timer: ReturnType<typeof setTimeout> | null = null;
-  let cancelled = false;
-  let inflight: Promise<void> | null = null;
-
-  const kick = async () => {
-    if (cancelled) return;
-    const run = (async () => {
-      try {
-        await fn();
-      } catch (err) {
-        log.error('loop iteration crashed', err);
-      }
-    })();
-    inflight = run;
-    try {
-      await run;
-    } finally {
-      inflight = null;
-      // Apply symmetric jitter so concurrent loops (and multi-instance daemons)
-      // don't lock-step on the same tick.
-      if (!cancelled) timer = setTimeout(kick, applyJitter(ms, config.jitterPct));
-    }
-  };
-
-  void kick();
-  return {
-    cancel() {
-      cancelled = true;
-      if (timer) clearTimeout(timer);
-    },
-    async settle() {
-      if (inflight) await inflight;
-    },
-  };
-}
-
-async function main() {
-  log.info(`pitchbox daemon starting (web=${config.webUrl})`);
-
-  const loops: Loop[] = [
-    {
-      name: 'heartbeat',
-      intervalMs: config.heartbeatIntervalMs,
-      run: () => beat('daemon'),
-    },
-    {
-      name: 'scheduler',
-      intervalMs: config.tickIntervalMs,
-      run: schedulerTick,
-    },
-  ];
-
-  loops.push({
-    name: 'retention',
-    intervalMs: config.retentionIntervalMs,
-    run: async () => {
-      const res = await retentionTick();
-      if (res.runEventsDeleted + res.draftEventsDeleted + res.draftsDeleted > 0) {
-        logger('retention').info(
-          `pruned run_events=${res.runEventsDeleted} draft_events=${res.draftEventsDeleted} drafts=${res.draftsDeleted}`,
-        );
-      }
-    },
-  });
-
-  loops.push({
-    name: 'keyword-watcher',
-    intervalMs: config.keywordWatcherIntervalMs,
-    run: async () => {
-      const res = await keywordWatcherTick();
-      if (res.checked > 0) {
-        logger('keyword-watcher').info(
-          `checked ${res.checked} watches → ${res.dispatched} dispatched`,
-        );
-      }
-    },
-  });
-
-  loops.push({
-    name: 'webhook-sender',
-    intervalMs: config.webhookSenderIntervalMs,
-    run: async () => {
-      await webhookSenderTick();
-    },
-  });
-
-  if (!config.repliesDisabled) {
-    loops.push({
-      name: 'reply-poller',
-      intervalMs: config.replyPollIntervalMs,
-      run: async () => {
-        const res = await replyPollerTick();
-        if (res.checked > 0) {
-          logger('reply-poller').info(
-            `checked ${res.checked} contacts → ${res.newReplies} new replies, ${res.skipped} skipped`,
-          );
-        }
-      },
-    });
-  }
-
-  const cancels = loops.map((l) => {
-    log.info(`starting loop "${l.name}" every ${l.intervalMs}ms`);
-    return every(l.intervalMs, l.run);
-  });
-
-  const shutdown = async (sig: string) => {
-    if (!running) return;
-    running = false;
-    log.info(`received ${sig}, draining loops`);
-    for (const c of cancels) c.cancel();
-    // Wait up to 10s for in-flight iterations (HTTP POST to /api/run, reply
-    // polling) to finish — beats killing them mid-request.
-    const drain = Promise.all(cancels.map((c) => c.settle()));
-    const timeout = new Promise<void>((resolve) => setTimeout(resolve, 10_000));
-    await Promise.race([drain, timeout]);
-    log.info('exit');
-    process.exit(0);
-  };
-
-  process.on('SIGINT', () => void shutdown('SIGINT'));
-  process.on('SIGTERM', () => void shutdown('SIGTERM'));
-}
-
-main().catch((err) => {
-  log.error('fatal', err);
-  process.exit(1);
-});
+process.on('SIGINT', () => void shutdown('SIGINT'));
+process.on('SIGTERM', () => void shutdown('SIGTERM'));

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -2,6 +2,16 @@
 
 A long-running Node process under `daemon/`. Start with `npm run -w daemon dev` (or wrap with systemd / PM2 for production).
 
+## Embedded mode
+
+Single-host self-hosters can avoid running a second process by booting the daemon loops inside the web server:
+
+```
+PITCHBOX_EMBED_DAEMON=1 npm run dev
+```
+
+The same loops (scheduler, reply-poller, heartbeat, retention, keyword-watcher, webhook-sender) run in the SvelteKit process and stop cleanly on `SIGINT`/`SIGTERM`. Heartbeat rows are tagged `module='web'` so Settings can tell embedded vs. standalone. Run both at once safely — the advisory lock on dispatch (#32) and `SELECT … FOR UPDATE SKIP LOCKED` on webhook deliveries (#36) keep behaviour exactly-once across processes. Standalone mode stays the recommended deploy for HA / multi-host setups.
+
 ## Modules
 
 - `scheduler.ts` — parses `cron_expression` on active campaigns via `cron-parser`. Due campaigns are dispatched by POSTing to the web `/api/run` endpoint, so the daemon never touches agent runners directly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12166,6 +12166,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@bytemd/plugin-gfm": "^1.22.0",
+        "@pitchbox/daemon": "*",
         "@pitchbox/shared": "*",
         "@tailwindcss/vite": "^4.2.4",
         "@types/dompurify": "^3.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@bytemd/plugin-gfm": "^1.22.0",
+    "@pitchbox/daemon": "*",
     "@pitchbox/shared": "*",
     "@tailwindcss/vite": "^4.2.4",
     "@types/dompurify": "^3.0.5",

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -38,6 +38,27 @@ async function reapOrphanedRuns() {
 // Run once at module load (first request to the server).
 await reapOrphanedRuns();
 
+/**
+ * Optional embedded daemon: when PITCHBOX_EMBED_DAEMON=1 the same loops the
+ * standalone `pitchbox daemon` process runs are started in-proc here. Useful
+ * for single-host self-hosters who don't want a second supervised process.
+ *
+ * The advisory lock around dispatch (#32) and `SELECT … FOR UPDATE SKIP LOCKED`
+ * on webhook deliveries (#36) keep behaviour consistent even if a standalone
+ * daemon is also running against the same DB. Heartbeat module is tagged 'web'
+ * so the Settings page can tell which process supplies liveness.
+ */
+if (process.env.PITCHBOX_EMBED_DAEMON === '1') {
+  const { startEmbeddedDaemon } = await import('@pitchbox/daemon/embed');
+  const daemon = startEmbeddedDaemon({ heartbeatModule: 'web' });
+  const stop = async (sig: string) => {
+    console.log(`[hooks] ${sig} — stopping embedded daemon`);
+    await daemon.stop();
+  };
+  process.once('SIGINT', () => void stop('SIGINT'));
+  process.once('SIGTERM', () => void stop('SIGTERM'));
+}
+
 const EXTENSION_ALLOWED_ORIGINS = new Set(['https://www.reddit.com', 'https://old.reddit.com']);
 
 function extensionCorsHeaders(origin: string | null): Record<string, string> {

--- a/web/src/lib/components/Sidebar.svelte
+++ b/web/src/lib/components/Sidebar.svelte
@@ -19,10 +19,8 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { cn } from '$lib/utils';
-	import { VERSION } from '$lib/shared/version';
-	import { daemonStatus } from '$lib/stores/daemon';
 	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
-	import SseIndicator from '$lib/realtime/SseIndicator.svelte';
+	import SystemStatusCard from '$lib/components/SystemStatusCard.svelte';
 	import { t } from '$lib/i18n';
 	import type { ComponentType } from 'svelte';
 
@@ -133,28 +131,8 @@
 			<LogOut class="size-4 shrink-0" />
 			{$t('nav.signOut')}
 		</button>
-		<div class="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
-			<span
-				class="size-2 rounded-full shrink-0 {$daemonStatus.loading
-					? 'bg-muted-foreground/40'
-					: $daemonStatus.alive
-						? 'bg-emerald-400 animate-pulse'
-						: 'bg-muted-foreground/40'}"
-			></span>
-			<span>
-				{$t('nav.daemon')}:
-				{#if $daemonStatus.loading}
-					…
-				{:else if $daemonStatus.alive}
-					{$t('nav.daemon.online')}
-				{:else}
-					{$t('nav.daemon.offline')}
-				{/if}
-			</span>
-			<span class="ml-auto font-mono opacity-50">{VERSION}</span>
-		</div>
-		<div class="px-3 pb-2">
-			<SseIndicator />
+		<div class="px-1 pt-1">
+			<SystemStatusCard />
 		</div>
 	</div>
 </aside>

--- a/web/src/lib/components/SystemStatusCard.svelte
+++ b/web/src/lib/components/SystemStatusCard.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { daemonStatus } from '$lib/stores/daemon';
+  import { getSseManager, type SseStatus } from '$lib/realtime/sse';
+  import { VERSION } from '$lib/shared/version';
+  import { t } from '$lib/i18n';
+
+  let sseState = $state<SseStatus>('connecting');
+  let unsub: (() => void) | null = null;
+
+  onMount(() => {
+    unsub = getSseManager().subscribeStatus((s) => (sseState = s));
+  });
+  onDestroy(() => unsub?.());
+
+  type RowTone = 'live' | 'idle' | 'warn' | 'down';
+
+  const daemonRow = $derived.by(() => {
+    if ($daemonStatus.loading) {
+      return { tone: 'idle' as RowTone, label: $t('status.checking') };
+    }
+    return $daemonStatus.alive
+      ? { tone: 'live' as RowTone, label: $t('nav.daemon.online') }
+      : { tone: 'down' as RowTone, label: $t('nav.daemon.offline') };
+  });
+
+  const sseRow = $derived.by(() => {
+    if (sseState === 'live') return { tone: 'live' as RowTone, label: $t('status.live') };
+    if (sseState === 'reconnecting')
+      return { tone: 'warn' as RowTone, label: $t('status.reconnecting') };
+    if (sseState === 'closed') return { tone: 'down' as RowTone, label: $t('status.offline') };
+    return { tone: 'idle' as RowTone, label: $t('status.connecting') };
+  });
+
+  function dotClass(tone: RowTone) {
+    switch (tone) {
+      case 'live':
+        return 'bg-emerald-400 animate-pulse';
+      case 'warn':
+        return 'bg-amber-400 animate-pulse';
+      case 'down':
+        return 'bg-rose-400';
+      default:
+        return 'bg-muted-foreground/40';
+    }
+  }
+
+  function valueClass(tone: RowTone) {
+    switch (tone) {
+      case 'live':
+        return 'text-emerald-600 dark:text-emerald-400';
+      case 'warn':
+        return 'text-amber-600 dark:text-amber-400';
+      case 'down':
+        return 'text-rose-600 dark:text-rose-400';
+      default:
+        return 'text-muted-foreground';
+    }
+  }
+</script>
+
+<div class="rounded-md border border-border bg-card/40 px-3 py-2 text-xs">
+  <div class="flex items-center justify-between gap-2 py-0.5">
+    <span class="flex items-center gap-2 text-muted-foreground">
+      <span class="size-1.5 rounded-full shrink-0 {dotClass(daemonRow.tone)}"></span>
+      {$t('nav.daemon')}
+    </span>
+    <span class="font-medium {valueClass(daemonRow.tone)}">{daemonRow.label}</span>
+  </div>
+  <div class="flex items-center justify-between gap-2 py-0.5">
+    <span class="flex items-center gap-2 text-muted-foreground">
+      <span class="size-1.5 rounded-full shrink-0 {dotClass(sseRow.tone)}"></span>
+      {$t('status.liveStream')}
+    </span>
+    <span class="font-medium {valueClass(sseRow.tone)}">{sseRow.label}</span>
+  </div>
+  <div class="mt-1 pt-1 border-t border-border/60 text-[10px] text-muted-foreground/70 font-mono">
+    pitchbox v{VERSION}
+  </div>
+</div>

--- a/web/src/lib/i18n/dict-en.ts
+++ b/web/src/lib/i18n/dict-en.ts
@@ -21,6 +21,14 @@ export const en: Dict = {
   'nav.daemon.online': 'online',
   'nav.daemon.offline': 'offline',
 
+  // System status footer
+  'status.liveStream': 'Live stream',
+  'status.live': 'live',
+  'status.reconnecting': 'reconnecting',
+  'status.connecting': 'connecting',
+  'status.offline': 'offline',
+  'status.checking': 'checking',
+
   // Inbox header
   'inbox.title': 'Inbox',
   'inbox.empty': 'No drafts to review',

--- a/web/src/lib/i18n/dict-it.ts
+++ b/web/src/lib/i18n/dict-it.ts
@@ -21,6 +21,14 @@ export const it: Dict = {
   'nav.daemon.online': 'online',
   'nav.daemon.offline': 'offline',
 
+  // System status footer
+  'status.liveStream': 'Stream live',
+  'status.live': 'attivo',
+  'status.reconnecting': 'riconnessione',
+  'status.connecting': 'connessione',
+  'status.offline': 'offline',
+  'status.checking': 'controllo',
+
   // Inbox header
   'inbox.title': 'Posta in arrivo',
   'inbox.empty': 'Nessuna bozza da rivedere',

--- a/web/src/routes/api/daemon/status/+server.ts
+++ b/web/src/routes/api/daemon/status/+server.ts
@@ -19,7 +19,9 @@ export async function GET() {
     };
   });
 
-  const alive = modules.some((m) => m.module === 'daemon' && m.alive);
+  // Either the standalone `pitchbox daemon` process (module='daemon') or the
+  // web's embedded loops (module='web', when PITCHBOX_EMBED_DAEMON=1) count.
+  const alive = modules.some((m) => (m.module === 'daemon' || m.module === 'web') && m.alive);
 
   return json({ alive, modules });
 }


### PR DESCRIPTION
## Summary

Single-host self-hosters can now boot the daemon loops inside the web server with `PITCHBOX_EMBED_DAEMON=1`, removing the need to supervise a second Node process. The standalone `pitchbox daemon` process stays untouched and remains the recommended deploy for HA or multi-host setups.

## What changes

- New `startEmbeddedDaemon({ heartbeatModule })` factory in `daemon/src/embed.ts` exposing the same loops (scheduler, reply-poller, heartbeat, retention, keyword-watcher, webhook-sender) as a start/stop handle.
- `daemon/src/index.ts` is now a thin wrapper that calls the factory and wires `SIGINT`/`SIGTERM` drain.
- `web/src/hooks.server.ts` dynamically imports the factory when `PITCHBOX_EMBED_DAEMON=1` is set, tags heartbeats `module='web'`, and stops cleanly on shutdown signals.
- `@pitchbox/daemon` now exports `./embed`; `web/package.json` depends on it.
- `docs/daemon.md` documents the new mode.

## Safety

The advisory lock around dispatch (#32) and `SELECT … FOR UPDATE SKIP LOCKED` on `webhook_deliveries` (#36) keep behaviour exactly-once even if a standalone daemon also runs against the same DB. So embedding doesn't introduce new race surface.

## Test plan

- [ ] `PITCHBOX_EMBED_DAEMON=1 npm run dev` — verify the dashboard boots and the web logs show `starting loop ...` lines from the embedded loops.
- [ ] Without the flag — embedded loops do not start (verify by absence of the log lines).
- [ ] Run both `npm run dev` (with flag) and `npm run -w daemon dev` simultaneously — no duplicate dispatches (covered by the advisory lock).
- [ ] `npm run lint`, `npm run typecheck`, `npm run -w web check` all green.