### PR TITLE
docs(docs): LinkedIn platform page and the automation boundary

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -36,6 +36,10 @@ export default defineConfig({
         ],
       },
       {
+        text: 'Platforms',
+        items: [{ text: 'LinkedIn', link: '/platforms/linkedin' }],
+      },
+      {
         text: 'Surfaces',
         items: [
           { text: 'Chrome extension', link: '/extension' },

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,7 +10,7 @@ An **account** is a platform identity (e.g. `u/myhandle` on Reddit) tied to a pr
 
 ## Campaigns
 
-A **campaign** scopes an outreach intent: which platform, which skill (`reddit-scout` for DMs, `reddit-commenter` for comment-replies, `reddit-poster` for top-level posts), which agent runner, which cron schedule. Campaigns snapshot their runner at creation; runs snapshot the runner and playbook at start.
+A **campaign** scopes an outreach intent: which platform, which skill (e.g. `reddit-scout` for DMs, `mastodon-commenter` for comment-replies, `linkedin-poster` for top-level posts), which agent runner, which cron schedule. Campaigns snapshot their runner at creation; runs snapshot the runner and playbook at start.
 
 ### Campaign readiness and live setup banner
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,8 @@ hero:
 features:
   - title: Human in the loop
     details: The agent researches, drafts, and bookkeeps. The dashboard lets you approve, edit, or reject before anything goes out.
-  - title: Reddit today, more later
-    details: First-class Reddit support (DMs and comment-replies). The platform layer is decoupled - new adapters drop in.
+  - title: Four platforms, one loop
+    details: First-class outreach on Reddit, Hacker News and Mastodon today. LinkedIn is landing next, extension-mediated because it has no discovery or comment API. The platform layer is decoupled, new adapters drop in.
   - title: Agent-runner agnostic
     details: Built around the AgentRunner interface - claude-code today, codex/opencode adapters when their ergonomics catch up.
 ---

--- a/docs/platforms/linkedin.md
+++ b/docs/platforms/linkedin.md
@@ -1,0 +1,66 @@
+# LinkedIn
+
+LinkedIn is Pitchbox's fourth outreach platform, and it is shaped differently from the other three on purpose. This page is about that shape: what Pitchbox does on LinkedIn, what it deliberately never does, and why. For the full architecture and the reasoning behind every decision below, see the [design doc](/linkedin-integration-design).
+
+## No API, so the browser is the discovery mechanism
+
+LinkedIn has no discovery API, no third-party comment API and no self-serve messaging API at any developer tier. Reading a third party's post well enough to comment on it (`r_member_social`) is "granted to select developers only"; `w_organization_social` only covers pages a member administers; a self-serve message API does not exist outside partner programs.
+
+So there is nothing on linkedin.com for a Pitchbox server to call or scrape. The only legitimate source of a LinkedIn candidate is the human's own logged-in browser, while the human is already looking at LinkedIn. The Chrome extension is not an add-on to LinkedIn support, it is the adapter: a content script watches the feed and post pages the human is already scrolling and records what LinkedIn already rendered there. It initiates nothing.
+
+## What Pitchbox never does on LinkedIn
+
+Section 8.2 of LinkedIn's User Agreement prohibits scraping, browser plugins used to scrape, and bots that create, comment on, like or share content on a member's behalf. That is not a technicality Pitchbox works around: it is the reason the LinkedIn integration is shaped the way it is. A restricted Reddit account costs a throwaway handle; a restricted LinkedIn account costs a real professional identity, its connections and its message history. So the rules below are prohibitions, not guidance.
+
+- **No LinkedIn session credential ever leaves the browser.** No `li_at`, no CSRF token, no cookie or storage value read and transmitted anywhere.
+- **No request to linkedin.com is ever initiated by Pitchbox.** The extension reads only the DOM the human's own navigation already rendered: no fetch, no background polling, no voluntary navigation to a LinkedIn URL.
+- **No synthetic interaction.** Pitchbox never calls `.click()` on a LinkedIn control and never dispatches a synthetic submit. It may insert drafted text into a composer the human already opened, and nothing more. The human presses LinkedIn's own button, always.
+- **No server-side automation of linkedin.com.** No Playwright, no headless browser, no stealth stack pointed at LinkedIn, in any edition.
+- **No direct messages.** The `dm` quota ships at zero and there is no `linkedin-scout` scenario to produce one. Cold DMs and unsolicited connection requests are the behavior most reliably associated with LinkedIn restricting an account, so Pitchbox does not offer it.
+
+## Why this looks different from Reddit and Mastodon
+
+The shape of a platform integration follows what that platform actually allows, not a house preference:
+
+| Capability                     | Reddit                        | Mastodon                                    | LinkedIn                                                         |
+| ------------------------------ | ----------------------------- | ------------------------------------------- | ---------------------------------------------------------------- |
+| Target discovery               | Server-side Playwright scrape | `GET /api/v1/timelines/tag`                 | No API at any tier: the extension observes what the human opened |
+| Comment on someone else's post | Scrape + extension            | `POST /api/v1/statuses`                     | Not available at any self-serve tier                             |
+| Post to your own profile       | Scrape                        | `POST /api/v1/statuses`, optional auto-post | Self-serve API exists but is out of scope for v1 (see below)     |
+| Direct message                 | Extension                     | `direct`-visibility status                  | Off entirely                                                     |
+
+Reddit's own rules tolerate server-side scraping, so Pitchbox scrapes it server-side with Playwright. Mastodon exposes an open REST API, so Pitchbox posts through it directly and can optionally auto-post with a pasted token. Neither option is available on LinkedIn, so the extension mediates instead: comments and top-level posts only, drafted from what the human's own browser already rendered, sent by the human's own click.
+
+## The tradeoff: a slower-filling candidate pool
+
+Because nothing is fetched or scraped, a LinkedIn candidate only arrives while a human is actually browsing LinkedIn with the extension installed and turned on. That candidate pool fills more slowly than a feed scrape would fill it. That is the correct trade given the alternative: the only ways to fill it faster are synthesizing a click to read a post's permalink, or patching the page's own network calls to read LinkedIn's internal payloads underneath it, and both sit on the wrong side of the boundary above.
+
+## LinkedIn's own posting API, deliberately not used
+
+`w_member_social` would let a connected member's own posts go out through LinkedIn's official API without the human pressing a button. It needs three-legged OAuth with a hosted redirect URI, and self-hosting Pitchbox should not require registering a LinkedIn developer app to work. It is recorded as a spike, not built, for v1.
+
+## Connecting an account
+
+Add a LinkedIn account from **Projects → [project] → Accounts** with your public vanity slug (`linkedin.com/in/<slug>`) and a display name. There is no password or session to enter, because Pitchbox never asks for one: a LinkedIn account row is an identity, not a credential.
+
+## Quota defaults
+
+LinkedIn ships with the tightest limits of any platform, because the constraint here is reputational rather than technical: an account that comments dozens of times a day looks like a bot to LinkedIn's velocity monitoring, regardless of whether a human approved every draft.
+
+| Kind           | Per day | Per week |
+| -------------- | ------- | -------- |
+| Comment        | 8       | 30       |
+| Post           | 1       | 4        |
+| Direct message | 0       | 0        |
+
+An operator can lower these from **Settings → Quota**. Unlike the other platforms, LinkedIn's ceiling is not meant to be raised past these defaults: the product deliberately does not offer a setting for that.
+
+## Status
+
+Most of the LinkedIn work tracked on the `v1.5 - LinkedIn` milestone (epics #296 and #297) is still open. What is merged today:
+
+- The `linkedin` platform row, its two scenarios (`linkedin-commenter`, `linkedin-poster`), the quota defaults above, and the credential-free account model, including the connect form described above.
+- An Inbox presenter that knows how to render a LinkedIn draft (vanity-slug labels, "Send clicked on LinkedIn").
+- On the in-page assistant side: an approved design brief, the shadow-DOM panel component the assistant will render into, and the real-time suggestion endpoint that will produce its drafted text.
+
+What is still open, and so does nothing useful yet if you try it: the browser-side observation collector and the table it writes to, the tool that drains observations into a campaign run, the two playbooks themselves, send detection, and reply ingestion for asynchronous campaigns. On the in-page assistant side: actually mounting the panel on a LinkedIn page, turning an accepted suggestion into a real draft, and the on-demand host-permission grant the panel needs to run at all. A LinkedIn campaign can already be created from the dashboard, since the scenario picker does not know which platforms are finished, but with none of the above landed it has nothing to draft from yet.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -26,7 +26,7 @@ The **`AgentRunner`** box is pluggable. With a local runner (Claude Code, Codex,
 `pg_dump pitchbox` is enough. Everything that matters lives in Postgres:
 
 - Campaigns, runs, drafts, contact history, blocklist, messages.
-- Encrypted account credentials (`accounts.cookie_session`).
+- Encrypted account credentials (`accounts.cookie_session`), for the platforms that have one. LinkedIn accounts carry no credential at all: see [LinkedIn](/platforms/linkedin).
 - App config (`app_config`) - quota defaults, runner configs, default runner, retention policy, notification webhooks. Extension auth uses per-device tokens in `extension_devices`, not a singleton here.
 - Built-in and user playbooks.
 


### PR DESCRIPTION
## Summary

Adds `docs/platforms/linkedin.md`: a user-facing page whose subject is the automation boundary, what Pitchbox does on LinkedIn, what it deliberately never does, and why.

- No discovery API, no third-party comment API, no self-serve messaging API: the extension observes what the human's own browser already rendered, nothing is fetched or scraped.
- The compliance boundary, named plainly against LinkedIn's User Agreement section 8.2 (prohibits scraping, browser plugins used to scrape, and bots that create/comment/like/share).
- Contrast with Reddit (server-side Playwright scrape) and Mastodon (open REST API, optional auto-post), to show the platform's own rules deciding the integration shape.
- The candidate-pool tradeoff (fills slower than a scrape would, and that is the correct trade).
- Conservative quota defaults (8 comments/day, 30/week; 1 post/day, 4/week; 0 DMs) and where to change them (Settings, Quota).
- A Status section separating what is actually merged (platform row, scenario registry, quota defaults, Inbox presenter, credential-free account connect flow, the in-page assistant's brief/panel host/suggestion endpoint) from what is still open on the `v1.5 - LinkedIn` milestone (the observation pipeline, the two playbooks, send detection, reply ingestion, the panel actually mounting on a page, turning a suggestion into a real draft, the on-demand host permission).

Also, per the issue's scope:

- Linked the new page from a new Platforms sidebar group in `docs/.vitepress/config.ts`.
- Updated the platform example in `docs/concepts.md`'s campaign definition (was Reddit-only) and the account-credentials line in `docs/self-hosting.md` (now notes LinkedIn accounts carry no credential).
- Fixed the `docs/index.md` feature card that said "Reddit today, more later" with Reddit as the only first-class platform.

## Verification

- `pnpm run docs:build` succeeds (VitePress 1.6.4, "build complete", no dead-link errors); `docs/.vitepress/dist/platforms/linkedin.html` is produced and reachable from the built sidebar via the new Platforms group.
- Grepped `docs/platforms/linkedin.md` and every other changed file for the full banned-character set in `shared/tests/playbook-house-style.test.ts` (em dash, en dash, curly single/double quotes, single-character ellipsis, non-breaking space): clean.
- `npx prettier --write` on all five changed files (only the new page needed reformatting, the four edited files were already formatted).
- `npx eslint docs/.vitepress/config.ts`: clean, no output.

## Scope note

`docs/platforms/hackernews.md` already existed but was not linked from the sidebar before this change. That is a pre-existing gap outside issue #309's scope, so I left it as is and only linked the new LinkedIn page.

Closes #309
