### PR TITLE
fix(cli-mcp,playbooks): build the compose URL server-side instead of asking the agent to percent-encode it

### DIFF
--- a/cli/src/commands/drafts.ts
+++ b/cli/src/commands/drafts.ts
@@ -16,7 +16,55 @@ import {
 import { notify } from '@pitchbox/shared/notifications';
 import { getProjectOrgId } from '@pitchbox/shared/orgs';
 import { loadQualityRubric } from '@pitchbox/shared/quality-judge';
+import { buildRedditComposeUrl } from '@pitchbox/shared/platforms/reddit';
+import { buildHackernewsComposeUrl } from '@pitchbox/shared/platforms/hackernews';
+import { buildMastodonComposeUrl } from '@pitchbox/shared/platforms/mastodon';
+import type { DraftKind } from '@pitchbox/shared/quota-types';
 import { ok, fail } from '../lib/output.js';
+
+// The compose URL is built here, server-side, from fields the caller already
+// supplies (platform, target, subject, body) rather than accepted as agent
+// input (issue #325): an agent-supplied URL and `body` are two independent
+// arguments with nothing enforcing that the URL's prefilled text is the body
+// a human reviews in the Inbox. Each platform owns its own URL shape
+// (shared/src/platforms/*/compose-url.ts); this only routes by slug.
+function buildComposeUrl(
+  platformSlug: string | null,
+  input: {
+    kind: DraftKind;
+    targetUser: string | null;
+    subreddit: string | null;
+    title: string | null;
+    body: string;
+    subject: string | null;
+    instanceUrl: string | null;
+    sourceRef: Record<string, unknown>;
+    metadata: Record<string, unknown>;
+  },
+): string | null {
+  switch (platformSlug) {
+    case 'reddit':
+      return buildRedditComposeUrl(input);
+    case 'hackernews':
+      return buildHackernewsComposeUrl(input);
+    case 'mastodon':
+      return buildMastodonComposeUrl(input);
+    default:
+      return null;
+  }
+}
+
+/** Pulls `campaign.config.offer.subject` out of jsonb config, if present. The
+ * Reddit DM compose URL is the only consumer (issue #325); other scenarios
+ * either have no subject field or build their compose URL from the body
+ * alone. */
+function extractOfferSubject(config: unknown): string | null {
+  if (config == null || typeof config !== 'object') return null;
+  const offer = (config as Record<string, unknown>).offer;
+  if (offer == null || typeof offer !== 'object') return null;
+  const subject = (offer as Record<string, unknown>).subject;
+  return typeof subject === 'string' && subject.trim() !== '' ? subject : null;
+}
 
 // Playbooks document their `drafts_create` payloads with an explicit `null`
 // for fields that do not apply to the kind being written: every commenter and
@@ -40,7 +88,6 @@ export const DraftInput = z.object({
   targetUser: absentOrNull(z.string()),
   title: absentOrNull(z.string()),
   body: z.string().min(1),
-  composeUrl: absentOrNull(z.url()),
   reasoning: absentOrNull(z.string()),
   sourceRef: z
     .record(z.string(), z.unknown())
@@ -97,7 +144,11 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
   // misattribute the draft's platform identity.
   const accountIds = [...new Set(draftsInput.map((d) => d.accountId))];
   const accountRows = await db
-    .select({ id: schema.accounts.id, projectId: schema.accounts.projectId })
+    .select({
+      id: schema.accounts.id,
+      projectId: schema.accounts.projectId,
+      instanceUrl: schema.accounts.instanceUrl,
+    })
     .from(schema.accounts)
     .where(inArray(schema.accounts.id, accountIds));
   const accountsById = new Map(accountRows.map((a) => [a.id, a]));
@@ -111,12 +162,14 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
     }
   }
 
-  // Reddit-only guard (issue #258): a `post` or `post_comment` draft cannot
-  // be acted on without a subreddit, so refuse to write one rather than
-  // storing a row the inbox has to paper over (see the fallback in
-  // web/src/lib/platforms/reddit/presenter.ts). Accept the subreddit from
-  // either the top-level `subreddit` field or an inline `metadata.subreddit`
-  // (both are in active use by the poster/commenter playbooks).
+  // `platform.slug` gates the Reddit-only subreddit guard below and also
+  // drives server-side compose URL construction further down (issue #325):
+  // a `post`/`post_comment` draft cannot be acted on without a subreddit, so
+  // refuse to write one rather than storing a row the inbox has to paper
+  // over (see the fallback in web/src/lib/platforms/reddit/presenter.ts).
+  // Accept the subreddit from either the top-level `subreddit` field or an
+  // inline `metadata.subreddit` (both are in active use by the
+  // poster/commenter playbooks).
   const [platform] = await db
     .select({ slug: schema.platforms.slug })
     .from(schema.platforms)
@@ -135,6 +188,11 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
       }
     }
   }
