### PR TITLE
ci(docs): auto-enable GitHub Pages on first deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,8 @@ jobs:
       - run: npm ci
       - run: npm run docs:build
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist


### PR DESCRIPTION
The docs workflow on \`main\` failed at \`actions/configure-pages\` because Pages
isn't enabled on the repo. Setting \`enablement: true\` lets the action create
the Pages site on first run, so the workflow becomes self-bootstrapping.

After this lands and gets promoted to \`main\`, the docs workflow should
succeed and publish \`docs/.vitepress/dist\` to GitHub Pages automatically.

Alternative: enable Pages manually in repo Settings → Pages → Source: GitHub
Actions. The flag-based fix avoids the manual step.