### PR TITLE
Promote: docs workflow Pages auto-enablement

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,8 @@ jobs:
       - run: npm ci
       - run: npm run docs:build
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist


### PR DESCRIPTION
Promotes #58 to main so the docs workflow can self-bootstrap GitHub Pages on its next run.