### PR TITLE
feat(extension,web,shared): detect and record undeliverable DM targets

### DIFF
--- a/cli/src/commands/drafts.ts
+++ b/cli/src/commands/drafts.ts
@@ -10,6 +10,7 @@ import {
 import { groupVariants } from '@pitchbox/shared/draft-variants';
 import {
   checkContactDedup,
+  checkUncontactable,
   parseDedupPolicy,
   DEFAULT_DEDUP_POLICY,
 } from '@pitchbox/shared/contact-dedup';
@@ -241,6 +242,25 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
       });
       if (r.blocked) {
         skipped.push({ targetUser: d.targetUser ?? null, reason: r.reason });
+        continue;
+      }
+    }
+
+    // Issue #335: a DM target already known to reject message requests on
+    // this platform is skipped outright, ahead of and regardless of the
+    // ordinary dedup window/mode below - "cannot be contacted" is not the
+    // same fact as "was contacted recently".
+    if (d.targetUser && d.kind === 'dm') {
+      const uncontactableCheck = await checkUncontactable(db, {
+        platformId: campaign.platformId,
+        targetUser: d.targetUser,
+        organizationId: orgId,
+      });
+      if (uncontactableCheck.uncontactable) {
+        skipped.push({
+          targetUser: d.targetUser,
+          reason: `uncontactable: ${uncontactableCheck.reason ?? 'unknown reason'}`,
+        });
         continue;
       }
     }

--- a/cli/tests/commands/drafts-create.test.ts
+++ b/cli/tests/commands/drafts-create.test.ts
@@ -238,6 +238,161 @@ describe('pitchbox drafts:create', () => {
     expect(events[0].draftId).toBe(drafts[0].id);
   });
 
