### PR TITLE
fix(tests): rule 2 of the compliance boundary scanned nothing, and missed the form the violation takes

### DIFF
--- a/tests/compliance/fixtures/rule2-dynamic-registration/manifest.config.ts
+++ b/tests/compliance/fixtures/rule2-dynamic-registration/manifest.config.ts
@@ -1,0 +1,9 @@
+// Fixture manifest for linkedin-boundary.test.ts (#308, rule 2, dynamic path).
+// Deliberately declares NO LinkedIn content script: the script is registered at
+// runtime instead, which is how the real extension does it (#317 keeps the
+// LinkedIn grant optional, and a declared content script is an install-time
+// grant). Inert - never referenced by the real extension build.
+export default {
+  content_scripts: [],
+  host_permissions: [],
+};

--- a/tests/compliance/fixtures/rule2-dynamic-registration/src/background.ts
+++ b/tests/compliance/fixtures/rule2-dynamic-registration/src/background.ts
@@ -1,5 +1,12 @@
 // Registers the LinkedIn content script at runtime, the way extension/src/background.ts
 // does, so rule 2 has to follow the `?script` import to find the file it must scan.
+// Declared locally rather than pulling in the webextension globals: this file is a
+// fixture outside extension/, where eslint applies no browser-extension env, and the
+// checker only reads the call's shape.
+declare const chrome: {
+  scripting: { registerContentScripts(scripts: unknown[]): Promise<void> };
+};
+
 import linkedinCommentScriptPath from './content/linkedin-comment.ts?script';
 
 export async function syncLinkedInContentScript(): Promise<void> {

--- a/tests/compliance/fixtures/rule2-dynamic-registration/src/background.ts
+++ b/tests/compliance/fixtures/rule2-dynamic-registration/src/background.ts
@@ -1,0 +1,14 @@
+// Registers the LinkedIn content script at runtime, the way extension/src/background.ts
+// does, so rule 2 has to follow the `?script` import to find the file it must scan.
+import linkedinCommentScriptPath from './content/linkedin-comment.ts?script';
+
+export async function syncLinkedInContentScript(): Promise<void> {
+  await chrome.scripting.registerContentScripts([
+    {
+      id: 'pitchbox-linkedin-comment',
+      js: [linkedinCommentScriptPath],
+      matches: ['https://www.linkedin.com/feed/update/*'],
+      runAt: 'document_idle',
+    },
+  ]);
+}

--- a/tests/compliance/fixtures/rule2-dynamic-registration/src/content/linkedin-comment.ts
+++ b/tests/compliance/fixtures/rule2-dynamic-registration/src/content/linkedin-comment.ts
@@ -1,0 +1,4 @@
+// The violation under test: a storage read inside a LinkedIn content script.
+export function readSomething(): string | null {
+  return localStorage.getItem('li_at');
+}

--- a/tests/compliance/fixtures/rule2-unaccounted-script/manifest.config.ts
+++ b/tests/compliance/fixtures/rule2-unaccounted-script/manifest.config.ts
@@ -1,0 +1,7 @@
+// Fixture manifest for linkedin-boundary.test.ts (#308, rule 2 safety net):
+// nothing registers the LinkedIn-looking script next door, statically or
+// dynamically, so rule 2 would never scan it. Inert.
+export default {
+  content_scripts: [],
+  host_permissions: [],
+};

--- a/tests/compliance/fixtures/rule2-unaccounted-script/src/content/linkedin-orphan.ts
+++ b/tests/compliance/fixtures/rule2-unaccounted-script/src/content/linkedin-orphan.ts
@@ -1,0 +1,3 @@
+// A file whose name says LinkedIn that no registration accounts for. Clean in
+// itself: the point is that rule 2 must refuse to pass over it in silence.
+export function noop(): void {}

--- a/tests/compliance/linkedin-boundary.test.ts
+++ b/tests/compliance/linkedin-boundary.test.ts
@@ -5,6 +5,7 @@ import {
   checkAll,
   checkAlarmsReachability,
   checkContentScriptStorageReads,
+  linkedinContentScriptFiles,
   checkHostPermissions,
   checkLinkedinPlatformNetworkCalls,
   checkNetworkTargets,
@@ -54,8 +55,44 @@ describe('rule 2: no cookie/storage read in a LinkedIn content script', () => {
     );
   });
 
-  it('passes on the real manifest, which registers no LinkedIn content script yet', async () => {
-    expect(await checkContentScriptStorageReads(REPO_PATHS.manifestPath)).toEqual([]);
+  it('follows a dynamic chrome.scripting.registerContentScripts registration to the file it registers', async () => {
+    // The hole this rule shipped with: #348 registered the first real LinkedIn
+    // content script at runtime rather than in the manifest (so the LinkedIn
+    // grant stays optional, #317), which took it out of the static array this
+    // rule derived its scan set from. A planted `document.cookie` in
+    // extension/src/content/linkedin-comment.ts then passed 13/13, measured.
+    const manifestPath = path.join(FIXTURES, 'rule2-dynamic-registration', 'manifest.config.ts');
+    const sourceRoot = path.join(FIXTURES, 'rule2-dynamic-registration', 'src');
+    const violations = await checkContentScriptStorageReads(manifestPath, sourceRoot);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe(2);
+    expect(violations[0].file).toContain('linkedin-comment.ts');
+    expect(violations[0].message).toContain('reads localStorage');
+  });
+
+  it('refuses to pass over a LinkedIn-looking script that no registration accounts for', async () => {
+    // A scan set that silently empties is the skippable check #308 forbids, in
+    // a slower form: it reports green on exactly the file it exists for.
+    const manifestPath = path.join(FIXTURES, 'rule2-unaccounted-script', 'manifest.config.ts');
+    const sourceRoot = path.join(FIXTURES, 'rule2-unaccounted-script', 'src');
+    const violations = await checkContentScriptStorageReads(manifestPath, sourceRoot);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].file).toContain('linkedin-orphan.ts');
+    expect(violations[0].message).toContain('would never scan it');
+  });
+
+  it('scans the real repo, and the file it scans is the dynamically registered one', async () => {
+    const files = await linkedinContentScriptFiles(
+      REPO_PATHS.manifestPath,
+      REPO_PATHS.extensionSrcDir,
+    );
+    // Asserting the set is non-empty and names the real script is the assertion
+    // that would have caught the hole above; `toEqual([])` on the violations
+    // alone passes just as well when nothing was scanned at all.
+    expect(files.some((f) => f.endsWith('content/linkedin-comment.ts'))).toBe(true);
+    expect(
+      await checkContentScriptStorageReads(REPO_PATHS.manifestPath, REPO_PATHS.extensionSrcDir),
+    ).toEqual([]);
   });
 });
 