+
+  // Reddit DM compose URLs carry the subject from campaign.config.offer.subject
+  // (issue #325); every other scenario either has no subject or builds its
+  // compose URL from the body alone.
+  const offerSubject = extractOfferSubject(campaign.config);
 
   // Load dedup policy from app_config.dedup_policy. Defaults to a 90-day
   // warn-only window when unset.
@@ -230,7 +288,17 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
           targetUser: d.targetUser ?? null,
           title: d.title ?? null,
           body: d.body,
-          composeUrl: d.composeUrl ?? null,
+          composeUrl: buildComposeUrl(platform?.slug ?? null, {
+            kind: d.kind,
+            targetUser: d.targetUser ?? null,
+            subreddit: d.subreddit ?? null,
+            title: d.title ?? null,
+            body: d.body,
+            subject: offerSubject,
+            instanceUrl: accountsById.get(d.accountId)?.instanceUrl ?? null,
+            sourceRef: d.sourceRef,
+            metadata: baseMeta,
+          }),
           reasoning: d.reasoning ?? null,
           sourceRef: d.sourceRef,
           metadata: baseMeta,
@@ -256,7 +324,17 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
       targetUser: d.targetUser ?? null,
       title: d.title ?? null,
       body: r.body,
-      composeUrl: d.composeUrl ?? null,
+      composeUrl: buildComposeUrl(platform?.slug ?? null, {
+        kind: d.kind,
+        targetUser: d.targetUser ?? null,
+        subreddit: d.subreddit ?? null,
+        title: d.title ?? null,
+        body: r.body,
+        subject: offerSubject,
+        instanceUrl: accountsById.get(d.accountId)?.instanceUrl ?? null,
+        sourceRef: d.sourceRef,
+        metadata: baseMeta,
+      }),
       reasoning: d.reasoning ?? null,
       sourceRef: d.sourceRef,
       metadata: baseMeta,

