### PR TITLE
chore(extension): pin vite dev to port 5175

### DIFF
--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
+    // Default Vite port (5173) is left free for the user's other projects.
+    port: 5175,
+    strictPort: true,
     cors: { origin: [/chrome-extension:\/\//] },
   },
 });


### PR DESCRIPTION
Frees up the default 5173 port for other local dev.