### PR TITLE
docs: harvest cloud-submodule, test-db, migration and security lessons

### DIFF
--- a/.claude/skills/pitchbox-cloud-submodules/SKILL.md
+++ b/.claude/skills/pitchbox-cloud-submodules/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: pitchbox-cloud-submodules
+description: Use when committing, branching, or landing a change inside the cloud/runner or cloud/adapter private submodules, or when editing the shared cloud protocol contract (shared/src/agents/cloud/protocol.ts).
+metadata:
+  version: 1.0.0
+  updated: 2026-08-24
+  origin: authored
+  source: harvested from ~/.claude/projects/-home-dev-projects-personal-pitchbox/memory/cloud-repos-dev-layout.md
+  status: active
+---
+
+Operational detail for `cloud/runner` (`@pitchbox/runner-service`) and `cloud/adapter`
+(`@pitchbox/cloud-adapter`), the two private git submodules of this umbrella. See
+`AGENTS.md`'s "Cloud runner & repo layout" for the submodule/gitlink basics this
+extends.
+
+**Verify before you branch.** A submodule frequently sits in detached HEAD at the
+recorded gitlink rather than on `main`. Before starting work: `git -C cloud/<x>
+checkout main`, then confirm `main == origin/main == <the umbrella's gitlink for
+cloud/<x>>`. If `main` looks stale, `git -C cloud/<x> reset --hard origin/main`
+before branching from it - branching off a stale or detached tip silently loses
+the relationship to what's actually deployed.
+
+**Landing a change:** commit inside the submodule -> `git -C cloud/<x> checkout
+main && git -C cloud/<x> merge --ff-only <branch>` -> `git -C cloud/<x> push
+origin main` -> then in the umbrella, `git add cloud/<x>` (stages only the
+gitlink pointer bump) and commit that here. Never `git add cloud/*` content
+from the umbrella - only the gitlink moves from the umbrella's side.
+
+**Protocol vendoring.** The OSS wire contract lives at
+`shared/src/agents/cloud/protocol.ts` and is kept dependency-free (hand-written
+validators, no zod/ajv) specifically so it vendors cleanly:
+- `cloud/runner` keeps a **vendored copy** at `src/protocol.generated.ts`,
+  regenerated with `cd cloud/runner && pnpm sync:protocol` - this must run from
+  inside the umbrella (it copies the umbrella file verbatim).
+- `cloud/adapter` does **not** vendor - it imports the umbrella protocol file by
+  relative path.
+After editing `protocol.ts`, regenerate the runner's copy before committing
+either side, or the two drift silently.
+
+**Worktree isolation does not fit a protocol change.** A protocol edit spans the
+umbrella (`shared/.../protocol.ts`) and the runner submodule
+(`protocol.generated.ts`) at once, and an umbrella `git worktree` does not
+cleanly carry a submodule's own working tree. Do this kind of cloud work
+sequentially, with one actor in the main tree, committing to each repo
+separately (`git -C <repo> ...`) - not via the parallel-worktree pattern used
+for the rest of the repo.

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ extension/*.zip
 # Web workspace
 web/.svelte-kit/
 web/build/
-.claude/settings.local.json
 shared/src/platforms/reddit/cache/
-.claude/
+.claude/*
+!.claude/skills/
 daemon/tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,14 @@ pnpm exec vitest run -t "pattern"         # single test by name
 
 Tests share one Postgres DB (`pitchbox_test`) and run sequentially - do **not** re-enable `fileParallelism`. Global setup (`tests/global-setup.ts`) migrates + seeds core; teardown intentionally leaves data for inspection.
 
+**Fresh devbox: `pitchbox_test` doesn't exist until you create it.**
+`docker-compose.yml` only provisions `POSTGRES_DB=pitchbox` (the dev DB);
+global setup migrates `pitchbox_test` but never creates it, so a first run
+fails at `migrate` with an InitPostgres error. One-time fix: `docker exec
+pitchbox-postgres psql -U pitchbox -d pitchbox -c "CREATE DATABASE
+pitchbox_test OWNER pitchbox;"` - it then persists in the `pitchbox-pg-data`
+volume until `docker compose down -v`.
+
 ### Local verification: run the minimal covering subset
 
 CI (`.github/workflows/ci.yml`) runs the full lint + typecheck + build + test
@@ -176,6 +184,13 @@ The cloud runner lets the agent run on managed compute without a local agent CLI
 
 **Repo layout (umbrella).** This public repo is the umbrella. Private cloud code lives in **separate git repos under `cloud/`**: `cloud/runner` and `cloud/adapter` are tracked as **git submodules** of this umbrella (see `.gitmodules`; their content lives in the private `pitchbox-runner-service` / `pitchbox-cloud-adapter` repos, and `.gitignore` keeps any other `cloud/*` path and `private/` untracked). The runner service is at `cloud/runner/`. To land a change: commit inside the submodule and push its own remote, then bump the umbrella's submodule pointer with `git add cloud/<x>` and commit that here (never `git add` submodule content from the umbrella). Always launch agents from this repo directory: chat history is keyed by the launch path (Claude Code + Emdash), so launching from a parent/other folder loses it. The submodules use pnpm standalone and import the OSS protocol contract by relative path.
 
+**A submodule often sits in detached HEAD at the recorded gitlink.** Before
+branching inside `cloud/runner` or `cloud/adapter`, `git -C cloud/<x> checkout
+main` and verify it matches `origin/main` and the umbrella's gitlink first -
+if it looks stale, `git -C cloud/<x> reset --hard origin/main`. Regenerating
+the vendored protocol copy and the rest of the submodule workflow:
+`.claude/skills/pitchbox-cloud-submodules/SKILL.md`.
+
 ## Docker (cloud-edition deployment)
 
 The client stack (web + daemon + Postgres) ships as Docker via `Dockerfile.app`
@@ -219,7 +234,8 @@ agent CLIs to stay lean.
 - **`PITCHBOX_ROOT`** in `.env` must be an absolute path; the daemon and CLI use it to locate the repo when spawned by an agent from a different cwd.
 - **Secrets.** Account credentials are encrypted with `ENCRYPTION_KEY` via `shared/src/crypto.ts`. Never log decrypted secrets or commit `.env`.
 - **Do not run tests against the dev DB.** Vitest pins `DATABASE_URL` to `pitchbox_test` in `vitest.config.ts`; if you override it, match that pattern.
-- **Migrations.** Edit `shared/src/db/schema.ts`, run `pnpm run migrate:generate`, then `pnpm run migrate`. Never hand-edit generated SQL unless you also regenerate.
+- **Migrations.** Edit `shared/src/db/schema.ts`, run `pnpm run migrate:generate`, then `pnpm run migrate`. Never hand-edit generated SQL unless you also regenerate. The baseline (`migrations/0000_baseline.sql`) preserves the live DB's historical constraint names (`_fkey`/`_key`), not drizzle-canonical ones - a generated migration that drops or renames an existing constraint may emit a name that doesn't exist in the DB; use the real historical name instead.
+- **Security disclosure.** This repo is public with a live prod deploy (`pitchbox.app`). Never put unpatched-vulnerability repro detail (steps, `file:line`) in a public issue, PR, or committed doc - file a private GitHub security advisory instead and leave a neutral `[security]` stub issue pointing to it.
 - **English everywhere.** All in-code comments and user-facing UI strings are in English (even when the conversation is in another language). No em dashes in any text - use regular hyphens or colons.
 
 ## Design and UI


### PR DESCRIPTION
Applies five rows from the harvest ledger (`~/.config/agents/docs/harvest/`) to this repo's always-on context.

**AGENTS.md** (+17 lines):
- Fresh-devbox trap: `pitchbox_test` doesn't exist until created manually (docker-compose only provisions the dev DB).
- Submodule detached-HEAD check before branching inside `cloud/runner`/`cloud/adapter`, with a pointer to the new skill below.
- Drizzle baseline durable caveat: the `0000_baseline.sql` keeps historical constraint names, not drizzle-canonical ones, so a generated migration that drops/renames a constraint can target a name that doesn't exist.
- New security-disclosure rule: this repo is public with a live prod deploy, so unpatched-vuln repro detail never goes in a public issue/PR/doc.

**New skill** `.claude/skills/pitchbox-cloud-submodules/SKILL.md`: the submodule landing workflow, protocol-vendoring regen step (`pnpm sync:protocol`), and why the parallel-worktree pattern doesn't fit a protocol change. Passes `agent-skill-lint.sh`.

**.gitignore**: un-ignores `.claude/skills/` so repo-local skills are trackable, keeps the rest of `.claude/` (local Claude Code state) ignored.

Two of the five ledger rows (`cloud-umbrella-layout`, and most of `cloud-repos-dev-layout`'s content) turned out to already be covered verbatim by the existing AGENTS.md and were left alone rather than duplicated. No exploit or vulnerability detail is included anywhere - the security row is a process rule only.