+  it('skips a target already marked uncontactable, and reports it in the response (issue #335)', async () => {
+    const db = getDb();
+    const [platform] = await db
+      .select()
+      .from(schema.platforms)
+      .where(eq(schema.platforms.slug, 'reddit'));
+    const [org] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(sql`slug = 'default'`);
+    const [project] = await db
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'demo-uncontactable', name: 'DU' })
+      .returning();
+    const [account] = await db
+      .insert(schema.accounts)
+      .values({
+        projectId: project.id,
+        platformId: platform.id,
+        handle: 'sender-u',
+        role: 'personal',
+      })
+      .returning();
+    const [campaign] = await db
+      .insert(schema.campaigns)
+      .values({
+        projectId: project.id,
+        platformId: platform.id,
+        name: 'c-uncontactable',
+        skillSlug: 'reddit-scout',
+        config: {},
+      })
+      .returning();
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ campaignId: campaign.id, trigger: 'manual', status: 'running' })
+      .returning();
+
+    // A prior draft to 'bob' already came back undeliverable (the extension
+    // route this mirrors is web/tests/extension-undeliverable.test.ts).
+    await db.insert(schema.contactHistory).values({
+      platformId: platform.id,
+      accountHandle: 'sender-u',
+      targetUser: 'bob',
+      organizationId: org.id,
+      uncontactable: true,
+      uncontactableReason: 'You are unable to send a message request to this account.',
+    });
+
+    const payload = JSON.stringify([
+      {
+        accountId: account.id,
+        kind: 'dm',
+        targetUser: 'alice',
+        body: 'hey alice, ...',
+        sourceRef: {},
+        metadata: {},
+      },
+      {
+        accountId: account.id,
+        kind: 'dm',
+        targetUser: 'bob',
+        body: 'hey bob, ...',
+        sourceRef: {},
+        metadata: {},
+      },
+    ]);
+
+    const out = cli(`drafts:create --run=${run.id}`, payload);
+    const lines = out.trim().split('\n');
+    const res = JSON.parse(lines[lines.length - 1]);
+    expect(res.ok).toBe(true);
+    expect(res.data.inserted).toBe(1);
+    expect(res.data.skipped).toHaveLength(1);
+    expect(res.data.skipped[0].targetUser).toBe('bob');
+    expect(res.data.skipped[0].reason).toBe(
+      'uncontactable: You are unable to send a message request to this account.',
+    );
+
+    // Only alice's draft exists - the loop actually closes: bob is never
+    // offered again by the path that would have drafted for him.
+    const drafts = await db.select().from(schema.drafts);
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].targetUser).toBe('alice');
+  });
+
+  it('does not skip a post/post_comment draft for an uncontactable DM target - the mark is DM-specific', async () => {
+    const db = getDb();
+    const [platform] = await db
+      .select()
+      .from(schema.platforms)
+      .where(eq(schema.platforms.slug, 'reddit'));
+    const [org] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(sql`slug = 'default'`);
+    const [project] = await db
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'demo-uncontactable-comment', name: 'DUC' })
+      .returning();
+    const [account] = await db
+      .insert(schema.accounts)
+      .values({
+        projectId: project.id,
+        platformId: platform.id,
+        handle: 'sender-uc',
+        role: 'personal',
+      })
+      .returning();
+    const [campaign] = await db
+      .insert(schema.campaigns)
+      .values({
+        projectId: project.id,
+        platformId: platform.id,
+        name: 'c-uncontactable-comment',
+        skillSlug: 'reddit-commenter',
+        config: {},
+      })
+      .returning();
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ campaignId: campaign.id, trigger: 'manual', status: 'running' })
+      .returning();
+
+    await db.insert(schema.contactHistory).values({
+      platformId: platform.id,
+      accountHandle: 'sender-uc',
+      targetUser: 'carol',
+      organizationId: org.id,
+      uncontactable: true,
+      uncontactableReason: 'You are unable to send a message request to this account.',
+    });
+
+    const payload = JSON.stringify([
+      {
+        accountId: account.id,
+        kind: 'post_comment',
+        targetUser: 'carol',
+        subreddit: 'fixture',
+        body: 'a public reply, not a DM',
+        sourceRef: {},
+        metadata: {},
+      },
+    ]);
+
+    const out = cli(`drafts:create --run=${run.id}`, payload);
+    const lines = out.trim().split('\n');
+    const res = JSON.parse(lines[lines.length - 1]);
+    expect(res.ok).toBe(true);
+    // Reddit cannot refuse a public reply the way it refuses a DM request -
+    // the uncontactable mark from the DM path must not block the comment path.
+    expect(res.data.inserted).toBe(1);
+    expect(res.data.skipped).toHaveLength(0);
+  });
+
   it('skips drafts targeting a blocklisted subreddit and reports them in the response', async () => {
     const db = getDb();
     const [platform] = await db

--- a/extension/src/content/dm-compose.ts
+++ b/extension/src/content/dm-compose.ts
@@ -1,7 +1,11 @@
 import { parseBackendUrl, parseDraftId } from '../lib/draft-param.js';
 import { api } from '../lib/api.js';
 import { logFromContent } from '../lib/log-from-content.js';
-import { findComposeTextarea, findComposeSendButton } from './shared/reddit-dom.js';
+import {
+  findComposeTextarea,
+  findComposeSendButton,
+  findUndeliverableReason,
+} from './shared/reddit-dom.js';
 
 const draftId = parseDraftId(location.href);
 const backendUrl = parseBackendUrl(location.href) ?? undefined;
@@ -10,6 +14,8 @@ if (draftId !== null) {
   let armed = false;
   let sent = false;
   let capturedBody: string | undefined;
+  let undeliverableReported = false;
+  let undeliverablePoll: ReturnType<typeof window.setInterval> | undefined;
 
   // Reddit's DM compose box is a real <textarea>, but new-Reddit wraps it in a
   // React-controlled component: assigning `.value` directly does not stick
@@ -88,6 +94,7 @@ if (draftId !== null) {
   async function onSendCompleted() {
     if (sent) return;
     sent = true;
+    if (undeliverablePoll != null) clearInterval(undeliverablePoll);
     const res = await api.sent(draftId!, capturedBody, undefined, undefined, undefined, backendUrl);
     if (res.ok) {
       logFromContent({
@@ -106,6 +113,46 @@ if (draftId !== null) {
         meta: {
           draftId,
           script: 'dm-compose',
+          reason: res.error || String(res.status),
+          status: res.status,
+          url: location.href,
+        },
+      });
+    }
+  }
+
+  // #335: Reddit's "unable to send a message request to this account" wall
+  // resolves asynchronously against the recipient, well after the compose
+  // page (and this script) load, and the page gives no event to hook - so
+  // poll instead of checking once. Stops on its own once found, once the
+  // draft is actually sent, or after 30s (long enough to outlast the
+  // validation round-trip on a normal page; most drafts are deliverable and
+  // this should never fire for them).
+  async function checkUndeliverable() {
+    if (undeliverableReported || sent) return;
+    const reason = findUndeliverableReason();
+    if (!reason) return;
+    undeliverableReported = true;
+    if (undeliverablePoll != null) clearInterval(undeliverablePoll);
+    const res = await api.undeliverable(draftId!, reason, backendUrl);
+    if (res.ok) {
+      logFromContent({
+        level: 'info',
+        source: 'reddit-action',
+        message: 'activity.reddit-action.undeliverable',
+        messageParams: { draftId: draftId!, reason },
+        meta: { draftId, reason, script: 'dm-compose', url: location.href },
+      });
+    } else {
+      logFromContent({
+        level: 'error',
+        source: 'reddit-action',
+        message: 'activity.reddit-action.fail',
+        messageParams: { draftId: draftId!, reason: res.error || String(res.status) },
+        meta: {
+          draftId,
+          script: 'dm-compose',
+          step: 'undeliverable',
           reason: res.error || String(res.status),
           status: res.status,
           url: location.href,
@@ -158,6 +205,10 @@ if (draftId !== null) {
 
   async function init() {
     await fill();
+    undeliverablePoll = window.setInterval(() => void checkUndeliverable(), 500);
+    window.setTimeout(() => {
+      if (undeliverablePoll != null) clearInterval(undeliverablePoll);
+    }, 30_000);
     if (!wireUp()) {
       let wired = false;
       const obs = new MutationObserver(() => {

--- a/extension/src/content/shared/reddit-dom.ts
+++ b/extension/src/content/shared/reddit-dom.ts
@@ -89,6 +89,27 @@ export function findComposeSendButton(): HTMLButtonElement | null {
   );
 }
 
+/**
+ * The reason Reddit gives for refusing a DM, once the async recipient
+ * validation resolves against a user who does not accept message requests
+ * (#335: "You are unable to send a message request to this account."). The
+ * page renders it as a faceplate-form-helper-text leaf under the recipient
+ * faceplate-text-input and disables Send, but carries neither role="alert"
+ * nor aria-invalid on it - there is nothing to observe until the helper
+ * text itself shows up, so callers must poll rather than read once at load.
+ * Requiring Send to also be disabled guards against matching leftover markup
+ * from a validation that has since cleared.
+ */
+export function findUndeliverableReason(): string | null {
+  const sendBtn = findComposeSendButton();
+  if (!sendBtn?.disabled) return null;
+  for (const helper of queryDeepAll<HTMLElement>('faceplate-form-helper-text')) {
+    const text = (helper.textContent ?? '').replace(/\s+/g, ' ').trim();
+    if (/unable to send a message request/i.test(text)) return text;
+  }
+  return null;
+}
+
 export function findCommentTextarea(): HTMLTextAreaElement | HTMLElement | null {
   return (
     queryDeep<HTMLTextAreaElement>('textarea[name="text"]') ??

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -230,6 +230,20 @@ export const api = {
     });
   },
 
+  undeliverable: async (
+    draftId: number,
+    /** Kept verbatim - the platform's own reason string, read from the page. */
+    reason: string,
+    backendUrl?: string,
+  ): Promise<ApiResult<{ ok: true }>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    return postJson(p, `/api/extension/draft/${draftId}/undeliverable`, {
+      reason,
+      detectedAt: new Date().toISOString(),
+    });
+  },
+
   sent: async (
     draftId: number,
     sentContent?: string,

--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -124,6 +124,7 @@ export const en = {
     'Could not determine your Reddit account for draft {draftId}; reply matching may be less accurate.',
   'activity.reddit-action.comment-id-unresolved':
     'Could not read the id of the comment posted for draft {draftId}; replies to it will not be detected.',
+  'activity.reddit-action.undeliverable': 'Draft {draftId} is undeliverable: {reason}',
   'activity.linkedin-action.comment-sent': 'Posted comment for draft {draftId}.',
   'activity.linkedin-action.fail': 'Backend flip failed for draft {draftId}: {reason}',
   'activity.linkedin-action.composer-missing':

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -129,6 +129,7 @@ export const it = {
     'Impossibile determinare il tuo account Reddit per il draft {draftId}; la corrispondenza delle risposte potrebbe essere meno precisa.',
   'activity.reddit-action.comment-id-unresolved':
     "Impossibile leggere l'id del commento pubblicato per il draft {draftId}; le risposte non verranno rilevate.",
+  'activity.reddit-action.undeliverable': 'Il draft {draftId} non è recapitabile: {reason}',
   'activity.linkedin-action.comment-sent': 'Commento pubblicato per il draft {draftId}.',
   'activity.linkedin-action.fail': 'Aggiornamento backend fallito per il draft {draftId}: {reason}',
   'activity.linkedin-action.composer-missing':

--- a/extension/tests/content/dm-compose.test.ts
+++ b/extension/tests/content/dm-compose.test.ts
@@ -45,12 +45,42 @@ function sendButton(): HTMLButtonElement {
   return document.querySelector('button[type="submit"]') as HTMLButtonElement;
 }
 
-function makeFetchMock(opts: { draftBody?: string; getDraftOk?: boolean; sentOk?: boolean } = {}) {
-  const { draftBody = 'hello there', getDraftOk = true, sentOk = true } = opts;
+function addUndeliverableHelperText(text: string): HTMLElement {
+  const helper = document.createElement('faceplate-form-helper-text');
+  helper.textContent = text;
+  document.body.appendChild(helper);
+  return helper;
+}
+
+function undeliverableCallBodies(fetchMock: ReturnType<typeof makeFetchMock>) {
+  return (fetchMock.mock.calls as unknown as Array<[string, RequestInit]>)
+    .filter(([u]) => u.endsWith('/undeliverable'))
+    .map(([, init]) => JSON.parse(init.body as string));
+}
+
+function makeFetchMock(
+  opts: {
+    draftBody?: string;
+    getDraftOk?: boolean;
+    sentOk?: boolean;
+    undeliverableOk?: boolean;
+  } = {},
+) {
+  const {
+    draftBody = 'hello there',
+    getDraftOk = true,
+    sentOk = true,
+    undeliverableOk = true,
+  } = opts;
   return vi.fn(async (url: string) => {
     const path = new URL(url).pathname;
     if (path.endsWith('/armed')) {
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    if (path.endsWith('/undeliverable')) {
+      return undeliverableOk
+        ? new Response(JSON.stringify({ ok: true }), { status: 200 })
+        : new Response('boom', { status: 500 });
     }
     if (path.endsWith('/sent')) {
       return sentOk
@@ -331,5 +361,125 @@ describe('dm-compose give-up paths (#173)', () => {
     await flush();
 
     expect(logCallsFor('activity.reddit-action.send-button-not-found')).toHaveLength(0);
+  });
+});
+
+describe('dm-compose undeliverable detection (#335)', () => {
+  const REASON = 'You are unable to send a message request to this account.';
+
+  it('detects the condition only after the async validation text appears, not before', async () => {
+    setPairing();
+    setComposeDom();
+    sendButton().disabled = true; // Reddit disables Send while the recipient check is in flight.
+    const fetchMock = makeFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useFakeTimers();
+
+    await importModule();
+    await flush();
+
+    // Several poll ticks pass with Send disabled but no helper text yet -
+    // there is nothing to report until the async validation actually lands.
+    await vi.advanceTimersByTimeAsync(2000);
+    await flush();
+    expect(undeliverableCallBodies(fetchMock)).toHaveLength(0);
+
+    // The validation resolves.
+    addUndeliverableHelperText(REASON);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await flush();
+
+    const calls = undeliverableCallBodies(fetchMock);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].reason).toBe(REASON);
+    expect((globalThis as any).chrome.runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({ message: 'activity.reddit-action.undeliverable' }),
+      }),
+    );
+  });
+
+  it('never reports anything on a normal, enabled compose page', async () => {
+    setPairing();
+    setComposeDom(); // Send stays enabled the whole time - nothing to detect.
+    const fetchMock = makeFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useFakeTimers();
+
+    await importModule();
+    await flush();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await flush();
+
+    expect(undeliverableCallBodies(fetchMock)).toHaveLength(0);
+  });
+
+  it('reports only once even though the poll keeps running', async () => {
+    setPairing();
+    setComposeDom();
+    sendButton().disabled = true;
+    addUndeliverableHelperText(REASON);
+    const fetchMock = makeFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useFakeTimers();
+
+    await importModule();
+    await flush();
+    await vi.advanceTimersByTimeAsync(500);
+    await flush();
+    await vi.advanceTimersByTimeAsync(5000);
+    await flush();
+
+    expect(undeliverableCallBodies(fetchMock)).toHaveLength(1);
+  });
+
+  it('stops polling once the draft is actually sent', async () => {
+    setPairing();
+    setComposeDom();
+    const fetchMock = makeFetchMock();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useFakeTimers();
+
+    await importModule();
+    await flush();
+
+    sendButton().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flush();
+    textarea().value = ''; // Reddit clearing the textarea signals a successful send.
+    await vi.advanceTimersByTimeAsync(600);
+    await flush();
+    expect(fetchMock.mock.calls.some(([u]) => String(u).endsWith('/sent'))).toBe(true);
+
+    // Now disable Send and add the helper text after the fact - the poll must
+    // already be stopped, so this must never fire.
+    sendButton().disabled = true;
+    addUndeliverableHelperText(REASON);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await flush();
+
+    expect(undeliverableCallBodies(fetchMock)).toHaveLength(0);
+  });
+
+  it('logs a failure event when the backend rejects the undeliverable flip', async () => {
+    setPairing();
+    setComposeDom();
+    sendButton().disabled = true;
+    addUndeliverableHelperText(REASON);
+    const fetchMock = makeFetchMock({ undeliverableOk: false });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.useFakeTimers();
+
+    await importModule();
+    await flush();
+    await vi.advanceTimersByTimeAsync(500);
+    await flush();
+
+    expect((globalThis as any).chrome.runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({ level: 'error', message: 'activity.reddit-action.fail' }),
+      }),
+    );
   });
 });

--- a/extension/tests/content/fixtures/reddit/README.md
+++ b/extension/tests/content/fixtures/reddit/README.md
@@ -61,3 +61,21 @@ for (const pat of [/your-handle/i, /redd\.it|redditmedia/i, /https?:\/\//i]) {
 Add the real handles, subreddit and thread id of whatever session produced the capture to
 that list: the point is to check the values that were actually on the page, not the ones
 that happened to be there in September 2026.
+
+
+## compose-undeliverable.html (synthetic, not captured)
+
+Unlike `comment-thread.html` above, this one is **not** a real capture. Issue #335
+needed a fixture for Reddit's "you are unable to send a message request to this
+account" DM-compose error before any live, signed-in Chrome endpoint was reachable
+from the environment that wrote the detection code, so this file is hand-written -
+modeled on the same `shreddit-*`/`faceplate-*` custom-element family and shadow-DOM
+convention the capture above already verified, using the exact wording issue #335
+quotes from a real session, but never checked against Reddit's live compose page.
+
+`scripts/capture-reddit-fixtures.mjs --target compose --recipient <handle>` now
+supports capturing the real thing (point `--recipient` at an account that has
+already declined message requests from the signed-in session). Regenerate this
+file with it and replace this section once that capture exists; until then, treat
+`findUndeliverableReason`'s tests against this fixture as "the selectors read the
+shape the issue describes", not "this is what Reddit currently renders".

--- a/extension/tests/content/fixtures/reddit/compose-undeliverable.html
+++ b/extension/tests/content/fixtures/reddit/compose-undeliverable.html
@@ -1,0 +1,16 @@
+<shreddit-compose-message-form>
+  <template data-fixture-shadow-root="open">
+    <faceplate-text-input name="to">
+      <template data-fixture-shadow-root="open">
+        <input type="text" name="to" placeholder="Username">
+        <faceplate-form-helper-text>You are unable to send a message request to this account.</faceplate-form-helper-text>
+      </template>
+    </faceplate-text-input>
+    <faceplate-textarea-input name="message-content">
+      <template data-fixture-shadow-root="open">
+        <textarea name="text" placeholder="Message"></textarea>
+      </template>
+    </faceplate-textarea-input>
+    <button type="submit" disabled="">Send</button>
+  </template>
+</shreddit-compose-message-form>

--- a/extension/tests/content/reddit-dom.test.ts
+++ b/extension/tests/content/reddit-dom.test.ts
@@ -6,8 +6,10 @@ import {
   findCommentTextarea,
   findCommentSubmitButton,
   findOurCommentId,
+  findUndeliverableReason,
 } from '../../src/content/shared/reddit-dom.js';
 import REDDIT_THREAD_HTML from './fixtures/reddit/comment-thread.html?raw';
+import COMPOSE_UNDELIVERABLE_HTML from './fixtures/reddit/compose-undeliverable.html?raw';
 
 // The synthetic cases below predate the real capture and are kept on purpose: they
 // cover shapes the captured page does not contain (a closed shadow root, two
@@ -23,6 +25,29 @@ function attachShadow(host: Element, mode: 'open' | 'closed', innerHTML: string)
   const shadow = host.attachShadow({ mode });
   shadow.innerHTML = innerHTML;
   return shadow;
+}
+
+/**
+ * The capture records each open shadow root as a `<template
+ * data-fixture-shadow-root="open">` rather than flattening it, since a content
+ * script has to pierce those for real. Re-attach them so `queryDeep` is
+ * exercised against the page's actual encapsulation.
+ */
+function hydrateShadowRoots(root: ParentNode): number {
+  let attached = 0;
+  for (const el of Array.from(root.querySelectorAll('template[data-fixture-shadow-root]'))) {
+    const tpl = el as HTMLTemplateElement;
+    const host = tpl.parentElement;
+    if (!host || host.shadowRoot) continue;
+    const shadow = host.attachShadow({ mode: 'open' });
+    tpl.remove();
+    // A <template>'s children live in its `.content` DocumentFragment per spec,
+    // not as ordinary childNodes on the element itself - move from there.
+    while (tpl.content.firstChild) shadow.appendChild(tpl.content.firstChild);
+    attached++;
+    attached += hydrateShadowRoots(shadow);
+  }
+  return attached;
 }
 
 describe('old.reddit.com style markup (plain form, no shadow DOM)', () => {
@@ -142,6 +167,81 @@ describe('www.reddit.com style markup (shadow-DOM encapsulated controls)', () =>
   });
 });
 
+describe('findUndeliverableReason (#335)', () => {
+  function composeDom(opts: { helperText?: string; sendDisabled: boolean }): void {
+    const host = document.createElement('faceplate-text-input');
+    document.body.appendChild(host);
+    attachShadow(
+      host,
+      'open',
+      opts.helperText
+        ? `<faceplate-form-helper-text>${opts.helperText}</faceplate-form-helper-text>`
+        : '',
+    );
+    const btn = document.createElement('button');
+    btn.type = 'submit';
+    btn.textContent = 'Send';
+    btn.disabled = opts.sendDisabled;
+    document.body.appendChild(btn);
+  }
+
+  it('returns the reason once the helper text lands and Send is disabled', () => {
+    composeDom({
+      helperText: 'You are unable to send a message request to this account.',
+      sendDisabled: true,
+    });
+
+    expect(findUndeliverableReason()).toBe(
+      'You are unable to send a message request to this account.',
+    );
+  });
+
+  it('returns null before the helper text exists, even with Send disabled', () => {
+    // The disabled state can precede the async validation result (e.g. while the
+    // request is still in flight) - nothing to report until the text shows up.
+    composeDom({ sendDisabled: true });
+
+    expect(findUndeliverableReason()).toBeNull();
+  });
+
+  it('returns null on a normal, enabled compose page - nothing to report', () => {
+    composeDom({ sendDisabled: false });
+
+    expect(findUndeliverableReason()).toBeNull();
+  });
+
+  it('returns null for a matching helper text while Send is still enabled', () => {
+    // Guards against matching stale markup from a validation that has since
+    // cleared: Send re-enabling is the signal the error no longer applies.
+    composeDom({
+      helperText: 'You are unable to send a message request to this account.',
+      sendDisabled: false,
+    });
+
+    expect(findUndeliverableReason()).toBeNull();
+  });
+
+  it('ignores an unrelated disabled-Send helper text', () => {
+    composeDom({ helperText: 'Recipient is required.', sendDisabled: true });
+
+    expect(findUndeliverableReason()).toBeNull();
+  });
+});
+
+// compose-undeliverable.html is a synthetic fixture (NOT a live capture, unlike
+// comment-thread.html above) - see fixtures/reddit/README.md for why and how to
+// replace it with a real one.
+describe('compose-undeliverable.html (synthetic - see fixtures/reddit/README.md)', () => {
+  it('finds the reason through the recipient input and message-body shadow roots', () => {
+    document.body.innerHTML = COMPOSE_UNDELIVERABLE_HTML;
+    hydrateShadowRoots(document.body);
+
+    expect(findUndeliverableReason()).toBe(
+      'You are unable to send a message request to this account.',
+    );
+  });
+});
+
 // comment-thread.html is an anonymised capture of a real, signed-in
 // www.reddit.com thread (2026-09-04) - see fixtures/reddit/README.md for what was
 // stripped and how to regenerate it. Loaded with Vite's `?raw` import (not
@@ -151,26 +251,6 @@ describe('comment-thread.html (real www.reddit.com capture)', () => {
   const OURS = 't1_fixture25';
   const OURS_CREATED_MS = Date.parse('2026-09-04T13:22:46.500Z');
   const NEWEST_OTHER_CREATED_MS = Date.parse('2026-09-04T00:40:33.978Z');
-
-  /**
-   * The capture records each open shadow root as a `<template
-   * data-fixture-shadow-root="open">` rather than flattening it, since a content
-   * script has to pierce those for real. Re-attach them so `queryDeep` is
-   * exercised against the page's actual encapsulation.
-   */
-  function hydrateShadowRoots(root: ParentNode): number {
-    let attached = 0;
-    for (const tpl of Array.from(root.querySelectorAll('template[data-fixture-shadow-root]'))) {
-      const host = tpl.parentElement;
-      if (!host || host.shadowRoot) continue;
-      const shadow = host.attachShadow({ mode: 'open' });
-      tpl.remove();
-      while (tpl.firstChild) shadow.appendChild(tpl.firstChild);
-      attached++;
-      attached += hydrateShadowRoots(shadow);
-    }
-    return attached;
-  }
 
   function renderCapture(): void {
     document.body.innerHTML = REDDIT_THREAD_HTML;

--- a/scripts/capture-reddit-fixtures.mjs
+++ b/scripts/capture-reddit-fixtures.mjs
@@ -16,9 +16,16 @@
 // Usage:
 //   node scripts/capture-reddit-fixtures.mjs --cdp http://127.0.0.1:9391
 //   node scripts/capture-reddit-fixtures.mjs --cdp <endpoint> --thread <permalink>
+//   node scripts/capture-reddit-fixtures.mjs --cdp <endpoint> --target compose --recipient <handle>
 //
 // The endpoint is any Chrome with an open CDP port signed in to Reddit. On Lorenzo's
 // devbox that is `omp-chrome up personal`, which prints the endpoint.
+//
+// `--target compose` (issue #335) captures the DM-compose page instead of a comment
+// thread, into compose-undeliverable.html. Point `--recipient` at an account the
+// signed-in session already knows declines message requests (Reddit's own async
+// validation is what renders "unable to send a message request to this account" - this
+// does not fabricate that state, it only waits for and records it).
 
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -42,6 +49,12 @@ const THREAD = arg(
   'thread',
   '/r/forgottenrealms/comments/1vst5rd/which_forgotten_realms_historical_event_deserves/',
 );
+const TARGET = arg('target', 'comment');
+const RECIPIENT = arg('recipient');
+if (TARGET === 'compose' && !RECIPIENT) {
+  console.error('--recipient <handle> is required with --target compose');
+  process.exit(1);
+}
 
 async function attach(cdpUrl) {
   const ver = await (await fetch(new URL('/json/version', cdpUrl))).json();
@@ -263,26 +276,63 @@ async function whoami(page) {
 }
 
 const page = await attach(CDP);
-await page.goto(`https://www.reddit.com${THREAD}`);
-const handle = await whoami(page);
-if (!handle) {
-  console.error('not signed in to Reddit on this endpoint (api/me.json gave no name)');
+
+if (TARGET === 'compose') {
+  await page.goto(`https://www.reddit.com/message/compose?to=${encodeURIComponent(RECIPIENT)}`);
+  const handle = await whoami(page);
+  if (!handle) {
+    console.error('not signed in to Reddit on this endpoint (api/me.json gave no name)');
+    page.close();
+    process.exit(1);
+  }
+  // The "unable to send a message request" validation is async (#335) - poll for the
+  // helper text or Send going disabled instead of a fixed sleep, up to 10s.
+  const settled = await page.eval(async () => {
+    for (let i = 0; i < 20; i++) {
+      const helper = document.querySelector('faceplate-form-helper-text');
+      if (helper && /unable to send a message request/i.test(helper.textContent || '')) return true;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    return false;
+  });
+  if (!settled) {
+    console.error(
+      `validation never resolved to "unable to send a message request" for ${RECIPIENT} within 10s - ` +
+        'pick a recipient known to decline message requests, or this account may accept them',
+    );
+    page.close();
+    process.exit(1);
+  }
+  const html = await page.eval(extractAnonymised, 'shreddit-app, main, body', handle, '');
+  mkdirSync(OUT_DIR, { recursive: true });
+  const out = join(OUT_DIR, 'compose-undeliverable.html');
+  writeFileSync(out, `${html}\n`);
+  console.log(
+    `compose-undeliverable.html: ${html.length} bytes (captured as ${handle} -> fixture_owner)`,
+  );
   page.close();
-  process.exit(1);
+} else {
+  await page.goto(`https://www.reddit.com${THREAD}`);
+  const handle = await whoami(page);
+  if (!handle) {
+    console.error('not signed in to Reddit on this endpoint (api/me.json gave no name)');
+    page.close();
+    process.exit(1);
+  }
+  await page.eval(async () => {
+    window.scrollBy(0, 1600);
+    await new Promise((r) => setTimeout(r, 2500));
+    window.scrollTo(0, 0);
+  });
+  const html = await page.eval(
+    extractAnonymised,
+    'shreddit-app, main, body',
+    handle,
+    /\/r\/([^/]+)/.exec(THREAD)?.[1] ?? '',
+  );
+  mkdirSync(OUT_DIR, { recursive: true });
+  const out = join(OUT_DIR, 'comment-thread.html');
+  writeFileSync(out, `${html}\n`);
+  console.log(`comment-thread.html: ${html.length} bytes (captured as ${handle} -> fixture_owner)`);
+  page.close();
 }
-await page.eval(async () => {
-  window.scrollBy(0, 1600);
-  await new Promise((r) => setTimeout(r, 2500));
-  window.scrollTo(0, 0);
-});
-const html = await page.eval(
-  extractAnonymised,
-  'shreddit-app, main, body',
-  handle,
-  /\/r\/([^/]+)/.exec(THREAD)?.[1] ?? '',
-);
-mkdirSync(OUT_DIR, { recursive: true });
-const out = join(OUT_DIR, 'comment-thread.html');
-writeFileSync(out, `${html}\n`);
-console.log(`comment-thread.html: ${html.length} bytes (captured as ${handle} -> fixture_owner)`);
-page.close();

--- a/shared/src/contact-dedup.ts
+++ b/shared/src/contact-dedup.ts
@@ -67,6 +67,47 @@ export async function checkContactDedup(
   };
 }
 
+export interface CheckUncontactableInput {
+  platformId: number;
+  targetUser: string;
+  organizationId: number;
+}
+
+export interface UncontactableResult {
+  uncontactable: boolean;
+  reason: string | null;
+}
+
+/**
+ * Whether `targetUser` was previously marked uncontactable on this platform
+ * (issue #335: Reddit disabling Send with "unable to send a message request
+ * to this account" is the first case that sets this). Unlike
+ * checkContactDedup, this has no time window and no warn-only mode: a
+ * platform-level "this account cannot be messaged" fact does not expire with
+ * the dedup policy, so drafts:create always skips a DM to it regardless of
+ * dedup_policy.mode.
+ */
+export async function checkUncontactable(
+  db: Db,
+  input: CheckUncontactableInput,
+): Promise<UncontactableResult> {
+  const { platformId, targetUser, organizationId } = input;
+  const [row] = await db
+    .select({ reason: contactHistory.uncontactableReason })
+    .from(contactHistory)
+    .where(
+      and(
+        eq(contactHistory.organizationId, organizationId),
+        eq(contactHistory.platformId, platformId),
+        eq(contactHistory.targetUser, targetUser),
+        eq(contactHistory.uncontactable, true),
+      ),
+    )
+    .orderBy(desc(contactHistory.lastContactedAt))
+    .limit(1);
+  return { uncontactable: !!row, reason: row?.reason ?? null };
+}
+
 export interface DedupPolicy {
   windowDays: number;
   mode: 'warn' | 'skip';

--- a/shared/src/db/migrations/0012_mature_lila_cheney.sql
+++ b/shared/src/db/migrations/0012_mature_lila_cheney.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "contact_history" ADD COLUMN "uncontactable" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "contact_history" ADD COLUMN "uncontactable_reason" text;--> statement-breakpoint
+ALTER TABLE "drafts" ADD COLUMN "undeliverable_reason" text;

--- a/shared/src/db/migrations/meta/0012_snapshot.json
+++ b/shared/src/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,3483 @@
+{
+  "id": "7d63b2d6-6c39-49d1-bae4-7e4593b0081d",
+  "prevId": "c03b5b00-6e97-4653-95d8-00f1560e8519",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cookie_session": {
+          "name": "cookie_session",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_limit": {
+          "name": "weekly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_project_id_projects_id_fk": {
+          "name": "accounts_project_id_projects_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_platform_id_platforms_id_fk": {
+          "name": "accounts_platform_id_platforms_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_failures": {
+      "name": "auth_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login_attempt'"
+        }
+      },
+      "indexes": {
+        "auth_failures_identifier_idx": {
+          "name": "auth_failures_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist": {
+      "name": "blocklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocklist_platform_id_platforms_id_fk": {
+          "name": "blocklist_platform_id_platforms_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocklist_project_id_projects_id_fk": {
+          "name": "blocklist_project_id_projects_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_recommendations": {
+      "name": "campaign_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_slug": {
+          "name": "scenario_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_recommendations_project_idx": {
+          "name": "campaign_recommendations_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_recommendations_project_id_projects_id_fk": {
+          "name": "campaign_recommendations_project_id_projects_id_fk",
+          "tableFrom": "campaign_recommendations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_slug": {
+          "name": "skill_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_attempts": {
+          "name": "failure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_due_to_failures": {
+          "name": "paused_due_to_failures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_post": {
+          "name": "auto_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_platform_id_platforms_id_fk": {
+          "name": "campaigns_platform_id_platforms_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_history": {
+      "name": "contact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_handle": {
+          "name": "account_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_checked_at": {
+          "name": "reply_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_room_id": {
+          "name": "chat_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_context_url": {
+          "name": "platform_context_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uncontactable": {
+          "name": "uncontactable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uncontactable_reason": {
+          "name": "uncontactable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_history_target_idx": {
+          "name": "contact_history_target_idx",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_target_idx": {
+          "name": "messages_account_target_idx",
+          "columns": [
+            {
+              "expression": "account_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_org_idx": {
+          "name": "contact_history_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_contacted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_history_platform_id_platforms_id_fk": {
+          "name": "contact_history_platform_id_platforms_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contact_history_draft_id_drafts_id_fk": {
+          "name": "contact_history_draft_id_drafts_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_history_organization_id_organizations_id_fk": {
+          "name": "contact_history_organization_id_organizations_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_heartbeats": {
+      "name": "daemon_heartbeats",
+      "schema": "",
+      "columns": {
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tick_at": {
+          "name": "tick_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_events": {
+      "name": "draft_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_events_kind_created_idx": {
+          "name": "draft_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_events_draft_id_drafts_id_fk": {
+          "name": "draft_events_draft_id_drafts_id_fk",
+          "tableFrom": "draft_events",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_regeneration_hints": {
+      "name": "draft_regeneration_hints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint_text": {
+          "name": "hint_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_regeneration_hints_draft_id_drafts_id_fk": {
+          "name": "draft_regeneration_hints_draft_id_drafts_id_fk",
+          "tableFrom": "draft_regeneration_hints",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "fit_score": {
+          "name": "fit_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_url": {
+          "name": "compose_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_content": {
+          "name": "sent_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_comment_id": {
+          "name": "platform_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dedup_warning": {
+          "name": "dedup_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_edited": {
+          "name": "body_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_send_after": {
+          "name": "scheduled_send_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerating_run_id": {
+          "name": "regenerating_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drafting_run_id": {
+          "name": "drafting_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_reason": {
+          "name": "quality_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_model": {
+          "name": "quality_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_id": {
+          "name": "variant_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undeliverable_reason": {
+          "name": "undeliverable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drafts_state_idx": {
+          "name": "drafts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_project_idx": {
+          "name": "drafts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_run_idx": {
+          "name": "drafts_state_run_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_campaign_created_idx": {
+          "name": "drafts_state_campaign_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_variant_group_idx": {
+          "name": "drafts_variant_group_idx",
+          "columns": [
+            {
+              "expression": "variant_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_run_id_runs_id_fk": {
+          "name": "drafts_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_project_id_projects_id_fk": {
+          "name": "drafts_project_id_projects_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_platform_id_platforms_id_fk": {
+          "name": "drafts_platform_id_platforms_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_accounts_id_fk": {
+          "name": "drafts_account_id_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_regenerating_run_id_runs_id_fk": {
+          "name": "drafts_regenerating_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "regenerating_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drafts_drafting_run_id_runs_id_fk": {
+          "name": "drafts_drafting_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "drafting_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_devices": {
+      "name": "extension_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unnamed device'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "extension_devices_token_hash_unique": {
+          "name": "extension_devices_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extension_devices_organization_id_organizations_id_fk": {
+          "name": "extension_devices_organization_id_organizations_id_fk",
+          "tableFrom": "extension_devices",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_pairings": {
+      "name": "extension_pairings",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extension_pairings_organization_id_organizations_id_fk": {
+          "name": "extension_pairings_organization_id_organizations_id_fk",
+          "tableFrom": "extension_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_watches": {
+      "name": "keyword_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_field": {
+          "name": "match_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keyword_watches_campaign_idx": {
+          "name": "keyword_watches_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_watches_project_idx": {
+          "name": "keyword_watches_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_watches_project_id_projects_id_fk": {
+          "name": "keyword_watches_project_id_projects_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keyword_watches_campaign_id_campaigns_id_fk": {
+          "name": "keyword_watches_campaign_id_campaigns_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_org_user_unique": {
+          "name": "memberships_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_from_us": {
+          "name": "is_from_us",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_platform": {
+          "name": "created_at_platform",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_contact_idx": {
+          "name": "messages_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_platform_message_unique": {
+          "name": "messages_platform_message_unique",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_contact_id_contact_history_id_fk": {
+          "name": "messages_contact_id_contact_history_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "contact_history",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_draft_id_drafts_id_fk": {
+          "name": "messages_draft_id_drafts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_platform_id_platforms_id_fk": {
+          "name": "messages_platform_id_platforms_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_unread_idx": {
+          "name": "notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_idx": {
+          "name": "notifications_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organization_id_organizations_id_fk": {
+          "name": "notifications_organization_id_organizations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observed_targets": {
+      "name": "observed_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_by_run_id": {
+          "name": "consumed_by_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "observed_targets_dedup_idx": {
+          "name": "observed_targets_dedup_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "observed_targets_project_unconsumed_idx": {
+          "name": "observed_targets_project_unconsumed_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_by_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "observed_targets_organization_id_organizations_id_fk": {
+          "name": "observed_targets_organization_id_organizations_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_project_id_projects_id_fk": {
+          "name": "observed_targets_project_id_projects_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_platform_id_platforms_id_fk": {
+          "name": "observed_targets_platform_id_platforms_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observed_targets_consumed_by_run_id_runs_id_fk": {
+          "name": "observed_targets_consumed_by_run_id_runs_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "consumed_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invites": {
+      "name": "org_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_invites_org_idx": {
+          "name": "org_invites_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invites_organization_id_organizations_id_fk": {
+          "name": "org_invites_organization_id_organizations_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invites_created_by_user_id_users_id_fk": {
+          "name": "org_invites_created_by_user_id_users_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invites_token_unique": {
+          "name": "org_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_run_budget_usd": {
+          "name": "monthly_run_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platforms": {
+      "name": "platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platforms_slug_unique": {
+          "name": "platforms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playbooks": {
+      "name": "playbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playbooks_slug_unique": {
+          "name": "playbooks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_insights": {
+      "name": "project_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary_md": {
+          "name": "summary_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_insights_project_idx": {
+          "name": "project_insights_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_insights_project_id_projects_id_fk": {
+          "name": "project_insights_project_id_projects_id_fk",
+          "tableFrom": "project_insights",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_runner": {
+          "name": "default_agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_unique": {
+          "name": "projects_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_events_run_idx": {
+          "name": "run_events_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_events_kind_created_idx": {
+          "name": "run_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'campaign'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout_log_path": {
+          "name": "stdout_log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playbook_body": {
+          "name": "playbook_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_project_kind_idx": {
+          "name": "runs_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_campaign_id_campaigns_id_fk": {
+          "name": "runs_campaign_id_campaigns_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_scout_candidates": {
+      "name": "staging_scout_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staging_scout_candidates_run_id_runs_id_fk": {
+          "name": "staging_scout_candidates_run_id_runs_id_fk",
+          "tableFrom": "staging_scout_candidates",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_project_kind_idx": {
+          "name": "templates_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_project_id_projects_id_fk": {
+          "name": "templates_project_id_projects_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_instance_admin": {
+          "name": "is_instance_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recent_idx": {
+          "name": "webhook_deliveries_recent_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_org_idx": {
+          "name": "webhook_deliveries_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_organization_id_organizations_id_fk": {
+          "name": "webhook_deliveries_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1788517632675,
       "tag": "0011_yellow_harry_osborn",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1788551298729,
+      "tag": "0012_mature_lila_cheney",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -443,6 +443,11 @@ export const drafts = pgTable(
     // triggered drafting. `drafts.kind` accepts 'reply_dm' / 'reply_comment'
     // alongside the existing outbound kinds.
     parentMessageId: bigint('parent_message_id', { mode: 'number' }),
+    // Issue #335: the platform's own reason string, kept verbatim, once a
+    // DM draft turns out to be undeliverable (Reddit disabling Send with
+    // "unable to send a message request to this account" is the first
+    // case). Set only when state flips to 'undeliverable'.
+    undeliverableReason: text('undeliverable_reason'),
   },
   (t) => ({
     byState: index('drafts_state_idx').on(t.state),
@@ -523,6 +528,14 @@ export const contactHistory = pgTable(
     replyCheckedAt: timestamp('reply_checked_at', { withTimezone: true }),
     chatRoomId: text('chat_room_id'),
     platformContextUrl: text('platform_context_url'),
+    // Issue #335: sticky "this account cannot be messaged" fact, distinct
+    // from an ordinary prior contact - checkUncontactable
+    // (shared/src/contact-dedup.ts) reads it with no time window, unlike
+    // checkContactDedup's windowed warn/skip. reason keeps the platform's
+    // own wording verbatim (the same string drafts.undeliverable_reason
+    // carries on the draft that produced this row).
+    uncontactable: boolean('uncontactable').notNull().default(false),
+    uncontactableReason: text('uncontactable_reason'),
   },
   (t) => ({
     byTarget: index('contact_history_target_idx').on(t.platformId, t.targetUser),

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,5 +1,13 @@
 export type DraftState =
-  'pending_review' | 'approved' | 'rejected' | 'sent' | 'not_sent' | 'replied' | 'dead';
+  | 'pending_review'
+  | 'approved'
+  | 'rejected'
+  | 'sent'
+  | 'not_sent'
+  | 'replied'
+  | 'dead'
+  // Issue #335: terminal, non-punitive - the platform refused delivery, distinct from a human rejection.
+  | 'undeliverable';
 
 export type DraftKind = 'dm' | 'post' | 'post_comment' | 'comment_reply';
 

--- a/web/src/lib/components/DraftDetail.svelte
+++ b/web/src/lib/components/DraftDetail.svelte
@@ -43,6 +43,7 @@
 		createdAt: string | Date | null;
 		sentAt: string | Date | null;
 		sentContent: string | null;
+		undeliverableReason?: string | null;
 		regeneratingRunId?: number | null;
 		regenerationCount?: number;
 		draftingRunId?: number | null;
@@ -350,6 +351,7 @@
 		sent: 'Sent',
 		edited: 'Edited',
 		replied: 'Replied',
+		undeliverable: 'Undeliverable',
 	};
 
 	function eventLabel(event: string): string {
@@ -429,6 +431,12 @@
 						>
 							Scheduled until {scheduledUntil.toLocaleString()}
 						</span>
+					</div>
+				{/if}
+				{#if draft.state === 'undeliverable' && draft.undeliverableReason}
+					<div class="rounded-md border px-3 py-2 text-sm {TONE_BANNER_CLASS.slate}">
+						<strong>Undeliverable.</strong>
+						{draft.undeliverableReason}
 					</div>
 				{/if}
 				{#if quotaKind && usage && limits}

--- a/web/src/lib/components/DraftListItem.svelte
+++ b/web/src/lib/components/DraftListItem.svelte
@@ -27,6 +27,7 @@
 		createdAt: string | Date | null;
 		project?: { id: number; slug: string; name: string };
 		dedupWarning?: string | null;
+		undeliverableReason?: string | null;
 		qualityScore?: number | null;
 		variantGroupId?: string | null;
 		variantLabel?: string | null;
@@ -90,6 +91,14 @@
 					title={draft.dedupWarning}
 				>
 					dedup
+				</span>
+			{/if}
+			{#if draft.state === 'undeliverable' && draft.undeliverableReason}
+				<span
+					class="inline-flex items-center rounded-sm px-1 py-0.5 text-[10px] font-medium {TONE_CLASS.slate}"
+					title={draft.undeliverableReason}
+				>
+					undeliverable
 				</span>
 			{/if}
 			{#if scheduledUntil}

--- a/web/src/lib/config/status-badges.ts
+++ b/web/src/lib/config/status-badges.ts
@@ -127,6 +127,9 @@ export const DRAFT_STATE: Record<string, BadgeStyle> = {
   sent: { label: 'Sent', tone: 'emerald' },
   replied: { label: 'Replied', tone: 'violet' },
   rejected: { label: 'Rejected', tone: 'rose' },
+  // Issue #335: the platform refused delivery, not the human - terminal like
+  // rejected/sent, but slate rather than rose since nothing went wrong.
+  undeliverable: { label: 'Undeliverable', tone: 'slate' },
 };
 
 // A run lifecycle mirrors draft state: queued/running → success (emerald) or

--- a/web/src/lib/server/inbox-query.ts
+++ b/web/src/lib/server/inbox-query.ts
@@ -18,6 +18,8 @@ const VALID_STATES: Record<string, true> = {
   approved: true,
   sent: true,
   rejected: true,
+  // Issue #335: filterable like every other terminal state.
+  undeliverable: true,
   all: true,
 };
 const VALID_KINDS: Record<string, true> = {
@@ -239,6 +241,7 @@ export type InboxDraft = {
   sentContent: string | null;
   platformCommentId: string | null;
   dedupWarning: string | null;
+  undeliverableReason: string | null;
   scheduledSendAfter: Date | null;
   qualityScore: number | null;
   qualityReason: string | null;
@@ -327,6 +330,7 @@ export async function queryInboxDraftsPage(
       sentContent: schema.drafts.sentContent,
       platformCommentId: schema.drafts.platformCommentId,
       dedupWarning: schema.drafts.dedupWarning,
+      undeliverableReason: schema.drafts.undeliverableReason,
       scheduledSendAfter: schema.drafts.scheduledSendAfter,
       qualityScore: schema.drafts.qualityScore,
       qualityReason: schema.drafts.qualityReason,

--- a/web/src/routes/api/extension/draft/[id]/undeliverable/+server.ts
+++ b/web/src/routes/api/extension/draft/[id]/undeliverable/+server.ts
@@ -1,0 +1,103 @@
+import { json, error } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '$lib/server/db.js';
+import { assertDraftInDeviceOrg, requireExtensionAuth } from '$lib/server/extension-auth.js';
+import { emit } from '$lib/server/events.js';
+import { updateDraftWithVersion } from '$lib/server/draft-state.js';
+import { requireDraftOrgId } from '@pitchbox/shared/orgs';
+
+type UndeliverableBody = {
+  reason?: string;
+  detectedAt?: string;
+  version?: number;
+};
+
+// States a draft can validly transition to `undeliverable` FROM. Mirrors
+// SENDABLE_STATES in the sibling `sent` route: the platform only exposes
+// this fact at compose time, after a human has approved (or is reviewing)
+// the draft, so anything already sent/rejected/undeliverable is locked out
+// (see the idempotent-repeat handling below for the `undeliverable` case).
+const UNDELIVERABLE_SOURCE_STATES = new Set(['proposed', 'pending_review', 'approved']);
+
+export async function POST({ params, request }: { params: { id: string }; request: Request }) {
+  const auth = await requireExtensionAuth(request);
+  const id = Number(params.id);
+  if (!Number.isInteger(id)) throw error(400, 'invalid id');
+  const body = (await request.json().catch(() => ({}))) as UndeliverableBody;
+  const reason = typeof body.reason === 'string' ? body.reason.trim() : '';
+  if (!reason) throw error(400, 'reason is required');
+
+  const db = getDb();
+  await assertDraftInDeviceOrg(db, id, auth);
+  const [draft] = await db.select().from(schema.drafts).where(eq(schema.drafts.id, id));
+  if (!draft) throw error(404, 'draft not found');
+  if (draft.state === 'undeliverable') {
+    return json({ ok: true, alreadyUndeliverable: true });
+  }
+  if (!UNDELIVERABLE_SOURCE_STATES.has(draft.state)) {
+    throw error(409, 'state_locked');
+  }
+
+  // Optimistic-locking: same convention as the sibling `sent`/`armed` routes -
+  // verify a caller-supplied version, otherwise accept the current one.
+  const expectedVersion = typeof body.version === 'number' ? body.version : draft.version;
+  const now = body.detectedAt ? new Date(body.detectedAt) : new Date();
+
+  const res = await updateDraftWithVersion(id, expectedVersion, {
+    state: 'undeliverable',
+    reviewedAt: draft.reviewedAt ?? now,
+    undeliverableReason: reason,
+  });
+  if (res.kind === 'conflict') {
+    return json(
+      { error: 'version_conflict', current_version: res.currentVersion },
+      { status: 409 },
+    );
+  }
+
+  await db.insert(schema.draftEvents).values({
+    draftId: id,
+    event: 'undeliverable',
+    actor: 'extension',
+    details: { reason },
+  });
+
+  // The contact carries the draft's org, same reasoning as the `sent` route:
+  // contact_history.organization_id is NOT NULL and must stay matchable after
+  // retention prunes the draft.
+  const orgId = await requireDraftOrgId(db, id);
+
+  // Record the target as uncontactable on this platform so a future run
+  // skips it (checkUncontactable, consulted from drafts:create) - see #335.
+  // No message was actually sent, so this is a new contact_history row (an
+  // attempt), not an update to a prior one - matching how the `sent` route
+  // always inserts rather than upserts.
+  if (draft.kind === 'dm' && draft.targetUser) {
+    const [account] = await db
+      .select()
+      .from(schema.accounts)
+      .where(eq(schema.accounts.id, draft.accountId));
+    if (account) {
+      await db.insert(schema.contactHistory).values({
+        platformId: draft.platformId,
+        accountHandle: account.handle,
+        targetUser: draft.targetUser,
+        lastContactedAt: now,
+        draftId: id,
+        organizationId: orgId,
+        uncontactable: true,
+        uncontactableReason: reason,
+      });
+    }
+  }
+
+  // Quota: nothing to release. shared/src/quota.ts computes usage live from
+  // COUNT(*) WHERE drafts.sent_at >= window_start (getUsageForAccounts) -
+  // there is no separate "reserved" or "consumed" counter written anywhere,
+  // and an undeliverable draft never sets sent_at (Send stayed disabled, so
+  // the content script's onSendCompleted never ran). So no quota was ever
+  // actually consumed by this attempt; releasing anything here would be
+  // decrementing a counter that was never incremented.
+  emit('drafts:changed', { id, state: 'undeliverable' }, orgId);
+  return json({ ok: true });
+}

--- a/web/src/routes/inbox/+page.svelte
+++ b/web/src/routes/inbox/+page.svelte
@@ -193,6 +193,7 @@
 		{ value: 'approved', label: 'Approved' },
 		{ value: 'sent', label: 'Sent' },
 		{ value: 'rejected', label: 'Rejected' },
+		{ value: 'undeliverable', label: 'Undeliverable' },
 		{ value: 'all', label: 'All' },
 	];
 

--- a/web/tests/extension-undeliverable.test.ts
+++ b/web/tests/extension-undeliverable.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { POST as draftUndeliverable } from '../src/routes/api/extension/draft/[id]/undeliverable/+server.js';
+
+/**
+ * Issue #335: the extension marks a DM draft `undeliverable` once Reddit's
+ * compose page refuses the recipient ("unable to send a message request to
+ * this account"). This is a terminal, non-punitive state distinct from
+ * `rejected` - the platform refused delivery, not the human - and it must
+ * record the target as uncontactable so a future run does not draft for it
+ * again (see cli/tests/commands/drafts-create.test.ts for the loop-closing
+ * half of that).
+ */
+
+const REASON = 'You are unable to send a message request to this account.';
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, draft_events, extension_devices, contact_history RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function bearer(
+  id: number,
+  token: string,
+  body: Record<string, unknown> = { reason: REASON },
+): Request {
+  return new Request(`http://x/api/extension/draft/${id}/undeliverable`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+  });
+}
+
+async function mintDevice(token: string, organizationId: number | null = null) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({ organizationId, tokenHash: tokenHash(token), label: 'test' });
+}
+
+async function seedDraft(
+  state: string,
+  opts: { orgSlug?: string; kind?: string; targetUser?: string | null } = {},
+) {
+  const db = getDb();
+  const orgSlug = opts.orgSlug ?? 'default';
+  const kind = opts.kind ?? 'dm';
+  const targetUser = opts.targetUser === undefined ? 'MyrthDM' : opts.targetUser;
+  let [org] = await db
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.slug, orgSlug));
+  if (!org) {
+    [org] = await db
+      .insert(schema.organizations)
+      .values({ slug: orgSlug, name: orgSlug })
+      .returning();
+  }
+  const [proj] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `und-${state}-${Date.now()}-${Math.random()}`,
+      name: 'undeliverable',
+    })
+    .returning();
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'reddit'));
+  const [account] = await db
+    .insert(schema.accounts)
+    .values({
+      projectId: proj.id,
+      platformId: platform.id,
+      handle: `h-${state}-${Date.now()}-${Math.random()}`,
+    })
+    .returning();
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({ projectId: proj.id, platformId: platform.id, name: state, skillSlug: 'reddit-scout' })
+    .returning();
+  const [run] = await db
+    .insert(schema.runs)
+    .values({ campaignId: campaign.id, trigger: 'manual', status: 'success' })
+    .returning();
+  const [draft] = await db
+    .insert(schema.drafts)
+    .values({
+      runId: run.id,
+      projectId: proj.id,
+      platformId: platform.id,
+      accountId: account.id,
+      kind,
+      body: 'hello there',
+      targetUser,
+      state,
+    })
+    .returning();
+  return { draft, org, account, platform };
+}
+
+async function readDraft(id: number) {
+  const [row] = await getDb().select().from(schema.drafts).where(eq(schema.drafts.id, id));
+  return row;
+}
+
+describe('extension mark-undeliverable route', () => {
+  beforeEach(reset);
+
+  it('flips the draft, keeps the reason verbatim, and records the contact as uncontactable', async () => {
+    const { draft, org, account } = await seedDraft('approved');
+    await mintDevice('tok-ok');
+
+    const res = await draftUndeliverable({
+      params: { id: String(draft.id) },
+      request: bearer(draft.id, 'tok-ok'),
+    } as never);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true });
+
+    const after = await readDraft(draft.id);
+    expect(after.state).toBe('undeliverable');
+    expect(after.undeliverableReason).toBe(REASON);
+
+    const events = await getDb()
+      .select()
+      .from(schema.draftEvents)
+      .where(eq(schema.draftEvents.draftId, draft.id));
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe('undeliverable');
+    expect(events[0].actor).toBe('extension');
+    expect(events[0].details).toMatchObject({ reason: REASON });
+
+    const contacts = await getDb()
+      .select()
+      .from(schema.contactHistory)
+      .where(eq(schema.contactHistory.draftId, draft.id));
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0]).toMatchObject({
+      uncontactable: true,
+      uncontactableReason: REASON,
+      targetUser: 'MyrthDM',
+      platformId: draft.platformId,
+      accountHandle: account.handle,
+      organizationId: org.id,
+    });
+  });
+
+  it('keeps arbitrary reason text verbatim, whitespace trimmed but otherwise untouched', async () => {
+    const { draft } = await seedDraft('approved');
+    await mintDevice('tok-verbatim');
+    const weird = '  Weird - platform copy with punctuation, casing AND trailing space.  ';
+
+    const res = await draftUndeliverable({
+      params: { id: String(draft.id) },
+      request: bearer(draft.id, 'tok-verbatim', { reason: weird }),
+    } as never);
+    expect(res.status).toBe(200);
+
+    const after = await readDraft(draft.id);
+    expect(after.undeliverableReason).toBe(weird.trim());
+  });
+
+  it('rejects a request with no reason', async () => {
+    const { draft } = await seedDraft('approved');
+    await mintDevice('tok-noreason');
+
+    await expect(
+      draftUndeliverable({
+        params: { id: String(draft.id) },
+        request: bearer(draft.id, 'tok-noreason', {}),
+      } as never),
+    ).rejects.toMatchObject({ status: 400 });
+
+    const after = await readDraft(draft.id);
+    expect(after.state).toBe('approved');
+  });
+
+  it('refuses a draft belonging to another org (404), same as the sibling routes', async () => {
+    const { draft } = await seedDraft('approved', { orgSlug: 'other-org' });
+    const [defaultOrg] = await getDb()
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(eq(schema.organizations.slug, 'default'));
+    // Device bound to 'default', not 'other-org'.
+    await mintDevice('tok-cross', defaultOrg.id);
+
+    await expect(
+      draftUndeliverable({
+        params: { id: String(draft.id) },
+        request: bearer(draft.id, 'tok-cross'),
+      } as never),
+    ).rejects.toMatchObject({ status: 404 });
+
+    const after = await readDraft(draft.id);
+    expect(after.state).toBe('approved');
+  });
+
+  it.each(['sent', 'rejected'])(
+    'refuses an illegal source state (409 state_locked): %s',
+    async (state) => {
+      const { draft } = await seedDraft(state);
+      await mintDevice(`tok-${state}`);
+
+      await expect(
+        draftUndeliverable({
+          params: { id: String(draft.id) },
+          request: bearer(draft.id, `tok-${state}`),
+        } as never),
+      ).rejects.toMatchObject({ status: 409, body: { message: 'state_locked' } });
+
+      const after = await readDraft(draft.id);
+      expect(after.state).toBe(state);
+      const events = await getDb()
+        .select()
+        .from(schema.draftEvents)
+        .where(eq(schema.draftEvents.draftId, draft.id));
+      expect(events).toHaveLength(0);
+    },
+  );
+
+  it.each(['proposed', 'pending_review', 'approved'])(
+    'accepts a legitimate %s draft',
+    async (state) => {
+      const { draft } = await seedDraft(state);
+      await mintDevice(`tok-legit-${state}`);
+
+      const res = await draftUndeliverable({
+        params: { id: String(draft.id) },
+        request: bearer(draft.id, `tok-legit-${state}`),
+      } as never);
+      expect(res.status).toBe(200);
+
+      const after = await readDraft(draft.id);
+      expect(after.state).toBe('undeliverable');
+    },
+  );
+
+  it('is idempotent on a repeat call: no duplicate events or contact rows, reason unchanged', async () => {
+    const { draft } = await seedDraft('approved');
+    await mintDevice('tok-repeat');
+
+    const first = await draftUndeliverable({
+      params: { id: String(draft.id) },
+      request: bearer(draft.id, 'tok-repeat'),
+    } as never);
+    expect(first.status).toBe(200);
+
+    const second = await draftUndeliverable({
+      params: { id: String(draft.id) },
+      request: bearer(draft.id, 'tok-repeat', { reason: 'a different reason string' }),
+    } as never);
+    expect(second.status).toBe(200);
+    expect(await second.json()).toMatchObject({ ok: true, alreadyUndeliverable: true });
+
+    const after = await readDraft(draft.id);
+    // The second call's different reason never lands - repeat is a no-op.
+    expect(after.undeliverableReason).toBe(REASON);
+
+    const events = await getDb()
+      .select()
+      .from(schema.draftEvents)
+      .where(eq(schema.draftEvents.draftId, draft.id));
+    expect(events).toHaveLength(1);
+
+    const contacts = await getDb()
+      .select()
+      .from(schema.contactHistory)
+      .where(eq(schema.contactHistory.draftId, draft.id));
+    expect(contacts).toHaveLength(1);
+  });
+
+  it('does not write a contact_history row for a non-DM kind (nothing to mark uncontactable)', async () => {
+    const { draft } = await seedDraft('approved', { kind: 'post_comment', targetUser: null });
+    await mintDevice('tok-comment');
+
+    const res = await draftUndeliverable({
+      params: { id: String(draft.id) },
+      request: bearer(draft.id, 'tok-comment'),
+    } as never);
+    expect(res.status).toBe(200);
+
+    const after = await readDraft(draft.id);
+    expect(after.state).toBe('undeliverable');
+
+    const contacts = await getDb()
+      .select()
+      .from(schema.contactHistory)
+      .where(eq(schema.contactHistory.draftId, draft.id));
+    expect(contacts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #335

## What this does

- **Extension.** `extension/src/content/dm-compose.ts` now polls (every 500ms, up to 30s, stopping once a real send completes) for Reddit's "You are unable to send a message request to this account." helper text, via the new `findUndeliverableReason()` in `extension/src/content/shared/reddit-dom.ts`. It requires Send to also be disabled, and the text does not appear until Reddit's async validation resolves, so this cannot read once at load - it has to wait. On detection it POSTs to the new route once, then stops.
- **Server.** New `POST /api/extension/draft/[id]/undeliverable`, authenticated exactly like its `armed`/`sent` siblings (`requireExtensionAuth`, `assertDraftInDeviceOrg`). Flips the draft to a new terminal state, `undeliverable`, keeps the platform's reason string verbatim in a new `drafts.undeliverable_reason` column, and inserts a `contact_history` row with `uncontactable = true` (also new columns) carrying the same reason.
- **Loop closing.** `drafts:create` (`cli/src/commands/drafts.ts`) now calls the new `checkUncontactable` (`shared/src/contact-dedup.ts`) before the ordinary dedup check, for DM drafts only, and skips outright regardless of `dedup_policy.mode` - a "cannot be contacted" fact is not a "was contacted recently" fact, so it does not expire with the dedup window the way an ordinary contact does.
- **Inbox.** `undeliverable` is a state, not an error: it got its own slate-toned badge in `web/src/lib/config/status-badges.ts` (D1 token layer, no raw colors), its own tab, and a banner + tooltip showing the verbatim reason in `DraftDetail.svelte`/`DraftListItem.svelte`. No Approve/Reject/Send buttons show for it (those are already gated on `pending_review`/`proposed`/`approved`, so a state outside that set just shows nothing to do, matching existing behavior for `sent`/`rejected`).
- **Migration.** One migration (`0012_mature_lila_cheney.sql`), purely additive: `drafts.undeliverable_reason` (text, nullable), `contact_history.uncontactable` (boolean, not null default false), `contact_history.uncontactable_reason` (text, nullable). No renamed/dropped constraints, so the historical-constraint-name warning in AGENTS.md does not apply here.

## Decisions taken as directed (not re-litigated)

- The state is named `undeliverable`, distinct from `rejected`.
- Whether Reddit outreach should prefer `post_comment` over `dm` in general is untouched - out of scope by the issue's own text.

## What I left out, and why

- **Quota release.** I measured this instead of guessing: `shared/src/quota.ts`'s `getUsageForAccounts` computes usage live via `COUNT(*) FILTER (WHERE drafts.sent_at >= window_start)` - there is no separate reserved/consumed counter anywhere. An undeliverable draft never sets `sent_at` (Send stayed disabled, so the content script's `onSendCompleted` never runs), so no quota was ever actually consumed by the attempt. There is nothing to release; adding release logic would be decrementing a counter that was never incremented.
- **EDITABLE_STATES / RESCHEDULABLE_STATES / the sent route's `SENDABLE_STATES`.** I deliberately did NOT add `undeliverable` to any of these - it is terminal, so it stays excluded from all three exactly the way `sent` and `rejected` already are. I did add it to `inbox-query.ts`'s `VALID_STATES` (the inbox's own filter vocabulary) and `shared/src/types.ts`'s `DraftState` (currently-unused elsewhere, but the closest thing to a canonical vocabulary type).

## A pre-existing test-infra bug found and fixed along the way

`hydrateShadowRoots` in `extension/tests/content/reddit-dom.test.ts` used `tpl.firstChild` to move a captured `<template data-fixture-shadow-root>`'s content into a real shadow root. Per spec, a `<template>` element's children live in `tpl.content`, not on the element itself, so `tpl.firstChild` is always `null` - this silently never moved anything. It went unnoticed because every existing test exercising it (the `comment-thread.html` capture) only reads light-DOM `shreddit-comment` attributes, never content that had to be relocated out of a non-empty template. My new `compose-undeliverable.html` fixture is the first to actually need it, which is how I found it. Fixed to read from `tpl.content.firstChild`; verified it makes no difference to any existing (empty-template) case and fixes the new one.

## Fixtures: captured vs synthetic

`extension/tests/content/fixtures/reddit/comment-thread.html` is unchanged (still a real capture). The new `compose-undeliverable.html` is **synthetic, not captured** - no live, signed-in Reddit session was reachable in the environment that wrote this. It is hand-written, modeled on the same `shreddit-*`/`faceplate-*` shadow-DOM family the real capture already verified, using the issue's exact quoted wording. `scripts/capture-reddit-fixtures.mjs` now supports `--target compose --recipient <handle>` to capture the real thing later (documented in the fixture README); until someone runs it against a real session with a recipient known to decline requests, treat the fixture tests as "the selectors read the shape the issue describes," not "this is what Reddit currently renders."

## Verified

- `pnpm exec vitest run web/tests/extension-undeliverable.test.ts` - 11/11 pass. Covers: flips state and keeps the reason verbatim, writes the `contact_history` row, rejects a request with no reason, refuses a cross-org draft (404), refuses an illegal source state (409 `state_locked`, both `sent` and `rejected`), accepts every legal source state, is idempotent on a repeat call (no duplicate events/contact rows, second call's different reason is dropped), and does not write `contact_history` for a non-DM kind.
- `pnpm exec vitest run cli/tests/commands/drafts-create.test.ts` - 9/9 pass, including the two new ones: a target already marked uncontactable is skipped by `drafts:create` and reported in `skipped[]` (the loop-closing test), and the mark is DM-specific (a `post_comment` draft to the same target is not skipped).
- `pnpm exec vitest run extension/tests/content/reddit-dom.test.ts` - 28/28 pass, including `findUndeliverableReason` on synthetic shadow-DOM markup (reason found only once Send is disabled AND the helper text exists; null before the text appears; null if Send is still enabled even with matching text) and on the synthetic `compose-undeliverable.html` fixture.
- `pnpm exec vitest run extension/tests/content/dm-compose.test.ts` - 15/15 pass, including: detects the condition only after the async validation text appears (not on several earlier poll ticks), never reports anything on a normal enabled compose page over a full 30s window, reports only once despite the poll continuing, stops polling once the draft is actually sent, and logs a failure event when the backend rejects the flip.
- **Every new/changed assertion above was proven to bite**: for each, I broke the corresponding production code (dropped the reason-verbatim write, removed the state gate, removed the idempotency short-circuit, disabled the contact_history write, removed the org guard, skipped the uncontactable check in `drafts:create`, removed the Send-disabled requirement, broke the detection regex, disabled the undeliverable poll, defeated both the sent-guard and its `clearInterval` together, and suppressed the failure log), watched the exact test go red with the expected diff, then restored the file and reran to confirm green. Not included in the PR since these are the un-broken files.
- `pnpm -F web check` - 5839 files, 0 errors, 0 warnings.
- `pnpm -F @pitchbox/extension check` - 739 files, 0 errors, 0 warnings.
- `pnpm -F @pitchbox/shared typecheck` - clean.
- `pnpm -F cli typecheck` - clean.
- `npx eslint <every changed .ts/.mjs file>` - 0 errors (3 expected "ignored" warnings for `.svelte` files, which this repo's eslint config globally excludes - `svelte-check` above is their gate).
- `npx prettier --check <every changed .ts/.mjs file>` - clean after `--write` on 5 files. `.svelte` files have no prettier-svelte plugin configured repo-wide (not something this PR introduces) and the new fixture sits under `.prettierignore`'s existing "captured markup" exclusion, both pre-existing repo conventions, not a gap I introduced.
- Migration applied to my worktree's test database (`pitchbox_test_w3335`) and confirmed both new columns exist via `\d drafts` / `\d contact_history`.

## Not verified (repo-wide / infra, out of scope per AGENTS.md)

- Repo-wide `pnpm run lint` / `pnpm test` / `pnpm run typecheck` (scoped to my diff instead, per this wave's instructions).
- `deploy-preview.yml` / `deploy-prod.yml` (self-hosted runner only, nothing local reproduces them).
- The real Reddit compose page - no live, signed-in Chrome session was reachable from this environment. See the fixtures section above.
