### PR TITLE
fix(web): sidebar polish, theme moved to Settings, login theme support

### DIFF
--- a/web/src/lib/components/SettingsAppearanceCard.svelte
+++ b/web/src/lib/components/SettingsAppearanceCard.svelte
@@ -6,6 +6,7 @@
 	import { onMount } from 'svelte';
 	import SelectField from '$lib/components/ui/select-field/select-field.svelte';
 	import { LOCALES, locale, setLocale, t, type Locale } from '$lib/i18n';
+	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
 
 	const STORAGE_KEY = 'pitchbox.ui_locale';
 
@@ -47,13 +48,20 @@
 		<Languages class="size-4 shrink-0 text-muted-foreground" />
 		<Card.Title class="text-base min-w-0 flex-1 truncate">{$t('settings.appearance.title')}</Card.Title>
 	</Card.Header>
-	<Card.Content class="flex flex-col gap-3">
+	<Card.Content class="flex flex-col gap-4">
+		<div class="flex flex-col gap-1.5">
+			<span class="text-xs font-medium text-muted-foreground">
+				{$t('settings.appearance.theme.label')}
+			</span>
+			<ThemeToggle />
+			<p class="text-xs text-muted-foreground">{$t('settings.appearance.theme.help')}</p>
+		</div>
 		<div class="flex flex-col gap-1.5">
 			<label class="text-xs font-medium text-muted-foreground" for="ui-locale">
 				{$t('settings.appearance.locale.label')}
 			</label>
 			<SelectField id="ui-locale" value={current} {options} onValueChange={onChange} />
+			<p class="text-xs text-muted-foreground">{$t('settings.appearance.locale.help')}</p>
 		</div>
-		<p class="text-xs text-muted-foreground">{$t('settings.appearance.locale.help')}</p>
 	</Card.Content>
 </Card.Root>

--- a/web/src/lib/components/Sidebar.svelte
+++ b/web/src/lib/components/Sidebar.svelte
@@ -76,15 +76,17 @@
 	const authOn = $derived(($page.data?.authOn ?? true) as boolean);
 </script>
 
-<aside class="w-60 h-full bg-background border-r border-border flex flex-col p-4 overflow-hidden">
+<aside class="w-60 h-full bg-background border-r border-border flex flex-col p-4 overflow-hidden min-h-0">
 	<!-- Brand -->
 	<div class="flex items-center gap-2 mb-6">
 		<img src="/favicon.svg" alt="" class="size-7 shrink-0" aria-hidden="true" />
 		<h1 class="font-semibold text-lg">Pitchbox</h1>
 	</div>
 
-	<!-- Nav links -->
-	<nav class="flex flex-col gap-1 flex-1">
+	<!-- Nav links. min-h-0 lets nav shrink under flex pressure so the footer
+	     status card always stays visible; only the nav itself can scroll if a
+	     viewport is too short for all entries. -->
+	<nav class="flex flex-col gap-1 flex-1 min-h-0 overflow-y-auto">
 		{#each navItems as item (item.href)}
 			{@const active = item.exact
 				? $page.url.pathname === item.href

--- a/web/src/lib/components/Sidebar.svelte
+++ b/web/src/lib/components/Sidebar.svelte
@@ -14,12 +14,12 @@
 		History,
 		BarChart3,
 		LogOut,
+		LogIn,
 		type Icon as LucideIcon,
 	} from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { cn } from '$lib/utils';
-	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
 	import SystemStatusCard from '$lib/components/SystemStatusCard.svelte';
 	import { t } from '$lib/i18n';
 	import type { ComponentType } from 'svelte';
@@ -70,9 +70,13 @@
 		void $page.url.pathname;
 		refreshUnread();
 	});
+
+	// Surfaced by web/src/routes/+layout.server.ts; falls back to `true` so
+	// nothing breaks if the loader hasn't run yet.
+	const authOn = $derived(($page.data?.authOn ?? true) as boolean);
 </script>
 
