### PR TITLE
feat: surface in-progress async operations across the dashboard

### DIFF
--- a/web/src/lib/server/campaign-readiness.ts
+++ b/web/src/lib/server/campaign-readiness.ts
@@ -1,17 +1,36 @@
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { getDb, schema } from './db.js';
 import { getSchema } from '@pitchbox/shared/campaigns';
 import { AGENT_RUNNER_META, type AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
 import { detectRunner } from '@pitchbox/shared/agents/detect';
 
 export type ReadinessIssue = {
-  id: 'profile_missing' | 'profile_invalid' | 'no_account' | 'runner_unavailable';
+  id:
+    | 'profile_missing'
+    | 'profile_invalid'
+    | 'profile_generating'
+    | 'no_account'
+    | 'runner_unavailable';
   title: string;
   hint: string;
-  fix: { label: string; kind: 'profile' | 'accounts' | 'runner'; href?: string };
+  // `kind: 'progress'` signals an in-progress async operation: the UI should
+  // render a spinner and no action button.
+  fix: {
+    label: string;
+    kind: 'profile' | 'accounts' | 'runner' | 'progress';
+    href?: string;
+  };
 };
 
-export type CampaignReadiness = { ready: boolean; issues: ReadinessIssue[] };
+export type CampaignReadiness = {
+  ready: boolean;
+  issues: ReadinessIssue[];
+  // Live operational state. The campaign page reads these so it can disable
+  // "Run now" / "Generate profile" buttons while an underlying run is still
+  // executing, even when the run itself doesn't block readiness.
+  generatingProfile: boolean;
+  campaignRunning: boolean;
+};
 
 export async function getCampaignReadiness(campaignId: number): Promise<CampaignReadiness> {
   const db = getDb();
@@ -19,14 +38,33 @@ export async function getCampaignReadiness(campaignId: number): Promise<Campaign
     .select()
     .from(schema.campaigns)
     .where(eq(schema.campaigns.id, campaignId));
-  if (!campaign) return { ready: false, issues: [] };
+  if (!campaign) {
+    return { ready: false, issues: [], generatingProfile: false, campaignRunning: false };
+  }
+
+  // Detect in-progress operations against this campaign so the banner can
+  // surface "Generating…" instead of nagging the user to start something
+  // that's already going, and so the page can disable redundant triggers.
+  const runningRuns = await db
+    .select({ kind: schema.runs.kind })
+    .from(schema.runs)
+    .where(and(eq(schema.runs.campaignId, campaignId), eq(schema.runs.status, 'running')));
+  const generatingProfile = runningRuns.some((r) => r.kind === 'campaign_skill_generation');
+  const campaignRunning = runningRuns.some((r) => r.kind === 'campaign');
 
   const issues: ReadinessIssue[] = [];
 
   const configKeys = Object.keys((campaign.config as Record<string, unknown> | null) ?? {});
   const profileEmpty = campaign.status === 'draft' || configKeys.length === 0;
 
-  if (profileEmpty) {
+  if (generatingProfile) {
+    issues.push({
+      id: 'profile_generating',
+      title: 'Generating campaign profile…',
+      hint: 'An agent run is producing the profile right now. This usually takes a minute or two.',
+      fix: { label: 'In progress', kind: 'progress' },
+    });
+  } else if (profileEmpty) {
     issues.push({
       id: 'profile_missing',
       title: 'Campaign profile not generated',
@@ -94,5 +132,15 @@ export async function getCampaignReadiness(campaignId: number): Promise<Campaign
     });
   }
 
-  return { ready: issues.length === 0, issues };
+  // `profile_generating` is informational, not blocking - the campaign is
+  // still "ready" if all the OTHER setup is done, so once the run finishes
+  // the user can hit Run now immediately. But while it's in progress, the
+  // page reads `generatingProfile` separately to disable the trigger.
+  const blockingIssues = issues.filter((i) => i.id !== 'profile_generating');
+  return {
+    ready: blockingIssues.length === 0,
+    issues,
+    generatingProfile,
+    campaignRunning,
+  };
 }

--- a/web/src/routes/campaigns/[id]/+page.svelte
+++ b/web/src/routes/campaigns/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { ChevronLeft } from 'lucide-svelte';
+	import { ChevronLeft, Loader2 } from 'lucide-svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import { invalidateAll } from '$app/navigation';
 	import { Button } from '$lib/components/ui/button';
@@ -17,10 +18,19 @@
 	type SkillRun = { id: number; status: string; params: { objective?: string } | null };
 
 	type ReadinessIssue = {
-		id: 'profile_missing' | 'profile_invalid' | 'no_account';
+		id:
+			| 'profile_missing'
+			| 'profile_invalid'
+			| 'profile_generating'
+			| 'no_account'
+			| 'runner_unavailable';
 		title: string;
 		hint: string;
-		fix: { label: string; kind: 'profile' | 'accounts'; href?: string };
+		fix: {
+			label: string;
+			kind: 'profile' | 'accounts' | 'runner' | 'progress';
+			href?: string;
+		};
 	};
 
 	let {
@@ -60,13 +70,38 @@
 				finishedAt: string | Date | null;
 				params: Record<string, unknown> | null;
 			}>;
-			readiness: { ready: boolean; issues: ReadinessIssue[] };
+			readiness: {
+				ready: boolean;
+				issues: ReadinessIssue[];
+				generatingProfile: boolean;
+				campaignRunning: boolean;
+			};
 		};
 	} = $props();
 
 	let isStarting = $state(false);
 	let tab = $state<'overview' | 'profile' | 'tuning' | 'runs'>('overview');
 	let regenOpen = $state(false);
