### PR TITLE
feat(shared,web,daemon): linkedin platform row, scenario registry and credential-free accounts

### DIFF
--- a/daemon/src/reply-readers.ts
+++ b/daemon/src/reply-readers.ts
@@ -37,6 +37,16 @@ export async function resolveMastodonClient(accountHandle: string): Promise<Mast
 const readers = new Map<string, ReplyReader>([
   ['reddit', new NullReplyReader('reddit')],
   ['mastodon', new MastodonReplyReader(resolveMastodonClient)],
+  // Unlike reddit's NullReplyReader above, which is a placeholder "until a
+  // real implementation lands" per the doc comment on `readers`, this one is
+  // permanent - there will never be a real LinkedIn reply reader. LinkedIn's
+  // User Agreement prohibits automated engagement and scraping (see
+  // docs/linkedin-integration-design.md "The compliance boundary"), so
+  // server-side reply polling against linkedin.com is both technically
+  // unavailable and against the rules even if it were possible. Replies are
+  // ingested passively instead, through the extension reading whatever the
+  // human's own browsing already rendered (LI-10, #307).
+  ['linkedin', new NullReplyReader('linkedin')],
 ]);
 
 export function getReplyReader(platformSlug: string): ReplyReader | null {

--- a/shared/src/campaigns/scenarios.ts
+++ b/shared/src/campaigns/scenarios.ts
@@ -13,11 +13,13 @@ export const SCENARIO_SLUGS = [
   'mastodon-scout',
   'mastodon-commenter',
   'mastodon-poster',
+  'linkedin-commenter',
+  'linkedin-poster',
 ] as const;
 
 export type ScenarioSlug = (typeof SCENARIO_SLUGS)[number];
 
-export type ScenarioPlatformSlug = 'reddit' | 'hackernews' | 'mastodon';
+export type ScenarioPlatformSlug = 'reddit' | 'hackernews' | 'mastodon' | 'linkedin';
 
 // Platforms whose account API can post on the caller's behalf, so a campaign on
 // that platform can opt into `campaigns.auto_post` (an approved draft is sent
@@ -100,6 +102,22 @@ export const SCENARIO_META: ScenarioMeta[] = [
     description: 'Draft proactive top-level statuses (toots) for the project.',
     platformSlug: 'mastodon',
     playbookFile: 'mastodon-poster.md',
+  },
+  {
+    slug: 'linkedin-commenter',
+    label: 'LinkedIn Commenter',
+    description:
+      'Draft a helpful comment on a LinkedIn post the human has already seen, using only what the extension observed in the browser. No discovery, no scraping.',
+    platformSlug: 'linkedin',
+    playbookFile: 'linkedin-commenter.md',
+  },
+  {
+    slug: 'linkedin-poster',
+    label: 'LinkedIn Poster',
+    description:
+      'Draft a proactive top-level LinkedIn post for the connected profile. Human reviews and posts manually - there is no auto-post API for LinkedIn in v1.',
+    platformSlug: 'linkedin',
+    playbookFile: 'linkedin-poster.md',
   },
 ];
 

--- a/shared/src/db/seed-core.ts
+++ b/shared/src/db/seed-core.ts
@@ -19,6 +19,17 @@ export const QUOTA_DEFAULTS = {
     comment: { perDay: 20, perWeek: 80 },
     post: { perDay: 3, perWeek: 10 },
   },
