### PR TITLE
fix(extension): thread the backend origin through compose URLs (armed/sent routing)

### DIFF
--- a/extension/src/content/dm-compose.ts
+++ b/extension/src/content/dm-compose.ts
@@ -1,9 +1,10 @@
-import { parseDraftId } from '../lib/draft-param.js';
+import { parseBackendUrl, parseDraftId } from '../lib/draft-param.js';
 import { api } from '../lib/api.js';
 import { logFromContent } from '../lib/log-from-content.js';
 import { findComposeTextarea, findComposeSendButton } from './shared/reddit-dom.js';
 
 const draftId = parseDraftId(location.href);
+const backendUrl = parseBackendUrl(location.href) ?? undefined;
 
 if (draftId !== null) {
   let armed = false;
@@ -15,13 +16,13 @@ if (draftId !== null) {
     armed = true;
     // Capture the textarea content at click time - Reddit clears it on success.
     capturedBody = findComposeTextarea()?.value || undefined;
-    await api.armed(draftId!);
+    await api.armed(draftId!, backendUrl);
   }
 
   async function onSendCompleted() {
     if (sent) return;
     sent = true;
-    const res = await api.sent(draftId!, capturedBody);
+    const res = await api.sent(draftId!, capturedBody, undefined, undefined, undefined, backendUrl);
     if (res.ok) {
       logFromContent({
         level: 'info',

--- a/extension/src/content/post-comment.ts
+++ b/extension/src/content/post-comment.ts
@@ -1,9 +1,10 @@
-import { parseDraftId } from '../lib/draft-param.js';
+import { parseBackendUrl, parseDraftId } from '../lib/draft-param.js';
 import { api } from '../lib/api.js';
 import { logFromContent } from '../lib/log-from-content.js';
 import { findCommentTextarea, findCommentSubmitButton } from './shared/reddit-dom.js';
 
 const draftId = parseDraftId(location.href);
+const backendUrl = parseBackendUrl(location.href) ?? undefined;
 
 function derivePostId(pathname: string): string | null {
   // /r/<sub>/comments/<postId>/<slug>/...   - Reddit's canonical pattern.
@@ -62,7 +63,7 @@ if (draftId !== null) {
   }
 
   async function fill() {
-    const r = await api.getDraft(draftId!);
+    const r = await api.getDraft(draftId!, backendUrl);
     if (!r.ok) return;
     const el = findCommentTextarea();
     if (!el) return;
@@ -79,7 +80,7 @@ if (draftId !== null) {
   async function onSendIntent() {
     if (armed) return;
     armed = true;
-    await api.armed(draftId!);
+    await api.armed(draftId!, backendUrl);
   }
 
   async function onSendCompleted() {
@@ -92,7 +93,14 @@ if (draftId !== null) {
       postId && handle
         ? { postId, accountHandle: handle, postedAt: new Date().toISOString() }
         : undefined;
-    const res = await api.sent(draftId!, sentContent, commentLookup);
+    const res = await api.sent(
+      draftId!,
+      sentContent,
+      commentLookup,
+      undefined,
+      undefined,
+      backendUrl,
+    );
     if (res.ok) {
       logFromContent({
         level: 'info',

--- a/extension/src/content/post-submit.ts
+++ b/extension/src/content/post-submit.ts
@@ -1,4 +1,4 @@
-import { parseDraftId } from '../lib/draft-param.js';
+import { parseBackendUrl, parseDraftId } from '../lib/draft-param.js';
 import { api } from '../lib/api.js';
 import { logFromContent } from '../lib/log-from-content.js';
 
@@ -9,6 +9,7 @@ import { logFromContent } from '../lib/log-from-content.js';
 // resulting t3_<id> so the reply poller can pick up future comments.
 
 const draftId = parseDraftId(location.href);
+const backendUrl = parseBackendUrl(location.href) ?? undefined;
 
 if (draftId !== null) {
   let sent = false;
@@ -28,7 +29,7 @@ if (draftId !== null) {
   async function onSubmitted(t3: string) {
     if (sent) return;
     sent = true;
-    const res = await api.sent(draftId!, undefined, undefined, t3);
+    const res = await api.sent(draftId!, undefined, undefined, t3, undefined, backendUrl);
     if (res.ok) {
       logFromContent({
         level: 'info',

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -14,16 +14,22 @@ type DraftSummary = {
 
 /**
  * Resolve which pairing a single-backend op should target. Compose-time
- * content scripts can pass an explicit `backendUrl` (the dashboard injects
- * it as a query param into compose URLs). When omitted we fall back to the
- * first pairing - keeps single-backend installs working without changes.
+ * content scripts pass the explicit `backendUrl` the dashboard tags onto the
+ * compose URL (`pitchbox_backend`), so armed/sent reach the backend the draft
+ * belongs to when several are paired. Resolution order:
+ *   1. exact match on the requested backend, when given;
+ *   2. otherwise the first pairing (the documented single-backend default) -
+ *      never fail a lone-pairing install just because an origin string differs
+ *      (e.g. localhost vs 127.0.0.1).
+ * Exported for unit testing.
  */
-async function pickPairing(backendUrl?: string): Promise<Pairing | null> {
+export async function pickPairing(backendUrl?: string): Promise<Pairing | null> {
   const { pairings } = await getSettings();
   if (pairings.length === 0) return null;
   if (backendUrl) {
     const url = backendUrl.replace(/\/$/, '');
-    return pairings.find((p) => p.backendUrl === url) ?? null;
+    const match = pairings.find((p) => p.backendUrl === url);
+    if (match) return match;
   }
   return pairings[0];
 }

--- a/extension/src/lib/draft-param.ts
+++ b/extension/src/lib/draft-param.ts
@@ -10,3 +10,22 @@ export function parseDraftId(href: string): number | null {
     return null;
   }
 }
+
+/**
+ * Read the backend origin the dashboard tagged the compose URL with
+ * (`pitchbox_backend`), normalized to an http(s) origin. Lets a compose tab
+ * route its armed/sent calls to the backend the draft belongs to when the
+ * user has more than one paired. Returns null when absent or not an http(s)
+ * origin.
+ */
+export function parseBackendUrl(href: string): string | null {
+  try {
+    const raw = new URL(href).searchParams.get('pitchbox_backend');
+    if (!raw) return null;
+    const parsed = new URL(raw);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return null;
+  }
+}

--- a/extension/tests/lib/draft-param.test.ts
+++ b/extension/tests/lib/draft-param.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseDraftId } from '../../src/lib/draft-param.js';
+import { parseBackendUrl, parseDraftId } from '../../src/lib/draft-param.js';
 
 describe('parseDraftId', () => {
   it('reads from current URL', () => {
@@ -18,5 +18,27 @@ describe('parseDraftId', () => {
   });
   it('returns null for zero', () => {
     expect(parseDraftId('https://x.test/?pitchbox_draft=0')).toBeNull();
+  });
+});
+
+describe('parseBackendUrl', () => {
+  it('reads the tagged backend origin from the compose URL', () => {
+    const href =
+      'https://www.reddit.com/message/compose?to=alice&pitchbox_draft=42' +
+      '&pitchbox_backend=' +
+      encodeURIComponent('https://pitchbox.app');
+    expect(parseBackendUrl(href)).toBe('https://pitchbox.app');
+  });
+  it('normalizes to an origin (strips any path/trailing slash)', () => {
+    const href = 'https://x.test/?pitchbox_backend=' + encodeURIComponent('http://localhost:5180/');
+    expect(parseBackendUrl(href)).toBe('http://localhost:5180');
+  });
+  it('returns null when absent', () => {
+    expect(parseBackendUrl('https://x.test/?pitchbox_draft=1')).toBeNull();
+  });
+  it('returns null for a non-http(s) value', () => {
+    expect(
+      parseBackendUrl('https://x.test/?pitchbox_backend=' + encodeURIComponent('ftp://evil')),
+    ).toBeNull();
   });
 });

--- a/extension/tests/lib/pick-pairing.test.ts
+++ b/extension/tests/lib/pick-pairing.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// Minimal chrome.storage.local mock so api.ts's getSettings() resolves.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(globalThis as any).chrome = {
+  storage: {
+    local: {
+      _s: {} as Record<string, unknown>,
+      async get(keys: string[] | string) {
+        const k = Array.isArray(keys) ? keys : [keys];
+        const out: Record<string, unknown> = {};
+        for (const x of k) if (x in this._s) out[x] = this._s[x];
+        return out;
+      },
+      async set(patch: Record<string, unknown>) {
+        Object.assign(this._s, patch);
+      },
+      async remove(keys: string[] | string) {
+        const k = Array.isArray(keys) ? keys : [keys];
+        for (const x of k) delete this._s[x];
+      },
+    },
+  },
+};
+
+function seed(pairings: Array<{ backendUrl: string; token: string }>) {
+  (globalThis as any).chrome.storage.local._s = { pairings };
+}
+
+beforeEach(() => {
+  (globalThis as any).chrome.storage.local._s = {};
+});
+
+const A = { backendUrl: 'https://a.example', token: 'ta' };
+const B = { backendUrl: 'https://b.example', token: 'tb' };
+
+describe('pickPairing', () => {
+  it('returns null when nothing is paired', async () => {
+    const { pickPairing } = await import('../../src/lib/api.js');
+    expect(await pickPairing()).toBeNull();
+    expect(await pickPairing('https://a.example')).toBeNull();
+  });
+
+  it('routes to the exact requested backend (trailing slash tolerant)', async () => {
+    seed([A, B]);
+    const { pickPairing } = await import('../../src/lib/api.js');
+    expect((await pickPairing('https://b.example'))?.backendUrl).toBe('https://b.example');
+    expect((await pickPairing('https://b.example/'))?.backendUrl).toBe('https://b.example');
+  });
+
+  it('falls back to the first pairing when omitted or unmatched (never fails a lone install)', async () => {
+    seed([A, B]);
+    const { pickPairing } = await import('../../src/lib/api.js');
+    expect((await pickPairing())?.backendUrl).toBe('https://a.example');
+    expect((await pickPairing('https://unknown.example'))?.backendUrl).toBe('https://a.example');
+  });
+});

--- a/web/src/lib/components/DraftDetail.svelte
+++ b/web/src/lib/components/DraftDetail.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { Clipboard, Check, Send, ExternalLink, MessageSquare } from '@lucide/svelte';
+	import { browser } from '$app/environment';
 	import { invalidateAll } from '$app/navigation';
+	import { composeHref } from '$lib/utils/compose-url';
 	import { toast } from 'svelte-sonner';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -372,7 +374,6 @@
 
 {#if draft}
 	{@const primary = getPresenter(draft.platformSlug).primaryLabel(draft)}
-	{@const urlSep = draft.composeUrl?.includes('?') ? '&' : '?'}
 	{@const openLabel =
 		draft.kind === 'dm'
 			? 'Open compose ↗'
@@ -485,7 +486,11 @@
 				{/if}
 				{#if draft.state === 'approved' && draft.composeUrl}
 					<Button
-						href={`${draft.composeUrl}${urlSep}pitchbox_draft=${draft.id}`}
+						href={composeHref(
+							draft.composeUrl,
+							draft.id,
+							browser ? window.location.origin : undefined,
+						)}
 						target="_blank"
 						rel="noopener"
 						size="sm"

--- a/web/src/lib/utils/compose-url.ts
+++ b/web/src/lib/utils/compose-url.ts
@@ -1,0 +1,15 @@
+/**
+ * Build the URL the dashboard opens for composing/sending a draft. Appends:
+ *   - `pitchbox_draft=<id>` so the extension knows which draft this tab is for;
+ *   - `pitchbox_backend=<origin>` so the extension routes its armed/sent calls
+ *     back to the backend the draft belongs to when several are paired.
+ * The backend origin is this dashboard's own public origin (the one the
+ * extension paired against). Omitted when unknown (e.g. server-side render).
+ * See docs/extension-connection-design.md.
+ */
+export function composeHref(composeUrl: string, draftId: number, backendOrigin?: string): string {
+  const sep = composeUrl.includes('?') ? '&' : '?';
+  let out = `${composeUrl}${sep}pitchbox_draft=${draftId}`;
+  if (backendOrigin) out += `&pitchbox_backend=${encodeURIComponent(backendOrigin)}`;
+  return out;
+}

--- a/web/src/routes/inbox/+page.svelte
+++ b/web/src/routes/inbox/+page.svelte
@@ -4,6 +4,7 @@
 	import { onMount, tick } from 'svelte';
 	import { invalidateAll, goto, replaceState } from '$app/navigation';
 	import { navigating, page } from '$app/stores';
+	import { composeHref } from '$lib/utils/compose-url';
 	import { ChevronDown, X, Inbox, Keyboard, ArrowLeft, SlidersHorizontal } from '@lucide/svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { Button } from '$lib/components/ui/button';
@@ -363,8 +364,10 @@
 				}
 				case 'o': {
 					if (selected?.composeUrl) {
-						const sep = selected.composeUrl.includes('?') ? '&' : '?';
-						window.open(`${selected.composeUrl}${sep}pitchbox_draft=${selected.id}`, '_blank');
+						window.open(
+							composeHref(selected.composeUrl, selected.id, window.location.origin),
+							'_blank',
+						);
 					}
 					break;
 				}

--- a/web/tests/compose-url.test.ts
+++ b/web/tests/compose-url.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { composeHref } from '../src/lib/utils/compose-url.js';
+
+describe('composeHref', () => {
+  it('appends the draft id with the right separator', () => {
+    expect(composeHref('https://www.reddit.com/message/compose?to=alice', 42)).toBe(
+      'https://www.reddit.com/message/compose?to=alice&pitchbox_draft=42',
+    );
+    expect(composeHref('https://news.ycombinator.com/reply', 7)).toBe(
+      'https://news.ycombinator.com/reply?pitchbox_draft=7',
+    );
+  });
+
+  it('appends the backend origin (encoded) when provided', () => {
+    expect(composeHref('https://x.test/c?a=1', 5, 'https://pitchbox.app')).toBe(
+      'https://x.test/c?a=1&pitchbox_draft=5&pitchbox_backend=https%3A%2F%2Fpitchbox.app',
+    );
+  });
+
+  it('omits the backend param when the origin is unknown', () => {
+    expect(composeHref('https://x.test/c', 5, undefined)).toBe('https://x.test/c?pitchbox_draft=5');
+  });
+});


### PR DESCRIPTION
Closes #172. Part of the connection-config epic #164.

`api.ts`'s doc comment long claimed the dashboard injects a backend into compose URLs, but nothing did, so the three content scripts always resolved `pairings[0]`. With more than one pairing (cloud + self-hosted, the design's own supported case) a compose tab for the second backend's draft routed armed/sent to the first, 404ing or flipping the wrong instance's draft.

- The dashboard tags each compose URL with `pitchbox_backend=<its own origin>` (new `web/src/lib/utils/compose-url.ts`, used by `DraftDetail` and the inbox open handler; origin is client-only so SSR omits it).
- `draft-param.ts` gains `parseBackendUrl()`; the three content scripts thread it into every api call.
- `pickPairing` prefers an exact match and otherwise falls back to the first pairing, so a lone-pairing install never fails on an origin-string mismatch (localhost vs 127.0.0.1).

Verified: new unit tests for `parseBackendUrl`, `pickPairing` (exact/omitted/unmatched), and `composeHref`; full extension suite 57/57; extension + web `check` clean; whole-repo lint clean.