--- a/cli/tests/commands/drafts-create.test.ts
+++ b/cli/tests/commands/drafts-create.test.ts
@@ -79,6 +79,15 @@ describe('pitchbox drafts:create', () => {
     expect(drafts[0].state).toBe('pending_review');
     expect(drafts[0].targetUser).toBe('bob');
     expect(drafts[0].metadata).toMatchObject({ subreddit: 'rpg' });
+    // issue #325: the agent-supplied composeUrl above is never honoured -
+    // drafts_create builds its own server-side from targetUser + body, so
+    // it can never disagree with the reviewed body. `message=` decodes back
+    // to exactly `body`.
+    expect(drafts[0].composeUrl).not.toBe('https://reddit.com/message/compose?to=bob&subject=hi');
+    const composeUrl = new URL(drafts[0].composeUrl!);
+    expect(composeUrl.origin + composeUrl.pathname).toBe('https://www.reddit.com/message/compose');
+    expect(composeUrl.searchParams.get('to')).toBe('bob');
+    expect(composeUrl.searchParams.get('message')).toBe('hey bob, ...');
     // No qualityScore supplied - persists as null (not scored).
     expect(drafts[0].qualityScore).toBeNull();
     expect(drafts[0].qualityReason).toBeNull();

--- a/cli/tests/commands/playbook-draft-payloads.test.ts
+++ b/cli/tests/commands/playbook-draft-payloads.test.ts
@@ -87,7 +87,6 @@ describe('playbook draft payloads validate against the schema that receives them
       subreddit: 'rpg',
       targetUser: null,
       title: null,
-      composeUrl: null,
       fitScore: null,
       metadata: null,
       sourceRef: null,
@@ -95,7 +94,6 @@ describe('playbook draft payloads validate against the schema that receives them
     // Null collapses to undefined, so downstream code keeps two states, not three.
     expect(parsed.targetUser).toBeUndefined();
     expect(parsed.title).toBeUndefined();
-    expect(parsed.composeUrl).toBeUndefined();
     expect(parsed.fitScore).toBeUndefined();
     // The containers still default, which `.default()` alone would not do for null.
     expect(parsed.metadata).toEqual({});

--- a/playbooks/hn-commenter.md
+++ b/playbooks/hn-commenter.md
@@ -72,15 +72,9 @@ Write like this instead:
 
 5. **Pick the account.** Use the first account with `role === 'personal'`. HN accounts only carry a `username` - no secret. Record `accountId`.
 
-6. **Build the URL.** The compose URL is HN's reply page for the story:
+6. **Score each draft.** Using `rubricTemplate` from the run context, score the comment 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted comments and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-   ```
-   https://news.ycombinator.com/reply?id=<itemId>&pitchbox_draft=<draftId>
-   ```
-
-7. **Score each draft.** Using `rubricTemplate` from the run context, score the comment 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted comments and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
-
-8. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+7. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft:
 
@@ -91,7 +85,6 @@ Write like this instead:
      "fitScore": 4,
      "targetUser": null,
      "body": "<comment text>",
-     "composeUrl": "https://news.ycombinator.com/reply?id=12345",
      "reasoning": "Why this story, what angle, what value you're adding.",
      "sourceRef": { "itemUrl": "https://news.ycombinator.com/item?id=12345", "title": "..." },
      "metadata": { "itemId": 12345, "listing": "top", "score": 142 },
@@ -102,7 +95,7 @@ Write like this instead:
 
    `targetUser` is null for `post_comment` - the audience is the thread.
 
-9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+8. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/hn-poster.md
+++ b/playbooks/hn-poster.md
@@ -80,13 +80,7 @@ Write like this instead:
 
 6. **Pick the account.** Use the first account with `role === 'personal'`. HN accounts only carry a `username` - no secret. Record `accountId`.
 
-7. **Build the compose URL.** The HN submit form does not honour query-string prefill, so the user pastes title and body manually. Always emit the plain submit URL plus `pitchbox_draft=<draftId>` so the extension's content script can attach:
-
-   ```
-   https://news.ycombinator.com/submit
-   ```
-
-8. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+7. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft:
 
@@ -98,7 +92,6 @@ Write like this instead:
      "targetUser": null,
      "title": "<post title>",
      "body": "<plain-text body, including disclosure where applicable>",
-     "composeUrl": "https://news.ycombinator.com/submit",
      "reasoning": "<one sentence: which format + why this angle now>",
      "sourceRef": { "format": "show-hn | ask-hn | text" },
      "metadata": { "format": "show-hn", "url": "<productUrl when format=show-hn>" },
@@ -107,7 +100,7 @@ Write like this instead:
    }
    ```
 
-9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
+8. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
 
 ## Hard rules
 

--- a/playbooks/mastodon-commenter.md
+++ b/playbooks/mastodon-commenter.md
@@ -85,41 +85,32 @@ Write like this instead:
 
 7. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
 
-8. **Build the compose URL.** Use the target status's own permalink so a human can open the thread and reply manually:
+8. **Score each draft.** Using `rubricTemplate` from the run context, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, contextual replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
+9. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+
+   > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
+
+   Each draft (sent later as a reply status via `in_reply_to_id`, on human approval):
+
+   ```json
+   {
+     "accountId": 1,
+     "kind": "post_comment",
+     "fitScore": 4,
+     "targetUser": null,
+     "body": "<reply text>",
+     "reasoning": "2-3 sentences on why this status, what angle, what value you're adding.",
+     "sourceRef": { "statusId": "109...", "statusUrl": "https://mastodon.social/@alice/109..." },
+     "metadata": { "matchedHashtag": "selfhosted", "matchedKeyword": "self-hosted" },
+     "qualityScore": 74,
+     "qualityReason": "concrete reference to their status, adds a real point"
+   }
    ```
-   <status.url>
-   ```
 
-   If `status.url` is null (rare, some instances omit it for local statuses), omit `composeUrl` from the draft and note the status id in `metadata` instead.
+   Note `targetUser` is null for `post_comment` - the audience is whoever reads the thread, not one user, mirroring the Reddit/HN commenter convention.
 
-9. **Score each draft.** Using `rubricTemplate` from the run context, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, contextual replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
-
-10. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
-
-    > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
-
-    Each draft (sent later as a reply status via `in_reply_to_id`, on human approval):
-
-    ```json
-    {
-      "accountId": 1,
-      "kind": "post_comment",
-      "fitScore": 4,
-      "targetUser": null,
-      "body": "<reply text>",
-      "composeUrl": "https://mastodon.social/@alice/109...",
-      "reasoning": "2-3 sentences on why this status, what angle, what value you're adding.",
-      "sourceRef": { "statusId": "109...", "statusUrl": "https://mastodon.social/@alice/109..." },
-      "metadata": { "matchedHashtag": "selfhosted", "matchedKeyword": "self-hosted" },
-      "qualityScore": 74,
-      "qualityReason": "concrete reference to their status, adds a real point"
-    }
-    ```
-
-    Note `targetUser` is null for `post_comment` - the audience is whoever reads the thread, not one user, mirroring the Reddit/HN commenter convention.
-
-11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/mastodon-poster.md
+++ b/playbooks/mastodon-poster.md
@@ -75,15 +75,7 @@ Write like this instead:
 
 6. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
 
-7. **Build the compose URL.**
-
-   ```
-   ${account.instanceUrl}/share?text=<urlencoded body>
-   ```
-
-   This opens Mastodon's compose intent prefilled with the text, defaulting to public visibility (correct for a top-level post - no manual visibility fix needed here, unlike a `dm` draft).
-
-8. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+7. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft (sent later as a public status, on human approval):
 
@@ -94,7 +86,6 @@ Write like this instead:
      "fitScore": 4,
      "targetUser": null,
      "body": "<plain-text status, including disclosure and hashtags>",
-     "composeUrl": "https://mastodon.social/share?text=...",
      "reasoning": "<one sentence: which angle + why now>",
      "sourceRef": { "postAngle": "<angle>" },
      "metadata": { "hashtags": ["selfhosted", "indiehackers"] },
@@ -103,7 +94,7 @@ Write like this instead:
    }
    ```
 
-9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
+8. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
 
 ## Hard rules
 

--- a/playbooks/mastodon-scout.md
+++ b/playbooks/mastodon-scout.md
@@ -85,14 +85,13 @@ Write like this instead:
    - Apply the House style section above literally: it outranks every default here and holds even when the campaign voice says nothing about it.
    - Never open with a pitch. Lead with the genuine reason you're mentioning them; the offer (if any) comes last, briefly.
    - The offer text comes from `campaign.config.offer.text` and the product URL from `campaign.config.offer.productUrl`. Never invent an offer. If `campaign.config.offer` is absent, do not draft any DMs this run - there is nothing honest to offer.
+   - The compose window Pitchbox opens for this draft defaults to public visibility, not direct - mention that in `reasoning` so the reviewer remembers to switch the visibility picker to "Only people I mention" before sending.
 
 8. **Pick the account.** Use the first account from `accounts` whose `role === 'personal'`. Record its `id` as `accountId`.
 
-9. **Build the compose URL.** `${account.instanceUrl}/share?text=<urlencoded body>`. This opens Mastodon's compose intent prefilled with the text but defaults to public visibility - the human must manually switch the visibility picker to "Only people I mention" (direct) before sending. Note this explicitly in `reasoning` so the reviewer doesn't miss it.
+9. **Score each draft.** Using `rubricTemplate` from the run context, score the DM 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, well-justified mentions and give low scores to anything that reads generic or pitchy. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-10. **Score each draft.** Using `rubricTemplate` from the run context, score the DM 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, well-justified mentions and give low scores to anything that reads generic or pitchy. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
-
-11. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`, one draft object per candidate that survived step 6.
+10. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`, one draft object per candidate that survived step 6.
 
     > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
 
@@ -105,8 +104,7 @@ Write like this instead:
       "fitScore": 4,
       "targetUser": "alice@mastodon.social",
       "body": "@alice@mastodon.social <mention body>",
-      "composeUrl": "https://mastodon.social/share?text=%40alice%40mastodon.social%20...",
-      "reasoning": "Why this candidate cleared the outreach gate in step 6, plus the visibility reminder from step 9.",
+      "reasoning": "Why this candidate cleared the outreach gate in step 6, plus the visibility reminder from step 7.",
       "sourceRef": {
         "statusUrl": "https://mastodon.social/@alice/109...",
         "matchedHashtag": "selfhosted"
@@ -117,11 +115,11 @@ Write like this instead:
     }
     ```
 
-12. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 
-- Never post or send the mention. The human reviews and sends from the Pitchbox dashboard, and must still fix the visibility manually (step 9).
+- Never post or send the mention. The human reviews and sends from the Pitchbox dashboard, and must still fix the visibility manually (step 7).
 - Cold DMs are off by default. Only draft one when step 6's gate is satisfied; when in doubt, skip.
 - `#nobot` is a hard, non-negotiable skip - never draft to a candidate flagged by it, even if the filter looks over-eager.
 - No generic openers, no pitch-first bodies. If you catch yourself writing a mention that could be sent unchanged to any of the candidates, stop and rewrite or drop it.

--- a/playbooks/reddit-commenter.md
+++ b/playbooks/reddit-commenter.md
@@ -83,17 +83,9 @@ Write like this instead:
 
 6. **Pick the account.** Comments almost always use the `personal` account (brand accounts commenting on other people's posts comes off as marketing spam). Use the first account with `role === 'personal'`. Record `accountId`.
 
-7. **Build the URL.** For `post_comment` drafts the compose URL is just the post permalink:
+7. **Score each draft.** Using `rubricTemplate` from the run context, score the comment 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted comments and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-   ```
-   https://www.reddit.com{post.permalink}?pitchbox_draft=<draftId>
-   ```
-
-   The `pitchbox_draft` query param is how the browser extension finds the draft to auto-fill the comment textarea.
-
-8. **Score each draft.** Using `rubricTemplate` from the run context, score the comment 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted comments and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
-
-9. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+8. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
 
@@ -107,7 +99,6 @@ Write like this instead:
      "subreddit": "Solo_Roleplaying",
      "targetUser": null,
      "body": "<comment markdown>",
-     "composeUrl": "https://www.reddit.com/r/Solo_Roleplaying/comments/abc/.../",
      "reasoning": "2-3 sentences on why this post, what angle, what value you're adding.",
      "sourceRef": { "permalink": "/r/Solo_Roleplaying/comments/abc/.../", "postTitle": "..." },
      "metadata": { "matchedBy": "search", "postAgeHours": 8 },
@@ -118,7 +109,7 @@ Write like this instead:
 
    Note `targetUser` is null for post_comment - the audience is the whole thread, not one user.
 
-10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/reddit-poster.md
+++ b/playbooks/reddit-poster.md
@@ -85,7 +85,6 @@ Write like this instead:
      "targetUser": null,
      "title": "<post title>",
      "body": "<markdown body, including disclosure>",
-     "composeUrl": "https://www.reddit.com/r/<sub>/submit?title=<urlencoded title>&text=<urlencoded body>",
      "reasoning": "<one sentence: which angle + why this subreddit>",
      "sourceRef": {
        "subreddit": "<sub>",

--- a/playbooks/reddit-scout.md
+++ b/playbooks/reddit-scout.md
@@ -82,8 +82,6 @@ Write like this instead:
 
    The offer text comes from `campaign.config.offer.text` and the product URL from `campaign.config.offer.productUrl`. Never invent an offer.
 
-   **c. Build the compose URL.** Take `composeUrlBase` from the candidate, append `&subject=<urlencoded>&message=<urlencoded>`. Subject comes from `campaign.config.offer.subject`.
-
 5. **Pick the account.** Use the first account from `accounts` whose `role === 'personal'`. Record its `id` as `accountId`.
 
 6. **Score each draft.** Using `rubricTemplate` from the run context, score the DM 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted DMs and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
@@ -102,7 +100,6 @@ Write like this instead:
      "subreddit": "rpg",
      "targetUser": "alice",
      "body": "<DM markdown>",
-     "composeUrl": "https://www.reddit.com/message/compose?to=alice&subject=...&message=...",
      "reasoning": "2-4 sentences citing specific words from their post.",
      "sourceRef": { "permalink": "/r/rpg/comments/abc/.../" },
      "metadata": { "matchedBy": "search" },

--- a/shared/src/platforms/hackernews/client.ts
+++ b/shared/src/platforms/hackernews/client.ts
@@ -92,6 +92,10 @@ export function replyUrl(id: number): string {
   return `${SITE_BASE}/reply?id=${id}`;
 }
 
+export function submitUrl(): string {
+  return `${SITE_BASE}/submit`;
+}
+
 export function profileUrl(username: string): string {
   return `${SITE_BASE}/user?id=${encodeURIComponent(username)}`;
 }

--- a/shared/src/platforms/hackernews/compose-url.ts
+++ b/shared/src/platforms/hackernews/compose-url.ts
@@ -1,0 +1,34 @@
+import type { DraftKind } from '../../quota-types.js';
+import { replyUrl, submitUrl } from './client.js';
+
+export interface HackernewsComposeUrlInput {
+  kind: DraftKind;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Builds the Hacker News compose URL server-side (issue #325). HN's submit
+ * form and reply page don't accept query-string prefill for title/body, so
+ * there is nothing to percent-encode here - only the story id (for a reply)
+ * needs to come from somewhere, and it is already on `metadata.itemId`
+ * (every hn-commenter draft carries it).
+ */
+export function buildHackernewsComposeUrl(input: HackernewsComposeUrlInput): string | null {
+  switch (input.kind) {
+    case 'post':
+      return submitUrl();
+    case 'post_comment':
+    case 'comment_reply': {
+      const raw = input.metadata.itemId;
+      const id = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
+      return Number.isFinite(id) ? replyUrl(id) : null;
+    }
+    case 'dm':
+      // HN has no DM primitive.
+      return null;
+    default: {
+      const exhaustive: never = input.kind;
+      return exhaustive;
+    }
+  }
+}

--- a/shared/src/platforms/hackernews/index.ts
+++ b/shared/src/platforms/hackernews/index.ts
@@ -1,3 +1,4 @@
 export * from './types.js';
 export * from './client.js';
 export { getAccountSchema } from './account.js';
+export * from './compose-url.js';

--- a/shared/src/platforms/mastodon/compose-url.ts
+++ b/shared/src/platforms/mastodon/compose-url.ts
@@ -1,0 +1,40 @@
+import type { DraftKind } from '../../quota-types.js';
+
+export interface MastodonComposeUrlInput {
+  kind: DraftKind;
+  body: string;
+  // The account's instance base URL (e.g. "https://mastodon.social"),
+  // read from accounts.instance_url. A `dm`/`post` draft can't build a
+  // compose URL without it.
+  instanceUrl: string | null;
+  sourceRef: Record<string, unknown>;
+}
+
+/**
+ * Builds the Mastodon compose URL server-side (issue #325). A `dm` (a
+ * direct-visibility status mentioning the target - see mastodon-scout.md)
+ * and a `post` both open the instance's share intent prefilled with the
+ * full body via `URLSearchParams`, so the text in the compose window can
+ * never diverge from `drafts.body`. A `post_comment`/`comment_reply` has no
+ * prefill on Mastodon; the compose URL is just the target status's own
+ * permalink, same as the reddit/HN comment-reply shape.
+ */
+export function buildMastodonComposeUrl(input: MastodonComposeUrlInput): string | null {
+  switch (input.kind) {
+    case 'dm':
+    case 'post': {
+      if (!input.instanceUrl) return null;
+      const params = new URLSearchParams({ text: input.body });
+      return `${input.instanceUrl}/share?${params.toString()}`;
+    }
+    case 'post_comment':
+    case 'comment_reply': {
+      const statusUrl = input.sourceRef.statusUrl;
+      return typeof statusUrl === 'string' && statusUrl.length > 0 ? statusUrl : null;
+    }
+    default: {
+      const exhaustive: never = input.kind;
+      return exhaustive;
+    }
+  }
+}

--- a/shared/src/platforms/mastodon/index.ts
+++ b/shared/src/platforms/mastodon/index.ts
@@ -3,3 +3,4 @@ export * from './client.js';
 export * from './scout.js';
 export * from './reply-reader.js';
 export * from './account-client.js';
+export * from './compose-url.js';

--- a/shared/src/platforms/reddit/compose-url.ts
+++ b/shared/src/platforms/reddit/compose-url.ts
@@ -1,0 +1,52 @@
+import type { DraftKind } from '../../quota-types.js';
+
+const BASE = 'https://www.reddit.com';
+
+export interface RedditComposeUrlInput {
+  kind: DraftKind;
+  targetUser: string | null;
+  subreddit: string | null;
+  title: string | null;
+  body: string;
+  // DM subject line, sourced from campaign.config.offer.subject. Only a `dm`
+  // draft uses it.
+  subject: string | null;
+  sourceRef: Record<string, unknown>;
+}
+
+/**
+ * Builds the Reddit compose URL server-side from the same fields already
+ * persisted on the draft (issue #325). `URLSearchParams` owns every bit of
+ * percent-encoding, so the query string can never diverge from
+ * `drafts.body`/`drafts.title` the way a hand-encoded, agent-supplied URL
+ * could.
+ */
+export function buildRedditComposeUrl(input: RedditComposeUrlInput): string | null {
+  switch (input.kind) {
+    case 'dm': {
+      if (!input.targetUser) return null;
+      const params = new URLSearchParams({ to: input.targetUser });
+      if (input.subject) params.set('subject', input.subject);
+      params.set('message', input.body);
+      return `${BASE}/message/compose?${params.toString()}`;
+    }
+    case 'post': {
+      if (!input.subreddit) return null;
+      const params = new URLSearchParams();
+      if (input.title) params.set('title', input.title);
+      params.set('text', input.body);
+      return `${BASE}/r/${encodeURIComponent(input.subreddit)}/submit?${params.toString()}`;
+    }
+    case 'post_comment':
+    case 'comment_reply': {
+      // A comment reply has no query-string prefill on Reddit; the compose
+      // URL is just the permalink of the thread it belongs to.
+      const permalink = input.sourceRef.permalink;
+      return typeof permalink === 'string' && permalink.length > 0 ? `${BASE}${permalink}` : null;
+    }
+    default: {
+      const exhaustive: never = input.kind;
+      return exhaustive;
+    }
+  }
+}

--- a/shared/src/platforms/reddit/index.ts
+++ b/shared/src/platforms/reddit/index.ts
@@ -3,3 +3,4 @@ export * from './types.js';
 export * from './scout.js';
 export * from './filter.js';
 export * from './env.js';
+export * from './compose-url.js';

--- a/web/tests/compose-url.test.ts
+++ b/web/tests/compose-url.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { composeHref } from '../src/lib/utils/compose-url.js';
+import { buildRedditComposeUrl } from '@pitchbox/shared/platforms/reddit';
 
 describe('composeHref', () => {
   it('appends the draft id with the right separator', () => {
@@ -19,5 +20,103 @@ describe('composeHref', () => {
 
   it('omits the backend param when the origin is unknown', () => {
     expect(composeHref('https://x.test/c', 5, undefined)).toBe('https://x.test/c?pitchbox_draft=5');
+  });
+});
+
+// issue #325: `composeUrl` used to be an agent-supplied input to
+// `drafts_create`, built by hand-percent-encoding subject/body - an
+// independent argument from `body` with nothing enforcing agreement between
+// the two. `buildRedditComposeUrl` (and its Hacker News / Mastodon siblings)
+// now build it server-side from the same fields already on the draft, so
+// the compose URL and the reviewed body can never diverge.
+describe('buildRedditComposeUrl (issue #325)', () => {
+  it('the dm message= param decodes to exactly drafts.body for characters hand percent-encoding gets wrong', () => {
+    // Spaces, &, =, #, +, a non-ASCII character and an apostrophe: each is
+    // either a query-string metacharacter or one `encodeURIComponent` and a
+    // hand-rolled encoder disagree on (+ in particular round-trips through
+    // `+` as a literal space unless it is itself escaped).
+    const body = "budget's tight: 50% off + free shipping (US & EU only) #deal café";
+    const url = buildRedditComposeUrl({
+      kind: 'dm',
+      targetUser: 'alice',
+      subreddit: null,
+      title: null,
+      body,
+      subject: 'quick question about your setup',
+      sourceRef: {},
+    });
+    expect(url).not.toBeNull();
+    const parsed = new URL(url!);
+    expect(parsed.origin + parsed.pathname).toBe('https://www.reddit.com/message/compose');
+    expect(parsed.searchParams.get('message')).toBe(body);
+    expect(parsed.searchParams.get('to')).toBe('alice');
+    expect(parsed.searchParams.get('subject')).toBe('quick question about your setup');
+  });
+
+  it('omits the subject param when the campaign has none', () => {
+    const url = buildRedditComposeUrl({
+      kind: 'dm',
+      targetUser: 'alice',
+      subreddit: null,
+      title: null,
+      body: 'hi',
+      subject: null,
+      sourceRef: {},
+    });
+    expect(new URL(url!).searchParams.has('subject')).toBe(false);
+  });
+
+  it('builds a post compose URL from subreddit + title + body, not a caller-supplied URL', () => {
+    const url = buildRedditComposeUrl({
+      kind: 'post',
+      targetUser: null,
+      subreddit: 'rpg',
+      title: 'Title with & and = in it',
+      body: 'body & more',
+      subject: null,
+      sourceRef: {},
+    });
+    const parsed = new URL(url!);
+    expect(parsed.origin + parsed.pathname).toBe('https://www.reddit.com/r/rpg/submit');
+    expect(parsed.searchParams.get('title')).toBe('Title with & and = in it');
+    expect(parsed.searchParams.get('text')).toBe('body & more');
+  });
+
+  it('a post_comment compose URL is just the thread permalink, with no body prefill', () => {
+    const url = buildRedditComposeUrl({
+      kind: 'post_comment',
+      targetUser: null,
+      subreddit: 'rpg',
+      title: null,
+      body: 'a comment',
+      subject: null,
+      sourceRef: { permalink: '/r/rpg/comments/abc/x/' },
+    });
+    expect(url).toBe('https://www.reddit.com/r/rpg/comments/abc/x/');
+  });
+
+  it('returns null rather than guessing when the required target is missing', () => {
+    expect(
+      buildRedditComposeUrl({
+        kind: 'dm',
+        targetUser: null,
+        subreddit: null,
+        title: null,
+        body: 'hi',
+        subject: null,
+        sourceRef: {},
+      }),
+    ).toBeNull();
+    expect(
+      buildRedditComposeUrl({
+        kind: 'post',
+        targetUser: null,
+        subreddit: null,
+        title: null,
+        body: 'hi',
+        subject: null,
+        sourceRef: {},
+      }),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## What

drafts_create now builds composeUrl server-side from the same fields it already receives (platform, kind, target/subreddit/title, subject from campaign.config.offer.subject, and body), instead of accepting it as an agent-supplied input. Each platform owns its own URL shape in shared/src/platforms/<platform>/compose-url.ts (reddit, hackernews, mastodon); cli/src/commands/drafts.ts only routes by platform slug and uses URLSearchParams for percent-encoding, so the compose URL's message=/text= query param can never diverge from drafts.body.

composeUrl is no longer an accepted field on DraftInput (a caller-supplied value is now silently stripped/ignored, never persisted).

Removed the "build the compose URL" / urlencode instructions from every playbook that had one (reddit-scout, reddit-commenter, reddit-poster, hn-commenter, hn-poster, mastodon-scout, mastodon-commenter, mastodon-poster) and renumbered their steps. No playbook literally asked the agent to count words via a shell command, so there was nothing to remove there - the shell usage in the reported run was purely to build the URL. shared/tests/playbook-house-style.test.ts's shared section is untouched. Playbook bodies are read live from disk at seed time (shared/src/db/seed-core.ts), so no separate seeded copy needed updating.

## Testing

- web/tests/compose-url.test.ts: new tests proving buildRedditComposeUrl's message= param decodes to exactly drafts.body for a body containing spaces, &, =, #, +, a non-ASCII character and an apostrophe, plus coverage of post/post_comment/missing-target shapes.
- cli/tests/commands/drafts-create.test.ts: updated the first test to assert the server ignores a caller-supplied composeUrl and builds its own from targetUser/body instead.
- cli/tests/commands/playbook-draft-payloads.test.ts: dropped the now-removed composeUrl field from the null-tolerance test.
- shared/cli typecheck clean; pnpm exec vitest run green for all touched test files, shared/tests/playbook-house-style.test.ts, and cli/tests/commands/playbook-draft-payloads.test.ts.
- eslint + prettier clean on every changed file.

Closes #325