+  // LinkedIn (LI-2): deliberately tighter than every other platform, because
+  // the constraint here is reputational rather than technical - LinkedIn's
+  // velocity monitoring treats a high-volume account as a bot regardless of
+  // whether a human approved every draft (see
+  // docs/linkedin-integration-design.md "Quota and blocklist"). dm is zero:
+  // there is no linkedin-scout scenario and cold DM is out of scope for v1.
+  linkedin: {
+    dm: { perDay: 0, perWeek: 0 },
+    comment: { perDay: 8, perWeek: 30 },
+    post: { perDay: 1, perWeek: 4 },
+  },
 } as const;
 
 const BUILTIN_PLAYBOOKS = [
@@ -63,6 +74,17 @@ const BUILTIN_PLAYBOOKS = [
     name: 'Mastodon poster',
     description: 'Draft proactive top-level statuses (toots) for the project.',
   },
+  {
+    slug: 'linkedin-commenter',
+    name: 'LinkedIn commenter',
+    description:
+      'Draft helpful comments on LinkedIn posts the human has already observed in their own browser.',
+  },
+  {
+    slug: 'linkedin-poster',
+    name: 'LinkedIn poster',
+    description: 'Draft proactive top-level LinkedIn posts for the connected profile.',
+  },
 ];
 
 function repoRoot(): string {
@@ -92,6 +114,10 @@ export async function seedCore() {
   await db
     .insert(schema.platforms)
     .values({ slug: 'mastodon', enabled: true })
+    .onConflictDoNothing();
+  await db
+    .insert(schema.platforms)
+    .values({ slug: 'linkedin', enabled: true })
     .onConflictDoNothing();
   await db
     .insert(schema.organizations)

--- a/shared/tests/seed-core.test.ts
+++ b/shared/tests/seed-core.test.ts
@@ -79,3 +79,76 @@ describe('seedCore (mastodon quota defaults + scenarios)', () => {
     });
   });
 });
+
+// Covers LI-2's seed-core contract: linkedin quota defaults are seeded
+// deliberately tighter than every other platform (dm at zero - no
+// linkedin-scout scenario exists), the linkedin platform row seeds
+// idempotently, and the two linkedin scenario slugs are registered so a
+// sibling playbook-writing agent's .md files get picked up (#305).
+describe('seedCore (linkedin platform row + quota defaults + scenarios)', () => {
+  it('defines a linkedin quota tighter than every other platform, with dm at zero', () => {
+    expect(QUOTA_DEFAULTS.linkedin).toBeDefined();
+    const l = QUOTA_DEFAULTS.linkedin;
+    const r = QUOTA_DEFAULTS.reddit;
+    const m = QUOTA_DEFAULTS.mastodon;
+    expect(l.dm.perDay).toBe(0);
+    expect(l.dm.perWeek).toBe(0);
+    expect(l.comment.perDay).toBeLessThan(m.comment.perDay);
+    expect(l.comment.perWeek).toBeLessThan(m.comment.perWeek);
+    expect(l.post.perDay).toBeLessThan(m.post.perDay);
+    expect(l.post.perWeek).toBeLessThan(m.post.perWeek);
+    expect(l.comment.perDay).toBeLessThan(r.comment.perDay);
+    expect(l.post.perDay).toBeLessThan(r.post.perDay);
+  });
+
+  it('seeds the linkedin platform row idempotently: seeding twice still leaves exactly one row', async () => {
+    const db = getDb();
+    await seedCore();
+    await seedCore();
+    const rows = await db
+      .select()
+      .from(schema.platforms)
+      .where(eq(schema.platforms.slug, 'linkedin'));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.enabled).toBe(true);
+  });
+
+  describe('linkedin scenario registration', () => {
+    const LINKEDIN_SLUGS = ['linkedin-commenter', 'linkedin-poster'];
+    let root: string;
+    let originalRoot: string | undefined;
+
+    afterEach(() => {
+      process.env.PITCHBOX_ROOT = originalRoot;
+      if (root) rmSync(root, { recursive: true, force: true });
+    });
+
+    it('registers the two linkedin scenario slugs as built-in playbooks (contract for the sibling playbook agent, #305)', async () => {
+      // #305 owns the actual playbooks/*.md bodies and this worktree's own
+      // playbooks/ dir may not have those files yet - point PITCHBOX_ROOT at a
+      // temp dir with fixture bodies so this exercises the real
+      // readPlaybookBody + seedCore path end to end, proving the slugs
+      // seed-core knows about are exactly the two #305 will reference.
+      originalRoot = process.env.PITCHBOX_ROOT;
+      root = mkdtempSync(join(tmpdir(), 'pitchbox-seed-core-'));
+      mkdirSync(join(root, 'playbooks'), { recursive: true });
+      for (const slug of LINKEDIN_SLUGS) {
+        writeFileSync(join(root, 'playbooks', `${slug}.md`), `# ${slug}\n\nfixture body\n`);
+      }
+      process.env.PITCHBOX_ROOT = root;
+
+      const db = getDb();
+      const out = await seedCore();
+      expect(out.playbooks).toBeGreaterThanOrEqual(LINKEDIN_SLUGS.length);
+
+      const rows = await db
+        .select({ slug: schema.playbooks.slug, isBuiltin: schema.playbooks.isBuiltin })
+        .from(schema.playbooks)
+        .where(eq(schema.playbooks.isBuiltin, true));
+      const slugs = rows.map((r) => r.slug);
+      for (const slug of LINKEDIN_SLUGS) {
+        expect(slugs).toContain(slug);
+      }
+    });
+  });
+});

