### PR TITLE
docs: ACP and live-setup-state refresh → main

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -92,4 +92,5 @@ Clients MAY include `"version": <int>` in their request body to opt in to strict
 
 - The server sends a `:ping` SSE comment every 15 s so reverse proxies keep the connection alive.
 - The client wrapper at [`web/src/lib/realtime/sse.ts`](https://github.com/fiorelorenzo/pitchbox/tree/development/web/src/lib/realtime/sse.ts) tracks the last event timestamp. If no named event lands for **30 s** it closes the underlying `EventSource` and reconnects with capped exponential backoff (1 s → 30 s max). The wrapper exposes a `live` / `reconnecting` / `closed` status the sidebar indicator renders.
-- Event kinds currently published: `hello`, `run:started`, `run:log`, `drafts:changed`, plus future ones registered via `lib/server/events.ts`.
+- Event kinds currently published: `hello`, `run:started`, `run:log`, `run:finished`, `drafts:changed`, `project:description:updated`, plus future ones registered via `lib/server/events.ts`.
+- `run:started` and `run:finished` carry `{ runId, campaignId?, projectId?, exitCode?, error? }`. The campaign detail page subscribes to both and calls `invalidateAll()` when the event's `campaignId` matches its own, so the "Setup required" / "In progress" banner and the "Run now" button reflect the new state without a manual reload. Other surfaces (Projects overview, Inbox) wire the same events in the same way.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -12,9 +12,20 @@ An **account** is a platform identity (e.g. `u/myhandle` on Reddit) tied to a pr
 
 A **campaign** scopes an outreach intent: which platform, which skill (`reddit-scout` for DMs, `reddit-commenter` for comment-replies, `reddit-poster` for top-level posts), which agent runner, which cron schedule. Campaigns snapshot their runner at creation; runs snapshot the runner and playbook at start.
 
+### Campaign readiness and live setup banner
+
+Each campaign page evaluates a small readiness check on every load (`web/src/lib/server/campaign-readiness.ts`) and renders the result as a banner at the top of the page. Two kinds of items can appear:
+
+- **Blocking issues** (orange "Setup required" header): the campaign cannot run until they are resolved. Examples: profile not generated, profile invalid against the skill schema, no account linked to the project, agent runner CLI not installed. Each blocking issue has an action button (Generate profile, Add account, Open settings, ...).
+- **In-progress operations** (amber "In progress" header with a spinner, no button): a long-running operation is already executing against this campaign. Today this surfaces a `campaign_skill_generation` run, i.e. the agent producing the profile. The banner reads "Generating campaign profile…" and updates live: the page subscribes to the dashboard's SSE stream and re-invalidates the readiness snapshot when a relevant `run:started` / `run:finished` arrives, so the banner clears itself without a manual refresh.
+
+The page also reads two booleans alongside the issues list, `generatingProfile` and `campaignRunning`, and uses them to disable redundant triggers. The "Run now" button shows "Running…" while a `campaign` run for this campaign is alive; clicking "Generate profile" while a generation is already running raises a toast instead of opening the modal.
+
+Project description extraction follows the same pattern: the **Auto-extract** button on a project page disables itself while a `project_extraction` run is alive (`extractionRunning` derived in `ProjectOverviewTab.svelte`).
+
 ## Runs
 
-A **run** is one execution of a campaign or background task. The dashboard streams `run_events` as the agent works, including normalised tool-use / message events.
+A **run** is one execution of a campaign or background task. The dashboard streams `run_events` as the agent works, including normalised tool-use / message events. The run-log UI (`web/src/lib/components/RunLog.svelte`) coalesces ACP-streamed `agent_message_chunk` tokens into a single assistant bubble per turn, pairs `tool_call` with its `tool_call_update` completion so each tool invocation renders as one expandable row with command + output, and timestamps every event with a granular `Ns ago` / `Nm Ks ago` label (see `relativeTimeFine` in `web/src/lib/utils/time.ts`).
 
 ## Drafts
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -4,16 +4,18 @@ Pitchbox's `AgentRunner` interface (`shared/src/agents/base.ts`) is the contract
 
 ## Supported backends
 
-| Slug          | Display name        | Binary   | Install / auth hint                                                                |
-| ------------- | ------------------- | -------- | ---------------------------------------------------------------------------------- |
-| `claude-code` | Claude Code         | `claude` | Install Anthropic Claude Code CLI and run `claude login`, or set `ANTHROPIC_API_KEY`. |
-| `codex`       | Codex               | `codex`  | Install OpenAI Codex CLI and run `codex login`, or set `OPENAI_API_KEY`.              |
-| `gemini`      | Gemini CLI          | `gemini` | Install Google Gemini CLI and authenticate, or set `GEMINI_API_KEY`.                  |
-| `copilot`     | GitHub Copilot CLI  | `copilot`| Install GitHub Copilot CLI and run `copilot auth login`.                              |
-| `opencode`    | opencode            | `opencode`| Install sst/opencode and configure a provider.                                       |
-| `qwen-code`   | Qwen Code           | `qwen`   | Install Qwen Code CLI and configure DashScope credentials.                            |
+Four of the six backends speak ACP natively (a CLI flag or sub-command on the agent's own binary). Two of them, Claude Code and Codex, do NOT expose an ACP server mode on their primary CLI; for those, Pitchbox launches a thin adapter package via `npx` that wraps the agent's SDK and re-exposes it as an ACP server. Authentication still flows through each agent's own local state (e.g. `claude login`), so no extra auth step is required.
 
-Backend specs (binary name, ACP flag, env passthrough, notes) live as data in `shared/src/agents/acp/backends.ts`.
+| Slug          | Display name        | How Pitchbox launches it                              | Install / auth hint                                                                |
+| ------------- | ------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `claude-code` | Claude Code         | `npx -y @agentclientprotocol/claude-agent-acp`        | Install Anthropic Claude Code CLI and run `claude login`, or set `ANTHROPIC_API_KEY`. Adapter is fetched on demand and cached after the first run. |
+| `codex`       | Codex               | `npx -y @zed-industries/codex-acp`                    | Install OpenAI Codex CLI and run `codex login`, or set `OPENAI_API_KEY`. Adapter is fetched on demand and cached after the first run.              |
+| `gemini`      | Gemini CLI          | `gemini --acp`                                        | Install `@google/gemini-cli` and authenticate, or set `GEMINI_API_KEY` / `GOOGLE_API_KEY`. ACP is native.            |
+| `copilot`     | GitHub Copilot CLI  | `copilot --acp`                                       | Install GitHub Copilot CLI and run `copilot auth login`. ACP is native (public preview).                            |
+| `opencode`    | opencode            | `opencode acp`                                        | Install `opencode-ai` and configure a provider. ACP is native via the `acp` sub-command.                            |
+| `qwen-code`   | Qwen Code           | `qwen --acp`                                          | Install Qwen Code CLI and configure DashScope credentials. ACP is native (replaces the deprecated `--experimental-acp` flag).                       |
+
+Backend specs (binary name, ACP args, env passthrough, install notes) live as data in `shared/src/agents/acp/backends.ts` and are surfaced verbatim in **Settings → Status → Agent runners**.
 
 ## How it works
 


### PR DESCRIPTION
Promotes the docs-only PR #71 from development to main.