--- a/tests/compliance/linkedin-boundary.ts
+++ b/tests/compliance/linkedin-boundary.ts
@@ -192,10 +192,29 @@ async function loadManifest(manifestPath: string): Promise<ManifestShape> {
   return mod.default;
 }
 
-/** The LinkedIn content-script file set, derived from manifest.config.ts
- * (never hardcoded): every `js` entry of every content_scripts block whose
- * `matches` mentions a linkedin.com/licdn.com origin. */
-export async function linkedinContentScriptFiles(manifestPath: string): Promise<string[]> {
+/**
+ * The LinkedIn content-script file set. Derived, never hardcoded, from the two
+ * ways a script can actually reach linkedin.com:
+ *
+ * 1. a static `content_scripts` block in manifest.config.ts whose `matches`
+ *    mention a linkedin/licdn origin;
+ * 2. a `chrome.scripting.registerContentScripts` call whose `matches` mention
+ *    one, with each `js` entry resolved back through the import that produced
+ *    it (crxjs hands the built path over a `?script` import, so the array holds
+ *    an identifier rather than a literal).
+ *
+ * The second source exists because of a hole this rule shipped with. #348
+ * registered the first real LinkedIn content script dynamically, precisely so
+ * the LinkedIn grant stays optional (#317), which took it out of the static
+ * array this function used to be the whole of - so the rule scanned nothing and
+ * passed by omission, on exactly the file it exists for. #308 says the check
+ * must never be skippable on some inputs; a scan set that silently empties is
+ * that, in a slower form.
+ */
+export async function linkedinContentScriptFiles(
+  manifestPath: string,
+  sourceRoot?: string,
+): Promise<string[]> {
   const manifest = await loadManifest(manifestPath);
   const dir = path.dirname(manifestPath);
   const files = new Set<string>();
@@ -204,12 +223,118 @@ export async function linkedinContentScriptFiles(manifestPath: string): Promise<
     if (!isLinkedIn) continue;
     for (const js of entry.js ?? []) files.add(path.resolve(dir, js));
   }
+  for (const file of dynamicallyRegisteredLinkedinScripts(sourceRoot ?? path.join(dir, 'src'))) {
+    files.add(file);
+  }
   return [...files];
 }
 
