### PR TITLE
feat(extension): request LinkedIn host permission on demand

### DIFF
--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -162,6 +162,16 @@ export const en = {
   'settings.about.github': 'GitHub',
   'settings.about.docs': 'Documentation',
 
+  'settings.linkedin.title': 'LinkedIn access',
+  'settings.linkedin.description':
+    "Grant LinkedIn access so the in-page assistant can read the post you're viewing and suggest a comment. Nothing is requested until you grant it, and no LinkedIn credential ever leaves your browser.",
+  'settings.linkedin.granted': 'Granted',
+  'settings.linkedin.not-granted': 'Not granted',
+  'settings.linkedin.grant': 'Grant access',
+  'settings.linkedin.revoke': 'Revoke access',
+  'settings.linkedin.denied': 'Permission was not granted. You can try again anytime.',
+  'settings.linkedin.request-failed': 'Could not request LinkedIn access. Try again.',
+
   'time.never': 'never',
   'time.seconds-ago': '{n}s ago',
   'time.minutes-ago': '{n}m ago',

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -166,6 +166,16 @@ export const it = {
   'settings.about.github': 'GitHub',
   'settings.about.docs': 'Documentazione',
 
+  'settings.linkedin.title': 'Accesso a LinkedIn',
+  'settings.linkedin.description':
+    'Concedi l’accesso a LinkedIn per permettere all’assistente in pagina di leggere il post che stai visualizzando e suggerire un commento. Non viene richiesto nulla finché non lo concedi, e nessuna credenziale di LinkedIn lascia mai il tuo browser.',
+  'settings.linkedin.granted': 'Concesso',
+  'settings.linkedin.not-granted': 'Non concesso',
+  'settings.linkedin.grant': 'Concedi accesso',
+  'settings.linkedin.revoke': 'Revoca accesso',
+  'settings.linkedin.denied': 'Permesso non concesso. Puoi riprovare quando vuoi.',
+  'settings.linkedin.request-failed': 'Impossibile richiedere l’accesso a LinkedIn. Riprova.',
+
   'time.never': 'mai',
   'time.seconds-ago': '{n}s fa',
   'time.minutes-ago': '{n}m fa',

--- a/extension/src/lib/permissions.ts
+++ b/extension/src/lib/permissions.ts
@@ -17,3 +17,31 @@ export function originStillNeeded(pairings: Pairing[], origin: string): boolean 
     }
   });
 }
+
+// #317: the LinkedIn host permission is optional (see
+// `manifest.config.ts`'s `optional_host_permissions: ['<all_urls>']`) and
+// must be requested on demand, from a user gesture, rather than declared in
+// `host_permissions` - a blanket grant at install time is both alarming and
+// a Chrome Web Store review risk. `*://*.linkedin.com/*` matches
+// `docs/linkedin-integration-design.md` decision 7.
+export const LINKEDIN_ORIGIN = '*://*.linkedin.com/*';
+
+/** The real current state, read from Chrome rather than assumed. */
+export function hasLinkedInPermission(): Promise<boolean> {
+  return chrome.permissions.contains({ origins: [LINKEDIN_ORIGIN] });
+}
+
+/**
+ * Requests the LinkedIn origin. Must be called synchronously from a user
+ * gesture (before any other `await` resolves) - Chrome rejects
+ * `chrome.permissions.request` outside one. Resolves `false` on an explicit
+ * user decline, distinct from a caller catching a thrown request failure.
+ */
+export function requestLinkedInPermission(): Promise<boolean> {
+  return chrome.permissions.request({ origins: [LINKEDIN_ORIGIN] });
+}
+
+/** Revokes the LinkedIn origin. Safe to call even if never granted. */
+export function revokeLinkedInPermission(): Promise<boolean> {
+  return chrome.permissions.remove({ origins: [LINKEDIN_ORIGIN] });
+}

