### PR TITLE
feat(shared,daemon): observed_targets table and ingest service for browser-observed posts

### DIFF
--- a/daemon/src/retention.ts
+++ b/daemon/src/retention.ts
@@ -1,8 +1,8 @@
 // Retention worker - runs once an hour and prunes ageing run_events,
-// draft_events, terminal drafts, and delivered/dead webhook_deliveries
-// according to the policy stored in `app_config.retention`. Contact history
-// is intentionally preserved so the blocklist / quota signals survive draft
-// cleanup.
+// draft_events, terminal drafts, delivered/dead webhook_deliveries, and
+// observed_targets, according to the policy stored in `app_config.retention`.
+// Contact history is intentionally preserved so the blocklist / quota
+// signals survive draft cleanup.
 //
 // Each delete is capped to a batch (10k rows) and loops until either it can't
 // fill a batch or it hits a per-tick safety ceiling, keeping a single tick
@@ -28,6 +28,7 @@ export interface RetentionTickResult {
   draftEventsDeleted: number;
   draftsDeleted: number;
   webhookDeliveriesDeleted: number;
+  observedTargetsDeleted: number;
 }
 
 async function deleteRunEventsBatch(cutoffIso: string): Promise<number> {
@@ -97,6 +98,26 @@ async function deleteWebhookDeliveriesBatch(cutoffIso: string): Promise<number> 
   return res.rowCount ?? 0;
 }
 
+async function deleteObservedTargetsBatch(cutoffIso: string): Promise<number> {
+  // #300: `observed_at` (not an insert-time column) is the age proxy on
+  // purpose - it is the moment the human's browser actually saw the post,
+  // which is what "not worth commenting on a week later" is measuring.
+  // Consumed and unconsumed rows both age out the same way: consumption
+  // only marks a row as drained into a run, it doesn't extend its shelf
+  // life, and a post nobody drained in time is exactly the stale buffer
+  // this prune exists to clear.
+  const res = await getDb().execute(sql`
+    DELETE FROM observed_targets
+    WHERE id IN (
+      SELECT id FROM observed_targets
+      WHERE observed_at < ${cutoffIso}
+      ORDER BY id
+      LIMIT ${RETENTION_BATCH_SIZE}
+    )
+  `);
+  return res.rowCount ?? 0;
+}
+
 async function drainTable(
   label: string,
   cutoffIso: string,
@@ -140,6 +161,11 @@ export async function tick(): Promise<RetentionTickResult> {
     cutoffIsoFromDays(policy.webhook_deliveries_days),
     deleteWebhookDeliveriesBatch,
   );
+  const observedTargetsDeleted = await drainTable(
+    'observed_targets',
+    cutoffIsoFromDays(policy.observed_targets_days),
+    deleteObservedTargetsBatch,
+  );
 
   return {
     policy,
@@ -147,5 +173,6 @@ export async function tick(): Promise<RetentionTickResult> {
     draftEventsDeleted,
     draftsDeleted,
     webhookDeliveriesDeleted,
+    observedTargetsDeleted,
   };
 }

--- a/daemon/tests/retention.test.ts
+++ b/daemon/tests/retention.test.ts
@@ -6,7 +6,7 @@ import { tick as retentionTick } from '../src/retention.js';
 
 async function reset() {
   await getDb().execute(
-    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, run_events, draft_events, contact_history, notifications, app_config, webhook_deliveries RESTART IDENTITY CASCADE`,
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, run_events, draft_events, contact_history, notifications, app_config, webhook_deliveries, observed_targets RESTART IDENTITY CASCADE`,
   );
 }
 
@@ -296,5 +296,67 @@ describe('retention worker', () => {
     expect(remainingIds).not.toContain(oldDead.id);
     expect(remainingIds).toContain(oldPending.id);
     expect(remainingIds).toContain(freshDelivered.id);
+  });
+
+  it('prunes observed_targets past the window and leaves fresher ones, consumed or not (#300)', async () => {
+    const { proj, platform } = await setupFixtures();
+    const db = getDb();
+
+    // Tight policy so we don't have to fabricate years-old timestamps. The
+    // window is deliberately much shorter than the other tables' - a
+    // LinkedIn post is not worth commenting on a week later.
+    await saveRetention(db, { observed_targets_days: 2 });
+
+    const now = new Date();
+    const aged = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000); // 5 days
+    const fresh = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000); // 1 day
+
+    const [agedUnconsumed] = await db
+      .insert(schema.observedTargets)
+      .values({
+        organizationId: proj.organizationId,
+        projectId: proj.id,
+        platformId: platform.id,
+        externalId: 'urn:li:activity:aged-unconsumed',
+        url: 'https://linkedin.com/feed/update/urn:li:activity:aged-unconsumed/',
+        observedAt: aged,
+      })
+      .returning();
+    // Aged AND already consumed - pruning must not special-case consumption,
+    // an aged row is aged either way.
+    const [agedConsumed] = await db
+      .insert(schema.observedTargets)
+      .values({
+        organizationId: proj.organizationId,
+        projectId: proj.id,
+        platformId: platform.id,
+        externalId: 'urn:li:activity:aged-consumed',
+        url: 'https://linkedin.com/feed/update/urn:li:activity:aged-consumed/',
+        observedAt: aged,
+      })
+      .returning();
+    const [freshRow] = await db
+      .insert(schema.observedTargets)
+      .values({
+        organizationId: proj.organizationId,
+        projectId: proj.id,
+        platformId: platform.id,
+        externalId: 'urn:li:activity:fresh',
+        url: 'https://linkedin.com/feed/update/urn:li:activity:fresh/',
+        observedAt: fresh,
+      })
+      .returning();
+
+    const result = await retentionTick();
+
+    expect(result.observedTargetsDeleted).toBe(2);
+
+    const remaining = await db
+      .select({ id: schema.observedTargets.id, externalId: schema.observedTargets.externalId })
+      .from(schema.observedTargets);
+    expect(remaining.map((r) => r.id)).not.toContain(agedUnconsumed.id);
+    expect(remaining.map((r) => r.id)).not.toContain(agedConsumed.id);
+    expect(remaining.map((r) => r.id)).toContain(freshRow.id);
+    expect(remaining).toHaveLength(1);
   });
 });

