### PR TITLE
fix(extension,tests): give the extension workspace its own vitest config with the browser resolve condition

### DIFF
--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+// `vite.config.ts` in this workspace also doubles as the crxjs *build*
+// config for the shipped MV3 bundle, so a fix that only tests need does not
+// belong there. Vitest resolves modules through its own SSR-style pipeline
+// regardless of `test.environment` (jsdom vs node), so without an explicit
+// `browser` condition, svelte's package `exports` map hands back the
+// *server* build and `mount()` throws `lifecycle_function_unavailable`
+// (mirrors the root `vitest.config.ts`'s comment on the same fix; see #339).
+// A separate vitest config, merged with the real build config for its
+// plugins and aliases, keeps the fix scoped to tests and leaves the
+// production build provably untouched.
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    resolve: {
+      conditions: ['browser'],
+    },
+  }),
+);


### PR DESCRIPTION
Closes #339

## What was wrong

`pnpm -F @pitchbox/extension exec vitest run` was red: 13 of 239 tests failed, all in `tests/content/panel-host.test.ts`, with `Svelte error: lifecycle_function_unavailable` / `` `mount(...)` is not available on the server ``. The root `pnpm exec vitest run extension/tests/` run of the same files was green.

The cause is a resolve-condition mismatch. The root `vitest.config.ts` sets `resolve.conditions: ['browser']` so `svelte`'s package `exports` map resolves to its client build (its own comment explains why). `extension/vite.config.ts`, which a workspace-scoped `vitest` run picks up, has no `test` block and no `resolve.conditions`, so Vitest's own SSR-style module resolution hands back Svelte's server build, and the test file's real call to `mount()` throws.

## The fix

New `extension/vitest.config.ts`, merging the workspace's real `vite.config.ts` (via `mergeConfig`) with a `resolve.conditions: ['browser']` override, mirroring the root config's fix and its comment.

I did not add `resolve.conditions` directly to `extension/vite.config.ts`. That file also doubles as the crxjs **build** config for the shipped MV3 bundle, so a test-only fix does not belong there, and I did not want to reason my way to "probably safe" on a production build config when a config that resolves a different Svelte is exactly the kind of change the issue itself warns is not guaranteed to differ in only one file. A separate `vitest.config.ts` keeps the fix scoped to tests and lets me prove the build is untouched instead of asserting it.

## Verified

- Reproduced first: `pnpm -F @pitchbox/extension exec vitest run` before the fix: 226 passed, 13 failed (all in `tests/content/panel-host.test.ts`), 239 total. `pnpm exec vitest run extension/tests/` (root config): 239 passed, 0 failed.
- After adding `extension/vitest.config.ts`: `pnpm -F @pitchbox/extension exec vitest run` now passes 239/239 (26 test files), matching the root-config run's totals exactly.
- Compared the full pass/fail sets, not just totals: ran both configs with `--reporter=verbose`, normalized away the path prefix (`extension/tests/...` vs `tests/...` depending on which cwd invoked vitest) and per-test timing, then diffed the two lists of `<status> <suite> > <test name>` lines. They are identical, same 239 test names, same statuses, same order. Nothing else diverges between the two configs.
- `pnpm run build:extension` still succeeds. `extension/dist/manifest.json` exists, `background.service_worker` is `service-worker-loader.js` as before. I captured the full `dist/` file list with byte sizes before and after the change (`find dist -type f | xargs stat -c '%s %n'`) and diffed them: byte-for-byte identical, including every content-hashed filename. Expected, since `extension/vite.config.ts` (the file the build actually reads) was never touched, only a new sibling file was added.
- `npx eslint extension/vitest.config.ts` and `npx prettier --check extension/vitest.config.ts`: clean.
- `pnpm -F @pitchbox/extension check` (svelte-check): 0 errors, 0 warnings, unchanged from before (the new file lives at the workspace root, outside `tsconfig.json`'s `include: ["src/**/*", "tests/**/*"]`, same as the pre-existing `vite.config.ts`, so neither was ever in scope for that check).

## Not verified

- The full repo-wide `pnpm test` / `pnpm run lint` / `pnpm run typecheck` matrix (out of scope per `AGENTS.md`'s local-verification guidance; that is CI's job).
- `deploy-preview.yml` / `deploy-prod.yml` (nothing local reproduces either, per `AGENTS.md`).
