### PR TITLE
fix(shared): seedCore fails loudly on a registered playbook with no markdown

### DIFF
--- a/shared/src/db/seed-core.ts
+++ b/shared/src/db/seed-core.ts
@@ -32,7 +32,10 @@ export const QUOTA_DEFAULTS = {
   },
 } as const;
 
-const BUILTIN_PLAYBOOKS = [
+// Single source of truth for the built-in playbook slugs, mirrored by
+// SCENARIO_SLUGS in shared/src/campaigns/scenarios.ts. Exported so a test can
+// assert the two agree with each other and with playbooks/*.md on disk (#351).
+export const BUILTIN_PLAYBOOKS = [
   {
     slug: 'reddit-scout',
     name: 'Reddit scout',
@@ -130,10 +133,14 @@ export async function seedCore() {
     .values({ key: 'quota_defaults', value: QUOTA_DEFAULTS })
     .onConflictDoNothing();
 
+  const missingSlugs: string[] = [];
   let playbookCount = 0;
   for (const pb of BUILTIN_PLAYBOOKS) {
     const body = readPlaybookBody(pb.slug);
-    if (!body) continue;
+    if (!body) {
+      missingSlugs.push(pb.slug);
+      continue;
+    }
     const [existing] = await db
       .select()
       .from(schema.playbooks)
@@ -156,6 +163,17 @@ export async function seedCore() {
       });
     }
     playbookCount += 1;
+  }
+
+  // A registered slug with no markdown on disk is not a warning, it is a
+  // scenario the campaign form offers that no playbook can serve (#351): this
+  // is a setup-time script run by a human or CI, so failing loudly and naming
+  // every missing slug is correct - the alternative is a healthy-looking
+  // "playbooks seeded: N" count that hides exactly which N it dropped.
+  if (missingSlugs.length > 0) {
+    throw new Error(
+      `seedCore: missing playbooks/<slug>.md for registered slug(s): ${missingSlugs.join(', ')}`,
+    );
   }
 
   const result = await db.execute<{ count: number }>(

--- a/shared/tests/seed-core-playbook-registry.test.ts
+++ b/shared/tests/seed-core-playbook-registry.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { SCENARIO_SLUGS } from '../src/campaigns/scenarios.js';
+import { BUILTIN_PLAYBOOKS } from '../src/db/seed-core.js';
+
+// Covers #351: SCENARIO_SLUGS (shared/src/campaigns/scenarios.ts),
+// BUILTIN_PLAYBOOKS (shared/src/db/seed-core.ts) and the playbooks/*.md files
+// on disk are three lists that have to agree. Nothing short of a test
+// comparing all three would have caught #299 registering linkedin-commenter
+// and linkedin-poster with no markdown behind them yet.
+//
+// playbooks/ also holds files that are deliberately not campaign scenarios:
+// web/src/lib/server/runner.ts's dispatchRun() reads these straight off disk
+// by a hardcoded slug (`resolve(PITCHBOX_ROOT, 'playbooks', \`${slug}.md\`)`)
+// for project extraction, insight generation, skill generation and reply
+// drafting - they never get a row in the `playbooks` table via seedCore, so
+// they have no business in SCENARIO_SLUGS or BUILTIN_PLAYBOOKS either. Naming
+// them here is a deliberate, reviewable decision: anything else found on disk
+// that isn't a registered scenario is treated as a mistake, not silently
+// ignored.
+const NON_SCENARIO_PLAYBOOK_SLUGS = [
+  'project-extractor',
+  'project-insighter',
+  'campaign-skill-generator',
+  'reply-drafter',
+  'draft-regenerator',
+];
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function playbookSlugsOnDisk(): string[] {
+  return readdirSync(resolve(repoRoot, 'playbooks'))
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => f.slice(0, -'.md'.length));
+}
+
+describe('playbook registry: SCENARIO_SLUGS, BUILTIN_PLAYBOOKS and playbooks/*.md agree (#351)', () => {
+  it('SCENARIO_SLUGS and BUILTIN_PLAYBOOKS name exactly the same slugs', () => {
+    const scenarioSlugs = [...SCENARIO_SLUGS].sort();
+    const builtinSlugs = BUILTIN_PLAYBOOKS.map((pb) => pb.slug).sort();
+    expect(builtinSlugs).toEqual(scenarioSlugs);
+  });
+
+  it('every registered scenario slug has a playbooks/<slug>.md file on disk', () => {
+    const onDisk = new Set(playbookSlugsOnDisk());
+    const missing = SCENARIO_SLUGS.filter((slug) => !onDisk.has(slug));
+    expect(missing).toEqual([]);
+  });
+
+  it('every non-internal playbook file on disk is registered as a scenario', () => {
+    const registered = new Set<string>(SCENARIO_SLUGS);
+    const orphaned = playbookSlugsOnDisk().filter(
+      (slug) => !registered.has(slug) && !NON_SCENARIO_PLAYBOOK_SLUGS.includes(slug),
+    );
+    expect(orphaned).toEqual([]);
+  });
+
+  it('the non-scenario allowlist itself names real files that are not also registered as scenarios', () => {
+    const onDisk = new Set(playbookSlugsOnDisk());
+    const registered = new Set<string>(SCENARIO_SLUGS);
+    for (const slug of NON_SCENARIO_PLAYBOOK_SLUGS) {
+      expect(onDisk.has(slug)).toBe(true);
+      expect(registered.has(slug)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
@/tmp/pr-body-351.md