### PR TITLE
feat(web): POST /api/extension/observations to receive browser-observed LinkedIn posts

### DIFF
--- a/web/src/routes/api/extension/observations/+server.ts
+++ b/web/src/routes/api/extension/observations/+server.ts
@@ -1,0 +1,97 @@
+import { json, error } from '@sveltejs/kit';
+import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import { getDb, schema } from '$lib/server/db.js';
+import { requireExtensionAuth } from '$lib/server/extension-auth.js';
+import { RateLimiter } from '$lib/server/rate-limit.js';
+import {
+  ingestObservedTargets,
+  MAX_OBSERVED_TARGETS_BATCH,
+} from '@pitchbox/shared/observed-targets';
+
+// Server side of the observation buffer (#301): the extension's content
+// script watches linkedin.com passively and posts what it saw here, on a
+// debounce, so a LinkedIn campaign has candidates without a discovery API
+// (docs/linkedin-integration-design.md, "Observation collection").
+
+// Per device. A human actively scrolling can produce several debounced
+// batches a minute, so this is looser than /suggest's perDevice(20, 60_000)
+// while still bounding what a stolen token can spend.
+const perDevice = new RateLimiter(30, 60_000);
+
+// Elements are validated per item by ingestObservedTargets
+// (shared/src/observed-targets.ts) and dropped individually rather than
+// failing the whole batch - the extension builds these from raw DOM reads,
+// so one degenerate sighting must not lose the rest of a debounce tick (same
+// posture as IncomingDmSchema in .../dm-sync/+server.ts, #182).
+const BodySchema = z.object({
+  platform: z.string().min(1),
+  projectId: z.number().int().positive(),
+  items: z.array(z.unknown()).max(MAX_OBSERVED_TARGETS_BATCH),
+});
+
+export async function POST({ request }: { request: Request }) {
+  const auth = await requireExtensionAuth(request);
+
+  // Consumed before any await: a burst of concurrent requests for the same
+  // device can't all slip past the check before any of them records an
+  // attempt (see rate-limit.ts's own doc comment).
+  if (!perDevice.consume(`device:${auth.deviceId}`)) {
+    throw error(429, 'too many observations');
+  }
+
+  const raw = await request.json().catch(() => null);
+  const parsed = BodySchema.safeParse(raw);
+  if (!parsed.success) throw error(400, 'invalid body');
+  const body = parsed.data;
+
+  const db = getDb();
+
+  // Org scoping is not optional: a device bound to an org may only write
+  // against one of its own projects. An id that doesn't resolve for this org
+  // 404s rather than 403s, matching assertDraftInDeviceOrg - it leaks
+  // nothing about other tenants' ids. A null-org device (self-host / auth
+  // off) is unrestricted, mirroring requireRole's no-op there.
+  const [project] = await db
+    .select({ id: schema.projects.id, organizationId: schema.projects.organizationId })
+    .from(schema.projects)
+    .where(
+      auth.organizationId == null
+        ? eq(schema.projects.id, body.projectId)
+        : and(
+            eq(schema.projects.id, body.projectId),
+            eq(schema.projects.organizationId, auth.organizationId),
+          ),
+    )
+    .limit(1);
+  if (!project) throw error(404, 'project not found');
+
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, body.platform))
+    .limit(1);
+  if (!platform) throw error(404, 'unknown platform');
+
+  // Delegate the write and the dedup entirely to LI-3's ingest service - no
+  // hand-rolled insert here. `body.items` is passed through unvalidated:
+  // ingestObservedTargets does the per-item zod check and reports how many
+  // it dropped. Never log the items themselves; `text`/`authorName` are
+  // third-party LinkedIn content, not ours to put in server logs.
+  const result = await ingestObservedTargets(db, {
+    organizationId: project.organizationId,
+    projectId: project.id,
+    platformId: platform.id,
+    observations: body.items,
+  });
+
+  // `written` only reports rows that actually landed post-dedup, so the
+  // duplicate count is everything that validated but didn't make it in.
+  const validCount = body.items.length - result.rejected;
+  return json({
+    ok: true,
+    inserted: result.written.length,
+    duplicates: validCount - result.written.length,
+    dropped: result.rejected,
+  });
+}