--- a/shared/package.json
+++ b/shared/package.json
@@ -44,6 +44,7 @@
     "./orgs": "./src/orgs.ts",
     "./edition": "./src/edition.ts",
     "./retention": "./src/retention.ts",
+    "./observed-targets": "./src/observed-targets.ts",
     "./runlog": "./src/runlog/index.ts",
     "./runlog/types": "./src/runlog/types.ts",
     "./runlog/classify-failure": "./src/runlog/classify-failure.ts",

--- a/shared/src/db/migrations/0011_yellow_harry_osborn.sql
+++ b/shared/src/db/migrations/0011_yellow_harry_osborn.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "observed_targets" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"organization_id" integer NOT NULL,
+	"project_id" integer NOT NULL,
+	"platform_id" integer NOT NULL,
+	"external_id" text NOT NULL,
+	"url" text NOT NULL,
+	"author_handle" text,
+	"author_name" text,
+	"text" text,
+	"observed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"consumed_by_run_id" integer
+);
+--> statement-breakpoint
+ALTER TABLE "observed_targets" ADD CONSTRAINT "observed_targets_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "observed_targets" ADD CONSTRAINT "observed_targets_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "observed_targets" ADD CONSTRAINT "observed_targets_platform_id_platforms_id_fk" FOREIGN KEY ("platform_id") REFERENCES "public"."platforms"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "observed_targets" ADD CONSTRAINT "observed_targets_consumed_by_run_id_runs_id_fk" FOREIGN KEY ("consumed_by_run_id") REFERENCES "public"."runs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "observed_targets_dedup_idx" ON "observed_targets" USING btree ("organization_id","platform_id","external_id");--> statement-breakpoint
+CREATE INDEX "observed_targets_project_unconsumed_idx" ON "observed_targets" USING btree ("project_id","consumed_by_run_id","observed_at");

