### PR TITLE
feat(extension): one-click pairing + multi-backend (cloud + self-hosted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,163 +1,39 @@
 <p align="left"><img src="assets/brand/wordmark-dark.svg#gh-dark-mode-only" alt="Pitchbox" height="64"><img src="assets/brand/wordmark-light.svg#gh-light-mode-only" alt="Pitchbox" height="64"></p>
 
-Self-hosted outreach agent for Reddit (and future platforms). You keep the human-in-the-loop; Pitchbox does the research, drafting, and bookkeeping.
+Self-hosted, human-in-the-loop outreach agent. The agent does the research and drafting; you approve before anything is sent.
 
-> ⚠️ Alpha — currently at **v0.4.0** (M6.1 shipped). Breaking changes possible until v1.0.0.
+> ⚠️ Alpha — currently at **v0.4.0**. Breaking changes possible until v1.0.0.
 
-## Quick start (macOS / Linux)
+**📖 Full documentation:** **<https://fiorelorenzo.github.io/pitchbox/>**
 
-**Prerequisites**: Node ≥22, Docker, the `claude` CLI logged in to your Claude subscription, an `ENCRYPTION_KEY` (generate with `openssl rand -hex 32`).
+## Quick start
 
 ```bash
-git clone <repo>
+git clone https://github.com/fiorelorenzo/pitchbox.git
 cd pitchbox
 cp .env.example .env
-# edit .env — set DATABASE_URL, PITCHBOX_ROOT (absolute path), ENCRYPTION_KEY
+# edit .env — set DATABASE_URL, PITCHBOX_ROOT (absolute path), ENCRYPTION_KEY (openssl rand -hex 32)
 docker compose up -d postgres
 npm install
-npx playwright install chromium
 npm run migrate
 npm run -w @pitchbox/shared seed:core
-cp scripts/seed-demo.ts.example scripts/seed-demo.ts
-npx tsx scripts/seed-demo.ts
 npm run dev            # dashboard at http://127.0.0.1:5180
-npm run -w daemon dev  # (optional) scheduler + reply poller
 ```
 
-### Browser extension (optional)
+Embedded daemon mode runs the scheduler + reply poller + retention loops inside the web process — set `PITCHBOX_EMBED_DAEMON=1` in `.env` and skip `npm run -w daemon dev`. See [the daemon docs](https://fiorelorenzo.github.io/pitchbox/daemon) for when to run it as a separate process instead.
 
-The companion Chrome extension does two things:
+Prerequisites: Node ≥ 22, Docker, and the `claude` CLI (or another supported runner) on PATH.
 
-1. **Auto-mark drafts as sent.** When you submit a DM or post-comment on Reddit, the extension flips the draft from `approved` → `sent` automatically — no need to click **Mark as sent** in the dashboard.
-2. **Sync DM replies back into the dashboard.** Every 10 min (and on demand) the extension reads your Reddit inbox and flips drafts to `replied` when the target user writes back. Replies appear in the Inbox draft detail and in the Conversations page.
+## Browser extension
 
-#### Install
+The companion Chrome extension auto-marks drafts as sent when you submit on Reddit, and syncs replies back into the dashboard.
 
 ```bash
-npm run build:extension   # outputs extension/dist/
+npm run build:extension   # then load extension/dist/ unpacked in chrome://extensions
 ```
 
-In Chrome: `chrome://extensions` → enable **Developer mode** → **Load unpacked** → pick `extension/dist/`.
-
-#### Connect to the dashboard
-
-1. Dashboard → **Settings → Browser extension** → **Generate token**. Copy the 64-character hex token.
-2. Open the Pitchbox popup (toolbar icon). Paste the dashboard URL (`http://127.0.0.1:5180` by default) and the token. Click **Connect**.
-3. The popup shows _Connected — dashboard vX.Y.Z_ when the handshake succeeds.
-
-#### Sync DM replies
-
-Reddit ships two parallel DM systems and the extension covers both:
-
-- **Legacy private messages** (`reddit.com/message/inbox`). The extension polls `inbox.json` every 10 min — works as long as you stay logged in to Reddit in the same Chrome profile.
-- **Reddit Chat** (Matrix-based, used for all DMs sent from new Reddit). The extension auto-captures the Matrix access token from `localStorage` of any open `reddit.com` tab, then talks to `matrix.redditspace.com` directly to fetch new messages. **Open at least one reddit.com tab** while logged in for this to work — closing all Reddit tabs stops the chat sync (the popup keeps the last token but it eventually expires).
-
-**Comment-reply tracking** is included: when someone replies to a comment you posted via Pitchbox, the same `Sync now` action picks it up. Make sure you submit your comments through the dashboard's Open post / extension flow so we can capture the comment id.
-
-Manually trigger a sync any time from the popup → **Sync now**. The popup reports `inserted: N new, M replied`.
-
-When a target user replies, you'll see:
-
-- The draft state flip to **Replied** in the Inbox.
-- The reply body shown under the draft, with a `replied` event on the timeline.
-- A row on the **Conversations** page with the latest reply snippet.
-
-## What ships today (v0.4.0, M0–M6.1)
-
-**Content pipeline**
-
-- Create projects, accounts, campaigns. Each campaign locks an agent runner (default: `claude-code`, stubs ready for `codex` / `opencode`).
-- Manual "Run now" on a scout campaign → Claude Code drafts Reddit DMs via the `reddit-scout` playbook.
-- Manual "Run now" on a commenter campaign → Claude Code drafts value-adding comments on relevant posts via the `reddit-commenter` playbook.
-- **Blocklist enforcement at draft creation**: `drafts:create` filters out targets matching subreddit / user / keyword entries (global or per-project) and reports skipped counts back to the playbook.
-
-**Review & send loop**
-
-- Inbox with filters (state, kind, run, campaign), keyboard shortcuts, bulk reject.
-- Approve a draft → "Open compose" deep-links to the Reddit DM compose URL or the original post/comment thread (for `post_comment` drafts).
-- The Chrome extension flips drafts to `sent` automatically when you submit on Reddit (manual **Mark as sent** still available as fallback).
-- Per-draft quota line surfaces remaining daily/weekly send budget; over-quota sends raise an audit warning but do not block.
-- Blocklist re-checked at send time — a 409 stops the send if the target was added to the blocklist after the draft was created.
-
-**Reply tracking (extension-driven)**
-
-- The Chrome extension polls Reddit's legacy inbox **and** Reddit Chat (Matrix) every 10 min and POSTs new messages to `/api/extension/dm-sync`.
-- DM replies match on `(account_handle, target_user)`; comment-replies match on `parent_id == drafts.platform_comment_id`. Both flip the draft to `replied` and append a `replied` event.
-- **Conversations** page lists every reply thread, with a kind filter (DM / comment) and per-kind deep links back to the original Reddit thread.
-
-**Dashboard & admin**
-
-- **Home** — drafts awaiting review, approved-not-sent, 24h sent, reply rate, 7-day run health, unique contacts; live recent-runs + campaigns panels.
-- **Inbox** — filters, bulk actions, per-draft quota line, blocklist warnings, draft detail with timeline of events and inline reply body.
-- **Campaigns** — list with live "Running" state and the last status + time + duration on a single row; detail page with expandable per-run log rows.
-- **Contacts** — every outreach with platform/account/kind, plus a `replied` badge.
-- **Conversations** — reply threads across DMs and comment-replies, with kind filter.
-- **Blocklist** — add/remove subreddit / user / keyword entries, scoped globally or per-project.
-- **Playbooks** — list of agent-runner playbooks (built-in + user-created), with inline markdown editor and **Duplicate** to fork a built-in.
-- **Notifications** — bell badge with unread count, recent system events (`run.success` / `run.failed` / `drafts.created` / `reply.received`), and an outgoing-webhook configuration so Slack / Discord / Telegram can be wired up.
-- **Settings** — tabbed layout (Status / Integrations / Quota): daemon heartbeat, auto-detected agent runners (CLI path + version, with **Re-detect**), extension API token (generate / rotate), editable per-platform quota limits.
-
-**Daemon**
-
-- Node process (`npm run -w daemon dev`) that writes heartbeats to `daemon_heartbeats`, wakes up on a tick, and:
-  - triggers active campaigns whose `cron_expression` is due (parsed with `cron-parser`) via the web `/api/run` endpoint,
-  - polls sent DMs for replies through a pluggable `ReplyReader` interface (null reader wired today; the Chrome extension covers reply ingestion in practice).
-- Graceful SIGINT/SIGTERM shutdown.
-
-## Architecture
-
-Monorepo using npm workspaces. Every workspace versions to the same number (`0.3.0` today), and the sidebar version is sourced from `web/package.json`.
-
-- **Postgres** (via Docker) — single source of truth: projects, campaigns, runs, run events, drafts, draft events, contact history, blocklist, daemon heartbeats.
-- **`shared/`** — Drizzle schema + migrations, platform adapters (Reddit), `AgentRunner` + `ReplyReader` interfaces, run-log parsers (claude-code + stubs for codex/opencode).
-- **`cli/`** — the `pitchbox` CLI that playbooks call to read/write DB (`run:start`, `run:finish`, `reddit:scout`, `drafts:create`, …).
-- **`web/`** — SvelteKit 2 + Svelte 5 + Tailwind 4 + shadcn-svelte dashboard. Routes: `/` (home), `/inbox`, `/campaigns`, `/campaigns/[id]`, `/contacts`, `/conversations`, `/blocklist`, `/settings`.
-- **`daemon/`** — heartbeat + scheduler + reply poller. Reply ingestion is handled by the Chrome extension; the daemon's `ReplyReader` slot stays in place for future server-side readers.
-- **`extension/`** — Chrome MV3 companion (Vite + `@crxjs/vite-plugin`) that auto-marks drafts as `sent` when you submit on Reddit and polls your DM inbox to flip drafts to `replied` once the target user writes back.
-- **`playbooks/`** — agent-agnostic markdown instructions. The on-disk files are the source for the **built-in** rows in the `playbooks` table; once seeded, the dashboard becomes the editor. Each run snapshots the body of the chosen playbook into `runs.playbook_body` at creation time so future edits never retroactively change past runs. The disk file remains a fallback for legacy runs and for project extraction / skill generation.
-
-## Roadmap
-
-- ✅ **M0** — repo scaffold, Postgres, Drizzle migrations, CLI skeleton
-- ✅ **M1** — reddit-scout + reddit-commenter playbooks, Inbox, manual "Run now"
-- ✅ **M2** — mark-as-sent flow, Home dashboard, Contacts, Blocklist, daemon scaffold (heartbeat + cron scheduler + reply-poller skeleton)
-- ✅ **M3** — Chrome extension, auto mark-as-sent for DM compose + post-comment drafts
-- ✅ **M4** — DM reply tracking via the extension's inbox poller, Conversations UI (post-comment reply tracking deferred to M4.5)
-- ✅ **M4.5** — comment-reply tracking via the extension's inbox poller
-- ✅ **M5** — blocklist enforcement (creation + send) + advisory rate-limiting (Inbox badge + over-quota warning)
-- ✅ **M6.1** — full project CRUD (UI + API; basic fields + versioned configs + accounts)
-- ⏳ **M6.2** — templates (few-shot examples + reusable snippets, scoped to project, override per campaign)
-- ⏳ **M6.x** — keyword watches, analytics, A/B tests
-- ⏳ **M7+** — additional platform adapters, posting automation, team mode
-
-## Documentation
-
-The full docs live in [`docs/`](./docs) and ship as a static VitePress site (`npm run docs:dev` for local preview, `npm run docs:build` for production output, auto-deployed to GitHub Pages on push to `main` via `.github/workflows/docs.yml`). Stable entry points:
-
-- [Getting started](./docs/getting-started.md)
-- [Concepts](./docs/concepts.md) · [Agent runners](./docs/runners.md) · [Playbooks](./docs/playbooks.md)
-- [Notifications](./docs/notifications.md) · [Authentication](./docs/auth.md)
-- [Chrome extension](./docs/extension.md) · [Daemon](./docs/daemon.md) · [CLI](./docs/cli.md) · [HTTP API](./docs/api.md) · [Self-hosting](./docs/self-hosting.md)
-
-## Authentication (opt-in)
-
-Set `PITCHBOX_AUTH=on` in `.env` to gate the dashboard behind a username + password login. The first user is created on first login — the credentials you submit become the admin account. Sessions are stored in the `sessions` table and pinned to an httpOnly cookie. Sign out lives at the bottom of the sidebar. Webhook and extension routes (`/api/extension/*`) stay unauthenticated by design — they have their own token.
-
-The self-hosted edition assumes a single user / single org. Multi-tenant orgs and SSO are intentionally deferred (umbrella issue #6 covered the long-term plan; this build ships Phase 1).
-
-## Agent runners
-
-Each campaign snapshots its runner at creation time; each run snapshots the runner it used. Today only `claude-code` is implemented (spawns `claude -p --verbose --output-format stream-json`). `codex` and `opencode` adapters exist as typed stubs so new runners can be wired in without touching the rest of the pipeline.
-
-Pitchbox auto-detects installed runner CLIs by probing `<binary> --version` on PATH. Detection is cached for the process lifetime and exposed in **Settings → Status → Agent runners** with a **Re-detect** button (and via `GET /api/runners` · `POST /api/runners` for a fresh probe). The campaign-creation form disables runners that are not installed, and `POST /api/run` refuses to dispatch a campaign whose runner is unavailable (returned as a readiness issue).
-
-Per-runner configuration (model · max turns · extra CLI args) lives under `app_config['runner_configs']` and is editable inline under each runner in **Settings → Status → Agent runners**. The dispatch path (`web/src/lib/server/runner.ts`) calls `loadRunnerConfig(slug)` and passes the config into `createAgentRunner(slug, config)` — for `claude-code` that translates to `--model`, `--max-turns`, and any extra flags appended after the standard `-p / --output-format stream-json` invocation.
-
-**Accounts** carry a `platform_id` (first-class column) and an `is_default` flag scoped per (project, platform). A partial unique index guarantees at most one default per scope. The CLI `run:start` filters accounts to the campaign's platform and surfaces them with the default first, so playbooks can pick the right account without explicit wiring. Toggle the default from **Projects → [id] → Accounts**.
+Pairing is one click: open your Pitchbox dashboard tab and hit **Pair with this tab** in the extension popup. You can pair multiple backends (cloud + self-hosted) at the same time. Details: <https://fiorelorenzo.github.io/pitchbox/extension>
 
 ## License
 
-**AGPL-3.0-or-later** for the open-source (self-hosted) edition — see
-[LICENSE](./LICENSE). A future **Pitchbox Cloud** edition will ship under a
-separate commercial licence. See [NOTICE.md](./NOTICE.md) for the full dual-
-licensing framework and the contributor terms.
+**AGPL-3.0-or-later** for the open-source (self-hosted) edition — see [LICENSE](./LICENSE). A future Pitchbox Cloud edition will ship under a separate commercial licence; see [NOTICE.md](./NOTICE.md) for the dual-licensing framework.

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -2,8 +2,8 @@
 
 The companion extension lives in `extension/` (MV3, Vite + `@crxjs/vite-plugin`). It does two jobs:
 
-1. **Auto mark-as-sent** — when you submit a draft on Reddit, the extension picks up the `pitchbox_draft=<id>` query parameter the dashboard appended to the compose URL and flips the draft to `sent` via the local backend.
-2. **Reply ingestion** — a background service worker polls Reddit's inbox (legacy PMs + comment-replies) and Reddit Chat (Matrix) every 10 min via `chrome.alarms`, posting matches to `POST /api/extension/dm-sync`. The server attributes incoming messages to the right drafts and flips them to `replied`.
+1. **Auto mark-as-sent** — when you submit a draft on Reddit, the extension picks up the `pitchbox_draft=<id>` query parameter the dashboard appended to the compose URL and flips the draft to `sent` on the linked backend.
+2. **Reply ingestion** — a background service worker polls Reddit's inbox (legacy PMs + comment-replies) and Reddit Chat (Matrix) every 10 min via `chrome.alarms`, posting matches to `POST /api/extension/dm-sync` on every paired backend.
 
 ## Stack
 
@@ -16,22 +16,33 @@ npm run build:extension
 # then load extension/dist/ unpacked in chrome://extensions
 ```
 
-## Pairing (recommended)
+## Pairing
 
-In **Dashboard → Settings → Integrations → Browser extension**, click **Generate code**. Paste the 8-char code into the extension popup ("Pair with code" tab) along with the backend URL. The server (`POST /api/extension/pair`) consumes the code once and returns a per-device token stored in `chrome.storage.local`. Each device row is independently revocable from the dashboard.
+One click. Open your Pitchbox dashboard in any tab while signed in, click the extension icon, and hit **Pair with this tab**. The extension:
 
-The legacy "Token" tab in the popup still works for the shared `app_config.extension_api_token` — useful for headless setups where you can't open Settings, but devices are preferred.
+1. Asks Chrome for host permission scoped to that origin only (one prompt the first time you pair that domain).
+2. Injects a tiny script into the tab that calls `GET /api/extension/auto-pair` with your session cookie.
+3. The dashboard mints a fresh device token tied to your org and returns it.
+4. The extension stores the token in `chrome.storage.local` keyed by backend URL.
+
+For the **cloud edition** (`https://app.pitchbox.io/*`) the same script runs automatically the first time you visit while signed in, so cloud users never see the pairing button.
+
+### Pair multiple backends
+
+You can pair both cloud and self-hosted at once — the popup lists every paired backend with a per-row **Disconnect** button. Reddit DM/comment syncs fan out: every paired backend receives the same traffic, so each Pitchbox instance sees every reply. The "auto mark-as-sent" path uses the backend the dashboard linked into the compose URL when the draft was opened, so drafts always flip on the correct backend.
 
 ## Auth & CORS
 
-The dashboard's `hooks.server.ts` exempts `/api/extension/*` from cookie auth. Requests must carry the API token in the `Authorization: Bearer <token>` header. CORS is restricted to `https://www.reddit.com` and `https://old.reddit.com`.
+The dashboard's `hooks.server.ts` exempts `/api/extension/*` from cookie auth. Requests must carry the API token in the `Authorization: Bearer <token>` header. CORS is restricted to `https://www.reddit.com` and `https://old.reddit.com` (the only third-party origins that need to call extension endpoints directly).
+
+The auto-pair endpoint is the one exception: it reads the dashboard session cookie (when `PITCHBOX_AUTH=on`) or falls back to the default org. It runs inside the dashboard origin so cookies travel without CORS.
 
 ## What the background workers do
 
 - `src/background/inbox-sync.ts` — polls `reddit.com/message/inbox.json`. Splits items into the `items[]` (PMs) and `comments[]` (`t1` items) arrays of the dm-sync request body.
 - `src/background/chat-sync.ts` — polls `matrix.redditspace.com/_matrix/client/v3/sync` for Reddit Chat. Before each tick it sends a cheap `GET /_matrix/client/v3/account/whoami` probe; if the Matrix token has expired (401/403) the heavier `/sync` call is skipped, the action badge turns red with `!`, and the popup displays a "Reddit Chat sync paused — please open reddit.com and refresh" notice with a one-click button to open reddit.com.
 
-Both call the same `POST /api/extension/dm-sync` endpoint. The request body now also includes a `status` field summarising channel liveness:
+Both call `POST /api/extension/dm-sync` once per paired backend. The request body includes a `status` field summarising channel liveness:
 
 ```jsonc
 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ Pitchbox is a Node monorepo. You need:
 
 - Node ≥ 22
 - Docker (for the Postgres dev DB)
-- The `claude` CLI logged into a Claude subscription (the default agent runner)
+- The `claude` CLI logged into a Claude subscription (the default agent runner; `codex` and `opencode` are also supported)
 
 ## Install
 
@@ -15,7 +15,7 @@ npm install
 cp .env.example .env  # then set ENCRYPTION_KEY (32-byte hex) and PITCHBOX_ROOT
 ```
 
-`ENCRYPTION_KEY` protects account secrets at rest — generate one with `openssl rand -hex 32`.
+`ENCRYPTION_KEY` protects account secrets at rest — generate one with `openssl rand -hex 32`. `PITCHBOX_ROOT` must be the absolute path to the repo root.
 
 ## Database
 
@@ -29,8 +29,15 @@ npm run -w @pitchbox/shared seed:core         # seeds platforms, default playboo
 
 ```bash
 npm run dev                # web dashboard on http://127.0.0.1:5180
-npm run -w daemon dev      # optional: scheduler + reply poller
 ```
+
+By default the dashboard runs on its own and you start the background daemon as a second process:
+
+```bash
+npm run -w daemon dev      # scheduler + reply poller + retention + webhook DLQ
+```
+
+For single-host installs you can skip the second process and run everything in one — set `PITCHBOX_EMBED_DAEMON=1` in your `.env` and the same loops boot inside the web server. See [Daemon](/daemon) for when each mode makes sense.
 
 ## Optional: turn on authentication
 
@@ -49,10 +56,10 @@ Press `Cmd+K` (macOS) or `Ctrl+K` (Windows/Linux) anywhere in the dashboard to o
 
 ## Appearance
 
-The sidebar footer hosts a System/Light/Dark toggle. Your choice persists locally per browser; `System` follows the OS preference.
+Theme (System/Light/Dark) and interface language (EN/IT) live under **Settings → Appearance**. Your choice persists locally per browser; `System` follows the OS preference.
 
 The dashboard is responsive down to roughly 375 px wide: on tablet and phone widths the sidebar collapses behind a hamburger button at top-left, the Inbox stacks the draft list and detail panel vertically with a back button, and filters fold into a popover.
 
 ## Chrome extension
 
-Build and load `extension/dist/` unpacked. See [the extension page](/extension) for the token wiring.
+Build and load `extension/dist/` unpacked, then open your dashboard in any tab and click **Pair with this tab** in the extension popup. Cloud users on `app.pitchbox.io` are paired automatically the first time they visit while signed in. Details: [the extension page](/extension).

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -53,12 +53,23 @@ export default defineManifest({
       js: ['src/content/chat-token.ts'],
       run_at: 'document_idle',
     },
+    {
+      // Auto-pair on the cloud edition. Self-hosted instances trigger the
+      // same script on demand via the popup's "Pair with this tab" button,
+      // which uses chrome.scripting.executeScript after a one-shot
+      // permission grant.
+      matches: ['https://app.pitchbox.io/*', 'http://127.0.0.1:5180/*', 'http://localhost:5180/*'],
+      js: ['src/content/auto-pair.ts'],
+      run_at: 'document_idle',
+    },
   ],
-  permissions: ['storage', 'alarms', 'tabs'],
+  permissions: ['storage', 'alarms', 'tabs', 'scripting'],
+  optional_host_permissions: ['<all_urls>'],
   host_permissions: [
     'https://www.reddit.com/*',
     'https://old.reddit.com/*',
     'https://matrix.redditspace.com/*',
+    'https://app.pitchbox.io/*',
     'http://127.0.0.1/*',
     'http://localhost/*',
   ],

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,6 +1,12 @@
 import { runInboxSync } from './background/inbox-sync.js';
 import { runChatSync } from './background/chat-sync.js';
-import { setSettings, type SyncChannelStatus } from './lib/storage.js';
+import {
+  getSettings,
+  patchPairing,
+  setSettings,
+  upsertPairing,
+  type SyncChannelStatus,
+} from './lib/storage.js';
 import { api } from './lib/api.js';
 
 const ALARM = 'pitchbox:dm-sync';
@@ -37,7 +43,11 @@ async function runAllSyncs() {
     legacy: classifyInbox(inbox),
     capturedAt: new Date().toISOString(),
   };
-  await setSettings({ syncStatus: status });
+  // Per-pairing status — every paired backend gets the same observation.
+  const { pairings } = await getSettings();
+  for (const p of pairings) {
+    await patchPairing(p.backendUrl, { syncStatus: status });
+  }
   // Heartbeat: report current channel status to the dashboard even when no
   // items moved. Fire-and-forget — failures here are non-fatal and the next
   // alarm tick will retry.
@@ -96,6 +106,21 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       matrixUserId: msg.matrixUserId,
       matrixDeviceId: msg.matrixDeviceId,
       matrixToken: msg.matrixToken,
+    }).then(() => sendResponse({ ok: true }));
+    return true;
+  }
+  if (msg?.type === 'pitchbox:auto-pair') {
+    // Persist token captured from the dashboard auto-pair handshake. Stored
+    // alongside any other pairings so cloud + self-hosted can coexist.
+    const { backendUrl, token } = msg as { backendUrl: string; token: string };
+    if (typeof backendUrl !== 'string' || typeof token !== 'string') {
+      sendResponse({ ok: false, reason: 'invalid_payload' });
+      return false;
+    }
+    upsertPairing({
+      backendUrl: backendUrl.replace(/\/$/, ''),
+      token,
+      lastHandshakeAt: new Date().toISOString(),
     }).then(() => sendResponse({ ok: true }));
     return true;
   }