--- a/web/tests/extension-observations.test.ts
+++ b/web/tests/extension-observations.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { POST as observationsPost } from '../src/routes/api/extension/observations/+server.js';
+
+/**
+ * POST /api/extension/observations (#301), the server side of the LinkedIn
+ * observation buffer. Modelled on extension-draft-org-scope.test.ts's
+ * seeding/mintDevice harness, plus the batch-ingest and rate-limit
+ * behaviours specific to this route.
+ */
+
+async function reset() {
+  await getDb().execute(sql`TRUNCATE observed_targets, projects RESTART IDENTITY CASCADE`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  // Deliberately a plain DELETE, not TRUNCATE ... RESTART IDENTITY: the
+  // route's rate limiter is keyed by numeric device id, and resetting the id
+  // sequence every test would give several tests' devices the same id,
+  // colliding in the same in-memory bucket for the limiter's 60s window. A
+  // monotonically increasing id keeps every test's device in its own bucket.
+  await getDb().execute(sql`DELETE FROM extension_devices`);
+}
+
+function bearer(token: string | null, body: unknown): Request {
+  return new Request('http://x/api/extension/observations', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+async function seedOrgWithProject(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug })
+    .returning();
+  return { org, project };
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({
+      organizationId,
+      tokenHash: createHash('sha256').update(token).digest('hex'),
+      label: 'test',
+    });
+}
+
+function observation(overrides: Record<string, unknown> = {}) {
+  return {
+    externalId: 'urn:li:activity:9999',
+    url: 'https://www.linkedin.com/feed/update/urn:li:activity:9999/',
+    authorHandle: 'jane-doe',
+    authorName: 'Jane Doe',
+    text: 'A post about outreach automation.',
+    observedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/** Narrows a caught value to the shape @sveltejs/kit's `error()` throws. */
+function isHttpError(value: unknown): value is { status: number } {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('status' in value)) return false;
+  return typeof value.status === 'number';
+}
+
+async function statusOf(promise: Promise<Response>): Promise<number> {
+  try {
+    return (await promise).status;
+  } catch (e) {
+    if (isHttpError(e)) return e.status;
+    throw e;
+  }
+}
+
+describe('POST /api/extension/observations', () => {
+  beforeEach(reset);
+
+  it('refuses a request with no bearer token (401)', async () => {
+    await expect(
+      observationsPost({
+        request: bearer(null, { platform: 'linkedin', projectId: 1, items: [] }),
+      } as never),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('refuses a revoked device token (401)', async () => {
+    const { project } = await seedOrgWithProject('obs-revoked');
+    await getDb()
+      .insert(schema.extensionDevices)
+      .values({
+        organizationId: null,
+        tokenHash: createHash('sha256').update('tokRevoked').digest('hex'),
+        label: 'test-revoked',
+        revokedAt: new Date(),
+      });
+
+    await expect(
+      observationsPost({
+        request: bearer('tokRevoked', {
+          platform: 'linkedin',
+          projectId: project.id,
+          items: [],
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('404s a projectId that does not belong to the device org, so it leaks no other tenant ids', async () => {
+    const { project: bProject } = await seedOrgWithProject('obs-org-b');
+    const { org: orgA } = await seedOrgWithProject('obs-org-a');
+    await mintDevice(orgA.id, 'tokA');
+
+    await expect(
+      observationsPost({
+        request: bearer('tokA', {
+          platform: 'linkedin',
+          projectId: bProject.id,
+          items: [observation()],
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 404 });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.observedTargets)
+      .where(eq(schema.observedTargets.projectId, bProject.id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('a duplicate externalId counts as a duplicate, not a second insert', async () => {
+    const { org, project } = await seedOrgWithProject('obs-dup');
+    await mintDevice(org.id, 'tokDup');
+
+    const firstRes = await observationsPost({
+      request: bearer('tokDup', {
+        platform: 'linkedin',
+        projectId: project.id,
+        items: [observation()],
+      }),
+    } as never);
+    expect(firstRes.status).toBe(200);
+    const first = (await firstRes.json()) as {
+      ok: boolean;
+      inserted: number;
+      duplicates: number;
+      dropped: number;
+    };
+    expect(first).toMatchObject({ ok: true, inserted: 1, duplicates: 0, dropped: 0 });
+
+    const secondRes = await observationsPost({
+      request: bearer('tokDup', {
+        platform: 'linkedin',
+        projectId: project.id,
+        items: [observation()],
+      }),
+    } as never);
+    expect(secondRes.status).toBe(200);
+    const second = (await secondRes.json()) as {
+      ok: boolean;
+      inserted: number;
+      duplicates: number;
+      dropped: number;
+    };
+    expect(second).toMatchObject({ ok: true, inserted: 0, duplicates: 1, dropped: 0 });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.observedTargets)
+      .where(eq(schema.observedTargets.projectId, project.id));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('drops a malformed item while its siblings still insert', async () => {
+    const { org, project } = await seedOrgWithProject('obs-malformed');
+    await mintDevice(org.id, 'tokMal');
+
+    const res = await observationsPost({
+      request: bearer('tokMal', {
+        platform: 'linkedin',
+        projectId: project.id,
+        items: [
+          observation({ externalId: 'urn:li:activity:1' }),
+          // Malformed: no externalId, not a URL, unparsable date.
+          { url: 'not-a-url', observedAt: 'not-a-date' },
+          observation({ externalId: 'urn:li:activity:2' }),
+        ],
+      }),
+    } as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      inserted: number;
+      duplicates: number;
+      dropped: number;
+    };
+    expect(body).toMatchObject({ ok: true, inserted: 2, duplicates: 0, dropped: 1 });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.observedTargets)
+      .where(eq(schema.observedTargets.projectId, project.id));
+    expect(rows).toHaveLength(2);
+  });
+
+  it('rate limits a device that sends too many batches', async () => {
+    const { org, project } = await seedOrgWithProject('obs-ratelimit');
+    await mintDevice(org.id, 'tokRate');
+
+    const statuses: number[] = [];
+    for (let i = 0; i < 31; i++) {
+      statuses.push(
+        await statusOf(
+          observationsPost({
+            request: bearer('tokRate', {
+              platform: 'linkedin',
+              projectId: project.id,
+              items: [observation({ externalId: `urn:li:activity:rate-${i}` })],
+            }),
+          } as never),
+        ),
+      );
+    }
+
+    const passedThrough = statuses.filter((s) => s === 200).length;
+    const throttled = statuses.filter((s) => s === 429).length;
+    expect(passedThrough).toBe(30);
+    expect(throttled).toBe(1);
+    expect(passedThrough + throttled).toBe(statuses.length);
+  });
+});


### PR DESCRIPTION
Closes #301

## What this adds

`POST /api/extension/observations`, the server side of the LinkedIn observation buffer (LI-4). Follows the conventions already used under `web/src/routes/api/extension/`:

- `requireExtensionAuth(request)` for auth and org resolution.
- Org scoping via a single scoped `projects` lookup, same shape as `api/extension/suggest`: a project outside the device's org 404s (not 403s), matching `assertDraftInDeviceOrg`'s posture, so no other tenant's id leaks. A null-org device (self-host / auth off) is unrestricted.
- Per-device rate limiting with the existing `RateLimiter` (`web/src/lib/server/rate-limit.ts`), same shape as `/suggest` and `/pair`, no second limiter implementation.
- The write and dedup are delegated entirely to `ingestObservedTargets` (`@pitchbox/shared/observed-targets`, LI-3/#300). The route only validates the envelope (`platform`, `projectId`, `items` capped at `MAX_OBSERVED_TARGETS_BATCH`); per-item validation and dropping malformed entries already lives in the shared ingest service, matching `dm-sync`'s posture of never 400ing a batch for one bad item.
- Response: `{ ok: true, inserted, duplicates, dropped }`.
- No observed post text (or any item field) is logged anywhere on this path.

## Tests

New `web/tests/extension-observations.test.ts`, modelled on `extension-draft-org-scope.test.ts`'s seeding/`mintDevice` harness:

- no bearer token -> 401
- a revoked device token -> 401
- a `projectId` from another org -> 404 (and confirms no row was written)
- a duplicate `externalId` counts as a duplicate, not a second insert
- a malformed item is dropped while its siblings still insert
- the rate limiter triggers after 30 requests from one device

All 6 pass: `pnpm exec vitest run web/tests/extension-observations.test.ts`.

## Proof the guards actually bite

Broke each guard in turn against the passing suite above and confirmed exactly the test defending it failed, nothing else:

- **Accept any project** (dropped the org-scoping condition, matched only on `projectId`): 1 test failed - the cross-org 404 test.
- **Count duplicates as inserts** (reported `validCount` as `inserted` and hardcoded `duplicates: 0`): 1 test failed - the duplicate-externalId test.
- **Drop the limiter** (removed the `perDevice.consume` check): 1 test failed - the rate-limit test.

Reverted all three after confirming, then re-ran the full file clean (6/6 passing) before opening this PR.

## Other verification

- `pnpm -F web check`: 0 errors, 0 warnings.
- `npx prettier --write` and `npx eslint` on both changed files: clean, no diffs.

No live LinkedIn session or request is involved anywhere in this change; it only writes to `observed_targets` from a JSON body the caller supplies.