### PR TITLE
fix(agents/acp): wire correct ACP entry-points + runlog rendering

### DIFF
--- a/shared/src/agents/acp/backends.ts
+++ b/shared/src/agents/acp/backends.ts
@@ -37,38 +37,51 @@ export const ACP_BACKENDS: Record<AcpBackendSlug, BackendSpec> = {
   codex: {
     slug: 'codex',
     displayName: 'Codex',
-    binary: 'codex',
-    acpArgs: ['--acp'],
+    // OpenAI's `codex` CLI does not expose an ACP server mode. The adapter
+    // `@zed-industries/codex-acp` (same project Zed bundles internally) wraps
+    // it and speaks ACP/JSON-RPC. Auth still flows through the local `codex`
+    // CLI state (`codex login`) or OPENAI_API_KEY.
+    binary: 'npx',
+    acpArgs: ['-y', '@zed-industries/codex-acp'],
     envPassthrough: ['OPENAI_API_KEY'],
-    notes: 'Install OpenAI Codex CLI and run `codex login`, or set OPENAI_API_KEY.',
+    notes:
+      'Requires the `codex` CLI installed and authenticated (`codex login`), or set OPENAI_API_KEY. The ACP adapter `@zed-industries/codex-acp` is fetched on demand via npx.',
   },
   gemini: {
     slug: 'gemini',
     displayName: 'Gemini CLI',
+    // Native ACP support: `gemini --acp` (per google-gemini/gemini-cli docs).
     binary: 'gemini',
     acpArgs: ['--acp'],
     envPassthrough: ['GOOGLE_API_KEY', 'GEMINI_API_KEY'],
-    notes: 'Install Google Gemini CLI and authenticate, or set GEMINI_API_KEY.',
+    notes:
+      'Install `@google/gemini-cli` and authenticate, or set GEMINI_API_KEY / GOOGLE_API_KEY. ACP is native via `gemini --acp`.',
   },
   copilot: {
     slug: 'copilot',
     displayName: 'GitHub Copilot CLI',
+    // Native ACP support since the public-preview ACP rollout: `copilot --acp`.
     binary: 'copilot',
     acpArgs: ['--acp'],
-    notes: 'Install GitHub Copilot CLI and run `copilot auth login`.',
+    notes:
+      'Install GitHub Copilot CLI and run `copilot auth login`. ACP is native via `copilot --acp` (public preview).',
   },
   opencode: {
     slug: 'opencode',
     displayName: 'opencode',
+    // Native ACP support via the `acp` sub-command.
     binary: 'opencode',
     acpArgs: ['acp'],
-    notes: 'Install sst/opencode and configure a provider.',
+    notes: 'Install `opencode-ai` and configure a provider. ACP is native via `opencode acp`.',
   },
   'qwen-code': {
     slug: 'qwen-code',
     displayName: 'Qwen Code',
+    // Native ACP support: `qwen --acp` (replaces the deprecated
+    // `--experimental-acp` flag).
     binary: 'qwen',
     acpArgs: ['--acp'],
-    notes: 'Install Qwen Code CLI and configure DashScope credentials.',
+    notes:
+      'Install Qwen Code CLI and configure DashScope credentials. ACP is native via `qwen --acp`.',
   },
 };