--- a/extension/src/background/chat-sync.ts
+++ b/extension/src/background/chat-sync.ts
@@ -191,7 +191,20 @@ export async function runChatSync(): Promise<SyncResult> {
 
   if (items.length === 0) return { ok: true, inserted: 0, replied: 0, chatStatus: 'ok' };
 
-  const r = await api.dmSync('reddit', items);
-  if (!r.ok) return { ok: false, reason: r.error, chatStatus: 'ok' };
-  return { ok: true, inserted: r.data.inserted, replied: r.data.replied, chatStatus: 'ok' };
+  // Fan-out to every paired backend; aggregate counts and take the worst
+  // outcome as the channel status (any backend failing surfaces a warning).
+  const results = await api.dmSync('reddit', items);
+  if (results.length === 0) return { ok: false, reason: 'not configured', chatStatus: 'ok' };
+  const successes = results.filter((r) => r.ok);
+  if (successes.length === 0) {
+    const first = results.find((r) => !r.ok);
+    return {
+      ok: false,
+      reason: first && !first.ok ? first.error : 'unknown',
+      chatStatus: 'ok',
+    };
+  }
+  const inserted = successes.reduce((acc, r) => acc + (r.ok ? r.data.inserted : 0), 0);
+  const replied = successes.reduce((acc, r) => acc + (r.ok ? r.data.replied : 0), 0);
+  return { ok: true, inserted, replied, chatStatus: 'ok' };
 }