-export async function checkContentScriptStorageReads(manifestPath: string): Promise<Violation[]> {
+/** Every file a `chrome.scripting.registerContentScripts` call registers against
+ * a linkedin/licdn match, anywhere under `sourceRoot`. */
+function dynamicallyRegisteredLinkedinScripts(sourceRoot: string): string[] {
+  const found = new Set<string>();
+  if (!fs.existsSync(sourceRoot)) return [];
+  for (const file of walkFiles(sourceRoot, ['.ts'])) {
+    const sf = parseSource(file);
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        /registerContentScripts$/.test(unwrap(node.expression).getText(sf)) &&
+        node.arguments.length > 0
+      ) {
+        const arg = unwrap(node.arguments[0]);
+        const entries = ts.isArrayLiteralExpression(arg) ? arg.elements : [arg];
+        for (const entry of entries) {
+          const obj = unwrap(entry);
+          if (!ts.isObjectLiteralExpression(obj)) continue;
+          const prop = (name: string) =>
+            obj.properties.find(
+              (p): p is ts.PropertyAssignment =>
+                ts.isPropertyAssignment(p) && p.name.getText(sf) === name,
+            );
+          const matches = prop('matches');
+          if (!matches || !NETWORK_TARGET_RE.test(matches.initializer.getText(sf))) continue;
+          const js = prop('js');
+          if (!js) continue;
+          const jsArr = unwrap(js.initializer);
+          const elements = ts.isArrayLiteralExpression(jsArr) ? jsArr.elements : [jsArr];
+          for (const el of elements) {
+            const resolved = resolveScriptReference(sf, file, unwrap(el));
+            if (resolved) found.add(resolved);
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+  }
+  return [...found];
+}
+
+/** Resolve a `js: [x]` entry to a source file: a string literal relative to the
+ * extension root, or an identifier whose import specifier names one (crxjs's
+ * `./content/foo.ts?script`). */
+function resolveScriptReference(
+  sf: ts.SourceFile,
+  file: string,
+  expr: ts.Expression,
+): string | null {
+  const fromSpecifier = (spec: string): string | null => {
+    const clean = spec.replace(/\?(script|iife|worker).*$/, '');
+    const candidate = path.resolve(path.dirname(file), clean);
+    for (const p of [candidate, `${candidate}.ts`, candidate.replace(/\.js$/, '.ts')]) {
+      if (fs.existsSync(p) && fs.statSync(p).isFile()) return p;
+    }
+    return null;
+  };
+  if (ts.isStringLiteral(expr)) return fromSpecifier(expr.text);
+  if (!ts.isIdentifier(expr)) return null;
+  let resolved: string | null = null;
+  ts.forEachChild(sf, (node) => {
+    if (resolved || !ts.isImportDeclaration(node) || !ts.isStringLiteral(node.moduleSpecifier)) {
+      return;
+    }
+    const clause = node.importClause;
+    const namedHere =
+      clause?.name?.text === expr.text ||
+      (clause?.namedBindings &&
+        ts.isNamedImports(clause.namedBindings) &&
+        clause.namedBindings.elements.some((e) => e.name.text === expr.text));
+    if (namedHere) resolved = fromSpecifier(node.moduleSpecifier.text);
+  });
+  return resolved;
+}
+
+export async function checkContentScriptStorageReads(
+  manifestPath: string,
+  sourceRoot?: string,
+): Promise<Violation[]> {
   const violations: Violation[] = [];
-  const files = await linkedinContentScriptFiles(manifestPath);
+  const root = sourceRoot ?? path.join(path.dirname(manifestPath), 'src');
+  const files = await linkedinContentScriptFiles(manifestPath, root);
+
+  // The net under the derivation above. A file whose own name says LinkedIn but
+  // which neither the manifest nor a dynamic registration accounts for is not a
+  // file this rule may pass over in silence: either it reaches linkedin.com by a
+  // third route nobody has told this checker about, or it is dead code claiming
+  // to be a content script. Both are worth a red build, and the alternative is
+  // the hole #348 walked into - a scan set that quietly went empty.
+  if (fs.existsSync(root)) {
+    const accounted = new Set(files.map((f) => path.resolve(f)));
+    for (const file of walkFiles(path.join(root, 'content'), ['.ts'])) {
+      if (!/linkedin/i.test(path.basename(file))) continue;
+      if (path.basename(file) === 'linkedin-dom.ts') continue; // selectors, not a script
+      if (accounted.has(path.resolve(file))) continue;
+      violations.push(
+        makeViolation(
+          2,
+          file,
+          `looks like a LinkedIn content script but is neither in manifest.config.ts's content_scripts nor registered by a chrome.scripting.registerContentScripts call this checker can see, so rule 2 would never scan it`,
+        ),
+      );
+    }
+  }
+
   for (const file of files) {
     if (!fs.existsSync(file)) {
       violations.push(
@@ -229,6 +354,17 @@ export async function checkContentScriptStorageReads(manifestPath: string): Prom
           violations.push(makeViolation(2, file, `reads document.cookie (${trim(chain)})`));
         } else if (/\bchrome\s*\.\s*cookies\b/.test(chain)) {
           violations.push(makeViolation(2, file, `uses chrome.cookies (${trim(chain)})`));
+        } else if (
+          // `localStorage.getItem('li_at')` is the form this violation actually
+          // takes, and it used to fall through every branch: the identifier
+          // check below skips anything whose parent is a property access, and
+          // the two patterns above only name cookies. A rule that catches a
+          // bare `localStorage` but not `localStorage.getItem` catches the
+          // spelling nobody writes.
+          ts.isIdentifier(node.expression) &&
+          (node.expression.text === 'localStorage' || node.expression.text === 'sessionStorage')
+        ) {
+          violations.push(makeViolation(2, file, `reads ${node.expression.text} (${trim(chain)})`));
         }
       } else if (ts.isIdentifier(node) && !ts.isPropertyAccessExpression(node.parent)) {
         if (node.text === 'localStorage' || node.text === 'sessionStorage') {
@@ -639,7 +775,7 @@ export function defaultRepoPaths(repoRoot: string): RepoPaths {
 export async function checkAll(paths: RepoPaths): Promise<Violation[]> {
   return [
     ...checkNetworkTargets(paths.extensionSrcDir),
-    ...(await checkContentScriptStorageReads(paths.manifestPath)),
+    ...(await checkContentScriptStorageReads(paths.manifestPath, paths.extensionSrcDir)),
     ...checkSyntheticInteractions(paths.extensionSrcDir, paths.linkedinDomPath),
     ...checkAlarmsReachability(paths.extensionSrcDir),
     ...checkLinkedinPlatformNetworkCalls(paths.linkedinPlatformDir),


### PR DESCRIPTION
Follow-up to #347, found by pointing that check at the first real LinkedIn content script (#348) instead of at its own fixtures. Two holes, and the second is the worse one.

**The scan set went empty.** Rule 2 derived the set of LinkedIn content scripts from `manifest.config.ts`'s static `content_scripts` array. #348 registers its script at runtime instead, deliberately, so the LinkedIn grant stays optional (#317) rather than being an install-time prompt. That took the file out of the static array, so rule 2 scanned nothing and reported green on exactly the file it exists for. `#308`'s own body says the check must never be skippable on some inputs; a scan set that silently empties is that, in a slower form.

It now unions two derivations, neither hardcoded: the static blocks, plus every `chrome.scripting.registerContentScripts` call whose `matches` mention LinkedIn, with each `js` entry resolved back through the `?script` import that produced it (crxjs hands over a built path, so the array holds an identifier). And a net under both: a file under `content/` whose own name says LinkedIn that no registration accounts for is itself a rule-2 violation, because the alternative is passing over it in silence.

**The detector missed the spelling people use.** `localStorage.getItem('li_at')` fell through every branch: the identifier branch skips anything whose parent is a property access, and the property-access branch only named `document.cookie` and `chrome.cookies`. So the rule caught a bare `localStorage` and not the form that actually appears in a credential-lifting content script, which is the whole thing it is guarding.

## Verification, by breaking main rather than by watching green

Both planted in the real `extension/src/content/linkedin-comment.ts`:

| planted violation | on `main` | with this PR |
|---|---|---|
| `document.cookie` | 13/13 passed | 2 tests fail, naming the file |
| `localStorage.getItem('li_at')` | 13/13 passed | 2 tests fail, naming the file |
| dynamic registration removed | n/a | 2 tests fail: "would never scan it" |

Three new tests keep it that way, including one that asserts the derived set actually contains `content/linkedin-comment.ts`. That last one matters more than it looks: `expect(violations).toEqual([])` passes just as happily when nothing was scanned at all, which is how the hole survived its own test suite.

Two new inert fixtures under `tests/compliance/fixtures/` (a dynamic registration, and an unaccounted script), neither reachable from the real build or manifest.

`pnpm run test:linkedin-compliance` 15/15, `npx tsc --noEmit --strict` clean on the checker, prettier and eslint clean.