-<aside class="w-60 h-full bg-background border-r border-border flex flex-col p-4 overflow-y-auto">
+<aside class="w-60 h-full bg-background border-r border-border flex flex-col p-4 overflow-hidden">
 	<!-- Brand -->
 	<div class="flex items-center gap-2 mb-6">
 		<img src="/favicon.svg" alt="" class="size-7 shrink-0" aria-hidden="true" />
@@ -106,13 +110,10 @@
 		{/each}
 	</nav>
 
-	<!-- Bottom section: theme + docs + version -->
+	<!-- Bottom section: docs + auth + system status -->
 	<div class="flex flex-col gap-1 border-t border-border mt-4 pt-4">
-		<div class="px-1 pb-1">
-			<ThemeToggle />
-		</div>
 		<a
-			href="/README.md"
+			href="https://github.com/fiorelorenzo/pitchbox#readme"
 			target="_blank"
 			rel="noopener"
 			class="flex items-center gap-2 px-3 py-2 rounded-md text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
@@ -120,17 +121,27 @@
 			<BookOpen class="size-4 shrink-0" />
 			{$t('nav.docs')}
 		</a>
-		<button
-			type="button"
-			onclick={async () => {
-				await fetch('/api/auth/logout', { method: 'POST' });
-				await goto('/login');
-			}}
-			class="flex items-center gap-2 px-3 py-2 rounded-md text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors text-left"
-		>
-			<LogOut class="size-4 shrink-0" />
-			{$t('nav.signOut')}
-		</button>
+		{#if authOn}
+			<button
+				type="button"
+				onclick={async () => {
+					await fetch('/api/auth/logout', { method: 'POST' });
+					await goto('/login');
+				}}
+				class="flex items-center gap-2 px-3 py-2 rounded-md text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors text-left"
+			>
+				<LogOut class="size-4 shrink-0" />
+				{$t('nav.signOut')}
+			</button>
+		{:else}
+			<a
+				href="/login"
+				class="flex items-center gap-2 px-3 py-2 rounded-md text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+			>
+				<LogIn class="size-4 shrink-0" />
+				{$t('nav.signIn')}
+			</a>
+		{/if}
 		<div class="px-1 pt-1">
 			<SystemStatusCard />
 		</div>

--- a/web/src/lib/components/SystemStatusCard.svelte
+++ b/web/src/lib/components/SystemStatusCard.svelte
@@ -75,6 +75,6 @@
     <span class="font-medium {valueClass(sseRow.tone)}">{sseRow.label}</span>
   </div>
   <div class="mt-1 pt-1 border-t border-border/60 text-[10px] text-muted-foreground/70 font-mono">
-    pitchbox v{VERSION}
+    pitchbox {VERSION}
   </div>
 </div>

--- a/web/src/lib/i18n/dict-en.ts
+++ b/web/src/lib/i18n/dict-en.ts
@@ -17,6 +17,7 @@ export const en: Dict = {
   'nav.settings': 'Settings',
   'nav.docs': 'Docs',
   'nav.signOut': 'Sign out',
+  'nav.signIn': 'Sign in',
   'nav.daemon': 'Daemon',
   'nav.daemon.online': 'online',
   'nav.daemon.offline': 'offline',
@@ -39,6 +40,8 @@ export const en: Dict = {
   'settings.appearance.locale.label': 'Language',
   'settings.appearance.locale.help':
     'Interface language. English is the default; Italian is a seed translation.',
+  'settings.appearance.theme.label': 'Theme',
+  'settings.appearance.theme.help': 'Follow system or pick light or dark explicitly.',
 
   // Login page
   'login.title': 'Sign in',

--- a/web/src/lib/i18n/dict-it.ts
+++ b/web/src/lib/i18n/dict-it.ts
@@ -17,6 +17,7 @@ export const it: Dict = {
   'nav.settings': 'Impostazioni',
   'nav.docs': 'Documentazione',
   'nav.signOut': 'Esci',
+  'nav.signIn': 'Accedi',
   'nav.daemon': 'Daemon',
   'nav.daemon.online': 'online',
   'nav.daemon.offline': 'offline',
@@ -39,6 +40,8 @@ export const it: Dict = {
   'settings.appearance.locale.label': 'Lingua',
   'settings.appearance.locale.help':
     "Lingua dell'interfaccia. L'inglese è il valore predefinito; l'italiano è una traduzione iniziale.",
+  'settings.appearance.theme.label': 'Tema',
+  'settings.appearance.theme.help': 'Segui il sistema oppure scegli chiaro o scuro esplicitamente.',
 
   // Login page
   'login.title': 'Accedi',

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -1,0 +1,11 @@
+import type { LayoutServerLoad } from './$types';
+
+/**
+ * Root layout loader. Exposes server-wide flags every page may need (currently
+ * just `authOn` so the Sidebar can show Sign in vs Sign out).
+ */
+export const load: LayoutServerLoad = () => {
+  return {
+    authOn: process.env.PITCHBOX_AUTH === 'on',
+  };
+};

--- a/web/src/routes/login/+layout@.svelte
+++ b/web/src/routes/login/+layout@.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
-	import '../../app.css';
-	let { children } = $props();
+  import '../../app.css';
+  import { ModeWatcher } from 'mode-watcher';
+  let { children } = $props();
 </script>
 
-<div class="dark min-h-screen bg-background text-foreground">
-	{@render children()}
+<!--
+  Login page bypasses the dashboard chrome but still needs the theme watcher
+  so the user's chosen mode (system/light/dark) is honored here too.
+-->
+<ModeWatcher defaultMode="dark" />
+
+<div class="min-h-screen bg-background text-foreground">
+  {@render children()}
 </div>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -41,7 +41,7 @@
 		<Card.Header>
 			<Card.Title>{data.firstUser ? 'Create the first user' : 'Sign in to Pitchbox'}</Card.Title>
 			{#if !data.authOn}
-				<p class="text-xs text-amber-300">Authentication is disabled — set PITCHBOX_AUTH=on in your environment.</p>
+				<p class="text-xs text-amber-700 dark:text-amber-300">Authentication is disabled — set PITCHBOX_AUTH=on in your environment.</p>
 			{:else if data.firstUser}
 				<p class="text-xs text-muted-foreground">
 					No user exists yet. The credentials you enter below will create the admin account.


### PR DESCRIPTION
## Summary

Cluster of small UX fixes reported on the sidebar / login surfaces.

## Changes

- **Theme toggle moved to Settings → Appearance** — was crowding the sidebar footer.
- **Docs link** in the sidebar now points to the GitHub README (was `/README.md` and 404'd).
- **Sign in vs Sign out** — when `PITCHBOX_AUTH` is not on, the footer button now links to `/login` with a 'Sign in' label. Backed by a new `web/src/routes/+layout.server.ts` that surfaces `authOn` to the layout.
- **Login page respects theme** — login layout no longer hardcodes `class="dark"`; mounts `ModeWatcher` so the user's preference (system/light/dark) is honored. The 'authentication is disabled' amber notice gets a light-mode contrast variant.
- **Sidebar no longer scrolls** — `overflow-y-auto` → `overflow-hidden`.

## Test plan

- [ ] `npm run dev`, navigate Settings → Appearance: see Theme + Language together.
- [ ] Reload sidebar: no scrollbar; theme toggle gone from footer; Docs link opens GitHub README.
- [ ] With `PITCHBOX_AUTH=on`: footer shows 'Sign out'. Without: 'Sign in' linking to `/login`.
- [ ] Visit `/login` in light mode (Settings → Appearance → Light): page background and amber notice both readable.