--- a/extension/src/background/inbox-sync.ts
+++ b/extension/src/background/inbox-sync.ts
@@ -33,8 +33,14 @@ export async function runInboxSync(): Promise<{
     const data = (await res.json()) as InboxResponse;
     const children = data?.data?.children ?? [];
 
-    const { lastDmSyncAt } = await getSettings();
-    const lastMs = lastDmSyncAt ? new Date(lastDmSyncAt).getTime() : 0;
+    // Multi-pairing: poll back as far as the OLDEST pairing's last sync,
+    // so each backend sees every reply it's missed. api.dmSync de-dupes
+    // by (account_handle, target_user, threadId) on the server.
+    const { pairings } = await getSettings();
+    const lastTimes = pairings
+      .map((p) => (p.lastDmSyncAt ? new Date(p.lastDmSyncAt).getTime() : 0))
+      .filter((t) => t > 0);
+    const lastMs = lastTimes.length === pairings.length ? Math.min(...lastTimes) : 0;
 
     const items: Array<{
       fromUser: string;
@@ -76,18 +82,30 @@ export async function runInboxSync(): Promise<{
     }
 
     if (items.length === 0 && comments.length === 0) {
-      await setSettings({ lastDmSyncAt: new Date().toISOString() });
+      // Bump every pairing's lastDmSyncAt so the next poll narrows again.
+      const now = new Date().toISOString();
+      const { pairings: ps } = await getSettings();
+      await setSettings({ pairings: ps.map((p) => ({ ...p, lastDmSyncAt: now })) });
       return { ok: true, inserted: 0, replied: 0 };
     }
 
-    const r = await api.dmSync('reddit', items, comments);
-    await setSettings({ lastDmSyncAt: new Date().toISOString() });
-    if (!r.ok) return { ok: false, reason: r.error };
-    return {
-      ok: true,
-      inserted: r.data.inserted + (r.data.commentsInserted ?? 0),
-      replied: r.data.replied + (r.data.commentsReplied ?? 0),
-    };
+    // api.dmSync fans out and stamps each pairing's lastDmSyncAt on success.
+    const results = await api.dmSync('reddit', items, comments);
+    if (results.length === 0) return { ok: false, reason: 'not configured' };
+    const successes = results.filter((r) => r.ok);
+    if (successes.length === 0) {
+      const first = results[0];
+      return { ok: false, reason: !first.ok ? first.error : 'unknown' };
+    }
+    const inserted = successes.reduce(
+      (acc, r) => acc + (r.ok ? r.data.inserted + (r.data.commentsInserted ?? 0) : 0),
+      0,
+    );
+    const replied = successes.reduce(
+      (acc, r) => acc + (r.ok ? r.data.replied + (r.data.commentsReplied ?? 0) : 0),
+      0,
+    );
+    return { ok: true, inserted, replied };
   } catch (e) {
     return { ok: false, reason: (e as Error).message };
   }

--- a/extension/src/content/auto-pair.ts
+++ b/extension/src/content/auto-pair.ts
@@ -1,0 +1,61 @@
+/**
+ * Auto-pair content script.
+ *
+ * Runs on any origin the user has granted host permission for. Detects a
+ * Pitchbox dashboard via the `<meta name="pitchbox-pair">` beacon (set in
+ * web/src/app.html) and pairs the extension by calling the dashboard's
+ * `/api/extension/auto-pair` endpoint. The fetch carries the user's session
+ * cookie because we run inside the page origin, so the server can mint a
+ * device token tied to the right org without any user input.
+ *
+ * Idempotent: if the extension already has a token for this origin we skip.
+ * The popup's "Pair with this tab" flow injects this same script on demand,
+ * so the auto and manual paths converge here.
+ */
+(async () => {
+  const beacon = document.querySelector('meta[name="pitchbox-pair"]');
+  if (!beacon) return;
+
+  const backendUrl = `${location.protocol}//${location.host}`;
+
+  // Skip when already paired with the current backend, to avoid burning a new
+  // device token on every page load.
+  const existing = await chrome.storage.local.get(['backendUrl', 'token']);
+  if (existing.token && existing.backendUrl === backendUrl) return;
+
+  let res: Response;
+  try {
+    res = await fetch(`${backendUrl}/api/extension/auto-pair`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: { accept: 'application/json' },
+    });
+  } catch (err) {
+    console.warn('[pitchbox] auto-pair fetch failed', err);
+    return;
+  }
+  if (!res.ok) {
+    if (res.status === 401) {
+      // User isn't signed in yet — quietly skip, we'll retry on next reload.
+      return;
+    }
+    console.warn('[pitchbox] auto-pair non-200', res.status);
+    return;
+  }
+
+  let body: { token?: string };
+  try {
+    body = (await res.json()) as { token?: string };
+  } catch {
+    return;
+  }
+  if (!body.token) return;
+
+  chrome.runtime.sendMessage(
+    { type: 'pitchbox:auto-pair', backendUrl, token: body.token },
+    (ack) => {
+      if (ack?.ok) console.log('[pitchbox] paired with', backendUrl);
+      else console.warn('[pitchbox] auto-pair save failed', ack);
+    },
+  );
+})();

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { getSettings } from './storage.js';
+import { getSettings, patchPairing, type Pairing } from './storage.js';
 
 export type ApiResult<T = unknown> =
   | { ok: true; data: T }