--- a/shared/src/db/migrations/meta/0011_snapshot.json
+++ b/shared/src/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,3464 @@
+{
+  "id": "c03b5b00-6e97-4653-95d8-00f1560e8519",
+  "prevId": "a1799a7f-1630-4f6a-8113-44b1875b1469",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cookie_session": {
+          "name": "cookie_session",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_limit": {
+          "name": "weekly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_project_id_projects_id_fk": {
+          "name": "accounts_project_id_projects_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_platform_id_platforms_id_fk": {
+          "name": "accounts_platform_id_platforms_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_failures": {
+      "name": "auth_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login_attempt'"
+        }
+      },
+      "indexes": {
+        "auth_failures_identifier_idx": {
+          "name": "auth_failures_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist": {
+      "name": "blocklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocklist_platform_id_platforms_id_fk": {
+          "name": "blocklist_platform_id_platforms_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocklist_project_id_projects_id_fk": {
+          "name": "blocklist_project_id_projects_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_recommendations": {
+      "name": "campaign_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_slug": {
+          "name": "scenario_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_recommendations_project_idx": {
+          "name": "campaign_recommendations_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_recommendations_project_id_projects_id_fk": {
+          "name": "campaign_recommendations_project_id_projects_id_fk",
+          "tableFrom": "campaign_recommendations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_slug": {
+          "name": "skill_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_attempts": {
+          "name": "failure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_due_to_failures": {
+          "name": "paused_due_to_failures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_post": {
+          "name": "auto_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_platform_id_platforms_id_fk": {
+          "name": "campaigns_platform_id_platforms_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_history": {
+      "name": "contact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_handle": {
+          "name": "account_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_checked_at": {
+          "name": "reply_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_room_id": {
+          "name": "chat_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_context_url": {
+          "name": "platform_context_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_history_target_idx": {
+          "name": "contact_history_target_idx",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_target_idx": {
+          "name": "messages_account_target_idx",
+          "columns": [
+            {
+              "expression": "account_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_org_idx": {
+          "name": "contact_history_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_contacted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_history_platform_id_platforms_id_fk": {
+          "name": "contact_history_platform_id_platforms_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contact_history_draft_id_drafts_id_fk": {
+          "name": "contact_history_draft_id_drafts_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_history_organization_id_organizations_id_fk": {
+          "name": "contact_history_organization_id_organizations_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_heartbeats": {
+      "name": "daemon_heartbeats",
+      "schema": "",
+      "columns": {
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tick_at": {
+          "name": "tick_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_events": {
+      "name": "draft_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_events_kind_created_idx": {
+          "name": "draft_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_events_draft_id_drafts_id_fk": {
+          "name": "draft_events_draft_id_drafts_id_fk",
+          "tableFrom": "draft_events",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_regeneration_hints": {
+      "name": "draft_regeneration_hints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint_text": {
+          "name": "hint_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_regeneration_hints_draft_id_drafts_id_fk": {
+          "name": "draft_regeneration_hints_draft_id_drafts_id_fk",
+          "tableFrom": "draft_regeneration_hints",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "fit_score": {
+          "name": "fit_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_url": {
+          "name": "compose_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_content": {
+          "name": "sent_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_comment_id": {
+          "name": "platform_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dedup_warning": {
+          "name": "dedup_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_edited": {
+          "name": "body_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_send_after": {
+          "name": "scheduled_send_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerating_run_id": {
+          "name": "regenerating_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drafting_run_id": {
+          "name": "drafting_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_reason": {
+          "name": "quality_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_model": {
+          "name": "quality_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_id": {
+          "name": "variant_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drafts_state_idx": {
+          "name": "drafts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_project_idx": {
+          "name": "drafts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_run_idx": {
+          "name": "drafts_state_run_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_campaign_created_idx": {
+          "name": "drafts_state_campaign_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_variant_group_idx": {
+          "name": "drafts_variant_group_idx",
+          "columns": [
+            {
+              "expression": "variant_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_run_id_runs_id_fk": {
+          "name": "drafts_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_project_id_projects_id_fk": {
+          "name": "drafts_project_id_projects_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_platform_id_platforms_id_fk": {
+          "name": "drafts_platform_id_platforms_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_accounts_id_fk": {
+          "name": "drafts_account_id_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_regenerating_run_id_runs_id_fk": {
+          "name": "drafts_regenerating_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "regenerating_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drafts_drafting_run_id_runs_id_fk": {
+          "name": "drafts_drafting_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "drafting_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_devices": {
+      "name": "extension_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unnamed device'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "extension_devices_token_hash_unique": {
+          "name": "extension_devices_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extension_devices_organization_id_organizations_id_fk": {
+          "name": "extension_devices_organization_id_organizations_id_fk",
+          "tableFrom": "extension_devices",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_pairings": {
+      "name": "extension_pairings",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extension_pairings_organization_id_organizations_id_fk": {
+          "name": "extension_pairings_organization_id_organizations_id_fk",
+          "tableFrom": "extension_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_watches": {
+      "name": "keyword_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_field": {
+          "name": "match_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keyword_watches_campaign_idx": {
+          "name": "keyword_watches_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_watches_project_idx": {
+          "name": "keyword_watches_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_watches_project_id_projects_id_fk": {
+          "name": "keyword_watches_project_id_projects_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keyword_watches_campaign_id_campaigns_id_fk": {
+          "name": "keyword_watches_campaign_id_campaigns_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_org_user_unique": {
+          "name": "memberships_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_from_us": {
+          "name": "is_from_us",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_platform": {
+          "name": "created_at_platform",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_contact_idx": {
+          "name": "messages_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_platform_message_unique": {
+          "name": "messages_platform_message_unique",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_contact_id_contact_history_id_fk": {
+          "name": "messages_contact_id_contact_history_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "contact_history",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_draft_id_drafts_id_fk": {
+          "name": "messages_draft_id_drafts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_platform_id_platforms_id_fk": {
+          "name": "messages_platform_id_platforms_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_unread_idx": {
+          "name": "notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_idx": {
+          "name": "notifications_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organization_id_organizations_id_fk": {
+          "name": "notifications_organization_id_organizations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observed_targets": {
+      "name": "observed_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_by_run_id": {
+          "name": "consumed_by_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "observed_targets_dedup_idx": {
+          "name": "observed_targets_dedup_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "observed_targets_project_unconsumed_idx": {
+          "name": "observed_targets_project_unconsumed_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_by_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "observed_targets_organization_id_organizations_id_fk": {
+          "name": "observed_targets_organization_id_organizations_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_project_id_projects_id_fk": {
+          "name": "observed_targets_project_id_projects_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_platform_id_platforms_id_fk": {
+          "name": "observed_targets_platform_id_platforms_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observed_targets_consumed_by_run_id_runs_id_fk": {
+          "name": "observed_targets_consumed_by_run_id_runs_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "consumed_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invites": {
+      "name": "org_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_invites_org_idx": {
+          "name": "org_invites_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invites_organization_id_organizations_id_fk": {
+          "name": "org_invites_organization_id_organizations_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invites_created_by_user_id_users_id_fk": {
+          "name": "org_invites_created_by_user_id_users_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invites_token_unique": {
+          "name": "org_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_run_budget_usd": {
+          "name": "monthly_run_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platforms": {
+      "name": "platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platforms_slug_unique": {
+          "name": "platforms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playbooks": {
+      "name": "playbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playbooks_slug_unique": {
+          "name": "playbooks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_insights": {
+      "name": "project_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary_md": {
+          "name": "summary_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_insights_project_idx": {
+          "name": "project_insights_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_insights_project_id_projects_id_fk": {
+          "name": "project_insights_project_id_projects_id_fk",
+          "tableFrom": "project_insights",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_runner": {
+          "name": "default_agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_unique": {
+          "name": "projects_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_events_run_idx": {
+          "name": "run_events_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_events_kind_created_idx": {
+          "name": "run_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'campaign'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout_log_path": {
+          "name": "stdout_log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playbook_body": {
+          "name": "playbook_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_project_kind_idx": {
+          "name": "runs_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_campaign_id_campaigns_id_fk": {
+          "name": "runs_campaign_id_campaigns_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_scout_candidates": {
+      "name": "staging_scout_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staging_scout_candidates_run_id_runs_id_fk": {
+          "name": "staging_scout_candidates_run_id_runs_id_fk",
+          "tableFrom": "staging_scout_candidates",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_project_kind_idx": {
+          "name": "templates_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_project_id_projects_id_fk": {
+          "name": "templates_project_id_projects_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_instance_admin": {
+          "name": "is_instance_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recent_idx": {
+          "name": "webhook_deliveries_recent_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_org_idx": {
+          "name": "webhook_deliveries_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_organization_id_organizations_id_fk": {
+          "name": "webhook_deliveries_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785930865721,
       "tag": "0010_overconfident_the_anarchist",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1788517632675,
+      "tag": "0011_yellow_harry_osborn",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -289,6 +289,84 @@ export const stagingScoutCandidates = pgTable('staging_scout_candidates', {
   capturedAt: timestamp('captured_at', { withTimezone: true }).notNull().defaultNow(),
 });
 
+// Posts the browser observed on linkedin.com outside of any campaign run -
+// LinkedIn has no discovery API, so an asynchronous LinkedIn campaign has no
+// targets unless the extension supplies them (see
+// docs/linkedin-integration-design.md, "Observation collection"/"Storage").
+// `staging_scout_candidates` above cannot hold these: it is `run_id NOT NULL`
+// with `onDelete: 'cascade'`, so a row cannot exist before the run that
+// consumes it, and an observation arrives with no run in sight.
+//
+// LinkedIn serves two frontends and only one exposes a stable per-post
+// identifier (design doc, "Two frontends, one identifier", corrected
+// 2026-09-03): the feed's server-driven UI has no `data-urn` at all, only a
+// render address that changes on reload, while a post detail page - the post
+// the human actually opened - carries the real URN. `external_id` is
+// therefore a generic column, not a URN-typed one: it is populated only for
+// a sighting with a genuine stable identifier, and the collector (#302) must
+// never call the ingest service for a feed sighting that has none.
+export const observedTargets = pgTable(
+  'observed_targets',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    // Both organization and project carried directly (not only reachable
+    // through a join), following #263's contact_history precedent: a row
+    // visible to no organization is a silent way to leak dedup across
+    // tenants. project_id is direct too because the drain (#304) and this
+    // table's own dedup are project-scoped - an org running several
+    // LinkedIn projects must not let a post scrolled for one seed another's
+    // candidate pool.
+    organizationId: integer('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    projectId: integer('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    platformId: integer('platform_id')
+      .notNull()
+      .references(() => platforms.id),
+    // The stable per-frontend identifier (an activity or comment URN on
+    // LinkedIn today). Never absent - see the table comment above.
+    externalId: text('external_id').notNull(),
+    url: text('url').notNull(),
+    authorHandle: text('author_handle'),
+    authorName: text('author_name'),
+    text: text('text'),
+    observedAt: timestamp('observed_at', { withTimezone: true }).notNull().defaultNow(),
+    // Set once `linkedin_candidates` (#304) drains this row into
+    // staging_scout_candidates for a run. The row stays in place rather than
+    // being deleted, so a repeat sighting of the same post after
+    // consumption still hits the unique index below and does not resurrect
+    // it as a fresh, unconsumed candidate.
+    consumedByRunId: integer('consumed_by_run_id').references(() => runs.id, {
+      onDelete: 'set null',
+    }),
+  },
+  (t) => ({
+    // Dedup key (issue #300): a repeat sighting of the same post while the
+    // human scrolls must be a no-op via onConflictDoNothing, not a second
+    // row. Deliberately NOT partial on consumed_by_run_id - the whole point
+    // is that a re-sighting of an already-consumed post must also be a
+    // no-op rather than resurrecting it (see verifying-on-conflict-dedupe:
+    // a partial predicate here would stop covering a row the moment it gets
+    // consumed, which is exactly the state a repeat sighting must still
+    // hit). organization_id leads the index, not just platform_id +
+    // external_id, because a public post is observable by more than one
+    // tenant's browser and each tenant's ingest must get its own row.
+    dedup: uniqueIndex('observed_targets_dedup_idx').on(
+      t.organizationId,
+      t.platformId,
+      t.externalId,
+    ),
+    // Drives the drain (#304): unconsumed rows for a project, oldest first.
+    byProjectUnconsumed: index('observed_targets_project_unconsumed_idx').on(
+      t.projectId,
+      t.consumedByRunId,
+      t.observedAt,
+    ),
+  }),
+);
+
 export const drafts = pgTable(
   'drafts',
   {

--- a/shared/src/observed-targets.ts
+++ b/shared/src/observed-targets.ts
@@ -1,0 +1,126 @@
+// Ingest for posts the browser observed on linkedin.com outside of any
+// campaign run. See docs/linkedin-integration-design.md ("Observation
+// collection" / "Storage" / "Two frontends, one identifier") and issue #300.
+//
+// The caller (POST /api/extension/observations, #301) resolves the
+// authenticated device's organization and the destination project; this
+// module only validates, normalises and writes the batch it is handed.
+// Malformed entries (a missing/empty external_id or url, or an unparsable
+// observed_at) are dropped individually rather than failing the whole
+// batch - the extension builds these from raw DOM reads, so one degenerate
+// sighting must not lose the rest of a debounce tick (same posture as
+// IncomingDmSchema in web/src/routes/api/extension/dm-sync/+server.ts).
+//
+// Dedup is `onConflictDoNothing` against `observed_targets_dedup_idx`
+// (organization_id, platform_id, external_id), a full (non-partial) unique
+// index, so a repeat sighting of an already-consumed post is also a no-op
+// rather than resurrecting it - see the verifying-on-conflict-dedupe skill.
+
+import { z } from 'zod';
+import type { Db } from './db/client.js';
+import { observedTargets } from './db/schema.js';
+
+// A legitimate batch is one debounce tick's worth of posts scrolled past -
+// at most a couple dozen. This bounds a malformed or hostile payload from
+// forcing an unbounded amount of DB work per call (mirrors dm-sync's
+// MAX_BATCH_SIZE in web/src/routes/api/extension/dm-sync/+server.ts).
+export const MAX_OBSERVED_TARGETS_BATCH = 200;
+
+const ObservationSchema = z.object({
+  // The stable per-frontend identifier (an activity or comment URN on
+  // LinkedIn today; see "Two frontends, one identifier" in the design doc).
+  // A sighting with none is not dedupable - the collector must only call
+  // this service for a post the human actually opened.
+  externalId: z.string().trim().min(1),
+  url: z.url(),
+  // Optional context fields: validated as strings when present (so a
+  // non-string value is still malformed), but an empty/whitespace-only
+  // value normalises to null below rather than rejecting the whole entry -
+  // author and text are context, not part of the dedup key.
+  authorHandle: z.string().nullish(),
+  authorName: z.string().nullish(),
+  text: z.string().nullish(),
+  observedAt: z.string().refine((v) => !Number.isNaN(Date.parse(v)), { message: 'invalid date' }),
+});
+
+export type RawObservedTarget = z.input<typeof ObservationSchema>;
+export type ObservedTargetRow = typeof observedTargets.$inferSelect;
+
+export interface IngestObservedTargetsInput {
+  organizationId: number;
+  projectId: number;
+  platformId: number;
+  observations: unknown[];
+}
+
+export interface IngestObservedTargetsResult {
+  /** Rows actually inserted (post-validation, post-dedup). */
+  written: ObservedTargetRow[];
+  /** Entries dropped for failing per-item validation. */
+  rejected: number;
+}
+
+function normaliseOptionalText(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Validate, normalise and insert a batch of browser-observed LinkedIn posts.
+ * Throws only when the batch itself exceeds `MAX_OBSERVED_TARGETS_BATCH`;
+ * a malformed individual entry is dropped, not thrown, and counted in
+ * `rejected`. Insert is a single statement so ON CONFLICT DO NOTHING also
+ * dedupes entries within the same batch against each other, not just
+ * against rows already in the table.
+ */
+export async function ingestObservedTargets(
+  db: Db,
+  input: IngestObservedTargetsInput,
+): Promise<IngestObservedTargetsResult> {
+  const { organizationId, projectId, platformId, observations } = input;
+  if (observations.length > MAX_OBSERVED_TARGETS_BATCH) {
+    throw new Error(
+      `observed targets batch of ${observations.length} exceeds the ${MAX_OBSERVED_TARGETS_BATCH} cap`,
+    );
+  }
+
+  let rejected = 0;
+  const values: (typeof observedTargets.$inferInsert)[] = [];
+  for (const raw of observations) {
+    const parsed = ObservationSchema.safeParse(raw);
+    if (!parsed.success) {
+      rejected++;
+      continue;
+    }
+    values.push({
+      organizationId,
+      projectId,
+      platformId,
+      externalId: parsed.data.externalId,
+      url: parsed.data.url,
+      authorHandle: normaliseOptionalText(parsed.data.authorHandle),
+      authorName: normaliseOptionalText(parsed.data.authorName),
+      text: normaliseOptionalText(parsed.data.text),
+      observedAt: new Date(parsed.data.observedAt),
+    });
+  }
+
+  if (values.length === 0) {
+    return { written: [], rejected };
+  }
+
+  const written = await db
+    .insert(observedTargets)
+    .values(values)
+    .onConflictDoNothing({
+      target: [
+        observedTargets.organizationId,
+        observedTargets.platformId,
+        observedTargets.externalId,
+      ],
+    })
+    .returning();
+
+  return { written, rejected };
+}

--- a/shared/src/retention.ts
+++ b/shared/src/retention.ts
@@ -1,24 +1,35 @@
-// Retention policy for drafts, run_events, draft_events, and webhook_deliveries.
+// Retention policy for drafts, run_events, draft_events, webhook_deliveries,
+// and observed_targets.
 //
 // Configuration lives in the existing `app_config` jsonb table under the
 // `retention` key, with shape:
 //   { drafts_days: 90, run_events_days: 30, draft_events_days: 90,
-//     webhook_deliveries_days: 30 }
+//     webhook_deliveries_days: 30, observed_targets_days: 3 }
 //
-// A floor of 7 days is enforced server-side so an accidental low value can't
-// nuke recent data. Contact history is never touched by this policy - it is
-// the long-term record used by the blocklist / quota systems.
+// A floor of 7 days is enforced server-side for the four original fields so
+// an accidental low value can't nuke recent data. Contact history is never
+// touched by this policy - it is the long-term record used by the
+// blocklist / quota systems.
 
 import { eq } from 'drizzle-orm';
 import { schema, type Db } from './db/client.js';
 
 export const RETENTION_FLOOR_DAYS = 7;
 
+// observed_targets (#300) holds other people's post text sighted in
+// passing, not outreach history - the design's own reasoning is that it
+// should age out fast ("a LinkedIn post is not worth commenting on a week
+// later"), well under the 7-day floor above. A separate, much lower floor
+// keeps an operator from zeroing the window out by accident while still
+// letting it default meaningfully shorter than every other table here.
+export const OBSERVED_TARGETS_RETENTION_FLOOR_DAYS = 1;
+
 export const RETENTION_DEFAULTS = {
   drafts_days: 90,
   run_events_days: 30,
   draft_events_days: 90,
   webhook_deliveries_days: 30,
+  observed_targets_days: 3,
 } as const;
 
 export type RetentionPolicy = {
@@ -26,13 +37,14 @@ export type RetentionPolicy = {
   run_events_days: number;
   draft_events_days: number;
   webhook_deliveries_days: number;
+  observed_targets_days: number;
 };
 
 const APP_CONFIG_KEY = 'retention';
 
-function clampDays(n: unknown, fallback: number): number {
+function clampDays(n: unknown, fallback: number, floor: number = RETENTION_FLOOR_DAYS): number {
   const v = typeof n === 'number' && Number.isFinite(n) ? Math.floor(n) : fallback;
-  return Math.max(RETENTION_FLOOR_DAYS, v);
+  return Math.max(floor, v);
 }
 
 /**
@@ -52,6 +64,11 @@ export function normaliseRetention(
     run_events_days: clampDays(r.run_events_days, base.run_events_days),
     draft_events_days: clampDays(r.draft_events_days, base.draft_events_days),
     webhook_deliveries_days: clampDays(r.webhook_deliveries_days, base.webhook_deliveries_days),
+    observed_targets_days: clampDays(
+      r.observed_targets_days,
+      base.observed_targets_days,
+      OBSERVED_TARGETS_RETENTION_FLOOR_DAYS,
+    ),
   };
 }
 

--- a/shared/tests/observed-targets.test.ts
+++ b/shared/tests/observed-targets.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import {
+  ingestObservedTargets,
+  MAX_OBSERVED_TARGETS_BATCH,
+  type RawObservedTarget,
+} from '../src/observed-targets.js';
+
+async function platformId(slug: string): Promise<number> {
+  const db = getDb();
+  const [p] = await db.select().from(schema.platforms).where(eq(schema.platforms.slug, slug));
+  return p!.id;
+}
+
+// Resolves an org by slug, creating it on first use - mirrors
+// contact-dedup.test.ts's ensureOrg so a second tenant is available for the
+// cross-org isolation test.
+async function ensureOrg(slug: string): Promise<number> {
+  const db = getDb();
+  await db.insert(schema.organizations).values({ slug, name: slug }).onConflictDoNothing();
+  const [org] = await db
+    .select()
+    .from(schema.organizations)
+    .where(eq(schema.organizations.slug, slug));
+  return org!.id;
+}
+
+async function makeProject(organizationId: number, slug: string): Promise<number> {
+  const db = getDb();
+  const [p] = await db
+    .insert(schema.projects)
+    .values({ organizationId, slug, name: slug })
+    .returning({ id: schema.projects.id });
+  return p.id;
+}
+
+function observation(overrides: Partial<RawObservedTarget> = {}): RawObservedTarget {
+  return {
+    externalId: 'urn:li:activity:1111',
+    url: 'https://www.linkedin.com/feed/update/urn:li:activity:1111/',
+    authorHandle: 'jane-doe',
+    authorName: 'Jane Doe',
+    text: 'A post about outreach automation.',
+    observedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('ingestObservedTargets', () => {
+  let linkedinId: number;
+  let orgAId: number;
+  let orgBId: number;
+  let projectAId: number;
+  let projectBId: number;
+
+  beforeEach(async () => {
+    await getDb().execute(
+      sql`TRUNCATE observed_targets, projects, organizations RESTART IDENTITY CASCADE`,
+    );
+    linkedinId = await platformId('linkedin');
+    orgAId = await ensureOrg('obs-targets-org-a');
+    orgBId = await ensureOrg('obs-targets-org-b');
+    projectAId = await makeProject(orgAId, 'obs-targets-proj-a');
+    projectBId = await makeProject(orgBId, 'obs-targets-proj-b');
+  });
+
+  it('repeat observation of the same post leaves exactly one row (row set, not an attempt count)', async () => {
+    const db = getDb();
+    const input = {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+    };
+
+    const first = await ingestObservedTargets(db, { ...input, observations: [observation()] });
+    expect(first.written).toHaveLength(1);
+    expect(first.rejected).toBe(0);
+
+    // A second sighting of the same post (a different debounce tick) must be
+    // a no-op, not a second row - even though the shape differs slightly
+    // (author/text can legitimately vary between reads of the same post).
+    const second = await ingestObservedTargets(db, {
+      ...input,
+      observations: [observation({ authorName: 'Jane D.', text: 'slightly different snapshot' })],
+    });
+    expect(second.written).toHaveLength(0);
+    expect(second.rejected).toBe(0);
+
+    const rows = await db
+      .select({ id: schema.observedTargets.id, externalId: schema.observedTargets.externalId })
+      .from(schema.observedTargets)
+      .where(eq(schema.observedTargets.organizationId, orgAId));
+    // Assert the row set itself, not a count of ingest attempts.
+    expect(rows.map((r) => r.externalId)).toEqual(['urn:li:activity:1111']);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('dedupes duplicates within a single batch against each other, not just against existing rows', async () => {
+    const db = getDb();
+    const result = await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [observation(), observation({ text: 'same post, seen twice in one tick' })],
+    });
+    expect(result.written).toHaveLength(1);
+    expect(result.rejected).toBe(0);
+
+    const rows = await db.select().from(schema.observedTargets);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('does not resurrect a row already consumed by a run', async () => {
+    const db = getDb();
+    await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [observation()],
+    });
+
+    // Simulate #304's drain marking the row consumed.
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ projectId: projectAId, trigger: 'manual', kind: 'project_extraction' })
+      .returning({ id: schema.runs.id });
+    await db
+      .update(schema.observedTargets)
+      .set({ consumedByRunId: run.id })
+      .where(eq(schema.observedTargets.organizationId, orgAId));
+
+    const repeat = await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [observation({ text: 'scrolled past it again after it was consumed' })],
+    });
+    expect(repeat.written).toHaveLength(0);
+
+    const rows = await db.select().from(schema.observedTargets);
+    expect(rows).toHaveLength(1);
+    // Still consumed - the repeat sighting did not clear it back to fresh.
+    expect(rows[0].consumedByRunId).toBe(run.id);
+  });
+
+  it('an observation ingested for org A is invisible to org B', async () => {
+    const db = getDb();
+    // Same public post, sighted by two different tenants' browsers - each
+    // must get its own row, not a cross-tenant dedup collision.
+    await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [observation()],
+    });
+    await ingestObservedTargets(db, {
+      organizationId: orgBId,
+      projectId: projectBId,
+      platformId: linkedinId,
+      observations: [observation()],
+    });
+
+    const rows = await db.select().from(schema.observedTargets);
+    expect(rows).toHaveLength(2);
+
+    const forOrgB = await db
+      .select()
+      .from(schema.observedTargets)
+      .where(eq(schema.observedTargets.organizationId, orgBId));
+    expect(forOrgB).toHaveLength(1);
+    expect(forOrgB.every((r) => r.organizationId === orgBId)).toBe(true);
+    // Org A's row never appears in an org-B-scoped read.
+    expect(forOrgB.some((r) => r.organizationId === orgAId)).toBe(false);
+  });
+
+  it('drops a malformed entry without failing the rest of the batch', async () => {
+    const db = getDb();
+    const result = await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [
+        observation({
+          externalId: 'urn:li:activity:2222',
+          url: 'https://linkedin.com/feed/update/urn:li:activity:2222/',
+        }),
+        // Malformed: no external_id at all (a feed sighting with no stable
+        // identifier - the design's "must not create an observed_targets
+        // row" case).
+        { url: 'https://linkedin.com/feed/', observedAt: new Date().toISOString() },
+      ],
+    });
+
+    expect(result.rejected).toBe(1);
+    expect(result.written).toHaveLength(1);
+    expect(result.written[0].externalId).toBe('urn:li:activity:2222');
+
+    const rows = await db.select().from(schema.observedTargets);
+    expect(rows.map((r) => r.externalId)).toEqual(['urn:li:activity:2222']);
+  });
+
+  it('rejects an entry with an unparsable observed_at or a non-URL url', async () => {
+    const db = getDb();
+    const result = await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [
+        observation({ externalId: 'urn:li:activity:bad-date', observedAt: 'not-a-date' }),
+        observation({ externalId: 'urn:li:activity:bad-url', url: 'not-a-url' }),
+        observation({ externalId: 'urn:li:activity:ok' }),
+      ],
+    });
+
+    expect(result.rejected).toBe(2);
+    expect(result.written.map((r) => r.externalId)).toEqual(['urn:li:activity:ok']);
+  });
+
+  it('normalises blank optional fields to null without rejecting the entry', async () => {
+    const db = getDb();
+    const result = await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [observation({ authorHandle: '   ', authorName: undefined, text: '' })],
+    });
+    expect(result.rejected).toBe(0);
+    expect(result.written).toHaveLength(1);
+    expect(result.written[0].authorHandle).toBeNull();
+    expect(result.written[0].authorName).toBeNull();
+    expect(result.written[0].text).toBeNull();
+  });
+
+  it('throws rather than writing when the batch exceeds the cap', async () => {
+    const db = getDb();
+    const observations = Array.from({ length: MAX_OBSERVED_TARGETS_BATCH + 1 }, (_, i) =>
+      observation({ externalId: `urn:li:activity:${i}` }),
+    );
+    await expect(
+      ingestObservedTargets(db, {
+        organizationId: orgAId,
+        projectId: projectAId,
+        platformId: linkedinId,
+        observations,
+      }),
+    ).rejects.toThrow();
+
+    const rows = await db.select().from(schema.observedTargets);
+    expect(rows).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

LinkedIn has no discovery API, so an asynchronous LinkedIn campaign has no targets unless the browser supplies them. This adds the storage and ingest side of that buffer, per docs/linkedin-integration-design.md ("Observation collection" / "Storage" / "Two frontends, one identifier").

- New observed_targets table (migration 0011_yellow_harry_osborn.sql): id, organization_id and project_id (both NOT NULL, following contact_history's #263 precedent rather than only reaching the org through a join), platform_id, external_id, url, author_handle, author_name, text, observed_at, consumed_by_run_id (nullable FK to runs, ON DELETE SET NULL).
- external_id is a generic column, not URN-typed: LinkedIn's feed is server-driven UI with no stable per-post identifier at all; only a post detail page (the post the human opened) exposes a real URN. A feed sighting with no identifier must never reach this table (see the finding on #300/#303 and "Two frontends, one identifier" in the design doc).
- Full (non-partial) unique index observed_targets_dedup_idx on (organization_id, platform_id, external_id). Deliberately not partial on consumed_by_run_id: the intent is that a repeat sighting of an already-consumed post is also a no-op, not just an unconsumed one, so the index has to cover every state (see the verifying-on-conflict-dedupe skill). ingestObservedTargets uses onConflictDoNothing against it in a single batch insert, which also dedupes duplicates within one batch, not just against existing rows.
- ingestObservedTargets (shared/src/observed-targets.ts, exported as @pitchbox/shared/observed-targets): a plain function that validates and normalises a batch, drops malformed entries (missing/empty external_id or url, unparsable observed_at) rather than failing the whole batch (same posture as dm-sync's route), caps the batch at 200, and returns the rows it actually wrote plus a rejected count. No HTTP route here - that's #301.
- Retention: wired into the existing daemon/src/retention.ts loop rather than a second pruner. observed_targets_days is a new RetentionPolicy field (default 3 days) with its own floor (OBSERVED_TARGETS_RETENTION_FLOOR_DAYS = 1), separate from the existing 7-day floor, since a LinkedIn post is not worth commenting on a week later and the existing floor would force it to at least a week.

## Migration proof

Dropped and recreated pitchbox_test_w300 (DROP DATABASE / CREATE DATABASE, confirmed empty via \dt), then ran the migrate script with DATABASE_URL pointed at it directly (not inherited from .env - see note below) and confirmed all 12 migrations, including 0011_yellow_harry_osborn.sql, applied cleanly with \d observed_targets showing the expected columns, indexes and FKs. Ran the full shared/daemon test suites against that same freshly-migrated database afterward.

## Verification

- vitest run shared/tests/observed-targets.test.ts - 8/8 pass (repeat-observation dedup asserted on the row set, dedup within one batch, does-not-resurrect-a-consumed-row, org A invisible to org B, malformed entry dropped without failing the batch, bad date/URL rejected, blank optional fields normalised to null, batch-size cap).
- vitest run daemon/tests/retention.test.ts - the new observed_targets prune test (aged row pruned, fresh row and an aged-but-already-consumed row both handled correctly - consumption doesn't extend shelf life) passes; the 3 pre-existing tests are unaffected in substance, only the shared TRUNCATE list gained observed_targets.
- shared typecheck (tsc --noEmit) - clean.
- eslint + prettier --write on every changed file - clean.

### A worktree-specific caveat, reported for transparency

This worktree's node_modules is symlinked to the parent checkout's warm install (per this wave's setup), and daemon/node_modules/@pitchbox/shared resolves through that chain to the parent checkout's shared/ source, not this branch's. That means the literal daemon typecheck and a bare vitest run of daemon/tests/retention.test.ts in this worktree fail on "Property observed_targets_days does not exist" / "schema.observedTargets is undefined" - not because of a defect here, but because they're type-checking/running against the parent's pre-#300 shared/. I could not touch node_modules (explicitly off-limits for this issue), so I verified the real code correctness with a tsc/vitest invocation using a paths/resolve.alias override (outside the repo, not committed) pointing @pitchbox/shared/* at this branch's actual shared/src/* files - both passed clean (0 typecheck errors; 5/5 daemon retention tests including the new one). Once this merges to main and the shared install refreshes, the plain commands will pass directly; a fresh pnpm install anywhere else already resolves this correctly since it links @pitchbox/shared to the sibling workspace in the same checkout.

## Not done here (by design)

- No HTTP route (POST /api/extension/observations is #301) and nothing under web/src/routes/api/extension/.
- No linkedin_candidates MCP drain (#304).
- web/src/routes/settings/retention isn't touched - observed_targets_days defaults sensibly and isn't yet exposed as an admin-editable field there; out of scope for this issue.

Closes #300