--- a/web/src/lib/components/projects/ProjectAccountsTab.svelte
+++ b/web/src/lib/components/projects/ProjectAccountsTab.svelte
@@ -34,9 +34,11 @@
   let newPlatform = $state(platforms[0]?.slug ?? 'reddit');
   let newInstanceUrl = $state('');
   let newAccessToken = $state('');
+  let newDisplayName = $state('');
   let busy = $state(false);
 
   let isMastodon = $derived(newPlatform === 'mastodon');
+  let isLinkedin = $derived(newPlatform === 'linkedin');
 
   function platformSlug(id: number) {
     return platforms.find((p) => p.id === id)?.slug ?? `#${id}`;
@@ -58,7 +60,12 @@
         : await fetch(`/api/projects/${projectId}/accounts`, {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ handle: newHandle, role: newRole, platformSlug: newPlatform }),
+            body: JSON.stringify({
+              handle: newHandle,
+              role: newRole,
+              platformSlug: newPlatform,
+              displayName: newDisplayName.trim() || undefined,
+            }),
           });
       if (!res.ok) {
         if (res.status === 403) {
@@ -74,6 +81,7 @@
       newHandle = '';
       newInstanceUrl = '';
       newAccessToken = '';
+      newDisplayName = '';
       addOpen = false;
       await invalidateAll();
     } finally {
@@ -178,6 +186,20 @@
           <p class="text-xs text-muted-foreground">
             Create a token in that instance's Preferences &gt; Development &gt; New application
             (scopes: read + write). Pitchbox verifies it before saving.
+          </p>
+        {:else if isLinkedin}
+          <label class="flex flex-col gap-1 text-xs">
+            Vanity slug
+            <Input bind:value={newHandle} placeholder="linkedin.com/in/your-slug" />
+          </label>
+          <label class="flex flex-col gap-1 text-xs">
+            Display name
+            <Input bind:value={newDisplayName} placeholder="Jane Doe" />
+          </label>
+          <p class="text-xs text-muted-foreground">
+            Pitchbox stores no LinkedIn credential: it never sees your password or session, and it
+            cannot post, comment or message on LinkedIn by itself either. Drafts land in your Inbox
+            and you open LinkedIn and send them yourself.
           </p>
         {:else}
           <label class="flex flex-col gap-1 text-xs">Handle<Input bind:value={newHandle} /></label>

--- a/web/src/lib/platforms/linkedin/presenter.ts
+++ b/web/src/lib/platforms/linkedin/presenter.ts
@@ -1,0 +1,20 @@
+import { registerPresenter, type Presenter } from '../presenter';
+
+export const linkedinPresenter: Presenter = {
+  primaryLabel(d) {
+    // Every kind that reaches the presenter carries the connected profile's
+    // own targetUser except a bare top-level post, which has no recipient.
+    return d.targetUser ? `linkedin.com/in/${d.targetUser}` : 'LinkedIn post';
+  },
+  // The handle is the vanity slug LinkedIn puts in a profile URL
+  // (linkedin.com/in/<handle>), not a conversational @handle - render it as
+  // the profile path instead of prefixing with "@" the way the generic
+  // presenter does.
+  userLabel: (handle) => `linkedin.com/in/${handle}`,
+  eventLabel(event) {
+    return event === 'armed' ? 'Send clicked on LinkedIn' : null;
+  },
+  replyActionLabel: () => 'Reply on LinkedIn',
+};
+
+registerPresenter('linkedin', linkedinPresenter);

--- a/web/src/lib/platforms/register.ts
+++ b/web/src/lib/platforms/register.ts
@@ -4,3 +4,4 @@
 import './reddit/presenter';
 import './hackernews/presenter';
 import './mastodon/presenter';
+import './linkedin/presenter';

--- a/web/src/routes/api/projects/[id]/accounts/+server.ts
+++ b/web/src/routes/api/projects/[id]/accounts/+server.ts
@@ -10,6 +10,10 @@ const PostBody = z.object({
   handle: z.string().min(1).max(64),
   role: z.enum(['personal', 'brand']),
   platformSlug: z.string().min(1),
+  // Only meaningful for platforms with no credential to derive an identity
+  // from (LinkedIn: the vanity slug alone isn't the name a human recognizes).
+  // Ignored by platforms that don't collect it in the connect form.
+  displayName: z.string().max(128).optional(),
 });
 
 function parseId(p: string | undefined): number | null {
@@ -57,6 +61,7 @@ export async function POST(event: RequestEvent) {
       platformId: platform.id,
       handle: parsed.data.handle,
       role: parsed.data.role,
+      displayName: parsed.data.displayName ?? null,
     })
     .returning();
   return json({ account: row }, { status: 201 });

--- a/web/tests/platforms/presenter.test.ts
+++ b/web/tests/platforms/presenter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { getPresenter, isExtensionAutomated } from '../../src/lib/platforms/presenter';
 import '../../src/lib/platforms/reddit/presenter';
 import '../../src/lib/platforms/mastodon/presenter';
+import '../../src/lib/platforms/linkedin/presenter';
 
 describe('presenter registry', () => {
   it('returns Reddit presenter with r/ and u/ semantics', () => {
@@ -56,6 +57,19 @@ describe('presenter registry', () => {
     expect(p.eventLabel('armed')).toBe('Send clicked on Mastodon');
   });
 
+  it('returns LinkedIn presenter with the vanity slug rendered as a profile path, not @handle', () => {
+    const p = getPresenter('linkedin');
+    expect(p.primaryLabel({ kind: 'post_comment', targetUser: 'jane-doe', metadata: {} })).toBe(
+      'linkedin.com/in/jane-doe',
+    );
+    expect(p.primaryLabel({ kind: 'comment_reply', targetUser: 'jane-doe', metadata: {} })).toBe(
+      'linkedin.com/in/jane-doe',
+    );
+    expect(p.primaryLabel({ kind: 'post', targetUser: null, metadata: {} })).toBe('LinkedIn post');
+    expect(p.userLabel('jane-doe')).toBe('linkedin.com/in/jane-doe');
+    expect(p.eventLabel('armed')).toBe('Send clicked on LinkedIn');
+  });
+
   it('falls back to a generic presenter for unknown slugs', () => {
     const p = getPresenter('mystery');
     expect(p.primaryLabel({ kind: 'dm', targetUser: 'bob', metadata: {} })).toBe('@bob');
@@ -72,6 +86,11 @@ describe('isExtensionAutomated', () => {
   it('is false for platforms without a content script (manual send)', () => {
     expect(isExtensionAutomated('hackernews')).toBe(false);
     expect(isExtensionAutomated('mastodon')).toBe(false);
+    // LinkedIn has no content script that arms a send in v1 (#299) - the
+    // extension only offers a drafted comment for the human to send
+    // themselves, it never automates the click (see the compliance boundary
+    // in docs/linkedin-integration-design.md).
+    expect(isExtensionAutomated('linkedin')).toBe(false);
     expect(isExtensionAutomated('mystery')).toBe(false);
   });
 


### PR DESCRIPTION
Closes #299. The foundation edit: the platform layer now knows `linkedin` exists. No behaviour beyond that, and nothing that talks to linkedin.com.

## What landed

The eight enumerations a new platform has to appear in, found by grepping for `mastodon` rather than trusting a list:

| File | What |
| --- | --- |
| `shared/src/campaigns/scenarios.ts:7-16,20,41-104` | `SCENARIO_SLUGS`, `ScenarioPlatformSlug`, two `SCENARIO_META` entries |
| `shared/src/db/seed-core.ts:8-22,24-66,87-95` | `QUOTA_DEFAULTS`, two `BUILTIN_PLAYBOOKS` entries, the `platforms` row |
| `web/src/lib/platforms/register.ts:4-6` | presenter registration |
| `daemon/src/reply-readers.ts:37-40` | `NullReplyReader` |

`AUTO_POST_PLATFORMS` is deliberately untouched: there is no API to post through in v1, so the flag would offer a mode that cannot work.

Two things the audit did not predict. `POST /api/projects/[id]/accounts` needed an optional `displayName`, because the connect form's display-name input had nowhere to land: that route had never accepted one. And `EXTENSION_AUTOMATED_PLATFORMS` was left alone on purpose, since send detection is #306, with a test asserting it is still false for LinkedIn today so the change is deliberate rather than forgotten.

The account model carries no credential at all. `instance_url`, `access_token_encrypted` and `cookie_session` are already nullable and stay null, so no migration and no new column. Unlike Mastodon there is nothing to encrypt, because the authentication is the human's own browser session and it never leaves it.

## Verified, not claimed

I re-ran every acceptance item myself rather than taking the report:

- `pnpm -F @pitchbox/shared typecheck`, `pnpm -F web check` (5790 files, 0 errors), `pnpm -F daemon typecheck`: clean.
- `shared/tests/seed-core.test.ts` + `web/tests/platforms/presenter.test.ts`: 15 tests pass.
- Seeding, against a database created fresh for this check and migrated from zero, run twice: `platforms` came back `reddit,hackernews,mastodon,linkedin` both times, and the quota defaults read back as `dm 0/0, post 1/4, comment 8/30`, exactly the specified values. Idempotency proven by the second run, not asserted.
- `eslint` and `prettier --check` on the changed files: clean. (`ProjectAccountsTab.svelte` is skipped by prettier for lack of a svelte parser, which is repo-wide and not new here.)

## One acceptance item that cannot pass yet, and why I am not faking it

The issue asks the seed to produce "the two playbook rows". It does not. `playbooks` stays at 8.

`readPlaybookBody()` returns null when `playbooks/linkedin-commenter.md` and `linkedin-poster.md` are absent, and `seedCore()`'s loop does `if (!body) continue`, so the two rows are silently skipped. Those files are #305's deliverable and writing them here would mean inventing the product's outreach voice inside a registry change.

The consequence is worth stating plainly rather than leaving to be discovered: from this commit the campaign form offers two LinkedIn scenarios whose playbook row does not exist, and `campaigns.skill_slug` has no foreign key to `playbooks.slug`, so that mismatch surfaces at dispatch and not at creation. It is exactly the invariant the issue named. Noted on #305, which has to land before either scenario is usable.

Not in scope and not touched: `observed_targets` (#300), any endpoint (#301), any extension code (#302, #303), the playbook bodies (#305). `shared/package.json` `exports` is unchanged because no `shared/src/platforms/linkedin/` directory landed here; the design assigns URN parsing to #303, and the two-frontend finding in #322 is why that placement now matters more than it did.