@@ -13,25 +13,34 @@ type DraftSummary = {
   version?: number;
 };
 
-async function authHeaders(): Promise<{ backendUrl: string; headers: HeadersInit } | null> {
-  const { backendUrl, token } = await getSettings();
-  if (!backendUrl || !token) return null;
+/**
+ * Resolve which pairing a single-backend op should target. Compose-time
+ * content scripts can pass an explicit `backendUrl` (the dashboard injects
+ * it as a query param into compose URLs). When omitted we fall back to the
+ * first pairing — keeps single-backend installs working without changes.
+ */
+async function pickPairing(backendUrl?: string): Promise<Pairing | null> {
+  const { pairings } = await getSettings();
+  if (pairings.length === 0) return null;
+  if (backendUrl) {
+    const url = backendUrl.replace(/\/$/, '');
+    return pairings.find((p) => p.backendUrl === url) ?? null;
+  }
+  return pairings[0];
+}
+
+function authHeaders(p: Pairing): HeadersInit {
   return {
-    backendUrl,
-    headers: {
-      'content-type': 'application/json',
-      authorization: `Bearer ${token}`,
-    },
+    'content-type': 'application/json',
+    authorization: `Bearer ${p.token}`,
   };
 }
 
-async function postJson<T>(path: string, body: unknown): Promise<ApiResult<T>> {
-  const auth = await authHeaders();
-  if (!auth) return { ok: false, status: 0, error: 'not configured' };
+async function postJson<T>(p: Pairing, path: string, body: unknown): Promise<ApiResult<T>> {
   try {
-    const res = await fetch(`${auth.backendUrl}${path}`, {
+    const res = await fetch(`${p.backendUrl}${path}`, {
       method: 'POST',
-      headers: auth.headers,
+      headers: authHeaders(p),
       body: JSON.stringify(body),
     });
     if (!res.ok) return { ok: false, status: res.status, error: await res.text() };
@@ -41,11 +50,9 @@ async function postJson<T>(path: string, body: unknown): Promise<ApiResult<T>> {
   }
 }
 
-async function getJson<T>(path: string): Promise<ApiResult<T>> {
-  const auth = await authHeaders();
-  if (!auth) return { ok: false, status: 0, error: 'not configured' };
+async function getJson<T>(p: Pairing, path: string): Promise<ApiResult<T>> {
   try {
-    const res = await fetch(`${auth.backendUrl}${path}`, { headers: auth.headers });
+    const res = await fetch(`${p.backendUrl}${path}`, { headers: authHeaders(p) });
     if (!res.ok) return { ok: false, status: res.status, error: await res.text() };
     return { ok: true, data: (await res.json()) as T };
   } catch (e) {
@@ -53,44 +60,21 @@ async function getJson<T>(path: string): Promise<ApiResult<T>> {
   }
 }
 
+export type DmSyncResult = ApiResult<{
+  ok: true;
+  inserted: number;
+  replied: number;
+  commentsInserted?: number;
+  commentsReplied?: number;
+}>;
+
+export type DmSyncFanout = Array<DmSyncResult & { backendUrl: string }>;
+
 export const api = {
-  handshake: () => postJson<{ ok: true; version: string }>('/api/extension/handshake', {}),
-  getDraft: (draftId: number) => getJson<DraftSummary>(`/api/extension/draft/${draftId}`),
-  armed: (draftId: number) =>
-    postJson<{ ok: true }>(`/api/extension/draft/${draftId}/armed`, {
-      composedAt: new Date().toISOString(),
-    }),
-  sent: async (
-    draftId: number,
-    sentContent?: string,
-    commentLookup?: { postId: string; accountHandle: string; postedAt: string },
-    platformPostId?: string,
-    version?: number,
-  ): Promise<ApiResult<{ ok: true }>> => {
-    const payload = {
-      sentContent,
-      sentAt: new Date().toISOString(),
-      commentLookup,
-      platformPostId,
-      version,
-    };
-    const first = await postJson<{ ok: true }>(`/api/extension/draft/${draftId}/sent`, payload);
-    if (first.ok || first.status !== 409) return first;
-    // Re-fetch the draft to read the latest version, then retry exactly once.
-    let parsed: { error?: string; current_version?: number } | null = null;
-    try {
-      parsed = JSON.parse(first.error) as { error?: string; current_version?: number };
-    } catch {
-      // Body wasn't JSON — bail out with the original failure.
-    }
-    if (!parsed || parsed.error !== 'version_conflict') return first;
-    const fresh = await getJson<DraftSummary>(`/api/extension/draft/${draftId}`);
-    if (!fresh.ok) return first;
-    return postJson<{ ok: true }>(`/api/extension/draft/${draftId}/sent`, {
-      ...payload,
-      version: fresh.data.version ?? parsed.current_version,
-    });
-  },
+  /**
+   * Fan-out: every paired backend gets the same Reddit traffic so each
+   * Pitchbox instance sees the user's full activity.
+   */
   dmSync: async (
     platform: string,
     items: unknown[],
@@ -100,20 +84,92 @@ export const api = {
       legacy: 'ok' | 'unauthorized' | 'error' | 'unknown';
       captured_at: string;
     },
-  ) => {
-    const stored = !status ? (await getSettings()).syncStatus : null;
-    const payloadStatus =
-      status ??
-      (stored
-        ? { chat: stored.chat, legacy: stored.legacy, captured_at: stored.capturedAt }
-        : undefined);
-    return postJson<{
-      ok: true;
-      inserted: number;
-      replied: number;
-      commentsInserted?: number;
-      commentsReplied?: number;
-    }>('/api/extension/dm-sync', { platform, items, comments, status: payloadStatus });
+  ): Promise<DmSyncFanout> => {
+    const { pairings } = await getSettings();
+    const out: DmSyncFanout = [];
+    for (const p of pairings) {
+      const payloadStatus =
+        status ??
+        (p.syncStatus
+          ? {
+              chat: p.syncStatus.chat,
+              legacy: p.syncStatus.legacy,
+              captured_at: p.syncStatus.capturedAt,
+            }
+          : undefined);
+      const r = await postJson<{
+        ok: true;
+        inserted: number;
+        replied: number;
+        commentsInserted?: number;
+        commentsReplied?: number;
+      }>(p, '/api/extension/dm-sync', { platform, items, comments, status: payloadStatus });
+      out.push({ ...r, backendUrl: p.backendUrl });
+      if (r.ok) await patchPairing(p.backendUrl, { lastDmSyncAt: new Date().toISOString() });
+    }
+    return out;
   },
-  dmSyncStatus: () => getJson<{ lastSyncAt: string | null }>('/api/extension/dm-sync/status'),
+
+  // Single-backend ops below. Compose-time content scripts pass the
+  // backendUrl from the URL query param; everything else uses the first
+  // pairing.
+  handshake: async (backendUrl?: string): Promise<ApiResult<{ ok: true; version: string }>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    return postJson(p, '/api/extension/handshake', {});
+  },
+
+  getDraft: async (draftId: number, backendUrl?: string): Promise<ApiResult<DraftSummary>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    return getJson(p, `/api/extension/draft/${draftId}`);
+  },
+
+  armed: async (draftId: number, backendUrl?: string): Promise<ApiResult<{ ok: true }>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    return postJson(p, `/api/extension/draft/${draftId}/armed`, {
+      composedAt: new Date().toISOString(),
+    });
+  },
+
+  sent: async (
+    draftId: number,
+    sentContent?: string,
+    commentLookup?: { postId: string; accountHandle: string; postedAt: string },
+    platformPostId?: string,
+    version?: number,
+    backendUrl?: string,
+  ): Promise<ApiResult<{ ok: true }>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    const payload = {
+      sentContent,
+      sentAt: new Date().toISOString(),
+      commentLookup,
+      platformPostId,
+      version,
+    };
+    const first = await postJson<{ ok: true }>(p, `/api/extension/draft/${draftId}/sent`, payload);
+    if (first.ok || first.status !== 409) return first;
+    let parsed: { error?: string; current_version?: number } | null = null;
+    try {
+      parsed = JSON.parse(first.error) as { error?: string; current_version?: number };
+    } catch {
+      // body wasn't JSON — bail out
+    }
+    if (!parsed || parsed.error !== 'version_conflict') return first;
+    const fresh = await getJson<DraftSummary>(p, `/api/extension/draft/${draftId}`);
+    if (!fresh.ok) return first;
+    return postJson<{ ok: true }>(p, `/api/extension/draft/${draftId}/sent`, {
+      ...payload,
+      version: fresh.data.version ?? parsed.current_version,
+    });
+  },
+
+  dmSyncStatus: async (backendUrl?: string): Promise<ApiResult<{ lastSyncAt: string | null }>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    return getJson(p, '/api/extension/dm-sync/status');
+  },
 };

--- a/extension/src/lib/storage.ts
+++ b/extension/src/lib/storage.ts
@@ -6,41 +6,125 @@ export type SyncStatus = {
   capturedAt: string;
 };
 
-export type Settings = {
+/**
+ * One paired backend. Users can be paired with multiple at the same time
+ * (e.g. cloud + self-hosted) — every DM/comment sync fans out to all of them
+ * so each Pitchbox instance sees the same Reddit traffic.
+ */
+export type Pairing = {
   backendUrl: string;
   token: string;
   lastHandshakeAt?: string;
   lastDmSyncAt?: string;
+  syncStatus?: SyncStatus;
+};
+
+export type Settings = {
+  pairings: Pairing[];
   matrixUserId?: string;
   matrixDeviceId?: string;
   matrixToken?: string;
   matrixSince?: string;
   matrixDisplayNames?: Record<string, string>;
   matrixRoomMembers?: Record<string, string[]>;
-  syncStatus?: SyncStatus;
 };
 
-const DEFAULTS: Partial<Settings> = { backendUrl: 'http://127.0.0.1:5180' };
-
 const KEYS = [
+  'pairings',
+  // Legacy single-backend keys, read once on first load to migrate forward.
   'backendUrl',
   'token',
   'lastHandshakeAt',
   'lastDmSyncAt',
+  'syncStatus',
   'matrixUserId',
   'matrixDeviceId',
   'matrixToken',
   'matrixSince',
   'matrixDisplayNames',
   'matrixRoomMembers',
-  'syncStatus',
 ];
 
-export async function getSettings(): Promise<Partial<Settings>> {
-  const stored = await chrome.storage.local.get(KEYS);
-  return { ...DEFAULTS, ...stored };
+type StoredShape = Partial<Settings> & {
+  // Legacy single-pairing fields.
+  backendUrl?: string;
+  token?: string;
+  lastHandshakeAt?: string;
+  lastDmSyncAt?: string;
+  syncStatus?: SyncStatus;
+};
+
+export async function getSettings(): Promise<Settings> {
+  // KEYS includes legacy string keys outside `keyof Settings` so we bypass
+  // chrome.storage's strict typing.
+  const stored = (await (chrome.storage.local.get as (k: string[]) => Promise<unknown>)(
+    KEYS,
+  )) as StoredShape;
+
+  let pairings: Pairing[] = Array.isArray(stored.pairings) ? stored.pairings : [];
+
+  // Migrate the old single-backend shape on first read; persist the migration
+  // so subsequent reads are clean and the legacy keys are gone.
+  if (pairings.length === 0 && stored.backendUrl && stored.token) {
+    pairings = [
+      {
+        backendUrl: stored.backendUrl,
+        token: stored.token,
+        lastHandshakeAt: stored.lastHandshakeAt,
+        lastDmSyncAt: stored.lastDmSyncAt,
+        syncStatus: stored.syncStatus,
+      },
+    ];
+    await chrome.storage.local.set({ pairings });
+    await chrome.storage.local.remove([
+      'backendUrl',
+      'token',
+      'lastHandshakeAt',
+      'lastDmSyncAt',
+      'syncStatus',
+    ]);
+  }
+
+  return {
+    pairings,
+    matrixUserId: stored.matrixUserId,
+    matrixDeviceId: stored.matrixDeviceId,
+    matrixToken: stored.matrixToken,
+    matrixSince: stored.matrixSince,
+    matrixDisplayNames: stored.matrixDisplayNames,
+    matrixRoomMembers: stored.matrixRoomMembers,
+  };
 }
 
 export async function setSettings(patch: Partial<Settings>): Promise<void> {
   await chrome.storage.local.set(patch);
+}
+
+/** Add or update a pairing keyed by backendUrl. */
+export async function upsertPairing(pairing: Pairing): Promise<Pairing[]> {
+  const { pairings } = await getSettings();
+  const url = pairing.backendUrl.replace(/\/$/, '');
+  const next: Pairing[] = pairings.filter((p) => p.backendUrl !== url);
+  next.push({ ...pairing, backendUrl: url });
+  await setSettings({ pairings: next });
+  return next;
+}
+
+export async function removePairing(backendUrl: string): Promise<Pairing[]> {
+  const { pairings } = await getSettings();
+  const url = backendUrl.replace(/\/$/, '');
+  const next = pairings.filter((p) => p.backendUrl !== url);
+  await setSettings({ pairings: next });
+  return next;
+}
+
+export async function patchPairing(
+  backendUrl: string,
+  patch: Partial<Pairing>,
+): Promise<Pairing[]> {
+  const { pairings } = await getSettings();
+  const url = backendUrl.replace(/\/$/, '');
+  const next = pairings.map((p) => (p.backendUrl === url ? { ...p, ...patch } : p));
+  await setSettings({ pairings: next });
+  return next;
 }

--- a/extension/src/popup/App.svelte
+++ b/extension/src/popup/App.svelte
@@ -1,281 +1,229 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { getSettings, setSettings } from '../lib/storage.js';
-	import { api } from '../lib/api.js';
+  import { onMount } from 'svelte';
+  import { getSettings, removePairing, type Pairing } from '../lib/storage.js';
 
-	type Status = { kind: 'idle' | 'ok' | 'err'; msg?: string };
+  type Status = { kind: 'idle' | 'ok' | 'err'; msg?: string };
 
-	let backendUrl = $state('');
-	let pairingCode = $state('');
-	let token = $state('');
-	let lastHandshakeAt = $state<string | null>(null);
-	let lastDmSyncAt = $state<string | null>(null);
-	let chatSyncStatus = $state<'ok' | 'unauthorized' | 'error' | 'unknown' | null>(null);
-	let status = $state<Status>({ kind: 'idle' });
-	let busy = $state(false);
-	let syncing = $state(false);
-	let mode = $state<'pair' | 'manual'>('pair');
+  let pairings = $state<Pairing[]>([]);
+  let chatSyncStatus = $state<'ok' | 'unauthorized' | 'error' | 'unknown' | null>(null);
+  let status = $state<Status>({ kind: 'idle' });
+  let busy = $state(false);
+  let syncing = $state(false);
 
-	onMount(async () => {
-		const s = await getSettings();
-		backendUrl = s.backendUrl ?? '';
-		token = s.token ?? '';
-		lastHandshakeAt = s.lastHandshakeAt ?? null;
-		lastDmSyncAt = s.lastDmSyncAt ?? null;
-		chatSyncStatus = s.syncStatus?.chat ?? null;
-		if (token) status = { kind: 'ok', msg: 'Connected' };
-	});
+  async function refresh() {
+    const s = await getSettings();
+    pairings = s.pairings;
+    chatSyncStatus = s.pairings[0]?.syncStatus?.chat ?? null;
+  }
 
-	function openReddit() {
-		try {
-			chrome.tabs?.create?.({ url: 'https://www.reddit.com/' });
-		} catch {
-			// noop — tabs API unavailable in this context.
-		}
-	}
+  onMount(refresh);
 
-	function fmtAgo(iso: string | null): string {
-		if (!iso) return 'never';
-		const ms = Date.now() - new Date(iso).getTime();
-		if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
-		if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
-		if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
-		return `${Math.floor(ms / 86_400_000)}d ago`;
-	}
+  function openReddit() {
+    try {
+      chrome.tabs?.create?.({ url: 'https://www.reddit.com/' });
+    } catch {
+      // tabs API may be unavailable
+    }
+  }
 
-	async function pair() {
-		const url = backendUrl.trim().replace(/\/$/, '');
-		const code = pairingCode.trim();
-		if (!url || !code) {
-			status = { kind: 'err', msg: 'Backend URL and pairing code required.' };
-			return;
-		}
-		busy = true;
-		try {
-			const res = await fetch(`${url}/api/extension/pair`, {
-				method: 'POST',
-				headers: { 'content-type': 'application/json' },
-				body: JSON.stringify({ code }),
-			});
-			if (!res.ok) {
-				const text = await res.text();
-				status = { kind: 'err', msg: `Pairing failed (${res.status}): ${text || 'no body'}` };
-				return;
-			}
-			const body = (await res.json()) as { token: string };
-			await setSettings({ backendUrl: url, token: body.token });
-			token = body.token;
-			const r = await api.handshake();
-			if (r.ok) {
-				await setSettings({ lastHandshakeAt: new Date().toISOString() });
-				lastHandshakeAt = new Date().toISOString();
-				status = { kind: 'ok', msg: `Paired — dashboard v${r.data.version}.` };
-				pairingCode = '';
-			} else {
-				status = { kind: 'err', msg: `Token saved but handshake failed: ${r.error || r.status}` };
-			}
-		} finally {
-			busy = false;
-		}
-	}
+  function fmtAgo(iso: string | undefined): string {
+    if (!iso) return 'never';
+    const ms = Date.now() - new Date(iso).getTime();
+    if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
+    if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+    if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+    return `${Math.floor(ms / 86_400_000)}d ago`;
+  }
 
-	async function manualConnect() {
-		const url = backendUrl.trim().replace(/\/$/, '');
-		const t = token.trim();
-		if (!url || !t) {
-			status = { kind: 'err', msg: 'Backend URL and token required.' };
-			return;
-		}
-		busy = true;
-		try {
-			await setSettings({ backendUrl: url, token: t });
-			const r = await api.handshake();
-			if (r.ok) {
-				await setSettings({ lastHandshakeAt: new Date().toISOString() });
-				lastHandshakeAt = new Date().toISOString();
-				status = { kind: 'ok', msg: `Connected — dashboard v${r.data.version}.` };
-			} else {
-				status = { kind: 'err', msg: `Failed (${r.status}): ${r.error || 'no response'}` };
-			}
-		} finally {
-			busy = false;
-		}
-	}
+  function shortHost(url: string): string {
+    try {
+      return new URL(url).host;
+    } catch {
+      return url;
+    }
+  }
 
-	async function disconnect() {
-		await setSettings({ token: undefined, lastHandshakeAt: undefined });
-		token = '';
-		lastHandshakeAt = null;
-		status = { kind: 'idle' };
-	}
+  async function pairWithThisTab() {
+    busy = true;
+    status = { kind: 'idle' };
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (!tab?.id || !tab.url) {
+        status = { kind: 'err', msg: 'No active tab.' };
+        return;
+      }
+      let origin: string;
+      try {
+        origin = new URL(tab.url).origin;
+      } catch {
+        status = { kind: 'err', msg: 'Active tab has no valid URL.' };
+        return;
+      }
+      if (tab.url.startsWith('chrome://') || tab.url.startsWith('chrome-extension://')) {
+        status = { kind: 'err', msg: 'Open your Pitchbox dashboard in this tab first.' };
+        return;
+      }
+      const granted = await chrome.permissions.request({ origins: [origin + '/*'] });
+      if (!granted) {
+        status = { kind: 'err', msg: 'Permission denied for this site.' };
+        return;
+      }
+      // Inject the auto-pair script into the granted tab. The script reads
+      // the dashboard's session cookie (same-origin), calls /api/extension/
+      // auto-pair, and posts the resulting token to the background, which
+      // persists it via upsertPairing.
+      await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        files: ['src/content/auto-pair.ts'],
+      });
+      // Wait briefly for the background to receive and persist the token.
+      await new Promise((r) => setTimeout(r, 700));
+      const before = pairings.length;
+      await refresh();
+      const matched = pairings.find((p) => p.backendUrl === origin);
+      if (matched) {
+        status = { kind: 'ok', msg: `Paired with ${shortHost(matched.backendUrl)}.` };
+      } else if (pairings.length > before) {
+        status = { kind: 'ok', msg: 'Paired.' };
+      } else {
+        status = {
+          kind: 'err',
+          msg: 'Pairing failed — make sure you are signed in to the dashboard in this tab.',
+        };
+      }
+    } finally {
+      busy = false;
+    }
+  }
 
-	async function syncNow() {
-		syncing = true;
-		try {
-			const reply = await new Promise<{
-				ok: boolean;
-				inserted?: number;
-				replied?: number;
-				reason?: string;
-			}>((resolve) => chrome.runtime.sendMessage({ type: 'pitchbox:dm-sync:run' }, resolve));
-			if (!reply.ok) {
-				status = { kind: 'err', msg: `Sync failed: ${reply.reason ?? 'unknown'}` };
-			} else {
-				status = {
-					kind: 'ok',
-					msg: `Sync OK — ${reply.inserted ?? 0} new, ${reply.replied ?? 0} replied.`,
-				};
-			}
-			const s = await getSettings();
-			lastDmSyncAt = s.lastDmSyncAt ?? null;
-			chatSyncStatus = s.syncStatus?.chat ?? null;
-		} finally {
-			syncing = false;
-		}
-	}
+  async function disconnect(backendUrl: string) {
+    await removePairing(backendUrl);
+    await refresh();
+  }
+
+  async function syncNow() {
+    syncing = true;
+    try {
+      const reply = await new Promise<{
+        ok: boolean;
+        inserted?: number;
+        replied?: number;
+        reason?: string;
+      }>((resolve) => chrome.runtime.sendMessage({ type: 'pitchbox:dm-sync:run' }, resolve));
+      if (!reply.ok) {
+        status = { kind: 'err', msg: `Sync failed: ${reply.reason ?? 'unknown'}` };
+      } else {
+        status = {
+          kind: 'ok',
+          msg: `Sync OK — ${reply.inserted ?? 0} new, ${reply.replied ?? 0} replied.`,
+        };
+      }
+      await refresh();
+    } finally {
+      syncing = false;
+    }
+  }
 </script>
 
 <main class="flex flex-col gap-3 p-4">
-	<header class="flex items-center gap-2 pb-2 border-b border-[var(--color-border)]">
-		<svg viewBox="0 0 512 512" class="size-7 shrink-0" aria-hidden="true">
-			<rect x="16" y="16" width="480" height="480" rx="112" fill="#0b1220" />
-			<path
-				d="M124 332 L124 200 L256 132 L388 200 L388 332 Z"
-				fill="none"
-				stroke="#38bdf8"
-				stroke-width="28"
-				stroke-linejoin="round"
-			/>
-			<path
-				d="M256 132 L256 240"
-				stroke="#38bdf8"
-				stroke-width="28"
-				stroke-linecap="round"
-			/>
-			<path
-				d="M178 280 L256 202 L334 280"
-				fill="none"
-				stroke="#f8fafc"
-				stroke-width="36"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-			/>
-		</svg>
-		<h1 class="text-sm font-semibold flex-1">Pitchbox</h1>
-		{#if token}
-			<button
-				class="text-[10px] text-[var(--color-muted)] hover:text-[var(--color-fg)] underline-offset-2 hover:underline"
-				onclick={disconnect}
-			>
-				Disconnect
-			</button>
-		{/if}
-	</header>
+  <header class="flex items-center gap-2 pb-2 border-b border-[var(--color-border)]">
+    <svg viewBox="0 0 512 512" class="size-7 shrink-0" aria-hidden="true">
+      <rect x="16" y="16" width="480" height="480" rx="112" fill="#0b1220" />
+      <path
+        d="M124 332 L124 200 L256 132 L388 200 L388 332 Z"
+        fill="none"
+        stroke="#38bdf8"
+        stroke-width="28"
+        stroke-linejoin="round"
+      />
+      <path d="M256 132 L256 240" stroke="#38bdf8" stroke-width="28" stroke-linecap="round" />
+      <path
+        d="M178 280 L256 202 L334 280"
+        fill="none"
+        stroke="#f8fafc"
+        stroke-width="36"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    <h1 class="text-sm font-semibold flex-1">Pitchbox</h1>
+  </header>
 
-	{#if !token}
-		<div class="flex gap-1 text-[11px]">
-			<button
-				class="flex-1 rounded-md py-1.5 px-2 transition-colors {mode === 'pair'
-					? 'bg-[var(--color-border)] text-[var(--color-fg)]'
-					: 'text-[var(--color-muted)] hover:text-[var(--color-fg)]'}"
-				onclick={() => (mode = 'pair')}
-			>
-				Pair with code
-			</button>
-			<button
-				class="flex-1 rounded-md py-1.5 px-2 transition-colors {mode === 'manual'
-					? 'bg-[var(--color-border)] text-[var(--color-fg)]'
-					: 'text-[var(--color-muted)] hover:text-[var(--color-fg)]'}"
-				onclick={() => (mode = 'manual')}
-			>
-				Token (legacy)
-			</button>
-		</div>
+  {#if pairings.length === 0}
+    <button
+      disabled={busy}
+      onclick={pairWithThisTab}
+      class="rounded-md bg-[var(--color-accent)] text-[var(--color-bg)] font-medium py-2 disabled:opacity-60 hover:brightness-110 text-[13px]"
+    >
+      {busy ? 'Pairing…' : 'Pair with this tab'}
+    </button>
+    <p class="text-[11px] text-[var(--color-muted)] -mt-1">
+      Open your Pitchbox dashboard in the active tab and click above. Granted access stays scoped
+      to that origin. You can pair multiple backends (e.g. cloud + self-hosted) — every Reddit
+      reply syncs to all of them.
+    </p>
+  {:else}
+    <div class="flex flex-col gap-2">
+      {#each pairings as p (p.backendUrl)}
+        <div class="rounded-md bg-[var(--color-bg-elev)] px-3 py-2">
+          <div class="flex items-center gap-2">
+            <span class="text-[12px] font-medium text-[var(--color-fg)] flex-1 truncate" title={p.backendUrl}>
+              {shortHost(p.backendUrl)}
+            </span>
+            <button
+              type="button"
+              class="text-[10px] text-[var(--color-muted)] hover:text-[var(--color-fg)] underline-offset-2 hover:underline"
+              onclick={() => disconnect(p.backendUrl)}
+            >
+              Disconnect
+            </button>
+          </div>
+          <div class="text-[10.5px] text-[var(--color-muted)] mt-0.5">
+            handshake {fmtAgo(p.lastHandshakeAt)} · sync {fmtAgo(p.lastDmSyncAt)}
+          </div>
+        </div>
+      {/each}
+    </div>
 
-		<label class="flex flex-col gap-1 text-[11px] text-[var(--color-muted)]">
-			Backend URL
-			<input
-				type="url"
-				bind:value={backendUrl}
-				placeholder="http://127.0.0.1:5180"
-				class="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev)] px-2 py-1.5 text-[13px] text-[var(--color-fg)] outline-none focus:border-[var(--color-accent)]"
-			/>
-		</label>
+    <button
+      disabled={busy}
+      onclick={pairWithThisTab}
+      class="rounded-md border border-[var(--color-border)] py-1.5 text-[12px] text-[var(--color-fg)] hover:bg-[var(--color-bg-elev)] disabled:opacity-60"
+    >
+      {busy ? 'Pairing…' : 'Pair with another tab'}
+    </button>
 
-		{#if mode === 'pair'}
-			<label class="flex flex-col gap-1 text-[11px] text-[var(--color-muted)]">
-				Pairing code
-				<input
-					type="text"
-					bind:value={pairingCode}
-					placeholder="from Dashboard → Settings → Integrations"
-					autocomplete="off"
-					class="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev)] px-2 py-1.5 text-[13px] text-[var(--color-fg)] outline-none focus:border-[var(--color-accent)]"
-				/>
-			</label>
-			<button
-				disabled={busy}
-				onclick={pair}
-				class="rounded-md bg-[var(--color-accent)] text-[var(--color-bg)] font-medium py-1.5 disabled:opacity-60 hover:brightness-110"
-			>
-				{busy ? 'Pairing…' : 'Pair'}
-			</button>
-		{:else}
-			<label class="flex flex-col gap-1 text-[11px] text-[var(--color-muted)]">
-				API token
-				<input
-					type="password"
-					bind:value={token}
-					placeholder="64-character hex"
-					autocomplete="off"
-					class="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev)] px-2 py-1.5 text-[13px] text-[var(--color-fg)] outline-none focus:border-[var(--color-accent)]"
-				/>
-			</label>
-			<button
-				disabled={busy}
-				onclick={manualConnect}
-				class="rounded-md bg-[var(--color-accent)] text-[var(--color-bg)] font-medium py-1.5 disabled:opacity-60 hover:brightness-110"
-			>
-				{busy ? 'Connecting…' : 'Connect'}
-			</button>
-		{/if}
-	{:else}
-		<div class="rounded-md bg-[var(--color-bg-elev)] px-3 py-2 text-[11px] text-[var(--color-muted)]">
-			<div class="text-[var(--color-fg)] font-medium">{backendUrl}</div>
-			<div>Last handshake: {fmtAgo(lastHandshakeAt)}</div>
-			<div>DM sync: {fmtAgo(lastDmSyncAt)}</div>
-		</div>
-		<button
-			disabled={syncing}
-			onclick={syncNow}
-			class="rounded-md border border-[var(--color-border)] py-1.5 text-[12px] text-[var(--color-fg)] hover:bg-[var(--color-bg-elev)] disabled:opacity-60"
-		>
-			{syncing ? 'Syncing…' : 'Sync now'}
-		</button>
+    <button
+      disabled={syncing}
+      onclick={syncNow}
+      class="rounded-md bg-[var(--color-accent)] text-[var(--color-bg)] font-medium py-1.5 disabled:opacity-60 hover:brightness-110"
+    >
+      {syncing ? 'Syncing…' : 'Sync now'}
+    </button>
 
-		{#if chatSyncStatus === 'unauthorized'}
-			<div class="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-300">
-				<div class="font-medium text-amber-200">Reddit Chat sync paused</div>
-				<div class="mt-0.5">
-					Please open reddit.com and refresh so the extension can capture a fresh Matrix token.
-				</div>
-				<button
-					onclick={openReddit}
-					class="mt-1.5 rounded-md bg-amber-500/20 hover:bg-amber-500/30 px-2 py-1 text-[11px] font-medium text-amber-100"
-				>
-					Open reddit.com
-				</button>
-			</div>
-		{/if}
-	{/if}
+    {#if chatSyncStatus === 'unauthorized'}
+      <div class="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-300">
+        <div class="font-medium text-amber-200">Reddit Chat sync paused</div>
+        <div class="mt-0.5">
+          Please open reddit.com and refresh so the extension can capture a fresh Matrix token.
+        </div>
+        <button
+          onclick={openReddit}
+          class="mt-1.5 rounded-md bg-amber-500/20 hover:bg-amber-500/30 px-2 py-1 text-[11px] font-medium text-amber-100"
+        >
+          Open reddit.com
+        </button>
+      </div>
+    {/if}
+  {/if}
 
-	{#if status.kind !== 'idle' && status.msg}
-		<div
-			class="rounded-md px-3 py-2 text-[11px] {status.kind === 'ok'
-				? 'bg-emerald-500/15 text-emerald-300'
-				: 'bg-rose-500/15 text-rose-300'}"
-		>
-			{status.msg}
-		</div>
-	{/if}
+  {#if status.kind !== 'idle' && status.msg}
+    <div
+      class="rounded-md px-3 py-2 text-[11px] {status.kind === 'ok'
+        ? 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/30'
+        : 'bg-rose-500/15 text-rose-200 border border-rose-500/30'}"
+    >
+      {status.msg}
+    </div>
+  {/if}
 </main>

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -15,6 +15,10 @@
     <meta property="og:description" content="Self-hosted, human-in-the-loop outreach agent." />
     <meta property="og:image" content="/og-image.png" />
     <meta name="twitter:card" content="summary_large_image" />
+    <!-- Beacon read by the Pitchbox browser extension's auto-pair content
+         script. Presence + value identify this origin as a Pitchbox dashboard
+         worth probing via GET /api/extension/auto-pair. -->
+    <meta name="pitchbox-pair" content="ready" />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/web/src/routes/api/extension/auto-pair/+server.ts
+++ b/web/src/routes/api/extension/auto-pair/+server.ts
@@ -1,0 +1,75 @@
+import { json, error } from '@sveltejs/kit';
+import { randomBytes, createHash } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { loadSession, loadOrganizationForUser } from '@pitchbox/shared/auth';
+import { getDb, schema } from '$lib/server/db.js';
+
+/**
+ * One-shot pairing endpoint for the browser extension.
+ *
+ * The extension's auto-pair content script runs inside the dashboard origin
+ * (cloud or self-hosted), so this fetch carries the user's session cookie
+ * automatically. We mint a fresh device token tied to the resolved org and
+ * return it. The client persists the token in `chrome.storage.local`.
+ *
+ * Auth modes:
+ *  - PITCHBOX_AUTH=on: requires a valid session cookie. Token is bound to the
+ *    user's primary org.
+ *  - PITCHBOX_AUTH off: single-user mode. Anyone with access to the dashboard
+ *    origin already passed whatever boundary the operator set up (LAN /
+ *    Tailscale / reverse proxy), so we bind the token to the default org.
+ *
+ * The endpoint lives under /api/extension/* which is exempt from cookie auth
+ * by hooks.server.ts; we re-implement the session check here so we can fall
+ * through cleanly when auth is off.
+ */
+const SESSION_COOKIE = 'pitchbox_session';
+const AUTH_ON = process.env.PITCHBOX_AUTH === 'on';
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+async function defaultOrgId(db: ReturnType<typeof getDb>): Promise<number | null> {
+  const [row] = await db
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.slug, 'default'))
+    .limit(1);
+  return row?.id ?? null;
+}
+
+export async function GET({
+  cookies,
+  request,
+}: {
+  cookies: import('@sveltejs/kit').Cookies;
+  request: Request;
+}) {
+  const db = getDb();
+
+  let organizationId: number | null;
+
+  if (AUTH_ON) {
+    const cookie = cookies.get(SESSION_COOKIE);
+    const session = cookie ? await loadSession(db, cookie) : null;
+    if (!session) throw error(401, 'unauthenticated');
+    const org = await loadOrganizationForUser(db, session.userId);
+    organizationId = org?.id ?? (await defaultOrgId(db));
+  } else {
+    organizationId = await defaultOrgId(db);
+  }
+
+  if (!organizationId) throw error(500, 'no_org');
+
+  const token = randomBytes(32).toString('hex');
+  const tokenHash = hashToken(token);
+  const userAgent = request.headers.get('user-agent') ?? '';
+  const label = `Browser extension${userAgent ? ` (${userAgent.slice(0, 80)})` : ''}`;
+  const [row] = await db
+    .insert(schema.extensionDevices)
+    .values({ organizationId, label, tokenHash })
+    .returning({ id: schema.extensionDevices.id });
+
+  return json({ token, deviceId: row.id });
+}


### PR DESCRIPTION
## Summary

Replaces the multi-step pairing flow (URL + code + paste) with a single 'Pair with this tab' button. Cloud users get a fully automatic handshake via the manifest's content_scripts on \`app.pitchbox.io\`. Self-hosted users grant a one-shot host permission for their dashboard origin and pair from there. Multiple backends can coexist — sync fans out to all of them.

## UX

| Edition | Steps |
| --- | --- |
| Cloud | Install extension → visit \`app.pitchbox.io\` while signed in → done. |
| Self-hosted | Install extension → open dashboard tab → click 'Pair with this tab' → grant permission once. |

Use both at once: pair both backends from their respective tabs. Reddit replies sync to all of them.

## Server

New \`GET /api/extension/auto-pair\`:
- Cookie-authenticated when \`PITCHBOX_AUTH=on\`; falls back to default org when off.
- Mints a fresh device token tied to the resolved org and returns it.
- Reachable from the dashboard origin so same-origin fetch carries the session cookie automatically.

The legacy \`POST /api/extension/pair\` (pairing code) endpoint stays for backward compatibility but is no longer surfaced in the popup.

## Storage

\`Settings.pairings: Pairing[]\` replaces the old single-backend keys (\`backendUrl\`, \`token\`, \`lastHandshakeAt\`, \`lastDmSyncAt\`, \`syncStatus\`). Existing single-backend installs migrate forward on first read of \`getSettings()\`.

## Test plan

- [ ] Install the unpacked extension, visit a Pitchbox dashboard, click 'Pair with this tab' → popup shows the host with handshake/sync timestamps.
- [ ] Pair a second dashboard from another tab → both rows visible, both receive subsequent DM syncs.
- [ ] Disconnect one → only the remaining one syncs.
- [ ] Quality gates: \`npm run typecheck\`, \`npm run -w web check\`, \`npm run lint\` all green; \`extension/dist/\` builds.