### PR TITLE
chore: v0.10.16

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.10.15",
+  "version": "0.10.16",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only, in lockstep across the six workspaces (`node scripts/set-version.mjs 0.10.16`, `version:check` passes). No lockfile change: pnpm doesn't record workspace versions.

This cuts the release that carries to production what has landed since v0.10.15 on 2026-08-05:

- #283 preview's blue-green pair moved off a port another app took, plus the idle-slot preflight
- #290 the app shell, its notification poll and the daemon health indicator no longer render on `/login`
- #291 26 Dependabot advisories closed and 15 safe minor/patch bumps

Prod is still serving the v0.10.15 image, so it holds the vulnerable `undici`/`ip-address`/`postcss` transitives and the broken login page on a public domain. I'll push the `v0.10.16` tag once CI is green on the squashed commit on `main`, not on this branch.