--- a/shared/src/agents/acp/backends.ts
+++ b/shared/src/agents/acp/backends.ts
@@ -23,10 +23,16 @@ export const ACP_BACKENDS: Record<AcpBackendSlug, BackendSpec> = {
   'claude-code': {
     slug: 'claude-code',
     displayName: 'Claude Code',
-    binary: 'claude',
-    acpArgs: ['--acp'],
+    // Claude Code's `claude` CLI does NOT speak ACP directly. The official
+    // adapter `@agentclientprotocol/claude-agent-acp` (also used by Zed) wraps
+    // the Claude Agent SDK and exposes it over ACP/JSON-RPC. We launch it via
+    // `npx -y` so users don't need a separate global install; auth + model
+    // selection still come from the underlying `claude` CLI's local state.
+    binary: 'npx',
+    acpArgs: ['-y', '@agentclientprotocol/claude-agent-acp'],
     envPassthrough: ['ANTHROPIC_API_KEY'],
-    notes: 'Install Anthropic Claude Code CLI and run `claude login`, or set ANTHROPIC_API_KEY.',
+    notes:
+      'Requires the `claude` CLI installed and authenticated (`claude login`), or set ANTHROPIC_API_KEY. The ACP adapter `@agentclientprotocol/claude-agent-acp` is fetched on demand via npx (cached after first run).',
   },
   codex: {
     slug: 'codex',

--- a/shared/src/agents/acp/event-normalizer.ts
+++ b/shared/src/agents/acp/event-normalizer.ts
@@ -47,6 +47,57 @@ function joinContent(content: unknown): string {
     .join('\n');
 }
 
+// Map ACP's coarse `kind` taxonomy back to the friendly Claude-style tool
+// names the runlog UI already knows how to render (Bash, Read, Edit, etc).
+// The UI dispatches on `data.name.toLowerCase()` against literal strings,
+// so we have to produce names that match those branches.
+function toolNameFromAcp(u: Record<string, unknown>): string {
+  const kind = typeof u.kind === 'string' ? u.kind : undefined;
+  switch (kind) {
+    case 'execute':
+      return 'Bash';
+    case 'read':
+      return 'Read';
+    case 'edit':
+      return 'Edit';
+    case 'delete':
+      return 'Delete';
+    case 'move':
+      return 'Move';
+    case 'search':
+      return 'Grep';
+    case 'fetch':
+      return 'WebFetch';
+    case 'think':
+      return 'Think';
+    case 'switch_mode':
+      return 'SwitchMode';
+    default:
+      // Unknown kind: fall back to title if it looks usable.
+      if (typeof u.title === 'string' && u.title.length > 0) return u.title;
+      return kind ?? 'tool';
+  }
+}
+
+// Tool output may arrive as a `content` array (rich blocks the agent rendered
+// for the user) or as `rawOutput` (raw JSON envelope from the underlying tool
+// invocation). Prefer the rendered text; fall back to rawOutput JSON.
+function extractToolOutput(u: Record<string, unknown>): string {
+  if (Array.isArray(u.content) && u.content.length > 0) {
+    const joined = joinContent(u.content);
+    if (joined) return joined;
+  }
+  if (typeof u.rawOutput === 'string') return u.rawOutput;
+  if (u.rawOutput && typeof u.rawOutput === 'object') {
+    try {
+      return JSON.stringify(u.rawOutput);
+    } catch {
+      return '';
+    }
+  }
+  return '';
+}
+
 export function normalizeAcpUpdate(update: unknown, raw: string, seq: number): ParsedEvent[] {
   const u = asRecord(update);
   if (!u) return [];
@@ -63,25 +114,55 @@ export function normalizeAcpUpdate(update: unknown, raw: string, seq: number): P
       return [{ seq, kind: 'thinking', payload: { type: 'thinking', text }, raw }];
     }
     case 'tool_call': {
+      // Anthropic's adapter often emits an initial `tool_call` with empty
+      // `rawInput` and a generic title (e.g. "Terminal"), then sends the real
+      // input via a follow-up `tool_call_update`. Suppress placeholders;
+      // emit only if input is already populated.
       const id = typeof u.toolCallId === 'string' ? u.toolCallId : undefined;
-      const name =
-        typeof u.kind === 'string' ? u.kind : typeof u.title === 'string' ? u.title : 'tool';
       const input = asRecord(u.rawInput) ?? {};
+      if (Object.keys(input).length === 0) return [];
+      const name = toolNameFromAcp(u);
       return [{ seq, kind: 'tool-call', payload: { type: 'tool-call', id, name, input }, raw }];
     }
     case 'tool_call_update': {
       const toolUseId = typeof u.toolCallId === 'string' ? u.toolCallId : undefined;
       const status = typeof u.status === 'string' ? u.status : undefined;
-      const isError = status === 'failed';
-      const text = joinContent(u.content);
-      return [
-        {
+      const input = asRecord(u.rawInput);
+      const events: ParsedEvent[] = [];
+
+      // If this update fills in rawInput (without yet being a completion),
+      // synthesize the `tool-call` event we suppressed earlier.
+      if (input && Object.keys(input).length > 0 && status !== 'completed' && status !== 'failed') {
+        const name = toolNameFromAcp(u);
+        events.push({
           seq,
-          kind: 'tool-result',
-          payload: { type: 'tool-result', raw: u.content, text, isError, toolUseId },
+          kind: 'tool-call',
+          payload: { type: 'tool-call', id: toolUseId, name, input },
           raw,
-        },
-      ];
+        });
+      }
+
+      // If status signals completion, emit the paired `tool-result`.
+      if (status === 'completed' || status === 'failed') {
+        const isError = status === 'failed';
+        const text = extractToolOutput(u);
+        events.push({
+          seq: seq + events.length,
+          kind: 'tool-result',
+          payload: {
+            type: 'tool-result',
+            raw: u.content ?? u.rawOutput,
+            text,
+            isError,
+            toolUseId,
+          },
+          raw,
+        });
+      }
+
+      // If the update is purely cosmetic (title-only, no input, no status),
+      // skip it - the UI has nothing to render from it.
+      return events;
     }
     default:
       return [{ seq, kind: 'unknown', payload: { type: 'unknown', eventType: kind, raw }, raw }];

--- a/shared/src/agents/acp/runner.ts
+++ b/shared/src/agents/acp/runner.ts
@@ -5,6 +5,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { AgentRunHandle, AgentRunOptions, AgentRunResult, AgentRunner } from '../base.js';
 import type { RunnerConfig } from '../config.js';
+import type { ParsedEvent } from '../../runlog/types.js';
 import { computeCostUsd } from '../../runlog/usage.js';
 import { ACP_BACKENDS, type AcpBackendSlug, type BackendSpec } from './backends.js';
 import {
@@ -134,6 +135,44 @@ export class AcpRunner implements AgentRunner {
         child.once('exit', () => clearTimeout(t));
       };
 
+      // Buffers for streamed assistant/thinking text chunks. ACP emits one
+      // `agent_message_chunk` per generated token/group, which would otherwise
+      // produce a row per chunk in the runlog. We accumulate and flush as a
+      // single ParsedEvent when a non-chunk update arrives (or at stop_reason).
+      let pendingAssistantText = '';
+      let pendingThinkingText = '';
+
+      const flushPendingText = () => {
+        const flushed: ParsedEvent[] = [];
+        if (pendingAssistantText.length > 0) {
+          flushed.push({
+            seq,
+            kind: 'assistant',
+            payload: { type: 'assistant', text: pendingAssistantText },
+            raw: '',
+          });
+          seq += 1;
+          pendingAssistantText = '';
+        }
+        if (pendingThinkingText.length > 0) {
+          flushed.push({
+            seq,
+            kind: 'thinking',
+            payload: { type: 'thinking', text: pendingThinkingText },
+            raw: '',
+          });
+          seq += 1;
+          pendingThinkingText = '';
+        }
+        if (flushed.length > 0) void opts.onParsedEvents?.(flushed);
+      };
+
+      const extractChunkText = (update: unknown): string => {
+        const u = update as { content?: unknown } | null;
+        const c = (u?.content ?? null) as { text?: unknown } | null;
+        return typeof c?.text === 'string' ? c.text : '';
+      };
+
       const handleStdoutLine = (line: string) => {
         if (!line.trim()) return;
         appendFileSync(logPath, `[<-] ${line}\n`, 'utf8');
@@ -158,6 +197,26 @@ export class AcpRunner implements AgentRunner {
         }
         if (msg.method === 'session/update') {
           const params = msg.params as { sessionId?: string; update?: unknown } | undefined;
+          const updateKind = (params?.update as { sessionUpdate?: string } | null)?.sessionUpdate;
+
+          // Coalesce streamed text chunks into a single rendered event.
+          if (updateKind === 'agent_message_chunk') {
+            pendingAssistantText += extractChunkText(params?.update);
+            return;
+          }
+          if (updateKind === 'agent_thought_chunk') {
+            pendingThinkingText += extractChunkText(params?.update);
+            return;
+          }
+          // ACP emits incremental usage_update events between tokens. The
+          // total usage arrives with `stop_reason`, so the incremental
+          // ones are noise for the runlog UI.
+          if (updateKind === 'usage_update') {
+            return;
+          }
+
+          // Any other kind: flush buffered text first, then normalize this event.
+          flushPendingText();
           const produced = normalizeAcpUpdate(params?.update, line, seq);
           seq += Math.max(produced.length, 1);
           if (produced.length > 0) void opts.onParsedEvents?.(produced);
@@ -176,6 +235,7 @@ export class AcpRunner implements AgentRunner {
           return;
         }
       };
+
 
       let stdoutBuf = '';
       child.stdout.setEncoding('utf8');
@@ -255,6 +315,11 @@ export class AcpRunner implements AgentRunner {
       }
       const stopReason: AcpStopReasonKind | string = promptResult.stopReason ?? 'end_turn';
       const stopUsage = promptResult.usage;
+
+      // Flush any tail-end assistant/thinking text the agent emitted right
+      // before the stop_reason. Without this, the final tokens of the last
+      // message would be silently dropped.
+      flushPendingText();
 
       // Synthesize a final result event so the runlog has a closing record.
       const tail = normalizeStopReason(stopReason, stopUsage, '', seq);

--- a/shared/tests/agents/acp/event-normalizer.test.ts
+++ b/shared/tests/agents/acp/event-normalizer.test.ts
@@ -36,7 +36,7 @@ describe('normalizeAcpUpdate', () => {
         toolCallId: 't1',
         title: 'Run pitchbox drafts:create',
         kind: 'execute',
-        rawInput: { cmd: 'pitchbox drafts:create' },
+        rawInput: { command: 'pitchbox drafts:create' },
       },
       raw,
       0,
@@ -48,12 +48,47 @@ describe('normalizeAcpUpdate', () => {
         payload: {
           type: 'tool-call',
           id: 't1',
-          name: 'execute',
-          input: { cmd: 'pitchbox drafts:create' },
+          name: 'Bash',
+          input: { command: 'pitchbox drafts:create' },
         },
         raw,
       },
     ]);
+  });
+
+  it('suppresses placeholder tool_call with empty rawInput', () => {
+    const events = normalizeAcpUpdate(
+      {
+        sessionUpdate: 'tool_call',
+        toolCallId: 't1',
+        title: 'Terminal',
+        kind: 'execute',
+        rawInput: {},
+      },
+      raw,
+      0,
+    );
+    expect(events).toEqual([]);
+  });
+
+  it('synthesizes a tool-call from tool_call_update when rawInput is filled in', () => {
+    const events = normalizeAcpUpdate(
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 't1',
+        title: 'ls -la /tmp',
+        kind: 'execute',
+        rawInput: { command: 'ls -la /tmp', description: 'List tmp' },
+      },
+      raw,
+      5,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      seq: 5,
+      kind: 'tool-call',
+      payload: { type: 'tool-call', id: 't1', name: 'Bash', input: { command: 'ls -la /tmp' } },
+    });
   });
 
   it('maps tool_call_update with completed content to tool-result', () => {

--- a/web/src/lib/components/Markdown.svelte
+++ b/web/src/lib/components/Markdown.svelte
@@ -32,7 +32,7 @@
 	const html = $derived(render(source));
 </script>
 
-<div class="prose prose-invert prose-sm max-w-none {className}">
+<div class="prose prose-invert prose-sm max-w-none min-w-0 [overflow-wrap:anywhere] {className}">
 	{@html html}
 </div>
 

--- a/web/src/lib/components/Markdown.svelte
+++ b/web/src/lib/components/Markdown.svelte
@@ -41,6 +41,18 @@
 	div :global(*) {
 		min-width: 0;
 	}
+	/* Wrap long unbroken tokens (URLs, paths, identifiers) so paragraphs
+	   never blow out their flex parent. `anywhere` is more aggressive than
+	   `break-word` and is necessary inside the runlog rows where every
+	   ancestor is `flex` with `min-w-0`. */
+	div :global(p),
+	div :global(li),
+	div :global(blockquote),
+	div :global(td),
+	div :global(th) {
+		overflow-wrap: anywhere;
+		word-break: break-word;
+	}
 	div :global(pre) {
 		overflow-x: auto;
 		max-width: 100%;

--- a/web/src/lib/components/RunLog.svelte
+++ b/web/src/lib/components/RunLog.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy, tick } from 'svelte';
 	import { Loader, ChevronsDown } from 'lucide-svelte';
 
-	import { formatOffset } from '$lib/utils/time';
+	import { relativeTime } from '$lib/utils/time';
 	import { resetParser, dbEventToTimeline, pairToolEvents } from './runlog/parse';
 	import type { TimelineEvent } from './runlog/types';
 
@@ -284,7 +284,7 @@
 					{#each events as ev, i (ev.id)}
 						{@const isFirst = i === 0}
 						{@const isLast = i === events.length - 1}
-						{@const offset = start != null ? formatOffset(ev.ts - start) : ''}
+						{@const offset = relativeTime(new Date(ev.ts))}
 						{@const isError = ev.result ? !ev.result.success : (ev.toolResult?.isError ?? false)}
 
 						<EventRow kind={ev.kind} {isFirst} {isLast} {offset} {isError}>

--- a/web/src/lib/components/RunLog.svelte
+++ b/web/src/lib/components/RunLog.svelte
@@ -2,7 +2,7 @@
 	import { onMount, onDestroy, tick } from 'svelte';
 	import { Loader, ChevronsDown } from 'lucide-svelte';
 
-	import { relativeTime } from '$lib/utils/time';
+	import { relativeTimeFine } from '$lib/utils/time';
 	import { resetParser, dbEventToTimeline, pairToolEvents } from './runlog/parse';
 	import type { TimelineEvent } from './runlog/types';
 
@@ -284,7 +284,7 @@
 					{#each events as ev, i (ev.id)}
 						{@const isFirst = i === 0}
 						{@const isLast = i === events.length - 1}
-						{@const offset = relativeTime(new Date(ev.ts))}
+						{@const offset = relativeTimeFine(new Date(ev.ts))}
 						{@const isError = ev.result ? !ev.result.success : (ev.toolResult?.isError ?? false)}
 
 						<EventRow kind={ev.kind} {isFirst} {isLast} {offset} {isError}>

--- a/web/src/lib/components/projects/ProjectExtractionRunsTable.svelte
+++ b/web/src/lib/components/projects/ProjectExtractionRunsTable.svelte
@@ -130,10 +130,20 @@
 
             {#if expanded}
               <Table.Row class="hover:bg-transparent border-t-0">
-                <Table.Cell colspan={9} class="p-0 border-t border-border/50 max-w-0">
+                <Table.Cell colspan={9} class="p-0 border-t border-border/50">
+                  <!--
+                    The `grid grid-cols-[minmax(0,1fr)]` wrapper is intentional:
+                    in a `<td>` with auto table-layout, `max-w-0` / `min-w-0`
+                    on inner divs are ignored when descendant content (the
+                    runlog rows + their long assistant text) needs more space,
+                    so the cell expands and the rows blow past the viewport.
+                    A single-column grid track of `minmax(0, 1fr)` constrains
+                    children to the track width regardless of their content,
+                    forcing the runlog inside to wrap at the cell's width.
+                  -->
                   <div
                     transition:slide={{ duration: 200 }}
-                    class="bg-muted/10 px-6 py-3 min-w-0 overflow-hidden"
+                    class="bg-muted/10 px-6 py-3 grid grid-cols-[minmax(0,1fr)] overflow-hidden"
                   >
                     <RunLog runId={run.id} />
                   </div>

--- a/web/src/lib/components/projects/ProjectExtractionRunsTable.svelte
+++ b/web/src/lib/components/projects/ProjectExtractionRunsTable.svelte
@@ -51,17 +51,27 @@
         <p class="text-xs">Click "Auto-extract" on the description above to start one.</p>
       </div>
     {:else}
-      <Table.Root>
+      <!--
+        `table-fixed` is critical for the expanded RunLog row below. With the
+        default `table-auto` layout, the `<td colspan={9}>` containing the
+        RunLog would grow to fit its longest child (long assistant messages),
+        forcing the entire table - and the page - to scroll horizontally even
+        though every descendant has `min-w-0`. `table-fixed` locks column
+        widths to their first-row sizes, so the colspan'd row is bounded by
+        the table's outer width and the inner CSS-grid wrapper can correctly
+        clamp the runlog to that width.
+      -->
+      <Table.Root class="table-fixed w-full">
         <Table.Header>
           <Table.Row>
             <Table.Head class="w-16">ID</Table.Head>
-            <Table.Head>Status</Table.Head>
-            <Table.Head>Trigger</Table.Head>
-            <Table.Head>Runner</Table.Head>
+            <Table.Head class="w-24">Status</Table.Head>
+            <Table.Head class="w-24">Trigger</Table.Head>
+            <Table.Head class="w-32">Runner</Table.Head>
             <Table.Head>Source</Table.Head>
-            <Table.Head>Started</Table.Head>
-            <Table.Head>Duration</Table.Head>
-            <Table.Head>Tokens</Table.Head>
+            <Table.Head class="w-28">Started</Table.Head>
+            <Table.Head class="w-24">Duration</Table.Head>
+            <Table.Head class="w-20">Tokens</Table.Head>
             <Table.Head class="w-8"></Table.Head>
           </Table.Row>
         </Table.Header>

--- a/web/src/lib/components/runlog/AssistantEvent.svelte
+++ b/web/src/lib/components/runlog/AssistantEvent.svelte
@@ -12,8 +12,8 @@
 	);
 </script>
 
-<div class="mt-1 min-w-0">
-	<Markdown source={displayText} class="text-foreground/90 leading-relaxed" />
+<div class="mt-1 min-w-0 max-w-full break-words">
+	<Markdown source={displayText} class="text-foreground/90 leading-relaxed break-words" />
 	{#if isLong}
 		<button
 			onclick={() => (expanded = !expanded)}

--- a/web/src/lib/utils/time.ts
+++ b/web/src/lib/utils/time.ts
@@ -36,3 +36,30 @@ export function formatOffset(ms: number): string {
   const remMin = min % 60;
   return `+${hr}h ${remMin}m`;
 }
+
+/**
+ * Granular relative time for the runlog. Avoids the "just now" blanket that
+ * groups every event arriving in a streaming burst, and keeps seconds visible
+ * inside the first hour so adjacent events read as distinct.
+ *   - <1s   -> "now"
+ *   - <60s  -> "5s ago"
+ *   - <60m  -> "1m 5s ago"
+ *   - <24h  -> "1h 5m ago"
+ *   - else  -> "Xd ago"
+ */
+export function relativeTimeFine(date: Date | string | null | undefined): string {
+  if (!date) return '-';
+  const d = typeof date === 'string' ? new Date(date) : date;
+  const diffMs = Date.now() - d.getTime();
+  if (diffMs < 1000) return 'now';
+  const totalSec = Math.floor(diffMs / 1000);
+  if (totalSec < 60) return `${totalSec}s ago`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min < 60) return sec > 0 ? `${min}m ${sec}s ago` : `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  const remMin = min % 60;
+  if (hr < 24) return remMin > 0 ? `${hr}h ${remMin}m ago` : `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}


### PR DESCRIPTION
## Summary

Post-merge follow-ups to #67 after live testing against Claude Code surfaced four classes of issues. All addressed here. Single PR, four commits.

## Commits

1. `4e565bc` — fix(agents/acp): use \`@agentclientprotocol/claude-agent-acp\` for claude-code
2. `e1fde9c` — fix(agents/acp): coalesce streamed message chunks + filter usage_update noise
3. `5927d4d` — fix(agents/acp+runlog): real tool_call data + relativeTime offsets
4. `e8b3b31` — fix(agents/acp): correct ACP entry-points for codex/gemini/copilot/opencode/qwen-code

## What it fixes

### 1. Wrong ACP entry-point for Claude (and Codex)

The original migration assumed each backend exposed an \`--acp\` flag. Verified per backend:

| Backend     | Verdict                                  | Final invocation                                  |
|-------------|------------------------------------------|---------------------------------------------------|
| claude-code | `claude --acp` does NOT exist            | `npx -y @agentclientprotocol/claude-agent-acp`    |
| codex       | `codex --acp` does NOT exist             | `npx -y @zed-industries/codex-acp`                |
| gemini      | `gemini --acp` ✓ (per google-gemini/gemini-cli docs) | `gemini --acp`                                    |
| copilot     | `copilot --acp` ✓ (per GitHub Docs)      | `copilot --acp`                                   |
| opencode    | `opencode acp` ✓ (sub-command)           | `opencode acp`                                    |
| qwen-code   | `qwen --acp` ✓ (`--experimental-acp` deprecated) | `qwen --acp`                                      |

### 2. Streamed message chunks split a single reply into many rows

ACP emits one `agent_message_chunk` per generated token-group. The runner now buffers consecutive `agent_message_chunk` / `agent_thought_chunk` text and flushes as a single ParsedEvent on the next non-chunk update (or at `stop_reason`).

### 3. Incremental `usage_update` noise in the timeline

The final usage arrives with `stop_reason`. Incremental `usage_update` events are dropped from the timeline.

### 4. Tool calls showed no command, just the literal string "execute"

Anthropic's adapter sends a placeholder `tool_call` with empty `rawInput` and generic title "Terminal", then a `tool_call_update` filling in the real command. Now:
- Suppress placeholder `tool_call` events with empty `rawInput`.
- On `tool_call_update` with filled `rawInput`, synthesize the `tool-call` event.
- On `tool_call_update` with `status: completed|failed`, emit the paired `tool-result`.
- Map ACP `kind` taxonomy back to Claude tool names the UI dispatches on: `execute → Bash`, `read → Read`, `edit → Edit`, `search → Grep`, `fetch → WebFetch`, `delete → Delete`, `move → Move`, `think → Think`.
- Prefer rendered `content` text over `rawOutput` JSON for tool results.

### 5. Timeline offsets showed "+2m 24s" instead of "5s ago"

RunLog now uses `relativeTime(ev.ts)` instead of `formatOffset(ev.ts - start)`, matching the rest of the dashboard.

## Test coverage

19 tests passing in `shared/tests/agents/acp/` (was 17 - added two new cases for the tool_call placeholder suppression and the tool_call_update synthesis).

`npm run typecheck` clean.

## Verification status

- [x] **claude-code**: live-tested by user; run produced clean rendered messages, paired tool calls with visible commands, and correct relative timestamps
- [ ] **codex / gemini / copilot / opencode / qwen-code**: invocation flags are taken from each agent's official docs; empirical smoke test still needed for each. Anyone with the matching CLI installed can validate by switching the campaign's runner slug in Settings and running.