### PR TITLE
docs: link the Hacker News platform page and other orphaned pages into the sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -33,11 +33,17 @@ export default defineConfig({
           { text: 'Playbooks', link: '/playbooks' },
           { text: 'Notifications', link: '/notifications' },
           { text: 'Authentication', link: '/auth' },
+          { text: 'Organizations', link: '/orgs' },
+          { text: 'Permissions', link: '/permissions' },
+          { text: 'Analytics', link: '/analytics' },
         ],
       },
       {
         text: 'Platforms',
-        items: [{ text: 'LinkedIn', link: '/platforms/linkedin' }],
+        items: [
+          { text: 'LinkedIn', link: '/platforms/linkedin' },
+          { text: 'Hacker News', link: '/platforms/hackernews' },
+        ],
       },
       {
         text: 'Surfaces',
@@ -50,7 +56,10 @@ export default defineConfig({
       },
       {
         text: 'Operations',
-        items: [{ text: 'Self-hosting', link: '/self-hosting' }],
+        items: [
+          { text: 'Self-hosting', link: '/self-hosting' },
+          { text: 'Retention', link: '/retention' },
+        ],
       },
     ],
     search: { provider: 'local' },

--- a/docs/platforms/hackernews.md
+++ b/docs/platforms/hackernews.md
@@ -1,7 +1,34 @@
 # Hacker News
 
-**Setup.** Add an HN account in **Settings → Accounts** with the platform `hackernews` and your `username`. No password or token is stored - HN has no public auth API for outreach, so you sign in to news.ycombinator.com in your browser and Pitchbox only tracks the handle.
+Hacker News is Pitchbox's second outreach platform. It has no official auth API for outreach and no DM primitive, so Pitchbox never authenticates against it: the human signs in to news.ycombinator.com in their own browser, and Pitchbox only drafts text for the human to paste and submit.
 
-**Scope.** Pitchbox uses the public Firebase HN API (`hacker-news.firebaseio.com/v0`) to fetch `top`/`new`/`best`/`ask`/`show` listings. The `hn-commenter` playbook drafts `post_comment` drafts targeting HN story discussion pages. Compose URLs point at `news.ycombinator.com/reply?id=<itemId>`.
+## Setup
 
-**Limitations.** No DMs (the platform doesn't have them) - only comment outreach. No reply tracking yet (M7+): the daemon uses the null reply reader for HN, so threads do not auto-advance to `replied`. Rate limits on the Firebase API are generous but not documented; the CLI caps `--limit` at 100 per call.
+Add an HN account from **Projects → [project] → Accounts** with the platform `hackernews` and your `username`. No password or token is stored: HN provides no auth API for outreach, so Pitchbox only tracks the handle.
+
+## What Pitchbox drafts
+
+Two scenarios, each backed by its own playbook:
+
+- **`hn-commenter`** (`playbooks/hn-commenter.md`) fetches candidate stories with `hn_search` and drafts `post_comment` replies on threads where the project genuinely adds value. Never a pitch.
+- **`hn-poster`** (`playbooks/hn-poster.md`) studies the current front page, Show HN and Ask HN listings, then drafts 1-3 proactive top-level submissions (`kind: "post"`): a Show HN launch, an Ask HN question, or a plain text post.
+
+Both playbooks call the same `hn_search` tool to fetch listings (`top` / `new` / `best` / `ask` / `show`, optionally filtered by a case-insensitive substring on title/text) from the public Firebase HN API (`hacker-news.firebaseio.com/v0`), and neither ever submits anything: the human reviews the draft in the inbox and posts it themselves.
+
+## Compose URLs
+
+The dashboard's "Open in HN" link is built server-side from the draft kind:
+
+- `post_comment` / `comment_reply` drafts open `news.ycombinator.com/reply?id=<itemId>`, using the story id recorded in the draft's `metadata`.
+- `post` drafts (from `hn-poster`) open `news.ycombinator.com/submit`. HN's submit form does not accept query-string prefill, so the human pastes the drafted title and body manually.
+- `dm` never applies: HN has no DM primitive, and both playbooks are hard-forbidden from emitting one.
+
+## Quota
+
+Hacker News has no platform-specific entry in the seeded `quota_defaults`, so it falls back to the platform-agnostic defaults: 50/day and 200/week for comments, 5/day and 20/week for posts, 10/day and 50/week for DMs (never used, since HN drafts no DMs). An operator can change these from **Settings → Quota**.
+
+## Limitations
+
+- **No DMs.** The platform has none, so `hn-commenter` and `hn-poster` only ever produce `post_comment` and `post` drafts.
+- **No reply tracking.** The daemon's reply poller only polls platforms with a registered reply reader, and Hacker News does not have one yet (not even the inert `NullReplyReader` used for Reddit): a comment or reply thread never auto-advances to `replied`.
+- **Rate limits on the Firebase API are generous but undocumented.** The shared adapter caps every listing fetch at 100 items per call regardless of the requested limit.


### PR DESCRIPTION
Closes #334

## What was orphaned and what I did about it

`docs/platforms/hackernews.md` existed and built but was not in the sidebar, because #332 added the `Platforms` sidebar group with only LinkedIn in it. That was one line to fix, but I also read the page against the current HN adapter (`shared/src/platforms/hackernews/`, both `playbooks/hn-*.md`, and the `hn_search` MCP tool) and found it stale in four places, so I rewrote it rather than just linking it as-is:

- **Account setup was wrong.** It said "Settings -> Accounts"; accounts are added per-project from **Projects -> [project] -> Accounts**, same place LinkedIn's page documents. Fixed to match `web/src/routes/projects/[id]/+page.svelte` (the `accounts` tab) and `account.ts`.
- **It only described half the adapter.** It documented `hn-commenter` (comment drafts) but not `hn-poster`, which drafts top-level Show HN / Ask HN / text submissions (`kind: "post"`). `buildHackernewsComposeUrl` (issue #325) has had a `post` branch pointing at `news.ycombinator.com/submit` for a while; the old page never mentioned it. Added a "What Pitchbox drafts" section covering both playbooks and a "Compose URLs" section covering both branches.
- **The reply-tracking claim was imprecise.** It said "the daemon uses the null reply reader for HN". Checked `daemon/src/reply-readers.ts`: hackernews is not in the `readers` map at all, not even as a `NullReplyReader` entry like Reddit's. `getReplyReader('hackernews')` returns `null` and the poller skips it via the `if (!reader)` branch, not via `NullReplyReader`. The end-user effect (no auto-advance to `replied`) was already correct, so I fixed the mechanism and dropped the stale "(M7+)" milestone reference, which doesn't appear anywhere else in the repo.
- **Rate limit / cap claim was attributed to the wrong layer.** It said "the CLI caps `--limit` at 100 per call". `cli/src/commands/hn.ts` only checks `limit > 0`; the 100-item cap is actually enforced in the shared adapter (`Math.min(options.limit ?? 30, 100)` in `fetchListings`), so it applies regardless of caller (CLI or MCP tool). Reworded to attribute it correctly.
- **Added a quota section** (the LinkedIn page has one, HN's didn't): `QUOTA_DEFAULTS` in `shared/src/db/seed-core.ts` has no `hackernews` key, so it falls back to `QUOTA_LIMITS_FALLBACK`, which is Reddit-shaped (comment 50/day, 200/week; post 5/day, 20/week; dm 10/day, 50/week, never used since HN never drafts a DM).

## Orphan sweep

Every markdown file under `docs/`, checked against `docs/.vitepress/config.ts`'s sidebar:

**Linked before this PR (unchanged):**
- `docs/index.md` - Introduction
- `docs/getting-started.md` - Getting started
- `docs/concepts.md` - Projects, accounts, campaigns
- `docs/runners.md` - Agent runners
- `docs/playbooks.md` - Playbooks
- `docs/notifications.md` - Notifications
- `docs/auth.md` - Authentication
- `docs/platforms/linkedin.md` - Platforms > LinkedIn
- `docs/extension.md` - Chrome extension
- `docs/daemon.md` - Daemon
- `docs/cli.md` - CLI
- `docs/api.md` - HTTP API
- `docs/self-hosting.md` - Self-hosting

**Newly linked in this PR:**
- `docs/platforms/hackernews.md` - Platforms > Hacker News (the fix the issue asked for)
- `docs/orgs.md` - Concepts > Organizations. Current, checkable (multi-org model, invite flow, `/settings/organization`), already cross-linked from `auth.md`.
- `docs/permissions.md` - Concepts > Permissions. Current, checkable (role model, route table, instance admin), already cross-linked from `orgs.md`.
- `docs/analytics.md` - Concepts > Analytics. Short, current page describing the `/analytics` funnel and its API.
- `docs/retention.md` - Operations > Retention. Current, checkable (retention defaults, floor, worker batching), already cross-linked from `self-hosting.md`.

**Deliberately left unlinked (design/decision records, not user-facing guide pages):**
- `docs/cloud-runner.md` - reads like a live doc but its own body is a design record: `[LOCKED]`/`[PROPOSED]`/`[OPEN]` decision tags, spike narratives, an open items list. It is reachable by URL and cross-linked from `getting-started.md` and `self-hosting.md` for readers who want the architecture; it does not belong in the curated sidebar next to `runners.md`.
- `docs/cloud-runner-productionization-design.md` - "Status: DESIGN (for review)", tracks issue #131.
- `docs/extension-connection-design.md` - "Status: approved", tracks epic #164, a closed design decision record.
- `docs/linkedin-integration-design.md` - "Status: approved", the LinkedIn feature's design doc; already the target of the "design doc" link from `platforms/linkedin.md`.
- `docs/mastodon-integration-design.md` - "Status: approved", the Mastodon feature's design doc.
- `docs/organization-isolation-design.md` - "Status: approved design", a multi-org design record; superseded in practice by the now-linked `orgs.md`/`permissions.md` as the current-state docs.
- `docs/organization-isolation-plan.md` - an agentic-worker implementation checklist ("REQUIRED SUB-SKILL: Use superpowers:..."), not reader-facing at all.
- `docs/design/DECISIONS.md` - the repo's internal UI/design decision log (`docs/design/DECISIONS.md` D1 etc.), an engineering artifact, not a product guide page.
- `docs/design/linkedin-assistant-brief.md` - an approved implementation brief for a specific feature (issue #310), same category as the design docs above.

I did not link any of the design-record group. If any of them should actually be in the nav, that is a product call outside the scope of an orphan sweep, and I would rather flag it here than link a design doc into the guide sidebar unasked.

## Verified

- `pnpm run docs:build` (`vitepress build docs`) succeeds, no warnings, no dead-link errors.
- `npx eslint docs/.vitepress/config.ts` - clean.
- `npx prettier --check docs/.vitepress/config.ts docs/platforms/hackernews.md` - clean.
- Read `shared/src/platforms/hackernews/{client,compose-url,types,account}.ts`, `playbooks/hn-commenter.md`, `playbooks/hn-poster.md`, the `hn_search` tool in `cli/src/mcp/server.ts`, `cli/src/commands/hn.ts`, `daemon/src/reply-readers.ts` and `daemon/src/reply-poller.ts`, and `shared/src/db/seed-core.ts` to check every claim in the rewritten page against current code.
- No em dashes in anything I wrote (checked with a literal search).

## Not verified

- I did not run the full repo test suite or the extension/web typecheck, since this PR touches no TypeScript source, only two markdown/config files under `docs/`.
- I did not check whether the LinkedIn platform page's own "Status" section is stale (it references work that may have shipped since); that page was not orphaned and is out of scope for this issue.
