### PR TITLE
chore: single-trunk branch model (PRs into main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, development]
+    branches: [main]
   pull_request:
-    branches: [main, development]
+    branches: [main]
 
 # One in-flight run per ref; new pushes cancel the old run.
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    branches: [main, development]
+    branches: [main]
     paths:
       - 'docs/**'
       - 'README.md'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,9 @@ Auto-memory **is** active for this project - keep using it. The split:
 
 ### PRs
 
-PRs target the `development` branch, not `main` - pass `--base development` to
-`gh pr create`. The nested private repos (below) use the same `main` +
-`development` workflow.
+Work on short-lived feature branches and open a PR into `main` (the default base
+for `gh pr create`). The nested private repos (below) are separate git repos with
+their own branching.
 
 ### Nested private repos (cloud/)
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Self-hosted, human-in-the-loop outreach agent. The agent does the research and drafting; you approve before anything is sent.
 
-[![CI](https://github.com/fiorelorenzo/pitchbox/actions/workflows/ci.yml/badge.svg?branch=development)](https://github.com/fiorelorenzo/pitchbox/actions/workflows/ci.yml)
-[![Docs](https://github.com/fiorelorenzo/pitchbox/actions/workflows/docs.yml/badge.svg?branch=development)](https://fiorelorenzo.github.io/pitchbox/)
+[![CI](https://github.com/fiorelorenzo/pitchbox/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/fiorelorenzo/pitchbox/actions/workflows/ci.yml)
+[![Docs](https://github.com/fiorelorenzo/pitchbox/actions/workflows/docs.yml/badge.svg?branch=main)](https://fiorelorenzo.github.io/pitchbox/)
 [![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](./LICENSE)
 [![Version](https://img.shields.io/github/package-json/v/fiorelorenzo/pitchbox?label=version)](./package.json)
 [![Node](https://img.shields.io/badge/node-%E2%89%A522-3c873a?logo=node.js&logoColor=white)](https://nodejs.org)


### PR DESCRIPTION
Collapse pitchbox to a single long-lived `main`. `development` was sitting 12 commits behind `main` with nothing unique on it, and nothing deploys from it, so it was pure overhead. Feature branches now PR into `main`.

- ci.yml / docs.yml: trigger on `main` only
- README: CI + Docs badges point at `main`
- CLAUDE.md: PRs target `main`

The nested cloud/private repos are separate and left untouched.