### PR TITLE
security(extension,tests): enforce the LinkedIn compliance boundary in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Workspace versions in lockstep (#207)
         run: pnpm run version:check
+      - name: LinkedIn compliance boundary (#308)
+        run: pnpm run test:linkedin-compliance
       - name: Lint (eslint + prettier)
         run: pnpm run lint
       - name: Typecheck (tsc + svelte-check)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "pnpm -r --if-present run build",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:linkedin-compliance": "vitest run --config vitest.compliance.config.ts",
     "lint": "eslint . && prettier --check .",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit -p shared && tsc --noEmit -p cli && tsc --noEmit -p daemon && pnpm -F @pitchbox/extension check && pnpm -F web check",

--- a/tests/compliance/fixtures/rule1-fetch-linkedin/content/bad-fetch.ts
+++ b/tests/compliance/fixtures/rule1-fetch-linkedin/content/bad-fetch.ts
@@ -1,0 +1,5 @@
+// Fixture for linkedin-boundary.test.ts (#308, rule 1). Deliberately violates
+// the compliance boundary. Never imported by real extension code - inert.
+export async function pollLinkedInFeed(): Promise<Response> {
+  return fetch('https://www.linkedin.com/voyager/api/feed/updates');
+}

--- a/tests/compliance/fixtures/rule1-fetch-linkedin/content/safe-fetch.ts
+++ b/tests/compliance/fixtures/rule1-fetch-linkedin/content/safe-fetch.ts
@@ -1,0 +1,5 @@
+// Sibling fixture proving rule 1 only flags fetch targets that mention
+// linkedin/licdn - a fetch toward Pitchbox's own backend must stay clean.
+export async function pingBackend(): Promise<Response> {
+  return fetch('https://pitchbox.app/api/health');
+}

--- a/tests/compliance/fixtures/rule2-content-script-storage/content/bad-cookie-read.ts
+++ b/tests/compliance/fixtures/rule2-content-script-storage/content/bad-cookie-read.ts
@@ -1,0 +1,6 @@
+// Fixture for linkedin-boundary.test.ts (#308, rule 2). Registered as a
+// LinkedIn content script by the sibling manifest.config.ts. Deliberately
+// violates the compliance boundary. Inert - never bundled by the real build.
+export function readSession(): string {
+  return document.cookie;
+}

--- a/tests/compliance/fixtures/rule2-content-script-storage/manifest.config.ts
+++ b/tests/compliance/fixtures/rule2-content-script-storage/manifest.config.ts
@@ -1,0 +1,13 @@
+// Fixture manifest for linkedin-boundary.test.ts (#308, rule 2). Mirrors the
+// shape of extension/manifest.config.ts's default export closely enough for
+// linkedinContentScriptFiles() to derive the content-script set from it.
+// Inert - never referenced by the real extension build.
+export default {
+  content_scripts: [
+    {
+      matches: ['https://www.linkedin.com/*'],
+      js: ['content/bad-cookie-read.ts'],
+    },
+  ],
+  host_permissions: [],
+};

--- a/tests/compliance/fixtures/rule3-synthetic-click/content/bad-click.ts
+++ b/tests/compliance/fixtures/rule3-synthetic-click/content/bad-click.ts
@@ -1,0 +1,9 @@
+// Fixture for linkedin-boundary.test.ts (#308, rule 3). Deliberately
+// violates the compliance boundary by clicking a node obtained from the
+// sibling linkedin-dom.ts stub. Inert - never imported by real code.
+import { findCommentSubmitButton } from '../linkedin-dom.js';
+
+export function submitComment(): void {
+  const button = findCommentSubmitButton();
+  button?.click();
+}

--- a/tests/compliance/fixtures/rule3-synthetic-click/linkedin-dom.ts
+++ b/tests/compliance/fixtures/rule3-synthetic-click/linkedin-dom.ts
@@ -1,0 +1,6 @@
+// Fixture for linkedin-boundary.test.ts (#308, rule 3). Stands in for
+// extension/src/content/shared/linkedin-dom.ts's shape (an accessor
+// returning a DOM node) without pulling in the real module. Inert.
+export function findCommentSubmitButton(): HTMLButtonElement | null {
+  return document.querySelector('button[type="submit"]');
+}

--- a/tests/compliance/fixtures/rule4-alarms-reachable/background.ts
+++ b/tests/compliance/fixtures/rule4-alarms-reachable/background.ts
@@ -1,0 +1,16 @@
+// Fixture for linkedin-boundary.test.ts (#308, rule 4). Registers a
+// chrome.alarms handler whose call graph reaches ./linkedin/poll.ts.
+// Deliberately violates the compliance boundary. Inert - never bundled.
+import { pollFromLinkedin } from './linkedin/poll.js';
+
+declare const chrome: {
+  alarms: { onAlarm: { addListener: (fn: (alarm: unknown) => void) => void } };
+};
+
+async function runSync(): Promise<void> {
+  await pollFromLinkedin();
+}
+
+chrome.alarms.onAlarm.addListener(async () => {
+  await runSync();
+});

--- a/tests/compliance/fixtures/rule4-alarms-reachable/linkedin/poll.ts
+++ b/tests/compliance/fixtures/rule4-alarms-reachable/linkedin/poll.ts
@@ -1,0 +1,6 @@
+// Fixture for linkedin-boundary.test.ts (#308, rule 4). A LinkedIn code path
+// reached from the sibling background.ts's chrome.alarms handler. Inert.
+export async function pollFromLinkedin(): Promise<void> {
+  // Stand-in for background polling of a LinkedIn endpoint - the pattern
+  // rule 4 forbids regardless of what this function actually does.
+}

--- a/tests/compliance/fixtures/rule5-platform-network-call/fetcher.ts
+++ b/tests/compliance/fixtures/rule5-platform-network-call/fetcher.ts
@@ -1,0 +1,9 @@
+// Fixture for linkedin-boundary.test.ts (#308, rule 5). Stands in for a file
+// under shared/src/platforms/linkedin/ that performs a network call, which
+// that directory must never do (parsing and mapping only). The URL need not
+// mention "linkedin" - being under that directory is what makes any network
+// call a violation. Inert - never imported by real code.
+export async function fetchProfile(urn: string): Promise<unknown> {
+  const res = await fetch(`https://example.com/profile/${urn}`);
+  return res.json();
+}

--- a/tests/compliance/fixtures/rule5-platform-network-call/http-import.ts
+++ b/tests/compliance/fixtures/rule5-platform-network-call/http-import.ts
@@ -1,0 +1,8 @@
+// Fixture for linkedin-boundary.test.ts (#308, rule 5). Covers the
+// node:http/node:https/undici import-detection branch of
+// checkLinkedinPlatformNetworkCalls. Inert - never imported by real code.
+import { request } from 'node:https';
+
+export function ping(): void {
+  request('https://example.com').end();
+}

--- a/tests/compliance/fixtures/rule5-platform-network-call/xhr.ts
+++ b/tests/compliance/fixtures/rule5-platform-network-call/xhr.ts
@@ -1,0 +1,7 @@
+// Fixture for linkedin-boundary.test.ts (#308, rule 5). Covers the
+// XMLHttpRequest branch of checkLinkedinPlatformNetworkCalls specifically -
+// this branch was dead code until the fix landed alongside this fixture.
+// Inert - never imported by real code.
+export function makeRequest(): XMLHttpRequest {
+  return new XMLHttpRequest();
+}

--- a/tests/compliance/fixtures/rule6-host-permissions/manifest.config.ts
+++ b/tests/compliance/fixtures/rule6-host-permissions/manifest.config.ts
@@ -1,0 +1,7 @@
+// Fixture manifest for linkedin-boundary.test.ts (#308, rule 6). Simulates a
+// later change that quietly promotes LinkedIn from an optional, on-demand
+// grant (#317) to a blanket host_permissions entry. Inert.
+export default {
+  content_scripts: [],
+  host_permissions: ['https://www.reddit.com/*', 'https://www.linkedin.com/*'],
+};

--- a/tests/compliance/linkedin-boundary.test.ts
+++ b/tests/compliance/linkedin-boundary.test.ts
@@ -1,0 +1,140 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  checkAll,
+  checkAlarmsReachability,
+  checkContentScriptStorageReads,
+  checkHostPermissions,
+  checkLinkedinPlatformNetworkCalls,
+  checkNetworkTargets,
+  checkSyntheticInteractions,
+  defaultRepoPaths,
+} from './linkedin-boundary.js';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const REPO_PATHS = defaultRepoPaths(REPO_ROOT);
+const FIXTURES = path.join(REPO_ROOT, 'tests', 'compliance', 'fixtures');
+
+describe('linkedin compliance boundary (#308): passes on main as it stands', () => {
+  it('finds zero violations across the real repo', async () => {
+    const violations = await checkAll(REPO_PATHS);
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('rule 1: no fetch/XMLHttpRequest/sendBeacon toward linkedin/licdn', () => {
+  const scanDir = path.join(FIXTURES, 'rule1-fetch-linkedin');
+
+  it('flags a fetch whose target mentions linkedin, and nothing else in the same tree', () => {
+    const violations = checkNetworkTargets(scanDir);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe(1);
+    expect(violations[0].file).toContain('bad-fetch.ts');
+    expect(violations[0].message).toBe(
+      'linkedin-compliance rule 1: tests/compliance/fixtures/rule1-fetch-linkedin/content/bad-fetch.ts calls fetch(\'https://www.linkedin.com/voyager/api/feed/updates\') whose target mentions "linkedin"/"licdn"',
+    );
+  });
+
+  it('passes on the real repo with this rule alone', () => {
+    expect(checkNetworkTargets(REPO_PATHS.extensionSrcDir)).toEqual([]);
+  });
+});
+
+describe('rule 2: no cookie/storage read in a LinkedIn content script', () => {
+  const manifestPath = path.join(FIXTURES, 'rule2-content-script-storage', 'manifest.config.ts');
+
+  it('flags document.cookie in a file the fixture manifest registers as a LinkedIn content script', async () => {
+    const violations = await checkContentScriptStorageReads(manifestPath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe(2);
+    expect(violations[0].file).toContain('bad-cookie-read.ts');
+    expect(violations[0].message).toBe(
+      'linkedin-compliance rule 2: tests/compliance/fixtures/rule2-content-script-storage/content/bad-cookie-read.ts reads document.cookie (document.cookie)',
+    );
+  });
+
+  it('passes on the real manifest, which registers no LinkedIn content script yet', async () => {
+    expect(await checkContentScriptStorageReads(REPO_PATHS.manifestPath)).toEqual([]);
+  });
+});
+
+describe('rule 3: no synthetic click/submit/dispatchEvent on a linkedin-dom.ts node', () => {
+  const scanDir = path.join(FIXTURES, 'rule3-synthetic-click');
+  const domModulePath = path.join(scanDir, 'linkedin-dom.ts');
+
+  it('flags .click() on a node returned by the fixture accessor', () => {
+    const violations = checkSyntheticInteractions(scanDir, domModulePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe(3);
+    expect(violations[0].file).toContain('bad-click.ts');
+    expect(violations[0].message).toBe(
+      'linkedin-compliance rule 3: tests/compliance/fixtures/rule3-synthetic-click/content/bad-click.ts calls .click() on a node obtained from linkedin-dom.ts',
+    );
+  });
+
+  it('passes on the real extension source against the real linkedin-dom.ts', () => {
+    expect(
+      checkSyntheticInteractions(REPO_PATHS.extensionSrcDir, REPO_PATHS.linkedinDomPath),
+    ).toEqual([]);
+  });
+});
+
+describe('rule 4: no chrome.alarms handler reachable from a LinkedIn code path', () => {
+  const scanDir = path.join(FIXTURES, 'rule4-alarms-reachable');
+
+  it('flags an alarms handler whose call graph reaches ./linkedin/poll.ts', () => {
+    const violations = checkAlarmsReachability(scanDir);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe(4);
+    expect(violations[0].file).toContain('background.ts');
+    expect(violations[0].message).toBe(
+      'linkedin-compliance rule 4: tests/compliance/fixtures/rule4-alarms-reachable/background.ts registers a chrome.alarms.onAlarm handler whose call graph reaches LinkedIn code through tests/compliance/fixtures/rule4-alarms-reachable/linkedin/poll.ts',
+    );
+  });
+
+  it('passes on the real extension source (the only alarm today is the Reddit dm-sync poller)', () => {
+    expect(checkAlarmsReachability(REPO_PATHS.extensionSrcDir)).toEqual([]);
+  });
+});
+
+describe('rule 5: shared/src/platforms/linkedin/ stays parsing and mapping only', () => {
+  const platformDir = path.join(FIXTURES, 'rule5-platform-network-call');
+
+  it('flags a fetch call anywhere under the platform directory, regardless of its target', () => {
+    const violations = checkLinkedinPlatformNetworkCalls(platformDir);
+    expect(violations).toHaveLength(3);
+    const byFile = Object.fromEntries(violations.map((v) => [path.basename(v.file), v]));
+    expect(byFile['fetcher.ts'].rule).toBe(5);
+    expect(byFile['fetcher.ts'].message).toBe(
+      'linkedin-compliance rule 5: tests/compliance/fixtures/rule5-platform-network-call/fetcher.ts calls fetch(...) - this directory must stay parsing and mapping only',
+    );
+    expect(byFile['xhr.ts'].message).toBe(
+      'linkedin-compliance rule 5: tests/compliance/fixtures/rule5-platform-network-call/xhr.ts constructs XMLHttpRequest - this directory must stay parsing and mapping only',
+    );
+    expect(byFile['http-import.ts'].message).toBe(
+      'linkedin-compliance rule 5: tests/compliance/fixtures/rule5-platform-network-call/http-import.ts imports "node:https" - this directory must stay parsing and mapping only',
+    );
+  });
+
+  it('passes today because shared/src/platforms/linkedin/ does not exist yet on main', () => {
+    expect(checkLinkedinPlatformNetworkCalls(REPO_PATHS.linkedinPlatformDir)).toEqual([]);
+  });
+});
+
+describe('rule 6: host_permissions never includes linkedin (#317 keeps it optional)', () => {
+  const manifestPath = path.join(FIXTURES, 'rule6-host-permissions', 'manifest.config.ts');
+
+  it('flags a linkedin entry in the fixture manifest host_permissions', async () => {
+    const violations = await checkHostPermissions(manifestPath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe(6);
+    expect(violations[0].message).toBe(
+      'linkedin-compliance rule 6: tests/compliance/fixtures/rule6-host-permissions/manifest.config.ts host_permissions includes "https://www.linkedin.com/*" - linkedin must stay an optional grant, never a blanket permission',
+    );
+  });
+
+  it('passes on the real manifest', async () => {
+    expect(await checkHostPermissions(REPO_PATHS.manifestPath)).toEqual([]);
+  });
+});

--- a/tests/compliance/linkedin-boundary.ts
+++ b/tests/compliance/linkedin-boundary.ts
@@ -1,0 +1,648 @@
+// Static enforcement of docs/linkedin-integration-design.md's "compliance
+// boundary" (#308). Each `checkRuleN` function below implements exactly one
+// of the six prohibitions and returns every violation it finds - it never
+// throws on a clean tree and never skips a rule because a file happens not
+// to exist (an empty scan directory legitimately produces zero violations,
+// which is not the same thing as skipping the rule).
+//
+// Implementation choice: AST-walking over `docs/linkedin-integration-design.md`'s
+// own text with `ts.createSourceFile`, in the same spirit as the source-text
+// assertions #303 already added to `linkedin-dom.test.ts`. A custom eslint
+// rule was the other option; a test wins here because three of the six rules
+// need cross-file reasoning (deriving the content-script set from
+// `manifest.config.ts`, tracing a value from a `linkedin-dom.ts` accessor to
+// a later `.click()`, walking the call graph reachable from a
+// `chrome.alarms` handler) that a single-file eslint rule cannot express
+// without a custom multi-pass program, while a plain module with the
+// TypeScript compiler API expresses each in a few dozen lines and is testable
+// in isolation against fixtures.
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import ts from 'typescript';
+
+export type RuleId = 1 | 2 | 3 | 4 | 5 | 6;
+
+export type Violation = {
+  rule: RuleId;
+  file: string;
+  message: string;
+};
+
+const EXCLUDED_DIRS: Record<string, true> = {
+  node_modules: true,
+  dist: true,
+  '.svelte-kit': true,
+  build: true,
+};
+const NETWORK_TARGET_RE = /linkedin|licdn/i;
+const CLICK_OR_SUBMIT_RE = /click|submit/i;
+const CLICK_SUBMIT_METHODS: Record<string, true> = { click: true, submit: true };
+
+function makeViolation(rule: RuleId, file: string, detail: string): Violation {
+  const rel = path.isAbsolute(file) ? path.relative(process.cwd(), file) : file;
+  return { rule, file: rel, message: `linkedin-compliance rule ${rule}: ${rel} ${detail}` };
+}
+
+function trim(text: string, max = 80): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  return flat.length > max ? `${flat.slice(0, max)}…` : flat;
+}
+
+export function walkFiles(dir: string, extensions: string[]): string[] {
+  const out: string[] = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRS[entry.name]) continue;
+      out.push(...walkFiles(full, extensions));
+    } else if (extensions.some((ext) => entry.name.endsWith(ext))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function extractScriptBlocks(svelteSource: string): string {
+  const blocks: string[] = [];
+  const re = /<script\b[^>]*>([\s\S]*?)<\/script>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(svelteSource))) blocks.push(m[1]);
+  return blocks.join('\n');
+}
+
+function parseSource(file: string): ts.SourceFile {
+  const raw = fs.readFileSync(file, 'utf8');
+  const text = file.endsWith('.svelte') ? extractScriptBlocks(raw) : raw;
+  return ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function unwrap(expr: ts.Expression): ts.Expression {
+  let cur = expr;
+  for (;;) {
+    if (ts.isParenthesizedExpression(cur)) {
+      cur = cur.expression;
+    } else if (ts.isNonNullExpression(cur)) {
+      cur = cur.expression;
+    } else if (ts.isAsExpression(cur)) {
+      cur = cur.expression;
+    } else {
+      return cur;
+    }
+  }
+}
+
+/** Resolves a relative import specifier to a file on disk. Bare specifiers
+ * (packages, `chrome`, `vitest`, ...) are intentionally not resolved. */
+export function resolveModuleFile(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith('.')) return null;
+  const base = path.resolve(path.dirname(fromFile), specifier);
+  const stripped = base.replace(/\.(js|jsx|ts|tsx)$/, '');
+  const candidates = [
+    `${stripped}.ts`,
+    `${stripped}.tsx`,
+    `${stripped}.svelte`,
+    base,
+    path.join(base, 'index.ts'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c) && fs.statSync(c).isFile()) return c;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 1: no fetch/XMLHttpRequest/sendBeacon whose target mentions linkedin/licdn.
+// ---------------------------------------------------------------------------
+export function checkNetworkTargets(scanDir: string): Violation[] {
+  const violations: Violation[] = [];
+  for (const file of walkFiles(scanDir, ['.ts', '.svelte'])) {
+    const sf = parseSource(file);
+    const usesXhr = /new\s+XMLHttpRequest\b/.test(sf.text);
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) {
+        const callee = node.expression;
+        if (ts.isIdentifier(callee) && callee.text === 'fetch' && node.arguments.length > 0) {
+          const target = node.arguments[0].getText(sf);
+          if (NETWORK_TARGET_RE.test(target)) {
+            violations.push(
+              makeViolation(
+                1,
+                file,
+                `calls fetch(${trim(target)}) whose target mentions "linkedin"/"licdn"`,
+              ),
+            );
+          }
+        } else if (ts.isPropertyAccessExpression(callee)) {
+          const method = callee.name.text;
+          if (method === 'open' && usesXhr && node.arguments.length > 1) {
+            const target = node.arguments[1].getText(sf);
+            if (NETWORK_TARGET_RE.test(target)) {
+              violations.push(
+                makeViolation(
+                  1,
+                  file,
+                  `calls XMLHttpRequest#open(..., ${trim(target)}) whose target mentions "linkedin"/"licdn"`,
+                ),
+              );
+            }
+          } else if (method === 'sendBeacon') {
+            const objectText = callee.expression.getText(sf);
+            if (/\bnavigator\b/.test(objectText)) {
+              const target = node.arguments[0]?.getText(sf) ?? '';
+              if (NETWORK_TARGET_RE.test(target)) {
+                violations.push(
+                  makeViolation(
+                    1,
+                    file,
+                    `calls navigator.sendBeacon(${trim(target)}, ...) whose target mentions "linkedin"/"licdn"`,
+                  ),
+                );
+              }
+            }
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 2: no document.cookie/chrome.cookies/localStorage/sessionStorage read
+// inside a file registered as a LinkedIn content script in manifest.config.ts.
+// ---------------------------------------------------------------------------
+type ManifestContentScript = { matches?: string[]; js?: string[] };
+type ManifestShape = { content_scripts?: ManifestContentScript[]; host_permissions?: string[] };
+
+async function loadManifest(manifestPath: string): Promise<ManifestShape> {
+  // manifestPath is runtime-selected: the real check points it at
+  // extension/manifest.config.ts, but the rule-2/rule-6 fixture tests below
+  // point it at inert fixture manifests, so the specifier cannot be static.
+  const mod = (await import(pathToFileURL(manifestPath).href)) as { default?: ManifestShape };
+  if (!mod.default) {
+    throw new Error(
+      `${manifestPath} has no default export - cannot derive the compliance boundary from it`,
+    );
+  }
+  return mod.default;
+}
+
+/** The LinkedIn content-script file set, derived from manifest.config.ts
+ * (never hardcoded): every `js` entry of every content_scripts block whose
+ * `matches` mentions a linkedin.com/licdn.com origin. */
+export async function linkedinContentScriptFiles(manifestPath: string): Promise<string[]> {
+  const manifest = await loadManifest(manifestPath);
+  const dir = path.dirname(manifestPath);
+  const files = new Set<string>();
+  for (const entry of manifest.content_scripts ?? []) {
+    const isLinkedIn = (entry.matches ?? []).some((m) => NETWORK_TARGET_RE.test(m));
+    if (!isLinkedIn) continue;
+    for (const js of entry.js ?? []) files.add(path.resolve(dir, js));
+  }
+  return [...files];
+}
+
+export async function checkContentScriptStorageReads(manifestPath: string): Promise<Violation[]> {
+  const violations: Violation[] = [];
+  const files = await linkedinContentScriptFiles(manifestPath);
+  for (const file of files) {
+    if (!fs.existsSync(file)) {
+      violations.push(
+        makeViolation(
+          2,
+          file,
+          `is registered in manifest.config.ts as a LinkedIn content script but does not exist on disk`,
+        ),
+      );
+      continue;
+    }
+    const sf = parseSource(file);
+    const visit = (node: ts.Node): void => {
+      if (ts.isPropertyAccessExpression(node)) {
+        const chain = node.getText(sf);
+        if (/\bdocument\s*\.\s*cookie\b/.test(chain)) {
+          violations.push(makeViolation(2, file, `reads document.cookie (${trim(chain)})`));
+        } else if (/\bchrome\s*\.\s*cookies\b/.test(chain)) {
+          violations.push(makeViolation(2, file, `uses chrome.cookies (${trim(chain)})`));
+        }
+      } else if (ts.isIdentifier(node) && !ts.isPropertyAccessExpression(node.parent)) {
+        if (node.text === 'localStorage' || node.text === 'sessionStorage') {
+          violations.push(makeViolation(2, file, `reads ${node.text}`));
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 3: no .click()/.submit()/dispatchEvent(click|submit) on a node
+// obtained from extension/src/content/shared/linkedin-dom.ts.
+// ---------------------------------------------------------------------------
+function tracesToAccessor(
+  expr: ts.Expression,
+  accessorNames: Set<string>,
+  tainted: Set<string>,
+): boolean {
+  let cur = unwrap(expr);
+  while (ts.isPropertyAccessExpression(cur) || ts.isElementAccessExpression(cur)) {
+    cur = unwrap(cur.expression);
+  }
+  if (ts.isCallExpression(cur)) {
+    const callee = unwrap(cur.expression);
+    return ts.isIdentifier(callee) && accessorNames.has(callee.text);
+  }
+  if (ts.isIdentifier(cur)) return tainted.has(cur.text);
+  return false;
+}
+
+function importedLocalNames(
+  sf: ts.SourceFile,
+  file: string,
+  targetModulePath: string,
+): Set<string> {
+  const names = new Set<string>();
+  const targetResolved = path.resolve(targetModulePath);
+  ts.forEachChild(sf, (node) => {
+    if (
+      !ts.isImportDeclaration(node) ||
+      !ts.isStringLiteral(node.moduleSpecifier) ||
+      !node.importClause
+    )
+      return;
+    const resolved = resolveModuleFile(file, node.moduleSpecifier.text);
+    if (!resolved || path.resolve(resolved) !== targetResolved) return;
+    const nb = node.importClause.namedBindings;
+    if (nb && ts.isNamedImports(nb)) for (const el of nb.elements) names.add(el.name.text);
+    if (nb && ts.isNamespaceImport(nb)) names.add(nb.name.text);
+    if (node.importClause.name) names.add(node.importClause.name.text);
+  });
+  return names;
+}
+
+function collectTaintedVariables(sf: ts.SourceFile, accessorNames: Set<string>): Set<string> {
+  const tainted = new Set<string>();
+  for (let pass = 0; pass < 4; pass++) {
+    let changed = false;
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.initializer &&
+        !tainted.has(node.name.text) &&
+        tracesToAccessor(node.initializer, accessorNames, tainted)
+      ) {
+        tainted.add(node.name.text);
+        changed = true;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+    if (!changed) break;
+  }
+  return tainted;
+}
+
+export function checkSyntheticInteractions(scanDir: string, domModulePath: string): Violation[] {
+  const violations: Violation[] = [];
+  const domResolved = path.resolve(domModulePath);
+  for (const file of walkFiles(scanDir, ['.ts', '.svelte'])) {
+    if (path.resolve(file) === domResolved) continue; // #303 already covers the module itself
+    const sf = parseSource(file);
+    const accessorNames = importedLocalNames(sf, file, domModulePath);
+    if (accessorNames.size === 0) continue;
+    const tainted = collectTaintedVariables(sf, accessorNames);
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+        const callee = node.expression;
+        const method = callee.name.text;
+        if (
+          CLICK_SUBMIT_METHODS[method] &&
+          tracesToAccessor(callee.expression, accessorNames, tainted)
+        ) {
+          violations.push(
+            makeViolation(3, file, `calls .${method}() on a node obtained from linkedin-dom.ts`),
+          );
+        } else if (method === 'dispatchEvent') {
+          const arg0 = node.arguments[0];
+          const argText = arg0 ? arg0.getText(sf) : '';
+          if (
+            CLICK_OR_SUBMIT_RE.test(argText) &&
+            tracesToAccessor(callee.expression, accessorNames, tainted)
+          ) {
+            violations.push(
+              makeViolation(
+                3,
+                file,
+                `calls dispatchEvent(${trim(argText)}) (a click/submit) on a node obtained from linkedin-dom.ts`,
+              ),
+            );
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 4: no chrome.alarms handler reachable from a LinkedIn code path.
+// ---------------------------------------------------------------------------
+type ImportInfo = { file: string | null; exportedName: string };
+type ModuleInfo = {
+  file: string;
+  sf: ts.SourceFile;
+  functions: Map<string, ts.Node>;
+  imports: Map<string, ImportInfo>;
+};
+
+function buildModuleInfo(file: string): ModuleInfo {
+  const sf = parseSource(file);
+  const functions = new Map<string, ts.Node>();
+  const imports = new Map<string, ImportInfo>();
+  ts.forEachChild(sf, (node) => {
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      functions.set(node.name.text, node);
+    } else if (ts.isVariableStatement(node)) {
+      for (const decl of node.declarationList.declarations) {
+        if (!ts.isIdentifier(decl.name) || !decl.initializer) continue;
+        const init = unwrap(decl.initializer);
+        if (ts.isArrowFunction(init) || ts.isFunctionExpression(init))
+          functions.set(decl.name.text, init);
+      }
+    } else if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      node.importClause
+    ) {
+      const resolved = resolveModuleFile(file, node.moduleSpecifier.text);
+      const nb = node.importClause.namedBindings;
+      if (nb && ts.isNamedImports(nb)) {
+        for (const el of nb.elements) {
+          const exportedName = (el.propertyName ?? el.name).text;
+          imports.set(el.name.text, { file: resolved, exportedName });
+        }
+      }
+      if (nb && ts.isNamespaceImport(nb))
+        imports.set(nb.name.text, { file: resolved, exportedName: '*' });
+      if (node.importClause.name)
+        imports.set(node.importClause.name.text, { file: resolved, exportedName: 'default' });
+    }
+  });
+  return { file, sf, functions, imports };
+}
+
+function collectCalledNames(
+  unit: ts.Node,
+): Array<{ kind: 'id'; name: string } | { kind: 'prop'; obj: string; prop: string }> {
+  const calls: Array<{ kind: 'id'; name: string } | { kind: 'prop'; obj: string; prop: string }> =
+    [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callee = unwrap(node.expression);
+      if (ts.isIdentifier(callee)) {
+        calls.push({ kind: 'id', name: callee.text });
+      } else if (ts.isPropertyAccessExpression(callee)) {
+        const obj = unwrap(callee.expression);
+        if (ts.isIdentifier(obj))
+          calls.push({ kind: 'prop', obj: obj.text, prop: callee.name.text });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(unit);
+  return calls;
+}
+
+/** BFS over the call graph reachable from `start`, resolving only relative
+ * (project-local) imports. Returns the first file whose path mentions
+ * "linkedin" that the graph reaches, or null if none does. */
+function bfsReachesLinkedinFile(
+  start: { file: string; node: ts.Node },
+  infoCache: Map<string, ModuleInfo>,
+): string | null {
+  const getInfo = (file: string): ModuleInfo => {
+    const key = path.resolve(file);
+    let info = infoCache.get(key);
+    if (!info) {
+      info = buildModuleInfo(file);
+      infoCache.set(key, info);
+    }
+    return info;
+  };
+  const visited = new Set<string>();
+  const queue: Array<{ file: string; node: ts.Node }> = [start];
+  let steps = 0;
+  while (queue.length > 0 && steps < 1000) {
+    steps++;
+    const { file, node } = queue.shift()!;
+    if (/linkedin/i.test(file)) return file;
+    const nodeKey = ts.isSourceFile(node) ? 'sf' : `${node.pos}:${node.end}`;
+    const key = `${path.resolve(file)}::${nodeKey}`;
+    if (visited.has(key)) continue;
+    visited.add(key);
+    const info = getInfo(file);
+    for (const call of collectCalledNames(node)) {
+      if (call.kind === 'id') {
+        const local = info.functions.get(call.name);
+        if (local) {
+          queue.push({ file, node: local });
+          continue;
+        }
+        const imp = info.imports.get(call.name);
+        if (imp?.file) {
+          if (/linkedin/i.test(imp.file)) return imp.file;
+          const targetInfo = getInfo(imp.file);
+          const fn =
+            imp.exportedName !== '*' ? targetInfo.functions.get(imp.exportedName) : undefined;
+          queue.push({ file: imp.file, node: fn ?? targetInfo.sf });
+        }
+      } else {
+        const imp = info.imports.get(call.obj);
+        if (imp?.file) {
+          if (/linkedin/i.test(imp.file)) return imp.file;
+          const targetInfo = getInfo(imp.file);
+          const fn = targetInfo.functions.get(call.prop);
+          queue.push({ file: imp.file, node: fn ?? targetInfo.sf });
+        }
+      }
+    }
+  }
+  return null;
+}
+
+export function checkAlarmsReachability(scanDir: string): Violation[] {
+  const violations: Violation[] = [];
+  const infoCache = new Map<string, ModuleInfo>();
+  for (const file of walkFiles(scanDir, ['.ts'])) {
+    const info = ((): ModuleInfo => {
+      const cached = buildModuleInfo(file);
+      infoCache.set(path.resolve(file), cached);
+      return cached;
+    })();
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+        const callee = node.expression;
+        if (
+          callee.name.text === 'addListener' &&
+          /\balarms\s*\.\s*onAlarm\b/.test(callee.getText(info.sf))
+        ) {
+          const handlerArg = node.arguments[0];
+          let start: { file: string; node: ts.Node } | null = null;
+          if (handlerArg) {
+            const h = unwrap(handlerArg);
+            if (ts.isArrowFunction(h) || ts.isFunctionExpression(h)) {
+              start = { file, node: h };
+            } else if (ts.isIdentifier(h)) {
+              const local = info.functions.get(h.text);
+              if (local) {
+                start = { file, node: local };
+              } else {
+                const imp = info.imports.get(h.text);
+                if (imp?.file) start = { file: imp.file, node: buildModuleInfo(imp.file).sf };
+              }
+            }
+          }
+          if (start) {
+            const hit = bfsReachesLinkedinFile(start, infoCache);
+            if (hit) {
+              violations.push(
+                makeViolation(
+                  4,
+                  file,
+                  `registers a chrome.alarms.onAlarm handler whose call graph reaches LinkedIn code through ${path.relative(process.cwd(), hit)}`,
+                ),
+              );
+            }
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(info.sf);
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 5: shared/src/platforms/linkedin/ is parsing and mapping only - no
+// network call of any kind belongs there.
+// ---------------------------------------------------------------------------
+export function checkLinkedinPlatformNetworkCalls(platformDir: string): Violation[] {
+  const violations: Violation[] = [];
+  const NETWORK_IMPORT_RE = /^(node:)?(https?|undici)$/;
+  for (const file of walkFiles(platformDir, ['.ts'])) {
+    const sf = parseSource(file);
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) {
+        const callee = unwrap(node.expression);
+        if (ts.isIdentifier(callee) && callee.text === 'fetch') {
+          violations.push(
+            makeViolation(
+              5,
+              file,
+              `calls fetch(...) - this directory must stay parsing and mapping only`,
+            ),
+          );
+        } else if (ts.isPropertyAccessExpression(callee) && callee.name.text === 'sendBeacon') {
+          violations.push(
+            makeViolation(
+              5,
+              file,
+              `calls navigator.sendBeacon(...) - this directory must stay parsing and mapping only`,
+            ),
+          );
+        }
+      } else if (
+        ts.isNewExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'XMLHttpRequest'
+      ) {
+        violations.push(
+          makeViolation(
+            5,
+            file,
+            `constructs XMLHttpRequest - this directory must stay parsing and mapping only`,
+          ),
+        );
+      } else if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+        if (NETWORK_IMPORT_RE.test(node.moduleSpecifier.text)) {
+          violations.push(
+            makeViolation(
+              5,
+              file,
+              `imports "${node.moduleSpecifier.text}" - this directory must stay parsing and mapping only`,
+            ),
+          );
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 6 (repo-level): `linkedin` must never appear in manifest.config.ts's
+// host_permissions - it stays an optional, on-demand grant (#317).
+// ---------------------------------------------------------------------------
+export async function checkHostPermissions(manifestPath: string): Promise<Violation[]> {
+  const manifest = await loadManifest(manifestPath);
+  const violations: Violation[] = [];
+  for (const entry of manifest.host_permissions ?? []) {
+    if (NETWORK_TARGET_RE.test(entry)) {
+      violations.push(
+        makeViolation(
+          6,
+          manifestPath,
+          `host_permissions includes "${entry}" - linkedin must stay an optional grant, never a blanket permission`,
+        ),
+      );
+    }
+  }
+  return violations;
+}
+
+export type RepoPaths = {
+  extensionSrcDir: string;
+  manifestPath: string;
+  linkedinDomPath: string;
+  linkedinPlatformDir: string;
+};
+
+export function defaultRepoPaths(repoRoot: string): RepoPaths {
+  return {
+    extensionSrcDir: path.join(repoRoot, 'extension', 'src'),
+    manifestPath: path.join(repoRoot, 'extension', 'manifest.config.ts'),
+    linkedinDomPath: path.join(
+      repoRoot,
+      'extension',
+      'src',
+      'content',
+      'shared',
+      'linkedin-dom.ts',
+    ),
+    linkedinPlatformDir: path.join(repoRoot, 'shared', 'src', 'platforms', 'linkedin'),
+  };
+}
+
+export async function checkAll(paths: RepoPaths): Promise<Violation[]> {
+  return [
+    ...checkNetworkTargets(paths.extensionSrcDir),
+    ...(await checkContentScriptStorageReads(paths.manifestPath)),
+    ...checkSyntheticInteractions(paths.extensionSrcDir, paths.linkedinDomPath),
+    ...checkAlarmsReachability(paths.extensionSrcDir),
+    ...checkLinkedinPlatformNetworkCalls(paths.linkedinPlatformDir),
+    ...(await checkHostPermissions(paths.manifestPath)),
+  ];
+}

--- a/vitest.compliance.config.ts
+++ b/vitest.compliance.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+// The linkedin-compliance boundary check (#308) is pure static analysis over
+// source files on disk - no Postgres, no globalSetup migrate/seed. It runs as
+// its own vitest project (via `pnpm run test:linkedin-compliance`) so the CI
+// `quality` job, which has no database service, can run it without paying for
+// one. The full `vitest.config.ts` suite (which needs Postgres) also picks up
+// this same test file through its `**/tests/**/*.test.ts` include pattern
+// when `pnpm test` runs in the `test` job - that's fine, the check itself
+// never touches the database either way.
+export default defineConfig({
+  test: {
+    include: ['tests/compliance/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
Closes #308

## What this does

Turns the five compliance-boundary prohibitions in `docs/linkedin-integration-design.md` ("The compliance boundary" section) plus the repo-level `host_permissions` rule into a check that fails a build, per the issue's six-rule scope. Six AST-based detectors over `extension/src/`, `extension/manifest.config.ts` and `shared/src/platforms/linkedin/`, implemented with the TypeScript compiler API in `tests/compliance/linkedin-boundary.ts` and exercised by `tests/compliance/linkedin-boundary.test.ts`.

## Test vs lint rule

Picked a test. Three of the six rules need cross-file reasoning a single-file eslint rule can't express without effectively building the same multi-pass program:

- Rule 2 needs the LinkedIn content-script file *set*, derived at run time from `extension/manifest.config.ts`'s `content_scripts` array (never hardcoded filenames).
- Rule 3 needs tainted-value tracing: does this `.click()`'s target expression trace back, through local variable assignment and property/element access, to a call into one of `linkedin-dom.ts`'s exported accessors?
- Rule 4 needs a call-graph BFS from every `chrome.alarms.onAlarm.addListener` registration, following relative imports across files, to see whether it ever reaches a module whose path mentions "linkedin".

A plain module with `ts.createSourceFile` expresses each rule in a few dozen lines and is directly unit-testable against fixtures, in the same spirit as the source-text assertions #303 already added in `linkedin-dom.test.ts` (this PR generalises that local check across the whole tree, per its own comment).

## Wiring

Runs as `pnpm run test:linkedin-compliance` (`vitest run --config vitest.compliance.config.ts`), added as its own step in the CI `quality` job. It's pure filesystem static analysis with no Postgres dependency, so it gets a dedicated vitest project instead of going through the root `vitest.config.ts`'s Postgres-backed `globalSetup` (which the `quality` job has no service for). The full-suite config also picks the same test file up through its existing `tests/**` include pattern when `pnpm test` runs in the `test` job - harmless, since the check never touches the database either way.

## Not conditional

No rule skips because a file is absent. Rules 2 and 5 return zero violations on `main` today because `shared/src/platforms/linkedin/` doesn't exist yet and `manifest.config.ts` registers no LinkedIn content script yet - the exact same code path (`walkFiles` over a directory, empty when the directory is empty or absent) that catches a real violation in the corresponding fixture runs unchanged over the empty tree. There's no early-return branch keyed on "does this file exist" anywhere in the six checkers.

## Verified

- `pnpm run test:linkedin-compliance` - 13 tests, all green: one "passes on the real repo" assertion per rule plus a top-level `checkAll` assertion, and one deliberately-violating-fixture assertion per rule (plus extra fixture coverage for rule 5's XMLHttpRequest and network-import branches, which caught a real bug: XMLHttpRequest detection was originally nested dead code inside the `fetch` branch and never ran until the fixture flagged it).
- `npx tsc --noEmit --strict` (ad hoc, root has no project covering top-level `tests/`) - clean.
- `npx prettier --check` and `npx eslint` on every file this PR touches - clean.

## The six failure messages, verbatim from the fixture tests

1. `linkedin-compliance rule 1: tests/compliance/fixtures/rule1-fetch-linkedin/content/bad-fetch.ts calls fetch('https://www.linkedin.com/voyager/api/feed/updates') whose target mentions "linkedin"/"licdn"`
2. `linkedin-compliance rule 2: tests/compliance/fixtures/rule2-content-script-storage/content/bad-cookie-read.ts reads document.cookie (document.cookie)`
3. `linkedin-compliance rule 3: tests/compliance/fixtures/rule3-synthetic-click/content/bad-click.ts calls .click() on a node obtained from linkedin-dom.ts`
4. `linkedin-compliance rule 4: tests/compliance/fixtures/rule4-alarms-reachable/background.ts registers a chrome.alarms.onAlarm handler whose call graph reaches LinkedIn code through tests/compliance/fixtures/rule4-alarms-reachable/linkedin/poll.ts`
5. `linkedin-compliance rule 5: tests/compliance/fixtures/rule5-platform-network-call/fetcher.ts calls fetch(...) - this directory must stay parsing and mapping only`
6. `linkedin-compliance rule 6: tests/compliance/fixtures/rule6-host-permissions/manifest.config.ts host_permissions includes "https://www.linkedin.com/*" - linkedin must stay an optional grant, never a blanket permission`

Each message names the rule and the file, not a generic assertion error - a real regression shows up in CI as one of these six sentences (or its real-file equivalent), not "expected [] to equal [...]" with no context.