--- a/extension/src/sidepanel/components/LinkedInAccessCard.svelte
+++ b/extension/src/sidepanel/components/LinkedInAccessCard.svelte
@@ -1,0 +1,108 @@
+<!-- LinkedIn access: on-demand grant of the optional LinkedIn host
+     permission (#317). Never declared in host_permissions - requested from
+     this card's own button click (a real user gesture, required by Chrome
+     for chrome.permissions.request) and reflected from chrome.permissions
+     itself rather than assumed, so a revoke made from chrome://extensions
+     shows up here too. See lib/permissions.ts and
+     docs/linkedin-integration-design.md decision 7. -->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { Card, CardContent, CardHeader, CardTitle } from '$ui/card';
+  import { Button } from '$ui/button';
+  import { t } from '$ext/i18n';
+  import {
+    hasLinkedInPermission,
+    requestLinkedInPermission,
+    revokeLinkedInPermission,
+  } from '$ext/permissions';
+
+  let granted = $state(false);
+  let busy = $state(false);
+  // Distinct failure states: the user explicitly declined Chrome's own
+  // prompt (first-class, not an error) vs. the request itself throwing
+  // (e.g. no longer in a user-gesture context).
+  let denied = $state(false);
+  let requestFailed = $state(false);
+
+  async function refresh() {
+    granted = await hasLinkedInPermission();
+  }
+
+  onMount(() => {
+    refresh();
+    // Keeps this card honest if the permission is revoked from
+    // chrome://extensions while the side panel is open, and after a grant
+    // made from elsewhere (e.g. a future in-page prompt).
+    chrome.permissions.onAdded.addListener(refresh);
+    chrome.permissions.onRemoved.addListener(refresh);
+    return () => {
+      chrome.permissions.onAdded.removeListener(refresh);
+      chrome.permissions.onRemoved.removeListener(refresh);
+    };
+  });
+
+  async function grant() {
+    denied = false;
+    requestFailed = false;
+    busy = true;
+    try {
+      // Must run in this click's user-gesture context, so request the host
+      // permission before any other await resolves.
+      let ok: boolean;
+      try {
+        ok = await requestLinkedInPermission();
+      } catch {
+        requestFailed = true;
+        return;
+      }
+      if (!ok) {
+        denied = true;
+        return;
+      }
+      granted = true;
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function revoke() {
+    busy = true;
+    try {
+      await revokeLinkedInPermission();
+      granted = await hasLinkedInPermission();
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<Card>
+  <CardHeader><CardTitle>{$t('settings.linkedin.title')}</CardTitle></CardHeader>
+  <CardContent class="flex flex-col gap-3">
+    <p class="text-xs text-muted-foreground">{$t('settings.linkedin.description')}</p>
+    <div class="flex items-center justify-between gap-2 text-sm">
+      <span
+        class="inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium {granted
+          ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+          : 'border-muted-foreground/30 bg-muted text-muted-foreground'}"
+      >
+        {granted ? $t('settings.linkedin.granted') : $t('settings.linkedin.not-granted')}
+      </span>
+      {#if granted}
+        <Button variant="outline" disabled={busy} onclick={revoke}>
+          {$t('settings.linkedin.revoke')}
+        </Button>
+      {:else}
+        <Button disabled={busy} onclick={grant}>
+          {$t('settings.linkedin.grant')}
+        </Button>
+      {/if}
+    </div>
+    {#if denied}
+      <p class="text-xs text-destructive">{$t('settings.linkedin.denied')}</p>
+    {/if}
+    {#if requestFailed}
+      <p class="text-xs text-destructive">{$t('settings.linkedin.request-failed')}</p>
+    {/if}
+  </CardContent>
+</Card>

--- a/extension/src/sidepanel/routes/Settings.svelte
+++ b/extension/src/sidepanel/routes/Settings.svelte
@@ -3,6 +3,7 @@
   import AppearanceCard from '../components/AppearanceCard.svelte';
   import LanguageCard from '../components/LanguageCard.svelte';
   import SyncSettingsCard from '../components/SyncSettingsCard.svelte';
+  import LinkedInAccessCard from '../components/LinkedInAccessCard.svelte';
   import DataCard from '../components/DataCard.svelte';
   import AboutCard from '../components/AboutCard.svelte';
 </script>
@@ -11,6 +12,7 @@
   <AppearanceCard />
   <LanguageCard />
   <SyncSettingsCard />
+  <LinkedInAccessCard />
   <DataCard />
   <AboutCard />
 </div>

--- a/extension/tests/lib/permissions.test.ts
+++ b/extension/tests/lib/permissions.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { originStillNeeded } from '../../src/lib/permissions.js';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  originStillNeeded,
+  LINKEDIN_ORIGIN,
+  hasLinkedInPermission,
+  requestLinkedInPermission,
+  revokeLinkedInPermission,
+} from '../../src/lib/permissions.js';
 
 const A = { backendUrl: 'https://a.example', token: 'ta' };
 const A_OTHER_TOKEN = { backendUrl: 'https://a.example', token: 'ta2' };
@@ -21,5 +27,48 @@ describe('originStillNeeded', () => {
     expect(originStillNeeded([{ backendUrl: 'not-a-url', token: 't' }], 'https://a.example')).toBe(
       false,
     );
+  });
+});
+
+describe('LinkedIn host permission (#317)', () => {
+  const contains = vi.fn();
+  const request = vi.fn();
+  const remove = vi.fn();
+
+  beforeEach(() => {
+    contains.mockReset();
+    request.mockReset();
+    remove.mockReset();
+    vi.stubGlobal('chrome', { permissions: { contains, request, remove } });
+  });
+
+  it('requests exactly the LinkedIn origin', async () => {
+    request.mockResolvedValue(true);
+    const granted = await requestLinkedInPermission();
+    expect(granted).toBe(true);
+    expect(request).toHaveBeenCalledWith({ origins: [LINKEDIN_ORIGIN] });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves false on an explicit decline rather than throwing', async () => {
+    request.mockResolvedValue(false);
+    expect(await requestLinkedInPermission()).toBe(false);
+  });
+
+  it('reflects chrome.permissions.contains, granted or not', async () => {
+    contains.mockResolvedValue(true);
+    expect(await hasLinkedInPermission()).toBe(true);
+    expect(contains).toHaveBeenCalledWith({ origins: [LINKEDIN_ORIGIN] });
+
+    contains.mockResolvedValue(false);
+    expect(await hasLinkedInPermission()).toBe(false);
+  });
+
+  it('revokes exactly the LinkedIn origin', async () => {
+    remove.mockResolvedValue(true);
+    const removed = await revokeLinkedInPermission();
+    expect(removed).toBe(true);
+    expect(remove).toHaveBeenCalledWith({ origins: [LINKEDIN_ORIGIN] });
+    expect(remove).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What was there before

`extension/manifest.config.ts` had no LinkedIn entry anywhere already:

- `host_permissions` (lines 95-104): Reddit, `matrix.redditspace.com`, `pitchbox.app` variants, `127.0.0.1`/`localhost`. No LinkedIn.
- `optional_host_permissions` (line 94): `['<all_urls>']`, already covers requesting a LinkedIn origin at runtime.
- `content_scripts`: five entries (DM compose, post comment, post submit, chat token, auto-pair), all Reddit/pitchbox.app/localhost. No LinkedIn content script is registered anywhere, static or dynamic.

So there was nothing to remove from `host_permissions` and no content script to convert to `chrome.scripting.registerContentScripts`. This PR adds the on-demand grant surface only.

## What changed

- `extension/src/lib/permissions.ts`: `LINKEDIN_ORIGIN` (`*://*.linkedin.com/*`, per `docs/linkedin-integration-design.md` decision 7) plus `hasLinkedInPermission`/`requestLinkedInPermission`/`revokeLinkedInPermission`, thin wrappers over `chrome.permissions.contains`/`request`/`remove`.
- `extension/src/sidepanel/components/LinkedInAccessCard.svelte` (new): a card in the side panel Settings tab, same shape as `SyncSettingsCard`/`ConnectionCard`. Shows Granted/Not granted read from `chrome.permissions.contains` (never assumed), a Grant/Revoke button, and listens to `chrome.permissions.onAdded`/`onRemoved` so a revoke made from `chrome://extensions` is reflected while the panel is open. `chrome.permissions.request` is called synchronously from the button click (before any other `await`), since Chrome rejects it outside a user gesture. An explicit decline renders its own message rather than an error.
- Wired into `extension/src/sidepanel/routes/Settings.svelte`.
- `dict-en.ts`/`dict-it.ts`: the eight `settings.linkedin.*` strings, added to both (dict-it is type-checked via `satisfies Record<keyof typeof en, string>` to always cover every `dict-en` key).
- `extension/tests/lib/permissions.test.ts`: unit tests over a mocked `chrome.permissions` for request/contains/revoke, asserting the exact `*://*.linkedin.com/*` origin is used each time.

## Scope note on content script registration (issue point 3/5)

No LinkedIn content script exists in this repo yet to register, so there is nothing to convert to `chrome.scripting.registerContentScripts` here. `extension/src/content/shared/panel-host.ts` is a shared mounting utility for a future panel, not a registered entry point. Issue #302 ("passive LinkedIn observation collector") explicitly assigns itself a static `content_scripts` entry for `linkedin-observe.ts` and explicitly says "Do not add `host_permissions`; that grant is LI-20 (#317)'s job" - it already expects a declarative entry, not dynamic registration. Chrome does not inject a declarative content script into a host that isn't currently granted (verified: MDN + Chrome docs, "Registered content scripts are only executed if the extension is granted host permissions for the domain"), but once the optional permission is granted at runtime, Chrome starts injecting matching declarative content scripts into that host's future navigations automatically, with no extra registration call needed. So a static `content_scripts` entry for LinkedIn (#302's own plan) will work correctly once this PR's grant exists; keeping this PR to the permission surface only.

## Manifest proof

```
pnpm run build:extension
```

`extension/dist/manifest.json`:

```json
"host_permissions": ["https://www.reddit.com/*", "https://old.reddit.com/*", "https://matrix.redditspace.com/*", "https://pitchbox.app/*", "https://www.pitchbox.app/*", "https://preview.pitchbox.app/*", "http://127.0.0.1/*", "http://localhost/*"]
"optional_host_permissions": ["<all_urls>"]
```

No `linkedin` in either array (LI-11/#308's future check).

## Verification

- `pnpm exec vitest run extension/tests/lib/permissions.test.ts extension/tests/lib/i18n.test.ts` (with `DATABASE_URL` exported from `.env`, an isolated `pitchbox_test_w317`): 2 files, 12 tests, all passed.
- `pnpm -F @pitchbox/extension check`: 734 files, 0 errors, 0 warnings (covers the new `.svelte` file and the `dict-it.ts` parity `satisfies` check).
- `pnpm run build:extension`: builds cleanly; manifest inspected above.
- `npx prettier --check <changed .ts files>` and `npx eslint <changed .ts files>`: clean. `.svelte` files are outside both tools' scope in this repo already (`eslint.config.js` ignores `**/*.svelte`; `prettier` has no Svelte plugin installed, so it silently skips `.svelte` files when given a directory, and errors only when given one explicitly) - pre-existing, not something this PR introduces or could fix without adding a dependency I'm not permitted to install.

### Not verified

- Live rendering of the side panel card in a real Chrome window. I built the extension and tried to load it unpacked and navigate straight to `chrome-extension://<id>/src/sidepanel/index.html` via CDP (headless and headful `google-chrome` on this devbox); Chrome returns `ERR_BLOCKED_BY_CLIENT` for a direct top-level navigation to a `side_panel`-designated document outside the actual side panel UI surface, in both modes. This isn't something this repo has infra for elsewhere either: there is no Svelte-component test harness (`panel-host.test.ts` notes "the root vitest config has no svelte plugin") and no other side panel card has an automated render test. Coverage here is the same as every existing card: `svelte-check` (types/props/imports) plus unit tests on the logic it calls.
- The manual acceptance steps that need a real logged-in LinkedIn session and an actual install-time Chrome permission prompt (fresh install shows no LinkedIn prompt, granting makes future declarative content scripts start running) - the latter has no content script to observe yet (see scope note above).