### PR TITLE
fix(extension): point cloud auto-pair at pitchbox.app, not the unprovisioned app.pitchbox.io

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -28,7 +28,7 @@ One click. Open your Pitchbox dashboard in any tab while signed in, open the sid
 3. The dashboard mints a fresh device token tied to your org and returns it.
 4. The extension stores the token in `chrome.storage.local` keyed by backend URL.
 
-For the **cloud edition** (`https://app.pitchbox.io/*`) the same script runs automatically the first time you visit while signed in, so cloud users never see the pairing button.
+For the **cloud edition** (`https://pitchbox.app/*`) the same script runs automatically the first time you visit while signed in, so cloud users never see the pairing button.
 
 ### Pair multiple backends
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,4 +78,4 @@ The dashboard is responsive down to roughly 375 px wide: on tablet and phone wid
 
 ## Chrome extension
 
-Build and load `extension/dist/` unpacked, then open your dashboard in any tab and click the Pitchbox toolbar icon to open the side panel. Hit **Pair with this tab** under the Dashboard tab. Cloud users on `app.pitchbox.io` are paired automatically the first time they visit while signed in. Details: [the extension page](/extension).
+Build and load `extension/dist/` unpacked, then open your dashboard in any tab and click the Pitchbox toolbar icon to open the side panel. Hit **Pair with this tab** under the Dashboard tab. Cloud users on `pitchbox.app` are paired automatically the first time they visit while signed in. Details: [the extension page](/extension).

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -60,7 +60,12 @@ export default defineManifest({
       // same script on demand via the popup's "Pair with this tab" button,
       // which uses chrome.scripting.executeScript after a one-shot
       // permission grant.
-      matches: ['https://app.pitchbox.io/*', 'http://127.0.0.1:5180/*', 'http://localhost:5180/*'],
+      matches: [
+        'https://pitchbox.app/*',
+        'https://www.pitchbox.app/*',
+        'http://127.0.0.1:5180/*',
+        'http://localhost:5180/*',
+      ],
       js: ['src/content/auto-pair.ts'],
       run_at: 'document_idle',
     },
@@ -71,7 +76,8 @@ export default defineManifest({
     'https://www.reddit.com/*',
     'https://old.reddit.com/*',
     'https://matrix.redditspace.com/*',
-    'https://app.pitchbox.io/*',
+    'https://pitchbox.app/*',
+    'https://www.pitchbox.app/*',
     'http://127.0.0.1/*',
     'http://localhost/*',
   ],


### PR DESCRIPTION
Closes #171. First step of the connection-config epic #164 (design in `docs/extension-connection-design.md`).

The manifest hardcoded `https://app.pitchbox.io` as the cloud auto-pair origin in both `content_scripts.matches` and `host_permissions`, but that subdomain was never provisioned: production only serves the apex `pitchbox.app` and `www`. So a signed-in user at `pitchbox.app` got no automatic pairing at all and had to discover the manual "Pair with this tab" button. This replaces it with `pitchbox.app` + `www.pitchbox.app` and fixes the two doc references.

Pure correctness fix, no new config surface: the build-time default plus the self-host/preview override UI land separately in #176.

Verified: built `dist/manifest.json` carries the corrected origins with no `app.pitchbox.io` remaining; `pnpm -F @pitchbox/extension check` clean; lint clean.