### PR TITLE
feat(cli-mcp): linkedin_candidates tool draining the observation buffer into run staging

### DIFF
--- a/cli/src/commands/linkedin.ts
+++ b/cli/src/commands/linkedin.ts
@@ -1,0 +1,210 @@
+import { Command } from 'commander';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type { Db } from '@pitchbox/shared/db';
+import { and, asc, eq, gte, inArray, isNull, lte } from 'drizzle-orm';
+import { isBlocklisted } from '@pitchbox/shared/blocklist';
+import {
+  checkContactDedup,
+  parseDedupPolicy,
+  DEFAULT_DEDUP_POLICY,
+} from '@pitchbox/shared/contact-dedup';
+import { getRunOrgId, getRunProjectId } from '@pitchbox/shared/orgs';
+import { ok, fail } from '../lib/output.js';
+
+// Unlike reddit_scout/mastodon_scout/hn_search, linkedin_candidates fetches
+// nothing itself: LinkedIn has no discovery API, so the only candidates that
+// exist are the ones the browser already wrote to `observed_targets` while a
+// human scrolled their own feed (see docs/linkedin-integration-design.md,
+// "Consumption"). This drains that buffer into `staging_scout_candidates`
+// for the run, exactly the shape `staging_candidates` already reads, so the
+// rest of the playbook (score fit, draft, run_finish) is unchanged.
+
+/** Rows claimed but older than this are dropped as stale. Mirrors Mastodon's maxAgeHours default. */
+const DEFAULT_MAX_AGE_HOURS = 72;
+/** No minimum wait by default: a row is eligible the moment it lands in the buffer. */
+const DEFAULT_MIN_AGE_MINUTES = 0;
+/** Default batch size for one drain call. */
+const DEFAULT_LIMIT = 20;
+/** Upper bound on how many rows one call can claim, matching the ingest side's own per-batch cap. */
+const MAX_LIMIT = 200;
+
+export interface LinkedinCandidatesInput {
+  runId: number;
+  /** Max observed_targets rows to claim in this call. Default 20, capped at 200. */
+  limit?: number;
+  /** Only claim rows observed at least this many minutes ago. Default 0. */
+  minAgeMinutes?: number;
+  /** Drop rows older than this as stale. Default 72. */
+  maxAgeHours?: number;
+}
+
+export interface LinkedinCandidatesResult {
+  runId: number;
+  candidatesFetched: number;
+}
+
+async function linkedinPlatformId(db: Db): Promise<number> {
+  const [row] = await db
+    .select({ id: schema.platforms.id })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'));
+  if (!row) throw new Error('linkedin platform not found');
+  return row.id;
+}
+
+/**
+ * Drains unconsumed `observed_targets` for the run's project into
+ * `staging_scout_candidates` for the run. Extracted so both the CLI and the
+ * Pitchbox MCP server share it (mirrors reddit.ts/mastodon.ts's scoutRun).
+ *
+ * Claiming (marking `consumed_by_run_id`) and staging happen in one
+ * transaction: the claim itself is a single `UPDATE ... WHERE id IN (SELECT
+ * ... FOR UPDATE SKIP LOCKED)` so two concurrent calls draining the same
+ * project's buffer never claim the same row - each transaction's inner
+ * SELECT skips rows already locked by the other rather than blocking on
+ * them, so both proceed concurrently over disjoint rows.
+ *
+ * Blocklist and contact-dedup are applied server-side, per candidate, the
+ * same helpers `drafts:create` uses (`isBlocklisted`, `checkContactDedup`)
+ * rather than trusting the playbook to re-check - a blocklisted or
+ * recently-contacted author's post is claimed (so it is never re-offered on
+ * a later drain) but not staged, so it never reaches the agent. Unlike
+ * `drafts:create`'s dedup policy, there is no draft yet to attach a "warn"
+ * to here, so any contact inside the window is unconditionally excluded
+ * rather than staged-with-a-warning.
+ */
+export async function linkedinCandidatesRun(
+  input: LinkedinCandidatesInput,
+): Promise<LinkedinCandidatesResult> {
+  const { runId } = input;
+  const limit = Math.max(1, Math.min(input.limit ?? DEFAULT_LIMIT, MAX_LIMIT));
+  const minAgeMinutes = Math.max(0, input.minAgeMinutes ?? DEFAULT_MIN_AGE_MINUTES);
+  const maxAgeHours = Math.max(0, input.maxAgeHours ?? DEFAULT_MAX_AGE_HOURS);
+
+  const db = getDb();
+  const [run] = await db.select().from(schema.runs).where(eq(schema.runs.id, runId));
+  if (!run) throw new Error(`run ${runId} not found`);
+
+  // Resolves via runs.project_id directly or runs.campaign_id -> campaigns.project_id
+  // (the same join runBelongsToOrg/checkOwnership use), so this works for a
+  // campaign-triggered LinkedIn run the same way the MCP boundary already does.
+  const projectId = await getRunProjectId(db, runId);
+  if (projectId == null) throw new Error(`run ${runId} has no project`);
+  const orgId = await getRunOrgId(db, runId);
+  if (orgId == null) throw new Error(`run ${runId} has no organization`);
+
+  const platformId = await linkedinPlatformId(db);
+
+  const [policyRow] = await db
+    .select()
+    .from(schema.appConfig)
+    .where(eq(schema.appConfig.key, 'dedup_policy'));
+  const dedupPolicy = policyRow ? parseDedupPolicy(policyRow.value) : { ...DEFAULT_DEDUP_POLICY };
+
+  const now = Date.now();
+  // Must be observed at least minAgeMinutes ago.
+  const notObservedAfter = new Date(now - minAgeMinutes * 60_000);
+  // Must not be older than maxAgeHours.
+  const notObservedBefore = new Date(now - maxAgeHours * 60 * 60_000);
+
+  const staged = await db.transaction(async (tx) => {
+    const claimIds = tx
+      .select({ id: schema.observedTargets.id })
+      .from(schema.observedTargets)
+      .where(
+        and(
+          eq(schema.observedTargets.organizationId, orgId),
+          eq(schema.observedTargets.projectId, projectId),
+          eq(schema.observedTargets.platformId, platformId),
+          isNull(schema.observedTargets.consumedByRunId),
+          lte(schema.observedTargets.observedAt, notObservedAfter),
+          gte(schema.observedTargets.observedAt, notObservedBefore),
+        ),
+      )
+      .orderBy(asc(schema.observedTargets.observedAt))
+      .limit(limit)
+      .for('update', { skipLocked: true });
+
+    const claimed = await tx
+      .update(schema.observedTargets)
+      .set({ consumedByRunId: runId })
+      .where(inArray(schema.observedTargets.id, claimIds))
+      .returning();
+    if (claimed.length === 0) return [];
+
+    // UPDATE ... RETURNING has no ordering guarantee; restore oldest-first.
+    claimed.sort((a, b) => a.observedAt.getTime() - b.observedAt.getTime());
+
+    const survivors: (typeof schema.stagingScoutCandidates.$inferInsert)[] = [];
+    for (const row of claimed) {
+      if (row.authorHandle) {
+        const block = await isBlocklisted(tx as unknown as Db, {
+          platformId,
+          projectId,
+          targetUser: row.authorHandle,
+        });
+        if (block.blocked) continue;
+
+        const dedup = await checkContactDedup(tx as unknown as Db, {
+          platformId,
+          targetUser: row.authorHandle,
+          windowDays: dedupPolicy.windowDays,
+          organizationId: orgId,
+        });
+        if (dedup.withinWindow) continue;
+      }
+      survivors.push({
+        runId,
+        raw: {
+          author: { handle: row.authorHandle, name: row.authorName },
+          post: {
+            externalId: row.externalId,
+            url: row.url,
+            text: row.text,
+            observedAt: row.observedAt.toISOString(),
+          },
+        },
+      });
+    }
+
+    if (survivors.length > 0) {
+      await tx.insert(schema.stagingScoutCandidates).values(survivors);
+    }
+    return survivors;
+  });
+
+  return { runId, candidatesFetched: staged.length };
+}
+
+export function registerLinkedinCommands(program: Command) {
+  program
+    .command('linkedin:candidates')
+    .requiredOption('--run <id>', 'run id')
+    .option('--limit <n>', 'max observed rows to claim (default 20)')
+    .option(
+      '--min-age-minutes <n>',
+      'only claim rows observed at least this many minutes ago (default 0)',
+    )
+    .option('--max-age-hours <n>', 'drop rows older than this as stale (default 72)')
+    .action(
+      async (opts: {
+        run: string;
+        limit?: string;
+        minAgeMinutes?: string;
+        maxAgeHours?: string;
+      }) => {
+        try {
+          ok(
+            await linkedinCandidatesRun({
+              runId: Number(opts.run),
+              limit: opts.limit != null ? Number(opts.limit) : undefined,
+              minAgeMinutes: opts.minAgeMinutes != null ? Number(opts.minAgeMinutes) : undefined,
+              maxAgeHours: opts.maxAgeHours != null ? Number(opts.maxAgeHours) : undefined,
+            }),
+          );
+        } catch (err) {
+          fail(String(err instanceof Error ? err.message : err));
+        }
+      },
+    );
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,6 +13,7 @@ async function main() {
   const { registerRedditCommands } = await import('./commands/reddit.js');
   const { registerHnCommands } = await import('./commands/hn.js');
   const { registerMastodonCommands } = await import('./commands/mastodon.js');
+  const { registerLinkedinCommands } = await import('./commands/linkedin.js');
   const { registerUtilityCommands } = await import('./commands/utility.js');
   const { registerProjectCommands } = await import('./commands/project.js');
   const { registerSkillCommands } = await import('./commands/skill.js');
@@ -22,6 +23,7 @@ async function main() {
   registerRedditCommands(program);
   registerHnCommands(program);
   registerMastodonCommands(program);
+  registerLinkedinCommands(program);
   registerUtilityCommands(program);
   registerProjectCommands(program);
   registerSkillCommands(program);

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -31,6 +31,7 @@ import {
   postRun as mastodonPostRun,
   type MastodonPostKind,
 } from '../commands/mastodon.js';
+import { linkedinCandidatesRun } from '../commands/linkedin.js';
 import { searchHn, HN_LISTINGS } from '../commands/hn.js';
 import type { HnListing } from '@pitchbox/shared/platforms/hackernews';
 import {
@@ -326,6 +327,55 @@ export function createPitchboxMcpServer(ctx: PitchboxMcpContext = {}): McpServer
         const ownershipErr = await checkOwnership('run', rid);
         if (ownershipErr) return errorResult(ownershipErr);
         return jsonResult(await mastodonScoutRun(rid));
+      } catch (err) {
+        return errorResult(String(err instanceof Error ? err.message : err));
+      }
+    },
+  );
+
+  server.registerTool(
+    'linkedin_candidates',
+    {
+      title: 'Drain observed LinkedIn posts into staged candidates',
+      description:
+        "Drain unconsumed observed_targets for the run's project (rows the browser already wrote to the observation buffer - this tool fetches nothing itself) into staged candidates for the run, applying blocklist + contact-history filters server-side. Returns { runId, candidatesFetched }.",
+      inputSchema: {
+        runId: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('run id (defaults to PITCHBOX_RUN_ID)'),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .max(200)
+          .optional()
+          .describe('max observed rows to claim (default 20)'),
+        minAgeMinutes: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe('only claim rows observed at least this many minutes ago (default 0)'),
+        maxAgeHours: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('drop rows older than this as stale (default 72)'),
+      },
+    },
+    async ({ runId, limit, minAgeMinutes, maxAgeHours }) => {
+      const rid = runId ?? defaultRunId();
+      if (rid == null) return errorResult('runId required (or set PITCHBOX_RUN_ID)');
+      try {
+        const ownershipErr = await checkOwnership('run', rid);
+        if (ownershipErr) return errorResult(ownershipErr);
+        return jsonResult(
+          await linkedinCandidatesRun({ runId: rid, limit, minAgeMinutes, maxAgeHours }),
+        );
       } catch (err) {
         return errorResult(String(err instanceof Error ? err.message : err));
       }

--- a/cli/tests/commands/linkedin-candidates.test.ts
+++ b/cli/tests/commands/linkedin-candidates.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { eq, sql } from 'drizzle-orm';
+
+// linkedinCandidatesRun (the linkedin_candidates MCP tool) drains
+// observed_targets - rows the browser already wrote to the observation
+// buffer - into staging_scout_candidates for a run. Unlike
+// mastodon-scout.test.ts, there is no network client to mock: this file
+// exercises the real claim + filter + stage logic against Postgres.
+
+async function reset() {
+  const db = getDb();
+  // Deliberately does not truncate `platforms`: tests share one Postgres
+  // across files run sequentially, and other suites rely on the
+  // core-seeded reddit/hackernews/mastodon/linkedin rows surviving between
+  // files.
+  await db.execute(
+    sql`TRUNCATE runs, campaigns, projects, blocklist, contact_history, staging_scout_candidates, observed_targets RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function linkedinPlatformId(): Promise<number> {
+  const db = getDb();
+  const [row] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'));
+  if (!row) throw new Error('linkedin platform not seeded by seed:core');
+  return row.id;
+}
+
+async function defaultOrgId(): Promise<number> {
+  const db = getDb();
+  const [org] = await db
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(sql`slug = 'default'`);
+  return org.id;
+}
+
+/** Seeds a project plus one campaign/run pair bound to it, mirroring how startRun creates a campaign run (campaignId set, runs.projectId left null). */
+async function seedRun(projectId: number, platformId: number, name: string) {
+  const db = getDb();
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({ projectId, platformId, name, skillSlug: 'linkedin-commenter' })
+    .returning();
+  const [run] = await db
+    .insert(schema.runs)
+    .values({ campaignId: campaign.id, trigger: 'manual' })
+    .returning();
+  return { campaignId: campaign.id, runId: run.id };
+}
+
+async function seedProject(orgId: number, slug: string) {
+  const db = getDb();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: orgId, slug, name: slug })
+    .returning();
+  return project.id;
+}
+
+async function seedObserved(opts: {
+  organizationId: number;
+  projectId: number;
+  platformId: number;
+  externalId: string;
+  authorHandle?: string | null;
+  observedAt?: Date;
+}) {
+  const db = getDb();
+  const [row] = await db
+    .insert(schema.observedTargets)
+    .values({
+      organizationId: opts.organizationId,
+      projectId: opts.projectId,
+      platformId: opts.platformId,
+      externalId: opts.externalId,
+      url: `https://www.linkedin.com/feed/update/${opts.externalId}/`,
+      authorHandle: opts.authorHandle ?? null,
+      authorName: opts.authorHandle ? `${opts.authorHandle} display name` : null,
+      text: `body of ${opts.externalId}`,
+      observedAt: opts.observedAt ?? new Date(),
+    })
+    .returning();
+  return row;
+}
+
+beforeEach(reset);
+
+describe('linkedinCandidatesRun', () => {
+  it('throws when the run does not exist', async () => {
+    const { linkedinCandidatesRun } = await import('../../src/commands/linkedin.js');
+    await expect(linkedinCandidatesRun({ runId: 987654 })).rejects.toThrow('not found');
+  });
+
+  it('returns an empty list rather than an error when the buffer is empty', async () => {
+    const orgId = await defaultOrgId();
+    const platformId = await linkedinPlatformId();
+    const projectId = await seedProject(orgId, 'li-empty');
+    const { runId } = await seedRun(projectId, platformId, 'LinkedIn Commenter');
+
+    const { linkedinCandidatesRun } = await import('../../src/commands/linkedin.js');
+    await expect(linkedinCandidatesRun({ runId })).resolves.toEqual({
+      runId,
+      candidatesFetched: 0,
+    });
+  });
+
+  it('stages an observed post and never returns the consumed row again', async () => {
+    const orgId = await defaultOrgId();
+    const platformId = await linkedinPlatformId();
+    const projectId = await seedProject(orgId, 'li-consume');
+    const { runId } = await seedRun(projectId, platformId, 'LinkedIn Commenter');
+    await seedObserved({
+      organizationId: orgId,
+      projectId,
+      platformId,
+      externalId: 'urn:li:activity:1',
+      authorHandle: 'alice',
+    });
+
+    const { linkedinCandidatesRun } = await import('../../src/commands/linkedin.js');
+    const first = await linkedinCandidatesRun({ runId });
+    expect(first).toEqual({ runId, candidatesFetched: 1 });
+
+    const db = getDb();
+    const staged = await db
+      .select()
+      .from(schema.stagingScoutCandidates)
+      .where(eq(schema.stagingScoutCandidates.runId, runId));
+    expect(staged).toHaveLength(1);
+    expect(staged[0]?.raw).toMatchObject({
+      author: { handle: 'alice' },
+      post: { externalId: 'urn:li:activity:1' },
+    });
+
+    // Same run, called again: the row is already consumed, so it must not
+    // be staged a second time.
+    const second = await linkedinCandidatesRun({ runId });
+    expect(second).toEqual({ runId, candidatesFetched: 0 });
+    const stagedAfter = await db
+      .select()
+      .from(schema.stagingScoutCandidates)
+      .where(eq(schema.stagingScoutCandidates.runId, runId));
+    expect(stagedAfter).toHaveLength(1);
+  });
+
+  it('claims a blocklisted author but never stages it', async () => {
+    const orgId = await defaultOrgId();
+    const platformId = await linkedinPlatformId();
+    const projectId = await seedProject(orgId, 'li-blocklist');
+    const { runId } = await seedRun(projectId, platformId, 'LinkedIn Commenter');
+    const db = getDb();
+    await db.insert(schema.blocklist).values({
+      platformId,
+      kind: 'user',
+      value: 'spammer',
+      reason: 'spam',
+    });
+    const observed = await seedObserved({
+      organizationId: orgId,
+      projectId,
+      platformId,
+      externalId: 'urn:li:activity:2',
+      authorHandle: 'spammer',
+    });
+
+    const { linkedinCandidatesRun } = await import('../../src/commands/linkedin.js');
+    const result = await linkedinCandidatesRun({ runId });
+    expect(result).toEqual({ runId, candidatesFetched: 0 });
+
+    const staged = await db
+      .select()
+      .from(schema.stagingScoutCandidates)
+      .where(eq(schema.stagingScoutCandidates.runId, runId));
+    expect(staged).toHaveLength(0);
+
+    // Claimed (consumed) even though filtered, so it is never re-offered.
+    const [row] = await db
+      .select()
+      .from(schema.observedTargets)
+      .where(eq(schema.observedTargets.id, observed.id));
+    expect(row?.consumedByRunId).toBe(runId);
+  });
+
+  it('filters a target contacted inside the dedup window', async () => {
+    const orgId = await defaultOrgId();
+    const platformId = await linkedinPlatformId();
+    const projectId = await seedProject(orgId, 'li-dedup');
+    const { runId } = await seedRun(projectId, platformId, 'LinkedIn Commenter');
+    const db = getDb();
+    await db.insert(schema.contactHistory).values({
+      platformId,
+      accountHandle: 'our-linkedin-profile',
+      targetUser: 'bob',
+      organizationId: orgId,
+      lastContactedAt: new Date(),
+    });
+    await seedObserved({
+      organizationId: orgId,
+      projectId,
+      platformId,
+      externalId: 'urn:li:activity:3',
+      authorHandle: 'bob',
+    });
+
+    const { linkedinCandidatesRun } = await import('../../src/commands/linkedin.js');
+    const result = await linkedinCandidatesRun({ runId });
+    expect(result).toEqual({ runId, candidatesFetched: 0 });
+
+    const staged = await db
+      .select()
+      .from(schema.stagingScoutCandidates)
+      .where(eq(schema.stagingScoutCandidates.runId, runId));
+    expect(staged).toHaveLength(0);
+  });
+
+  it('two concurrent drains of the same project never claim the same row', async () => {
+    const orgId = await defaultOrgId();
+    const platformId = await linkedinPlatformId();
+    const projectId = await seedProject(orgId, 'li-concurrent');
+    const { runId: runIdA } = await seedRun(projectId, platformId, 'Campaign A');
+    const { runId: runIdB } = await seedRun(projectId, platformId, 'Campaign B');
+
+    const db = getDb();
+    const externalIds = Array.from({ length: 6 }, (_, i) => `urn:li:activity:concurrent-${i}`);
+    for (const [i, externalId] of externalIds.entries()) {
+      // Distinct authors so nothing is filtered by blocklist/dedup - the
+      // point of this test is the claim race, not the filters.
+      await seedObserved({
+        organizationId: orgId,
+        projectId,
+        platformId,
+        externalId,
+        authorHandle: `author-${i}`,
+        // Stagger observedAt so ordering is deterministic if either call
+        // drains everything on its own.
+        observedAt: new Date(Date.now() - (externalIds.length - i) * 1000),
+      });
+    }
+
+    const { linkedinCandidatesRun } = await import('../../src/commands/linkedin.js');
+    // Each call asks for more than half the buffer (4 of 6), so if both
+    // transactions claimed the same rows without excluding each other's
+    // in-flight claim, the totals would double-count and/or the same
+    // external_id would land in both runs' staged candidates.
+    const [resultA, resultB] = await Promise.all([
+      linkedinCandidatesRun({ runId: runIdA, limit: 4 }),
+      linkedinCandidatesRun({ runId: runIdB, limit: 4 }),
+    ]);
+
+    expect(resultA.candidatesFetched + resultB.candidatesFetched).toBe(6);
+
+    const stagedA = await db
+      .select()
+      .from(schema.stagingScoutCandidates)
+      .where(eq(schema.stagingScoutCandidates.runId, runIdA));
+    const stagedB = await db
+      .select()
+      .from(schema.stagingScoutCandidates)
+      .where(eq(schema.stagingScoutCandidates.runId, runIdB));
+    const idsA = stagedA.map((s) => {
+      const raw = s.raw as { post: { externalId: string } }; // shape this test inserted above
+      return raw.post.externalId;
+    });
+    const idsB = stagedB.map((s) => {
+      const raw = s.raw as { post: { externalId: string } }; // shape this test inserted above
+      return raw.post.externalId;
+    });
+    expect(idsA).toHaveLength(resultA.candidatesFetched);
+    expect(idsB).toHaveLength(resultB.candidatesFetched);
+    // No external_id claimed by both runs.
+    expect(idsA.filter((id) => idsB.includes(id))).toHaveLength(0);
+    // Every row in the buffer ended up consumed by exactly one of the two runs.
+    const rows = await db
+      .select({ consumedByRunId: schema.observedTargets.consumedByRunId })
+      .from(schema.observedTargets)
+      .where(eq(schema.observedTargets.projectId, projectId));
+    expect(rows).toHaveLength(6);
+    expect(rows.every((r) => r.consumedByRunId === runIdA || r.consumedByRunId === runIdB)).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Closes #304

## What
`linkedinCandidatesRun` in `cli/src/commands/linkedin.ts` fetches nothing: it claims unconsumed `observed_targets` rows for the run's project (oldest-relevant first) and marks `consumed_by_run_id` in the same transaction as the `staging_scout_candidates` insert. Registered as the `linkedin_candidates` MCP tool next to `mastodon_scout` (same session-bound run/campaign/project resolution, never agent-supplied) and as the `linkedin:candidates` CLI command via the existing lazy-import pattern in `cli/src/index.ts`.

Blocklist and contact-dedup are applied server-side, per candidate, with the same helpers `drafts:create` uses (`isBlocklisted`, `checkContactDedup` from `shared/src/blocklist.ts` / `shared/src/contact-dedup.ts`): a blocklisted or recently-contacted author's post is claimed (so it's never re-offered) but not staged, so it never reaches the agent. Unlike `drafts:create`'s dedup policy, there's no draft yet to attach a "warn" to at this stage, so a contact inside the window is unconditionally excluded rather than staged-with-a-warning.

The candidate `raw` shape staged is `{ author: { handle, name }, post: { externalId, url, text, observedAt } }`, confirmed over IRC with the sibling agent building the `linkedin-commenter`/`linkedin-poster` playbooks (#305), which reference exactly those field names.

## Concurrency
The claim is a single `UPDATE observed_targets SET consumed_by_run_id = $runId WHERE id IN (SELECT id FROM observed_targets WHERE ... FOR UPDATE SKIP LOCKED)`, drizzle-expressed via `.for('update', { skipLocked: true })` on the inner select. Two concurrent transactions draining the same project's buffer each skip rows the other has already locked, so they proceed concurrently over disjoint rows with no double-claim.

**Proved the concurrency test bites.** I temporarily replaced the atomic claim with a naive two-step version: SELECT unconsumed ids with no lock, then UPDATE by that id list (the UPDATE's WHERE didn't recheck `consumed_by_run_id IS NULL` either). Against that broken version, "two concurrent drains of the same project never claim the same row" failed for real: `expected 8 to be 6` (both runs asked for 4 of 6 rows and both got 4, double-claiming 2 of them). I reverted to the real atomic query and the full suite is green again.

## Verified
- `pnpm exec vitest run cli/tests/commands/linkedin-candidates.test.ts`: 6/6 passing (empty buffer returns `{ candidatesFetched: 0 }` not an error, a consumed row is not returned twice, a blocklisted author is claimed but never staged, a contact inside the dedup window is filtered, two genuinely concurrent `Promise.all` calls never claim the same row).
- `pnpm exec vitest run cli/tests/mcp/server.test.ts`: 49/49 passing, no regression from the new tool registration.
- `pnpm -F @pitchbox/cli typecheck`: clean.
- `npx prettier --write` / `npx eslint` on every changed file: clean.
- Manual smoke: seeded a project/campaign/run/observed_targets row against the test DB and ran the real `pitchbox linkedin:candidates --run=<id>` CLI command twice. First call staged the candidate (`candidatesFetched: 1`), second call against the same run returned `candidatesFetched: 0`.
