### PR TITLE
chore(extension,web): port-agnostic localhost auto-pair + onboarding backend URL from origin

### DIFF
--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -64,8 +64,10 @@ export default defineManifest({
         'https://pitchbox.app/*',
         'https://www.pitchbox.app/*',
         'https://preview.pitchbox.app/*',
-        'http://127.0.0.1:5180/*',
-        'http://localhost:5180/*',
+        // Port-agnostic so a self-host on a non-default WEB_PORT still
+        // auto-pairs (matches the port-agnostic host_permissions below).
+        'http://127.0.0.1/*',
+        'http://localhost/*',
       ],
       js: ['src/content/auto-pair.ts'],
       run_at: 'document_idle',

--- a/web/src/lib/components/ExtensionCard.svelte
+++ b/web/src/lib/components/ExtensionCard.svelte
@@ -48,8 +48,11 @@
         </li>
         <li>Click the Pitchbox icon to open the side panel, then pair as above.</li>
       </ol>
-      <div class="mt-2 font-mono">
-        <div>Backend URL: <code>{backendUrl}</code></div>
+      <div class="mt-2">
+        <div>
+          Backend URL (enter this in the extension's <em>Add connection</em> form, or use a
+          pairing code): <code class="font-mono">{backendUrl}</code>
+        </div>
       </div>
     </details>
   </Card.Content>

--- a/web/src/routes/settings/+page.server.ts
+++ b/web/src/routes/settings/+page.server.ts
@@ -5,7 +5,7 @@ import { loadRunnerConfigs } from '@pitchbox/shared/agents/config';
 import { eq } from 'drizzle-orm';
 import { getDb, schema } from '$lib/server/db.js';
 
-export async function load() {
+export async function load({ url }) {
   const db = getDb();
   const platforms = await db
     .select({ slug: schema.platforms.slug })
@@ -38,7 +38,11 @@ export async function load() {
 
   return {
     extension: {
-      backendUrl: process.env.PITCHBOX_BACKEND_URL ?? 'http://127.0.0.1:5180',
+      // What the user should point the extension at: an explicit override if
+      // set, otherwise this dashboard's own public origin (which is exactly
+      // the backend the extension auto-pairs against and what you type into
+      // its "Add connection" form). See docs/extension-connection-design.md.
+      backendUrl: process.env.PITCHBOX_BACKEND_URL ?? url.origin,
     },
     quota,
     runners,


### PR DESCRIPTION
Closes #191 and #199. Completes the connection-config epic #164.

- **#191**: the auto-pair content script matched only `127.0.0.1:5180`/`localhost:5180`, so a self-host on a non-default `WEB_PORT` never auto-paired. Widened to port-agnostic `http://127.0.0.1/*` + `http://localhost/*` (matching `host_permissions`).
- **#199**: Settings > Integrations showed a hardcoded `http://127.0.0.1:5180` as the backend URL whenever `PITCHBOX_BACKEND_URL` was unset (every cloud deploy). Default it to the dashboard's own request origin, which is what the extension auto-pairs against and what you enter in its "Add connection" form. Copy clarified.

Verified: build carries the port-agnostic matches; web + extension `check` clean; whole-repo lint clean.