### PR TITLE
feat(web,shared): real-time suggestion endpoint for the in-page assistant

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -29,6 +29,8 @@
     "./blocklist": "./src/blocklist.ts",
     "./contact-dedup": "./src/contact-dedup.ts",
     "./templates": "./src/templates.ts",
+    "./house-style": "./src/house-style.ts",
+    "./assist/suggest-prompt": "./src/assist/suggest-prompt.ts",
     "./draft-send": "./src/draft-send.ts",
     "./draft-regenerate": "./src/draft-regenerate.ts",
     "./quality-judge": "./src/quality-judge.ts",

--- a/shared/src/agents/acp/runner.ts
+++ b/shared/src/agents/acp/runner.ts
@@ -76,8 +76,16 @@ export class AcpRunner implements AgentRunner {
       const logPath = join(this.logDir, `run-${Date.now()}-${opts.slug}.log`);
       writeFileSync(logPath, `# run ${opts.slug} started ${new Date().toISOString()}\n`, 'utf8');
 
-      const playbook = await readFile(opts.playbookPath, 'utf8');
-      const promptText = buildPrompt(opts, playbook);
+      // A direct `prompt` wins over `playbookPath`; one of the two is required,
+      // because prompting with an empty string burns a spawn and returns nothing.
+      let promptText: string;
+      if (opts.prompt != null) {
+        promptText = opts.prompt;
+      } else if (opts.playbookPath) {
+        promptText = buildPrompt(opts, await readFile(opts.playbookPath, 'utf8'));
+      } else {
+        throw new Error('AcpRunner.run needs either a prompt or a playbookPath');
+      }
 
       const envPass: Record<string, string | undefined> = {};
       for (const key of this.spec.envPassthrough ?? []) {
@@ -217,9 +225,12 @@ export class AcpRunner implements AgentRunner {
           const params = msg.params as { sessionId?: string; update?: unknown } | undefined;
           const updateKind = (params?.update as { sessionUpdate?: string } | null)?.sessionUpdate;
 
-          // Coalesce streamed text chunks into a single rendered event.
+          // Coalesce streamed text chunks into a single rendered event for the
+          // runlog, and hand each chunk straight to a streaming caller.
           if (updateKind === 'agent_message_chunk') {
-            pendingAssistantText += extractChunkText(params?.update);
+            const text = extractChunkText(params?.update);
+            pendingAssistantText += text;
+            if (text) opts.onTextChunk?.(text);
             return;
           }
           if (updateKind === 'agent_thought_chunk') {
@@ -327,7 +338,10 @@ export class AcpRunner implements AgentRunner {
         // into the Agent SDK query). Other backends keep their own defaults today.
         const sessionParams: Record<string, unknown> = {
           cwd: opts.cwd,
-          mcpServers: [buildPitchboxMcpServer(opts)],
+          // `attachMcp: false` opens a session with no tools at all, which is
+          // what a single-turn suggestion wants: nothing to write, and a tool
+          // loop is what a real-time path cannot afford.
+          mcpServers: opts.attachMcp === false ? [] : [buildPitchboxMcpServer(opts)],
         };
         const claudeMeta = buildClaudeCodeMeta(this.slug, this.config);
         if (claudeMeta) sessionParams._meta = claudeMeta;

--- a/shared/src/agents/base.ts
+++ b/shared/src/agents/base.ts
@@ -1,7 +1,27 @@
 import type { ParsedEvent } from '../runlog/types.js';
 
 export interface AgentRunOptions {
-  playbookPath: string;
+  /**
+   * Path to the markdown the agent executes. Optional only because a
+   * playbook-less invocation exists (see `prompt`); every campaign run still
+   * passes it. A runner given neither must fail loudly rather than prompt with
+   * an empty string.
+   */
+  playbookPath?: string;
+  /**
+   * Prompt text supplied directly instead of read from `playbookPath`. Used by
+   * the in-page assistant's suggestion endpoint, which has no playbook and no
+   * `runs` row: one prompt, one turn, streamed back. Wins over `playbookPath`
+   * when both are set.
+   */
+  prompt?: string;
+  /**
+   * Whether to attach the Pitchbox MCP server to the session. Defaults to true,
+   * which is every campaign run: all state is read and written through it. A
+   * suggestion sets this false, because there is nothing for it to write and a
+   * tool loop is exactly what a real-time path cannot afford.
+   */
+  attachMcp?: boolean;
   slug: string;
   env: Record<string, string>;
   cwd: string;
@@ -16,6 +36,14 @@ export interface AgentRunOptions {
   onRawLine?: (line: string) => void;
   /** Called with one or more normalized ParsedEvents extracted from that line. */
   onParsedEvents?: (events: ParsedEvent[]) => void | Promise<void>;
+  /**
+   * Called with each assistant text chunk as it arrives, before any
+   * coalescing. `onParsedEvents` deliberately batches chunks into one event per
+   * message, which is right for a runlog row and useless for a stream: a reader
+   * would get the whole answer at once. A caller that streams to a client uses
+   * this instead.
+   */
+  onTextChunk?: (text: string) => void;
 }
 
 export interface AgentRunResult {

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -1,0 +1,111 @@
+// shared/src/assist/suggest-prompt.ts
+//
+// Composes the prompt behind the in-page assistant's suggestion endpoint
+// (#312). This is not a playbook: no tools, no state, one turn, and nothing it
+// produces is persisted until the human accepts it (#313 owns that).
+//
+// What it deliberately shares with a playbook is the house style. A suggestion
+// is text that goes out under a real name, so it is held to exactly the rules a
+// drafted comment is held to. The section comes from `shared/src/house-style.ts`
+// rather than a second copy, and a test asserts every playbook matches it.
+
+import { HOUSE_STYLE_HEADING, HOUSE_STYLE_SECTION } from '../house-style.js';
+
+/** The two kinds the in-page assistant can suggest. */
+export type SuggestionKind = 'post_comment' | 'post';
+
+export interface ObservedPost {
+  /** The post's URN, when the page exposed one. Feed pages do not; see the
+   * "Two frontends, one identifier" section of docs/linkedin-integration-design.md. */
+  urn?: string;
+  authorHandle?: string;
+  authorName?: string;
+  text: string;
+  url?: string;
+}
+
+export interface ProjectVoice {
+  name: string;
+  description?: string | null;
+  /** Active few-shot templates for this project, already filtered by kind. */
+  examples?: Array<{ title: string; body: string }>;
+}
+
+/** Hard ceiling on the post text we forward. A LinkedIn post is short; anything
+ * past this is either a pasted article or a hostile payload, and neither
+ * improves the suggestion. */
+export const MAX_POST_CHARS = 4000;
+/** How many few-shot examples are worth carrying. More lengthens the prompt
+ * without changing the voice, and the first token is what the human waits on. */
+export const MAX_EXAMPLES = 3;
+
+function clamp(text: string, max: number): string {
+  const t = text.trim();
+  return t.length <= max ? t : `${t.slice(0, max)}\n[truncated]`;
+}
+
+const TASK: Record<SuggestionKind, string> = {
+  post_comment:
+    'Write one comment to leave on the post below. One paragraph, two at most. It has to add something the author or another reader would not already know: a specific experience, a number, a disagreement worth having. If you have nothing to add, say so in one sentence instead of padding.',
+  post: 'Write one short post for this account, taking the post below as the starting point rather than something to summarise. Say one thing and stop.',
+};
+
+/**
+ * Builds the single-turn prompt. Pure and synchronous: everything it needs is
+ * passed in, so it is testable without a database and cannot reach one.
+ */
+export function buildSuggestionPrompt(args: {
+  kind: SuggestionKind;
+  post: ObservedPost;
+  project: ProjectVoice;
+  /** Optional steer the human typed into the panel. */
+  hint?: string;
+}): string {
+  const { kind, post, project } = args;
+  const parts: string[] = [];
+
+  parts.push(
+    `You are drafting for ${project.name}, whose operator will read what you write, edit it if they want, and post it themselves under their own name. Nothing you write is sent by anyone but them.`,
+  );
+  if (project.description?.trim()) {
+    parts.push(`What ${project.name} is:\n${clamp(project.description, 1200)}`);
+  }
+
+  const examples = (project.examples ?? []).slice(0, MAX_EXAMPLES);
+  if (examples.length > 0) {
+    parts.push(
+      [
+        'Things this account has written before. Match this voice, do not reuse the content:',
+        ...examples.map((e) => `- ${e.title}: ${clamp(e.body, 600)}`),
+      ].join('\n'),
+    );
+  }
+
+  const who = post.authorName ?? post.authorHandle ?? 'someone';
+  parts.push(
+    [
+      `The post, by ${who}${post.url ? ` (${post.url})` : ''}:`,
+      '"""',
+      clamp(post.text, MAX_POST_CHARS),
+      '"""',
+    ].join('\n'),
+  );
+
+  parts.push(`Your task: ${TASK[kind]}`);
+
+  if (args.hint?.trim()) {
+    parts.push(
+      `The operator added this steer, which outranks your own angle but not the house style:\n${clamp(args.hint, 500)}`,
+    );
+  }
+
+  parts.push(`${HOUSE_STYLE_HEADING}${HOUSE_STYLE_SECTION}`);
+
+  // Last, because it is the instruction most often lost in the middle of a
+  // prompt, and a suggestion wrapped in commentary is one the panel cannot show.
+  parts.push(
+    'Reply with the text itself and nothing else. No preamble, no quotes around it, no explanation of your choices, no options to pick from.',
+  );
+
+  return parts.join('\n\n');
+}

--- a/shared/src/house-style.ts
+++ b/shared/src/house-style.ts
@@ -1,0 +1,19 @@
+// shared/src/house-style.ts
+//
+// The canonical "House style" rules. Every playbook carries this section verbatim
+// in its own body, because a playbook body ships standalone (seeded into
+// `playbooks.body` and handed to the agent as the whole prompt, with no include
+// mechanism). This module is the copy that non-playbook prompts use, and
+// `shared/tests/playbook-house-style.test.ts` asserts every playbook section
+// equals it, so there is one text with many copies rather than many texts.
+//
+// It is deliberately byte-identical to what the playbooks carry today, including
+// the platform list, which names the three platforms whose playbooks existed when
+// it was written. Adding LinkedIn to that sentence means editing every playbook in
+// the same commit; the test is what makes that safe.
+
+export const HOUSE_STYLE_HEADING = '## House style: write like a human';
+
+/** The section body, exactly as it appears in every playbook after the heading. */
+export const HOUSE_STYLE_SECTION =
+  '\n\nEverything you draft is read by people who spot machine-written text instantly, and on Reddit, Hacker News and Mastodon that alone gets a message ignored, downvoted or reported. Write the way a real person types. This applies to every piece of text you produce (bodies, titles, `reasoning`, summaries), and campaign config can only tighten these rules, never relax them.\n\nCharacters to never emit: em dashes, en dashes between words, curly quotes, curly apostrophes, the single-character ellipsis, non-breaking spaces. Use plain ASCII instead: hyphens, straight quotes, straight apostrophes, three dots when you really need them.\n\nPhrases and habits to never use:\n\n- Filler openers: "Great question", "Great post", "Hope this finds you well", "Thanks for sharing", "You\'re absolutely right".\n- The "not just X, but Y" and "it\'s not X, it\'s Y" constructions.\n- Rule-of-three lists where two items would do, and triads stacked inside one sentence.\n- Puffery: "leverage", "seamless", "robust", "comprehensive", "delve", "unlock", "elevate", "game-changer", "in today\'s fast-paced world".\n- Wrap-up closers: "hope this helps", "at the end of the day", "the bottom line is", "happy to chat", "let me know if you have any questions".\n- Bold labels sprinkled through a short body, section headings inside a comment or DM, emoji as decoration.\n- Symmetrical hedging ("while X has its merits, Y also offers benefits") and restating the question before answering it.\n\nWrite like this instead:\n\n- Vary sentence length. Let one sentence run long and the next be four words.\n- Use contractions, and open a sentence with "and" or "but" when that is how it reads.\n- Be concrete. A number, a name, a specific thing that happened is the strongest human signal there is.\n- Take a position. Say the thing directly instead of surveying both sides of it.\n- Leave the small imperfections in: a fragment, an aside in parentheses, the ordinary word instead of the precise one.\n- Reread the draft and ask whether a person would actually type this sentence into a comment box. If not, rewrite it.\n';

--- a/shared/tests/playbook-house-style.test.ts
+++ b/shared/tests/playbook-house-style.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { HOUSE_STYLE_HEADING, HOUSE_STYLE_SECTION } from '../src/house-style.js';
 
 // Every playbook carries the same verbatim "House style" section: the rules that
 // keep drafted outreach reading like a person wrote it. The section is duplicated
@@ -46,19 +47,33 @@ describe('playbooks house style', () => {
     expect(bodies.get(file)).toContain(HEADING);
   });
 
-  it('keeps the section byte-identical across every playbook', () => {
-    const reference = houseStyleSection(bodies.get(files[0]!)!);
-    expect(reference.length).toBeGreaterThan(500);
+  it('keeps the section byte-identical across every playbook, and equal to the shared constant', () => {
+    // The constant is what non-playbook prompts use (the in-page assistant's
+    // suggestion endpoint), so a playbook that drifts from it means a suggestion
+    // and a drafted comment are held to different rules.
+    expect(HOUSE_STYLE_SECTION.length).toBeGreaterThan(500);
     for (const file of files) {
-      expect(houseStyleSection(bodies.get(file)!), `${file} diverged from ${files[0]}`).toBe(
-        reference,
-      );
+      expect(
+        houseStyleSection(bodies.get(file)!),
+        `${file} diverged from the shared constant`,
+      ).toBe(HOUSE_STYLE_SECTION);
     }
   });
 
+  it('uses the same heading as the playbooks', () => {
+    expect(HOUSE_STYLE_HEADING).toBe(HEADING);
+  });
+
   it('states the rule outranks campaign config', () => {
-    const reference = houseStyleSection(bodies.get(files[0]!)!);
-    expect(reference).toMatch(/campaign config can only tighten these rules, never relax them/);
+    expect(HOUSE_STYLE_SECTION).toMatch(
+      /campaign config can only tighten these rules, never relax them/,
+    );
+  });
+
+  it('the shared constant contains no AI typography either', () => {
+    for (const [char, name] of BANNED_CHARS) {
+      expect(HOUSE_STYLE_SECTION.indexOf(char), `shared constant contains ${name}`).toBe(-1);
+    }
   });
 
   it.each(files)('%s contains no AI typography', (file) => {

--- a/shared/tests/suggest-prompt.test.ts
+++ b/shared/tests/suggest-prompt.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSuggestionPrompt,
+  MAX_EXAMPLES,
+  MAX_POST_CHARS,
+} from '../src/assist/suggest-prompt.js';
+import { HOUSE_STYLE_SECTION } from '../src/house-style.js';
+
+// The prompt behind the in-page assistant. Pure, so the boundaries are worth
+// pinning: a suggestion is text that goes out under a real name, and the two
+// things that decide whether it is usable are the house style being present and
+// the prompt not being padded with content that does not change the answer.
+
+const post = { text: 'We cut p99 in half by dropping a cache.', authorName: 'Giulia Bianchi' };
+const project = { name: 'Embertold', description: 'A world wiki for tabletop GMs.' };
+
+describe('buildSuggestionPrompt', () => {
+  it('carries the house style verbatim, not a paraphrase of it', () => {
+    const prompt = buildSuggestionPrompt({ kind: 'post_comment', post, project });
+    expect(prompt).toContain(HOUSE_STYLE_SECTION);
+  });
+
+  it('asks for the text alone, since the panel cannot render commentary', () => {
+    const prompt = buildSuggestionPrompt({ kind: 'post_comment', post, project });
+    expect(prompt).toMatch(/Reply with the text itself and nothing else/);
+    // And that instruction is last, where it is least likely to be lost.
+    expect(prompt.trimEnd().endsWith('no options to pick from.')).toBe(true);
+  });
+
+  it('states that the human posts it, which is the whole compliance premise', () => {
+    const prompt = buildSuggestionPrompt({ kind: 'post_comment', post, project });
+    expect(prompt).toMatch(/post it themselves under their own name/);
+  });
+
+  it('truncates a post longer than the cap instead of forwarding it whole', () => {
+    const long = 'x'.repeat(MAX_POST_CHARS + 5000);
+    const prompt = buildSuggestionPrompt({ kind: 'post_comment', post: { text: long }, project });
+    expect(prompt).toContain('[truncated]');
+    expect(prompt.length).toBeLessThan(long.length);
+  });
+
+  it('caps the few-shot examples', () => {
+    const examples = Array.from({ length: MAX_EXAMPLES + 4 }, (_, i) => ({
+      title: `ex-${i}`,
+      body: `body ${i}`,
+    }));
+    const prompt = buildSuggestionPrompt({
+      kind: 'post_comment',
+      post,
+      project: { ...project, examples },
+    });
+    const used = examples.filter((e) => prompt.includes(e.title));
+    expect(used).toHaveLength(MAX_EXAMPLES);
+  });
+
+  it('subordinates the operator hint to the house style rather than above it', () => {
+    const prompt = buildSuggestionPrompt({
+      kind: 'post_comment',
+      post,
+      project,
+      hint: 'be blunt about the cache',
+    });
+    expect(prompt).toContain('be blunt about the cache');
+    expect(prompt).toMatch(/outranks your own angle but not the house style/);
+  });
+
+  it('asks for different things for a comment and a post', () => {
+    const comment = buildSuggestionPrompt({ kind: 'post_comment', post, project });
+    const standalone = buildSuggestionPrompt({ kind: 'post', post, project });
+    expect(comment).not.toBe(standalone);
+    expect(comment).toMatch(/comment to leave on the post/);
+    expect(standalone).toMatch(/short post for this account/);
+  });
+
+  it('never emits the typography the house style bans', () => {
+    const prompt = buildSuggestionPrompt({
+      kind: 'post_comment',
+      post,
+      project,
+      hint: 'anything',
+    });
+    for (const char of ['\u2014', '\u2013', '\u2018', '\u2019', '\u201c', '\u201d', '\u2026']) {
+      expect(prompt.includes(char), `prompt contains ${JSON.stringify(char)}`).toBe(false);
+    }
+  });
+});

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -1,0 +1,161 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getDb } from './db.js';
+import { createAgentRunner } from '@pitchbox/shared/agents/registry';
+import type { AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
+import { loadRunnerConfig } from '@pitchbox/shared/agents/config';
+import {
+  buildSuggestionPrompt,
+  type ObservedPost,
+  type ProjectVoice,
+  type SuggestionKind,
+} from '@pitchbox/shared/assist/suggest-prompt';
+
+/**
+ * Runs one suggestion: a single-turn agent invocation with no playbook, no MCP
+ * server and no `runs` row, streaming its text out as it is produced.
+ *
+ * It goes through the same `AgentRunner` a campaign run goes through, on
+ * purpose. The alternative was a second spawn path next to the first, which
+ * would drift: this way the cloud edition dispatches a suggestion to the
+ * managed runner exactly as it dispatches a run, and a self-host with a local
+ * agent CLI spawns it locally, with no per-edition branch here.
+ *
+ * No provider API key is introduced. Pitchbox authenticates through the
+ * human's own subscription, and requiring a key would break self-hosting to
+ * save a few seconds of first-token latency. Expect five to ten seconds,
+ * dominated by process spawn; #318 is the recorded follow-up if that proves
+ * too slow in real use.
+ */
+export interface SuggestionResult {
+  text: string;
+  ms: number;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    costUsd: number | null;
+  };
+}
+
+export interface SuggestionHandle {
+  result: Promise<SuggestionResult>;
+  cancel: () => void;
+}
+
+/** A suggestion the human is waiting on has a much shorter patience than a
+ * campaign run. Past this the answer is not worth having. */
+const SUGGESTION_TIMEOUT_MS = 90_000;
+
+export function runSuggestion(args: {
+  kind: SuggestionKind;
+  post: ObservedPost;
+  project: ProjectVoice;
+  hint?: string;
+  projectId: number;
+  orgId?: number;
+  runnerSlug: string;
+  onFirstChunk?: () => void;
+  onChunk?: (text: string) => void;
+}): SuggestionHandle {
+  const prompt = buildSuggestionPrompt({
+    kind: args.kind,
+    post: args.post,
+    project: args.project,
+    hint: args.hint,
+  });
+
+  // `cancel()` can arrive before the runner exists: resolving its config and
+  // making a temp directory are both awaits, and a human who closes the panel
+  // immediately lands in that window. A cancel that only forwards to a handle
+  // would do nothing there and the agent would then start and run to
+  // completion for nobody, which is the exact failure this path exists to
+  // prevent. So the flag is authoritative and the handle is best-effort.
+  let cancelHandle: (() => void) | null = null;
+  let cancelled = false;
+  const cancel = () => {
+    cancelled = true;
+    cancelHandle?.();
+  };
+  const started = Date.now();
+
+  class Cancelled extends Error {
+    constructor() {
+      super('cancelled');
+    }
+  }
+
+  const result: Promise<SuggestionResult> = (async () => {
+    const db = getDb();
+    if (cancelled) throw new Cancelled();
+    const config = await loadRunnerConfig(db, args.runnerSlug as AgentRunnerSlug);
+    if (cancelled) throw new Cancelled();
+    const runner = createAgentRunner(args.runnerSlug, config);
+
+    // The agent still gets a working directory, and it must not be the repo:
+    // this session has no tools attached, but a cwd it could read is a cwd it
+    // should not have. An empty temp directory is the smallest thing that
+    // satisfies the ACP `session/new` contract.
+    const cwd = await mkdtemp(join(tmpdir(), 'pitchbox-suggest-'));
+    // Last gate before the spawn, and the one that matters most: past here a
+    // process exists and only the handle can stop it.
+    if (cancelled) {
+      await rm(cwd, { recursive: true, force: true }).catch(() => {});
+      throw new Cancelled();
+    }
+
+    let text = '';
+    let sawChunk = false;
+
+    try {
+      const handle = runner.run({
+        prompt,
+        attachMcp: false,
+        slug: `assist-${args.kind}`,
+        env: {},
+        cwd,
+        timeoutMs: SUGGESTION_TIMEOUT_MS,
+        orgId: args.orgId,
+        onTextChunk: (chunk) => {
+          if (!sawChunk) {
+            sawChunk = true;
+            args.onFirstChunk?.();
+          }
+          text += chunk;
+          args.onChunk?.(chunk);
+        },
+      });
+      cancelHandle = handle.cancel;
+      // A cancel that landed between the last gate and this assignment still
+      // has to reach the process it just missed.
+      if (cancelled) handle.cancel();
+      const run = await handle.result;
+
+      if (cancelled) throw new Cancelled();
+      if (!text.trim()) {
+        // A zero-text turn is a failure the panel has to be told about: an
+        // empty suggestion area with a "done" event reads as a broken panel.
+        throw new Error(
+          run.exitCode === 0
+            ? 'the agent produced no text'
+            : `the agent exited ${run.exitCode} without producing text`,
+        );
+      }
+      return {
+        text: text.trim(),
+        ms: Date.now() - started,
+        usage: run.usage
+          ? {
+              inputTokens: run.usage.inputTokens,
+              outputTokens: run.usage.outputTokens,
+              costUsd: run.usage.costUsd,
+            }
+          : undefined,
+      };
+    } finally {
+      await rm(cwd, { recursive: true, force: true }).catch(() => {});
+    }
+  })();
+
+  return { result, cancel };
+}

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -1,0 +1,199 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import { getDb, schema } from '$lib/server/db.js';
+import { requireExtensionAuth } from '$lib/server/extension-auth.js';
+import { RateLimiter } from '$lib/server/rate-limit.js';
+import { runSuggestion } from '$lib/server/suggest.js';
+import { loadActiveTemplates } from '@pitchbox/shared/templates';
+import { getAccountUsage, checkQuota, loadQuotaLimits } from '@pitchbox/shared/quota';
+import { mapDraftKindToQuotaKind } from '@pitchbox/shared/quota-types';
+import { MAX_POST_CHARS, type SuggestionKind } from '@pitchbox/shared/assist/suggest-prompt';
+
+// The real-time plane. What makes the in-page assistant a separate subsystem
+// rather than a view onto campaigns:
+//
+//   - No `runs` row and no draft. A suggestion is ephemeral until the human
+//     accepts it, and #313 owns what happens then. Mixing the two planes here
+//     is the mistake the design exists to avoid.
+//   - No playbook and no MCP server. One prompt, one turn, streamed out.
+//   - The API is the enforcement boundary, not the panel: auth, org scoping,
+//     rate limit and quota are all decided here.
+
+// Per device. A human reads a suggestion before asking for another, so this is
+// generous for real use and still bounds what a stolen token can spend.
+const perDevice = new RateLimiter(20, 60_000);
+// Per org, so one compromised device cannot spend a whole tenant's budget and
+// several legitimate devices still add up to something sane.
+const perOrg = new RateLimiter(60, 60_000);
+
+const BodySchema = z.object({
+  projectId: z.number().int().positive(),
+  kind: z.enum(['post_comment', 'post']),
+  post: z.object({
+    urn: z.string().max(200).optional(),
+    authorHandle: z.string().max(200).optional(),
+    authorName: z.string().max(200).optional(),
+    text: z
+      .string()
+      .min(1)
+      .max(MAX_POST_CHARS * 2),
+    url: z.string().max(2000).optional(),
+  }),
+  hint: z.string().max(500).optional(),
+  platform: z.string().min(1).max(40).default('linkedin'),
+});
+
+function sse(controller: ReadableStreamDefaultController, encoder: TextEncoder) {
+  return (kind: string, data: unknown) => {
+    controller.enqueue(encoder.encode(`event: ${kind}\ndata: ${JSON.stringify(data)}\n\n`));
+  };
+}
+
+export async function POST(event: RequestEvent) {
+  const auth = await requireExtensionAuth(event.request);
+
+  // Both limiters are consumed before any await that could interleave, which is
+  // what makes a synchronous check-and-increment safe (see rate-limit.ts).
+  if (!perDevice.consume(`device:${auth.deviceId}`)) throw error(429, 'too many suggestions');
+  if (auth.organizationId != null && !perOrg.consume(`org:${auth.organizationId}`)) {
+    throw error(429, 'too many suggestions for this organization');
+  }
+
+  const parsed = BodySchema.safeParse(await event.request.json());
+  if (!parsed.success) throw error(400, parsed.error.issues[0]?.message ?? 'invalid body');
+  const body = parsed.data;
+
+  const db = getDb();
+
+  // Org scoping: a device bound to an org may only write as one of its own
+  // projects, and an unknown project is a 404 rather than a 403 so it leaks
+  // nothing about other tenants' ids. A null-org device (self-host, auth off)
+  // is unrestricted, mirroring requireRole.
+  const [project] = await db
+    .select()
+    .from(schema.projects)
+    .where(
+      auth.organizationId == null
+        ? eq(schema.projects.id, body.projectId)
+        : and(
+            eq(schema.projects.id, body.projectId),
+            eq(schema.projects.organizationId, auth.organizationId),
+          ),
+    )
+    .limit(1);
+  if (!project) throw error(404, 'project not found');
+
+  // Suggesting what cannot be sent wastes the human's attention and a model
+  // call, so the platform's own daily quota is a precondition and not a
+  // post-hoc check. The refusal is a 200 with a body the panel can render:
+  // a 500 would look like a defect, and this is the system working.
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, body.platform))
+    .limit(1);
+  if (!platform) throw error(400, `unknown platform: ${body.platform}`);
+
+  const [account] = await db
+    .select()
+    .from(schema.accounts)
+    .where(
+      and(
+        eq(schema.accounts.projectId, project.id),
+        eq(schema.accounts.platformId, platform.id),
+        eq(schema.accounts.active, true),
+      ),
+    )
+    .limit(1);
+
+  if (account) {
+    const quotaKind = mapDraftKindToQuotaKind(body.kind);
+    const [limits, usage] = await Promise.all([
+      loadQuotaLimits(db, platform.slug),
+      getAccountUsage(db, account.id),
+    ]);
+    const day = checkQuota({
+      platformLimit: limits[quotaKind].perDay,
+      accountLimit: account.dailyLimit,
+      used: usage[quotaKind].day,
+    });
+    if (day.remaining <= 0) {
+      return json({
+        refused: 'quota_exhausted',
+        kind: quotaKind,
+        window: 'day',
+        limit: day.limit,
+        used: day.used,
+        boundBy: day.kind,
+      });
+    }
+  }
+
+  const examples = (
+    await loadActiveTemplates(db, {
+      projectId: project.id,
+      kind: body.kind === 'post' ? 'post' : 'comment',
+    })
+  ).map((t) => ({ title: t.title, body: t.body }));
+
+  let cancel: () => void = () => {};
+  let settled = false;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const send = sse(controller, encoder);
+
+      // Padding first: Chrome buffers a small event-stream body until it has
+      // enough of it, which would hide exactly the early chunks this endpoint
+      // exists to deliver.
+      controller.enqueue(encoder.encode(': ' + ' '.repeat(2048) + '\n\n'));
+      send('status', { phase: 'reading' });
+
+      const handle = runSuggestion({
+        kind: body.kind as SuggestionKind,
+        post: body.post,
+        project: { name: project.name, description: project.description, examples },
+        hint: body.hint,
+        projectId: project.id,
+        orgId: auth.organizationId ?? undefined,
+        runnerSlug: project.defaultAgentRunner,
+        onFirstChunk: () => send('status', { phase: 'writing' }),
+        onChunk: (text) => send('chunk', { text }),
+      });
+      cancel = handle.cancel;
+
+      handle.result
+        .then((res) => {
+          if (settled) return;
+          settled = true;
+          send('done', { text: res.text, usage: res.usage, ms: res.ms });
+          controller.close();
+        })
+        .catch((err: unknown) => {
+          if (settled) return;
+          settled = true;
+          send('failed', { message: err instanceof Error ? err.message : String(err) });
+          controller.close();
+        });
+    },
+    cancel() {
+      // The human scrolled away or closed the panel. Cancelling here is the
+      // difference between a stream nobody reads and a model call nobody pays
+      // for; without it the agent process runs to completion unobserved.
+      settled = true;
+      cancel();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+      'x-accel-buffering': 'no',
+    },
+  });
+}

--- a/web/tests/extension-suggest.test.ts
+++ b/web/tests/extension-suggest.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type { AgentRunHandle, AgentRunOptions, AgentRunner } from '@pitchbox/shared/agents';
+
+/**
+ * The real-time suggestion endpoint (#312). What these tests defend is the
+ * enforcement boundary and the stream's contract, because the panel is not the
+ * boundary: auth, cross-tenant scoping, an exhausted quota, incremental
+ * delivery, and a disconnect actually cancelling the model call rather than
+ * leaving it running for nobody.
+ *
+ * The agent itself is the one thing faked. Everything below it is real: the
+ * route, the quota read, the prompt composition and the SSE framing.
+ */
+
+const chunks = ['A specific ', 'thing that ', 'happened.'];
+let lastOptions: AgentRunOptions | null = null;
+let cancelCalls = 0;
+/** Set by a test to hold the fake agent open so a disconnect can be observed. */
+let hangForever = false;
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (): AgentRunner => ({
+    slug: 'fake',
+    run(opts: AgentRunOptions): AgentRunHandle {
+      lastOptions = opts;
+      let stop: (() => void) | null = null;
+      const result = new Promise<never>((_resolve, reject) => {
+        stop = () => reject(new Error('cancelled'));
+      }).catch((e: unknown) => {
+        throw e;
+      }) as unknown as Promise<{ exitCode: number; logPath: string }>;
+
+      if (hangForever) {
+        return {
+          result,
+          cancel: () => {
+            cancelCalls += 1;
+            stop?.();
+          },
+        };
+      }
+      for (const c of chunks) opts.onTextChunk?.(c);
+      return {
+        result: Promise.resolve({
+          exitCode: 0,
+          logPath: '/dev/null',
+          usage: {
+            inputTokens: 1200,
+            outputTokens: 40,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            costUsd: 0.004,
+            costReported: true,
+          },
+        }),
+        cancel: () => {
+          cancelCalls += 1;
+        },
+      };
+    },
+  }),
+}));
+
+const { POST: suggest } = await import('../src/routes/api/extension/suggest/+server.js');
+const { runSuggestion } = await import('../src/lib/server/suggest.js');
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, contact_history, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  lastOptions = null;
+  cancelCalls = 0;
+  hangForever = false;
+}
+
+async function seedOrgProject(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug, description: `about ${slug}` })
+    .returning();
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'));
+  return { org, project, platform };
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({ organizationId, tokenHash: tokenHash(token), label: 'test' });
+}
+
+function request(token: string | null, body: unknown) {
+  return new Request('http://x/api/extension/suggest', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+/** Reads an SSE body into its parsed events, in order. */
+async function readEvents(res: Response): Promise<Array<{ kind: string; data: unknown }>> {
+  const text = await res.text();
+  return text
+    .split('\n\n')
+    .map((block) => {
+      const kind = /^event: (.+)$/m.exec(block)?.[1];
+      const data = /^data: (.+)$/m.exec(block)?.[1];
+      return kind && data ? { kind, data: JSON.parse(data) } : null;
+    })
+    .filter((e): e is { kind: string; data: unknown } => e !== null);
+}
+
+const POST_BODY = {
+  kind: 'post_comment' as const,
+  post: {
+    urn: 'urn:li:activity:7000000000000000001',
+    authorName: 'Giulia Bianchi',
+    text: 'We cut p99 in half.',
+  },
+};
+
+describe('POST /api/extension/suggest', () => {
+  beforeEach(reset);
+
+  it('refuses a request with no bearer token', async () => {
+    await expect(
+      suggest({ request: request(null, { ...POST_BODY, projectId: 1 }) } as never),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('404s a project outside the device org, so it leaks no other tenant ids', async () => {
+    const { project: bProject } = await seedOrgProject('org-b');
+    const { org: orgA } = await seedOrgProject('org-a');
+    await mintDevice(orgA.id, 'tokA');
+
+    await expect(
+      suggest({ request: request('tokA', { ...POST_BODY, projectId: bProject.id }) } as never),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('streams the suggestion in chunks and closes with a terminal event', async () => {
+    const { org, project } = await seedOrgProject('org-a');
+    await mintDevice(org.id, 'tok');
+
+    const res = await suggest({
+      request: request('tok', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+    const events = await readEvents(res);
+    const kinds = events.map((e) => e.kind);
+    // Incremental: one event per chunk, not one event carrying the whole answer.
+    expect(kinds.filter((k) => k === 'chunk')).toHaveLength(chunks.length);
+    expect(kinds).toContain('status');
+    expect(kinds[kinds.length - 1]).toBe('done');
+
+    const done = events.at(-1)!.data as { text: string; usage?: { outputTokens: number } };
+    expect(done.text).toBe(chunks.join(''));
+    expect(done.usage?.outputTokens).toBe(40);
+  });
+
+  it('attaches no MCP server and passes a prompt rather than a playbook', async () => {
+    const { org, project } = await seedOrgProject('org-a');
+    await mintDevice(org.id, 'tok');
+    await readEvents(
+      await suggest({ request: request('tok', { ...POST_BODY, projectId: project.id }) } as never),
+    );
+
+    expect(lastOptions?.attachMcp).toBe(false);
+    expect(lastOptions?.playbookPath).toBeUndefined();
+    expect(lastOptions?.prompt).toContain('We cut p99 in half.');
+    // The house style is not optional on this path: a suggestion is text that
+    // goes out under a real name.
+    expect(lastOptions?.prompt).toContain('House style: write like a human');
+  });
+
+  it('writes no runs row and no draft', async () => {
+    const { org, project } = await seedOrgProject('org-a');
+    await mintDevice(org.id, 'tok');
+    await readEvents(
+      await suggest({ request: request('tok', { ...POST_BODY, projectId: project.id }) } as never),
+    );
+
+    const runs = await getDb().select().from(schema.runs);
+    const drafts = await getDb().select().from(schema.drafts);
+    expect(runs).toHaveLength(0);
+    expect(drafts).toHaveLength(0);
+  });
+
+  it('refuses with a renderable body, not a 500, when the daily quota is spent', async () => {
+    const db = getDb();
+    const { org, project, platform } = await seedOrgProject('org-a');
+    await mintDevice(org.id, 'tok');
+    // A LinkedIn account whose own daily limit is already zero: the binding
+    // limit is the smaller of platform and account, so this exhausts it
+    // without depending on the platform defaults.
+    await db
+      .insert(schema.accounts)
+      .values({
+        projectId: project.id,
+        platformId: platform.id,
+        handle: 'lorenzo',
+        dailyLimit: 0,
+        active: true,
+      })
+      .returning();
+
+    const res = await suggest({
+      request: request('tok', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = (await res.json()) as { refused: string; window: string };
+    expect(body.refused).toBe('quota_exhausted');
+    expect(body.window).toBe('day');
+    // And it never reached the agent.
+    expect(lastOptions).toBeNull();
+  });
+
+  // A disconnect has two windows, and the first one is the one that bites:
+  // resolving the runner config and making a temp directory are awaits, so a
+  // human who closes the panel immediately cancels something that does not
+  // exist yet. The invariant both tests defend is the same one, stated as an
+  // effect rather than a call count: no model call is left running for nobody.
+  it('never starts the agent when cancelled before it spawns', async () => {
+    const { project } = await seedOrgProject('org-a');
+    hangForever = true;
+
+    // Driven through the service rather than the route, because this window is
+    // only observable by awaiting the rejection: by the time the route's stream
+    // is cancelled the response is already closed, so an assertion made right
+    // after the cancel would run before the spawn could have happened and pass
+    // whether or not the gate exists.
+    const handle = runSuggestion({
+      kind: 'post_comment',
+      post: POST_BODY.post,
+      project: { name: project.name, description: project.description },
+      projectId: project.id,
+      runnerSlug: project.defaultAgentRunner,
+    });
+    handle.cancel();
+
+    await expect(handle.result).rejects.toThrow('cancelled');
+    expect(lastOptions).toBeNull();
+    expect(cancelCalls).toBe(0);
+  });
+
+  it('cancels a running agent when the client disconnects after it spawned', async () => {
+    const { org, project } = await seedOrgProject('org-a');
+    await mintDevice(org.id, 'tok');
+    hangForever = true;
+
+    const res = await suggest({
+      request: request('tok', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    const reader = res.body!.getReader();
+    await reader.read(); // the padding
+    // Wait for the spawn itself, so this test is about the window it names.
+    await vi.waitFor(() => expect(lastOptions).not.toBeNull());
+    await reader.cancel();
+
+    await vi.waitFor(() => expect(cancelCalls).toBeGreaterThan(0));
+  });
+});


### PR DESCRIPTION
Closes #312. The real-time plane: a synchronous request in, a streamed suggestion out. No cron, no playbook, no MCP server, and no `runs` row driving it.

## The endpoint

`POST /api/extension/suggest`, on the existing device bearer token and org-scoped like every other extension route. A project outside the device's org is a 404 rather than a 403, so it leaks no other tenant's ids. Server-sent events, one per chunk, because D12 already decided that a mute wait longer than about a second reads as stuck.

An exhausted daily quota returns a 200 with `{ refused: 'quota_exhausted', ... }`, not an error. Suggesting what cannot be sent wastes the human's attention and a model call, and a 500 would look like a defect when the system is working exactly as intended. It never reaches the agent, which the tests assert.

## One runner, not a second spawn path

The suggestion goes through the same `AgentRunner` a campaign run goes through. That needed three additions to its options, each with a reason the interface did not already cover:

- `prompt` instead of `playbookPath`, since there is no playbook. One of the two is required; prompting with an empty string burns a spawn and returns nothing.
- `attachMcp: false`, opening a session with no tools at all. Nothing to write, and a tool loop is what a real-time path cannot afford.
- `onTextChunk`, for per-chunk delivery. `onParsedEvents` deliberately batches chunks into one event per message, which is right for a runlog row and useless for a stream: a reader would get the whole answer at once.

The payoff is that the cloud edition dispatches a suggestion to the managed runner exactly as it dispatches a run, with no per-edition branch in the endpoint. That matters more than it looks: the Docker images omit the local agent CLIs on purpose, so a local-spawn-only implementation would have worked in dev and been dead in preview and prod. The private adapter carries the same two options and sends the prompt through the `playbook` field the protocol already has, so the wire contract is unchanged (`cloud/adapter` bumped in this PR).

No provider API key. Pitchbox authenticates through the human's own subscription, and requiring a key would break self-hosting to save a few seconds of first-token latency. #318 is the recorded follow-up if five to ten seconds proves too slow in real use.

## The house style is now one text, not fourteen copies

A suggestion is text that goes out under a real name, so it is held to exactly the rules a drafted comment is held to. `shared/src/house-style.ts` holds the canonical section and `shared/tests/playbook-house-style.test.ts` now asserts every playbook's copy equals it byte for byte, which is a stronger invariant than the copies matching each other. The constant is byte-identical to what the playbooks carry today, including the sentence naming three platforms: adding LinkedIn there means editing every playbook in the same commit, and #305 has to carry the section anyway.

## The bug the tests found, and the test that did not find it

Cancelling only forwarded to the runner's handle. But a disconnect has two windows: resolving the runner config and creating the temp cwd are both awaits, so a human who closed the panel immediately cancelled something that did not exist yet, and the agent then started and ran to completion for nobody. That is precisely the failure the issue's third scope point exists to prevent. The flag is now authoritative, the handle best-effort, with a gate before the spawn and one after it for the cancel that lands in between.

Worth flagging because I nearly shipped a green test that proved nothing: my first version asserted `lastOptions` was still null right after the cancel, and `vi.waitFor` on an already-true assertion returns immediately, before the spawn could have happened. It passed on the unfixed code. The test now drives the service directly and awaits the rejection, and I verified it fails without the gates: `AssertionError: expected { …(8) } to be null`.

## Verification

- `shared/tests/suggest-prompt.test.ts`, `shared/tests/playbook-house-style.test.ts`, `web/tests/extension-suggest.test.ts`: 47 tests pass.
- The eight route tests cover the issue's acceptance list: 401 with no token, 404 cross-org, incremental chunks plus a terminal event, a quota refusal that never reaches the agent, both disconnect windows, and the two invariants stated as assertions rather than comments (no `runs` row and no draft; `attachMcp` false and no `playbookPath`).
- `pnpm -F @pitchbox/shared typecheck`, `pnpm -F web check` (5797 files, 0 errors), `pnpm -F daemon typecheck`, repo-wide `prettier --check` and `eslint`: clean.
- `cloud/adapter`: its own `typecheck` and 21 tests pass.

Not in scope: the panel that consumes this (#314), the ledger write on accept (#313), and the session pool (#318). The manual latency measurement the issue asks for needs a real post in a browser, which is #314's territory; nothing here has been timed against a live model call yet, and I have not claimed otherwise.