+
+	// Live-refresh readiness + run lists when a profile-gen or campaign run
+	// starts or finishes (this tab, another tab, or the daemon). Without this,
+	// the banner stays stuck on the snapshot taken at page load.
+	let es: EventSource | null = null;
+	onMount(() => {
+		es = new EventSource('/api/stream');
+		const refreshIfRelevant = (e: MessageEvent) => {
+			try {
+				const payload = JSON.parse(e.data);
+				if (payload?.campaignId === data.campaign.id) void invalidateAll();
+			} catch {
+				// non-JSON heartbeat: ignore
+			}
+		};
+		es.addEventListener('run:started', refreshIfRelevant);
+		es.addEventListener('run:finished', refreshIfRelevant);
+		es.addEventListener('run:failed', refreshIfRelevant);
+	});
+	onDestroy(() => es?.close());
 
 	const tabs = [
 		{ k: 'overview' as const, label: 'Overview' },
@@ -78,6 +113,8 @@
 	const isDraft = $derived(data.campaign.status === 'draft');
 	const ready = $derived(data.readiness?.ready ?? false);
 	const issues = $derived(data.readiness?.issues ?? []);
+	const generatingProfile = $derived(data.readiness?.generatingProfile ?? false);
+	const campaignRunning = $derived(data.readiness?.campaignRunning ?? false);
 	const hasRateLimit = $derived(
 		!!data.campaign.rateLimit && JSON.stringify(data.campaign.rateLimit) !== '{}',
 	);
@@ -132,7 +169,17 @@
 	}
 
 	function handleIssueAction(issue: ReadinessIssue) {
+		// In-progress issues have no action: the spinner is the affordance.
+		if (issue.fix.kind === 'progress') return;
 		if (issue.fix.kind === 'profile') {
+			// Belt-and-braces: even if SSE hasn't refreshed yet, don't let the
+			// user open the modal while a generation run is already underway.
+			if (generatingProfile) {
+				toast.info('Profile is already being generated', {
+					description: 'Wait for the current run to finish, then regenerate if needed.',
+				});
+				return;
+			}
 			if (isDraft || (data.campaign.config && Object.keys(data.campaign.config).length === 0)) {
 				regenOpen = true;
 			} else {
@@ -140,7 +187,7 @@
 			}
 			return;
 		}
-		if (issue.fix.kind === 'accounts' && issue.fix.href) {
+		if ((issue.fix.kind === 'accounts' || issue.fix.kind === 'runner') && issue.fix.href) {
 			window.location.assign(issue.fix.href);
 		}
 	}
@@ -190,37 +237,61 @@
 	<Button
 		onclick={runNow}
 		size="sm"
-		disabled={!ready}
-		loading={isStarting}
-		title={!ready ? 'Resolve the setup items below first' : undefined}
+		disabled={!ready || campaignRunning}
+		loading={isStarting || campaignRunning}
+		title={!ready
+			? 'Resolve the setup items below first'
+			: campaignRunning
+				? 'A run is already in progress for this campaign'
+				: undefined}
 	>
-		Run now
+		{campaignRunning ? 'Running…' : 'Run now'}
 	</Button>
 </header>
 
-{#if !ready && issues.length > 0}
+{#if issues.length > 0}
+	{@const blocking = issues.filter((i) => i.fix.kind !== 'progress').length}
 	<div class="mb-6 rounded-md border border-amber-500/40 bg-amber-500/10 p-4">
 		<div class="flex items-baseline justify-between gap-3 mb-3">
-			<h2 class="text-sm font-medium text-amber-700 dark:text-amber-300">Setup required</h2>
+			<h2 class="text-sm font-medium text-amber-700 dark:text-amber-300">
+				{blocking > 0 ? 'Setup required' : 'In progress'}
+			</h2>
 			<span class="text-xs text-amber-700/70 dark:text-amber-300/70">
-				{issues.length} item{issues.length === 1 ? '' : 's'} blocking this campaign
+				{#if blocking > 0}
+					{blocking} item{blocking === 1 ? '' : 's'} blocking this campaign
+				{:else}
+					An operation is running for this campaign
+				{/if}
 			</span>
 		</div>
 		<ul class="space-y-3">
 			{#each issues as issue (issue.id)}
 				<li class="flex items-start justify-between gap-3">
-					<div class="min-w-0">
-						<p class="text-sm font-medium">{issue.title}</p>
-						<p class="text-xs text-muted-foreground">{issue.hint}</p>
+					<div class="min-w-0 flex items-start gap-2">
+						{#if issue.fix.kind === 'progress'}
+							<Loader2 class="size-4 animate-spin text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+						{/if}
+						<div class="min-w-0">
+							<p class="text-sm font-medium">{issue.title}</p>
+							<p class="text-xs text-muted-foreground">{issue.hint}</p>
+						</div>
 					</div>
-					<Button
-						size="sm"
-						variant="outline"
-						class="shrink-0"
-						onclick={() => handleIssueAction(issue)}
-					>
-						{issue.fix.label}
-					</Button>
+					{#if issue.fix.kind === 'progress'}
+						<span
+							class="shrink-0 text-xs font-mono text-amber-700/80 dark:text-amber-300/80 px-2 py-1"
+						>
+							{issue.fix.label}
+						</span>
+					{:else}
+						<Button
+							size="sm"
+							variant="outline"
+							class="shrink-0"
+							onclick={() => handleIssueAction(issue)}
+						>
+							{issue.fix.label}
+						</Button>
+					{/if}
 				</li>
 			{/each}
 		</ul>


### PR DESCRIPTION
## Summary

User reported: "the profile is already being generated. there is no indication of it and it still lets me open the profile generation modal. that is not good. we need to handle the loading state in this case and in every other case."

Surface in-progress async operations consistently across the campaign page and unblock the trigger UI so users can't accidentally fire duplicate operations.

## Audit of async long-running operations

| Operation                  | Run kind                     | State before                                  | State after                                                       |
|----------------------------|------------------------------|-----------------------------------------------|-------------------------------------------------------------------|
| Project description extract| `project_extraction`         | ✅ `extractionRunning` derived in OverviewTab | unchanged                                                         |
| Campaign run               | `campaign`                   | ⚠️ list page detected it via `isRunning`; detail page only knew about local `isStarting` | detail page now reads server `campaignRunning`, button disables + shows "Running…" |
| Campaign profile generation| `campaign_skill_generation`  | ❌ no detection; banner kept showing "not generated" with active Generate button | full detection; banner shows spinner + "Generating campaign profile…"; button replaced with "In progress" label; modal click guarded |

## Changes

### `web/src/lib/server/campaign-readiness.ts`
- New `ReadinessIssue` id: `'profile_generating'`.
- New `fix.kind: 'progress'` for in-progress operations (no action).
- `CampaignReadiness` now exposes `generatingProfile` and `campaignRunning` booleans alongside the existing readiness check.
- `profile_generating` is treated as informational (doesn't block `ready: true`), so once the run finishes the user can hit Run now immediately.

### `web/src/routes/campaigns/[id]/+page.svelte`
- Banner renders progress issues with a `Loader2` spinner + label instead of an action button.
- Banner header flips to "In progress" when only informational issues remain.
- Banner is shown whenever issues exist (was only when not-ready).
- "Run now" disabled and shows "Running…" when `campaignRunning`.
- `handleIssueAction` short-circuits on `kind: 'progress'` and toasts a friendly message if a user tries to regenerate while a generation is already running (race-safe fallback if SSE hasn't refreshed yet).
- Subscribes to `/api/stream` SSE on mount: `run:started` / `run:finished` for this campaign triggers `invalidateAll()` so the banner is live across the dashboard.

## Verification

- `npm run typecheck` clean
- Manual trigger: open `/campaigns/[id]` while a `campaign_skill_generation` run is alive in the DB. Banner should show "Generating campaign profile…" with spinner; clicking it does nothing. Once the run finishes (or you kill its row), an SSE event refreshes the banner.
- Existing pattern in `ProjectOverviewTab.extractionRunning` is unchanged; this PR uses the same idea on the campaign side.

## Out of scope (potential follow-ups)

- Reply-draft regeneration loading states (per-draft, less critical).
- Draft send action (synchronous, not long-running today).
- Cron-scheduled run start indicators outside the campaign page.