### PR TITLE
feat(web): LinkedIn assist settings, per-project binding and kill switch

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -61,6 +61,9 @@ already limits them to the active org). Listed here for completeness.
 `playbooks/[id]` PATCH + DELETE,
 `settings/default-runner` GET, `settings/quota` GET, `settings/runner-config` GET
 (view only - saving these needs instance admin, see below),
+`settings/linkedin-assist` GET + POST (org-scoped, unlike the instance-wide
+settings above - the page's own loader also throws here, see the #254 note
+below),
 `orgs/[slug]/invites` POST, `orgs/[slug]/invites/[token]` DELETE,
 `orgs/[slug]/members/[userId]` PATCH + DELETE (with the member-management rules).
 
@@ -90,7 +93,11 @@ viewing the page, and the three GET routes above, stay `requireRole(event,
 The General settings page (four tabs behind one route) was flattened into
 seven top-level routes, one flat rail with no tabs (#254): `settings/status`,
 `settings/runners`, `settings/extension`, `settings/quota`,
-`settings/organization`, `settings/retention`, `settings/security`. `/settings`
+`settings/organization`, `settings/retention`, `settings/security`. LI-19
+(#316) later added an eighth, `settings/linkedin-assist` (the in-page
+LinkedIn assistant's on/off switch, bound project, daily caps and kill
+switch - org-scoped, so it throws `requireRole(event, 'admin')` like
+Retention/Security rather than narrowing like Quota below). `/settings`
 itself now just redirects (307) to `/settings/status`. The four routes that
 used to be General's tabs each gate their own data set in their own loader,
 the same per-data-set split #237 landed on the old combined page: `status`
@@ -106,8 +113,8 @@ empty/misleading state when it isn't. `extension`'s paired-devices list
 status); only revoking a device (DELETE) and minting a pairing code (POST
 `settings/extension-pairing`) are admin-gated. The settings rail
 (`web/src/routes/settings/+layout.svelte`) hides the `organization` link when
-auth is off (no org context to show), and hides the `retention`/`security`
-links from a non-admin since those two routes' loaders
+auth is off (no org context to show), and hides the `retention`/`security`/
+`linkedin-assist` links from a non-admin since those routes' loaders call
 `requireRole(event, 'admin')` and would 403; `status`/`runners`/`extension`/
 `quota` are always shown because none of their loaders throw, they only
 narrow the payload.

--- a/shared/package.json
+++ b/shared/package.json
@@ -54,7 +54,8 @@
     "./scheduler/jitter": "./src/scheduler/jitter.ts",
     "./scheduler/backoff": "./src/scheduler/backoff.ts",
     "./scheduler/dispatch-lock": "./src/scheduler/dispatch-lock.ts",
-    "./project-extraction": "./src/project-extraction/index.ts"
+    "./project-extraction": "./src/project-extraction/index.ts",
+    "./linkedin-assist": "./src/linkedin-assist.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",

--- a/shared/src/linkedin-assist.ts
+++ b/shared/src/linkedin-assist.ts
@@ -1,0 +1,132 @@
+import { eq } from 'drizzle-orm';
+import { schema, type Db } from './db/client.js';
+import { QUOTA_DEFAULTS } from './db/seed-core.js';
+import { projectBelongsToOrg } from './orgs.js';
+
+// The org-level off switch and owner for the in-page LinkedIn assistant
+// (LI-19, #316, docs/linkedin-integration-design.md). Until this exists the
+// collector (#302) and the panel (#314) have no legitimate way to know
+// whether they should be running or which project they write as.
+//
+// Stored in app_config the same way quota_defaults is (shared/src/quota.ts):
+// one row, keyed by a sub-entity inside the jsonb blob. quota_defaults keys
+// by platform slug because it is instance-wide; this keys by organization id
+// because assist is a per-org setting (bound project, per-org caps).
+
+const CONFIG_KEY = 'linkedin_assist';
+
+/**
+ * Hard ceilings a daily cap may never exceed, matching the LinkedIn quota
+ * defaults (docs/linkedin-integration-design.md, "Quota and blocklist"): an
+ * account that comments forty times a day is indistinguishable from a bot to
+ * LinkedIn's velocity monitoring, so the product does not offer that knob.
+ * These track QUOTA_DEFAULTS.linkedin rather than duplicating the numbers.
+ */
+export const ASSIST_COMMENT_CAP_CEILING = QUOTA_DEFAULTS.linkedin.comment.perDay;
+export const ASSIST_POST_CAP_CEILING = QUOTA_DEFAULTS.linkedin.post.perDay;
+
+export type LinkedInAssistSettings = {
+  /** Whether the in-page assistant may be used at all. Off by default: a fresh install must not start collecting. */
+  enabled: boolean;
+  /** The project a suggestion is written as. A suggestion has to be written as some project's voice, so `enabled` cannot be saved true without one. */
+  projectId: number | null;
+  /** Whether the passive observation collector runs. Independent of `enabled` so an operator can gather observations without yet exposing suggestions, or vice versa. */
+  collectorEnabled: boolean;
+  /** Comments/day, clamped to ASSIST_COMMENT_CAP_CEILING. */
+  dailyCommentCap: number;
+  /** Posts/day, clamped to ASSIST_POST_CAP_CEILING. */
+  dailyPostCap: number;
+  /**
+   * Emergency stop, separate from `enabled`. Flipping this must be visible on
+   * the extension's very next poll (docs/linkedin-integration-design.md: "a
+   * kill switch that takes ten minutes to apply is not a kill switch") - there
+   * is no cache between this flag and the read path, so that is automatic.
+   */
+  killSwitch: boolean;
+};
+
+export function defaultLinkedInAssistSettings(): LinkedInAssistSettings {
+  return {
+    enabled: false,
+    projectId: null,
+    collectorEnabled: false,
+    dailyCommentCap: ASSIST_COMMENT_CAP_CEILING,
+    dailyPostCap: ASSIST_POST_CAP_CEILING,
+    killSwitch: false,
+  };
+}
+
+type StoredBlob = Record<string, Partial<LinkedInAssistSettings>>;
+
+export async function loadLinkedInAssistSettings(
+  db: Db,
+  organizationId: number,
+): Promise<LinkedInAssistSettings> {
+  const [row] = await db
+    .select({ value: schema.appConfig.value })
+    .from(schema.appConfig)
+    .where(eq(schema.appConfig.key, CONFIG_KEY))
+    .limit(1);
+  const blob = (row?.value ?? {}) as StoredBlob;
+  const stored = blob[String(organizationId)];
+  return { ...defaultLinkedInAssistSettings(), ...stored };
+}
+
+export async function saveLinkedInAssistSettings(
+  db: Db,
+  organizationId: number,
+  settings: LinkedInAssistSettings,
+): Promise<void> {
+  const [row] = await db
+    .select({ value: schema.appConfig.value })
+    .from(schema.appConfig)
+    .where(eq(schema.appConfig.key, CONFIG_KEY))
+    .limit(1);
+  const blob = (row?.value ?? {}) as StoredBlob;
+  const next: StoredBlob = { ...blob, [String(organizationId)]: settings };
+  await db
+    .insert(schema.appConfig)
+    .values({ key: CONFIG_KEY, value: next })
+    .onConflictDoUpdate({ target: schema.appConfig.key, set: { value: next } });
+}
+
+/** The exact shape served to the extension by GET /api/extension/linkedin-assist. */
+export type LinkedInAssistDeviceState = {
+  /** Effective, not raw: false whenever the bound project no longer exists, or `killSwitch` is set, even if the stored flag is true. */
+  enabled: boolean;
+  /** Effective: also requires `enabled` and a live bound project. */
+  collectorEnabled: boolean;
+  /** Raw flag, exposed separately so a consumer can render "stopped by an admin" distinctly from "never turned on". */
+  killSwitch: boolean;
+  /** Null when unbound or when the stored project id no longer resolves in this org. */
+  projectId: number | null;
+  dailyCommentCap: number;
+  dailyPostCap: number;
+};
+
+/**
+ * Collapses stored settings into the effective state a device should act on.
+ * Re-validates the bound project against the org on every read (jsonb holds
+ * no foreign key) so a deleted project can't leave a stale "enabled: true,
+ * projectId: <gone>" reading after the fact.
+ */
+export async function loadLinkedInAssistDeviceState(
+  db: Db,
+  organizationId: number,
+): Promise<LinkedInAssistDeviceState> {
+  const settings = await loadLinkedInAssistSettings(db, organizationId);
+  const projectId =
+    settings.projectId != null &&
+    (await projectBelongsToOrg(db, settings.projectId, organizationId))
+      ? settings.projectId
+      : null;
+  const boundAndLive = settings.enabled && projectId != null && !settings.killSwitch;
+  return {
+    enabled: boundAndLive,
+    collectorEnabled: boundAndLive && settings.collectorEnabled,
+    killSwitch: settings.killSwitch,
+    projectId,
+    dailyCommentCap: settings.dailyCommentCap,
+    dailyPostCap: settings.dailyPostCap,
+  };
+}

--- a/web/src/routes/api/extension/linkedin-assist/+server.ts
+++ b/web/src/routes/api/extension/linkedin-assist/+server.ts
@@ -1,0 +1,50 @@
+import { json, error } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { getDb, schema, type Db } from '$lib/server/db.js';
+import { requireExtensionAuth } from '$lib/server/extension-auth.js';
+import { RateLimiter } from '$lib/server/rate-limit.js';
+import { loadLinkedInAssistDeviceState } from '@pitchbox/shared/linkedin-assist';
+
+// The read path #302's collector and #314's panel poll to learn whether they
+// should be running at all and which project a suggestion writes as (LI-19,
+// #316). No auth story of its own: it reuses the device bearer token every
+// other /api/extension/* route already requires. There is no cache between
+// this route and app_config, so a flipped kill switch is visible on the very
+// next poll - "a kill switch that takes ten minutes to apply is not a kill
+// switch" (docs/linkedin-integration-design.md).
+//
+// Response shape (see PR body for the frozen contract):
+//   { assist: LinkedInAssistDeviceState }
+// LinkedInAssistDeviceState (shared/src/linkedin-assist.ts) carries only
+// booleans, the bound project id and the two daily caps - nothing org-scoped
+// beyond what the device already handles in observations/suggest bodies.
+
+// Polled on an interval by a background script, not user-driven, so this is
+// tighter than /suggest's perDevice(20, 60_000) while still generous for any
+// reasonable poll cadence.
+const perDevice = new RateLimiter(12, 60_000);
+
+async function resolveDeviceOrgId(db: Db, organizationId: number | null): Promise<number | null> {
+  if (organizationId != null) return organizationId;
+  // A null-org device only happens on self-host / auth-off pairing paths
+  // that predate #196's fail-loud fix. Fall back to the default org, the
+  // same resolution auto-pair itself uses in that mode.
+  const [row] = await db
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.slug, 'default'))
+    .limit(1);
+  return row?.id ?? null;
+}
+
+export async function GET({ request }: { request: Request }) {
+  const auth = await requireExtensionAuth(request);
+  if (!perDevice.consume(`device:${auth.deviceId}`)) throw error(429, 'too many requests');
+
+  const db = getDb();
+  const orgId = await resolveDeviceOrgId(db, auth.organizationId);
+  if (orgId == null) throw error(404, 'not_found');
+
+  const assist = await loadLinkedInAssistDeviceState(db, orgId);
+  return json({ assist });
+}

--- a/web/src/routes/api/settings/linkedin-assist/+server.ts
+++ b/web/src/routes/api/settings/linkedin-assist/+server.ts
@@ -1,0 +1,61 @@
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId, requireRole } from '$lib/server/auth.js';
+import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
+import {
+  ASSIST_COMMENT_CAP_CEILING,
+  ASSIST_POST_CAP_CEILING,
+  loadLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+
+// GET + POST the caller's own org's LinkedIn assist settings (LI-19, #316):
+// on/off, the bound project, the observation collector on/off, daily caps and
+// the kill switch. Org-scoped via requireOrgId (never from the request body)
+// and role-gated to admin, same level as Retention/Security
+// (docs/permissions.md) - this is org structural config, not something a
+// member should even view, unlike the platform-wide Quota page.
+
+const Body = z.object({
+  enabled: z.boolean(),
+  projectId: z.number().int().positive().nullable(),
+  collectorEnabled: z.boolean(),
+  dailyCommentCap: z.number().int().min(0).max(ASSIST_COMMENT_CAP_CEILING),
+  dailyPostCap: z.number().int().min(0).max(ASSIST_POST_CAP_CEILING),
+  killSwitch: z.boolean(),
+});
+
+export async function GET(event: RequestEvent) {
+  const orgId = await requireOrgId(event);
+  requireRole(event, 'admin');
+  const settings = await loadLinkedInAssistSettings(getDb(), orgId);
+  return json(settings);
+}
+
+export async function POST(event: RequestEvent) {
+  const orgId = await requireOrgId(event);
+  requireRole(event, 'admin');
+
+  const parsed = Body.safeParse(await event.request.json().catch(() => null));
+  if (!parsed.success) {
+    throw error(
+      400,
+      parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+    );
+  }
+  const body = parsed.data;
+
+  // A suggestion has to be written as some project's voice
+  // (docs/linkedin-integration-design.md), so assist cannot go live unbound.
+  if (body.enabled && body.projectId == null) {
+    throw error(400, 'a project must be bound before assist can be enabled');
+  }
+  const db = getDb();
+  if (body.projectId != null && !(await projectBelongsToOrg(db, body.projectId, orgId))) {
+    throw error(400, 'project not found in this organization');
+  }
+
+  await saveLinkedInAssistSettings(db, orgId, body);
+  return json(body);
+}

--- a/web/src/routes/settings/+layout.svelte
+++ b/web/src/routes/settings/+layout.svelte
@@ -2,24 +2,30 @@
   import type { Snippet } from 'svelte';
   import type { LayoutData } from './$types';
   import { page } from '$app/stores';
-  import { Activity, Bot, Puzzle, Gauge, Building2, Archive, ShieldCheck } from '@lucide/svelte';
+  import { Activity, Bot, Puzzle, Gauge, Building2, Archive, ShieldCheck, Sparkles } from '@lucide/svelte';
 
   let { data, children }: { data: LayoutData; children: Snippet } = $props();
 
-  // Flat rail of seven (#254, replaces the General-page-plus-tabs layout).
+  // Flat rail of eight (#254 shipped seven; LI-19/#316 added LinkedIn assist).
   // Status/Agent runners/Browser extension/Quota never 403 - each loader
   // gates its own data set (member sees an "Admin access required" card
   // instead of a thrown error) - so they're always shown, same as General
-  // used to be. Organization needs an org context (auth on); Retention and
-  // Security loaders call requireRole(event, 'admin') and do throw, so those
-  // stay role-filtered here too. The server loaders enforce the real rule;
-  // this only hides links that would otherwise 403.
+  // used to be. Organization needs an org context (auth on); Retention,
+  // Security and LinkedIn assist loaders call requireRole(event, 'admin')
+  // and do throw, so those stay role-filtered here too. The server loaders
+  // enforce the real rule; this only hides links that would otherwise 403.
   const items = $derived(
     [
       { href: '/settings/status', label: 'Status', icon: Activity, show: true },
       { href: '/settings/runners', label: 'Agent runners', icon: Bot, show: true },
       { href: '/settings/extension', label: 'Browser extension', icon: Puzzle, show: true },
       { href: '/settings/quota', label: 'Quota', icon: Gauge, show: true },
+      {
+        href: '/settings/linkedin-assist',
+        label: 'LinkedIn assist',
+        icon: Sparkles,
+        show: data.isAdmin,
+      },
       { href: '/settings/organization', label: 'Organization', icon: Building2, show: data.authOn },
       { href: '/settings/retention', label: 'Retention', icon: Archive, show: data.isAdmin },
       { href: '/settings/security', label: 'Security', icon: ShieldCheck, show: data.isAdmin },

--- a/web/src/routes/settings/linkedin-assist/+page.server.ts
+++ b/web/src/routes/settings/linkedin-assist/+page.server.ts
@@ -1,0 +1,31 @@
+import type { PageServerLoad } from './$types';
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId, requireRole } from '$lib/server/auth.js';
+import { listProjects } from '@pitchbox/shared/projects';
+import {
+  ASSIST_COMMENT_CAP_CEILING,
+  ASSIST_POST_CAP_CEILING,
+  loadLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+
+// LinkedIn assist settings (LI-19, #316): the off switch and owner for the
+// in-page assistant. This is org structural config in the same class as
+// Retention/Security (docs/permissions.md) - not something a member should
+// even view, unlike the platform-wide Quota page - so the loader throws
+// requireRole('admin') rather than narrowing the payload. The rail
+// (settings/+layout.svelte) hides this link from a non-admin for the same
+// reason it hides retention/security.
+export const load: PageServerLoad = async (event) => {
+  requireRole(event, 'admin');
+  const orgId = await requireOrgId(event);
+  const db = getDb();
+  const [settings, projects] = await Promise.all([
+    loadLinkedInAssistSettings(db, orgId),
+    listProjects(db, { organizationId: orgId }),
+  ]);
+  return {
+    settings,
+    projects: projects.map((p) => ({ id: p.id, name: p.name })),
+    ceilings: { comment: ASSIST_COMMENT_CAP_CEILING, post: ASSIST_POST_CAP_CEILING },
+  };
+};

--- a/web/src/routes/settings/linkedin-assist/+page.svelte
+++ b/web/src/routes/settings/linkedin-assist/+page.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+	import * as Alert from '$lib/components/ui/alert';
+	import { Checkbox } from '$lib/components/ui/checkbox';
+	import { Input } from '$lib/components/ui/input';
+	import { SelectField } from '$lib/components/ui/select-field';
+	import { Button } from '$lib/components/ui/button';
+	import { Info, TriangleAlert, RadioTower } from '@lucide/svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import Seo from '$lib/components/Seo.svelte';
+	import PageContainer from '$lib/components/PageContainer.svelte';
+	import { toast } from 'svelte-sonner';
+	import { fly } from 'svelte/transition';
+	import { untrack } from 'svelte';
+
+	type Settings = {
+		enabled: boolean;
+		projectId: number | null;
+		collectorEnabled: boolean;
+		dailyCommentCap: number;
+		dailyPostCap: number;
+		killSwitch: boolean;
+	};
+	type PageData = {
+		settings: Settings;
+		projects: Array<{ id: number; name: string }>;
+		ceilings: { comment: number; post: number };
+	};
+
+	let { data }: { data: PageData } = $props();
+
+	// Dirty-tracking state - untrack to silence state_referenced_locally.
+	let initial = $state(untrack(() => structuredClone(data.settings)));
+	let s = $state(untrack(() => structuredClone(data.settings)));
+	const dirty = $derived(JSON.stringify(s) !== JSON.stringify(initial));
+	let saving = $state(false);
+
+	// The stored project id can point at a project that has since been
+	// deleted (app_config holds no foreign key); if it's not among the org's
+	// current projects, show the picker unset rather than a dead selection.
+	const projectOptions = $derived(data.projects.map((p) => ({ value: p.id, label: p.name })));
+	$effect(() => {
+		if (s.projectId != null && !data.projects.some((p) => p.id === s.projectId)) {
+			s.projectId = null;
+		}
+	});
+
+	function discard() {
+		s = structuredClone(initial);
+	}
+
+	async function save() {
+		if (s.enabled && s.projectId == null) {
+			toast.error('Bind a project before enabling assist');
+			return;
+		}
+		saving = true;
+		try {
+			const res = await fetch('/api/settings/linkedin-assist', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify(s),
+			});
+			if (res.ok) {
+				initial = structuredClone(s);
+				toast.success('LinkedIn assist settings saved');
+			} else if (res.status === 403) {
+				toast.error('You need admin access for that');
+			} else {
+				toast.error('Save failed', { description: await res.text() });
+			}
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<Seo
+	title="Settings - LinkedIn assist"
+	description="On/off, bound project, daily caps and the kill switch for the in-page LinkedIn assistant."
+/>
+
+<PageContainer size="default">
+	<PageHeader
+		title="LinkedIn assist"
+		description="Controls the in-page assistant on linkedin.com: who it writes as, how much it may send, and a kill switch that applies immediately."
+	/>
+
+	{#if s.killSwitch}
+		<Alert.Root variant="destructive" class="mb-4">
+			<TriangleAlert class="size-4" />
+			<Alert.Title>Kill switch is on</Alert.Title>
+			<Alert.Description>
+				Suggestions and observation collection are stopped for every device in this
+				organization, regardless of the settings below.
+			</Alert.Description>
+		</Alert.Root>
+	{/if}
+
+	<div class="max-w-2xl flex flex-col gap-4">
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>Assist</Card.Title>
+				<Card.Description>
+					Off by default. A suggestion is written as a project's voice, so a project must be
+					bound before assist can be enabled.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content class="flex flex-col gap-4">
+				<label class="flex items-center gap-2 text-sm">
+					<Checkbox checked={s.enabled} onCheckedChange={(v) => (s.enabled = !!v)} />
+					Assist enabled
+				</label>
+				<div class="grid gap-1.5">
+					<span class="text-sm font-medium">Writes as project</span>
+					<SelectField
+						value={s.projectId ?? undefined}
+						onValueChange={(v) => (s.projectId = v as number)}
+						options={projectOptions}
+						placeholder="No project bound"
+						fullWidth
+					/>
+				</div>
+				<label class="flex items-center gap-2 text-sm">
+					<Checkbox
+						checked={s.collectorEnabled}
+						onCheckedChange={(v) => (s.collectorEnabled = !!v)}
+					/>
+					Observation collector enabled
+				</label>
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>Daily caps</Card.Title>
+				<Card.Description>
+					Can be lowered, never raised past the code ceiling: LinkedIn's velocity monitoring
+					treats a high-volume account as a bot regardless of how carefully it was written.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content class="grid gap-4 sm:grid-cols-2">
+				<div class="grid gap-1.5">
+					<label class="text-sm font-medium" for="dailyCommentCap">Comments / day</label>
+					<Input
+						id="dailyCommentCap"
+						type="number"
+						min={0}
+						max={data.ceilings.comment}
+						value={s.dailyCommentCap}
+						oninput={(e) => (s.dailyCommentCap = Number(e.currentTarget.value))}
+					/>
+					<p class="text-xs text-muted-foreground">Ceiling: {data.ceilings.comment} / day</p>
+				</div>
+				<div class="grid gap-1.5">
+					<label class="text-sm font-medium" for="dailyPostCap">Posts / day</label>
+					<Input
+						id="dailyPostCap"
+						type="number"
+						min={0}
+						max={data.ceilings.post}
+						value={s.dailyPostCap}
+						oninput={(e) => (s.dailyPostCap = Number(e.currentTarget.value))}
+					/>
+					<p class="text-xs text-muted-foreground">Ceiling: {data.ceilings.post} / day</p>
+				</div>
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root class="border-destructive/40">
+			<Card.Header>
+				<Card.Title>Kill switch</Card.Title>
+				<Card.Description>
+					Stops both collection and suggestion immediately, on every device, without waiting for
+					the next alarm. Separate from turning assist off: use this for "something is wrong right
+					now", not for routine pausing.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content>
+				<label class="flex items-center gap-2 text-sm">
+					<Checkbox checked={s.killSwitch} onCheckedChange={(v) => (s.killSwitch = !!v)} />
+					Kill switch engaged
+				</label>
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root>
+			<Card.Header>
+				<Card.Title class="flex items-center gap-2"><RadioTower class="size-4" /> Selector health</Card.Title>
+				<Card.Description>
+					Whether the extension can still find LinkedIn's feed, composer and submit controls
+					(LI-6, #303). The failure mode this guards against is silent breakage: an assistant
+					that quietly stops finding posts looks identical to a quiet week.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content>
+				<Alert.Root>
+					<Info class="size-4" />
+					<Alert.Title>No reports yet</Alert.Title>
+					<Alert.Description>
+						Nothing has been reported by an installed extension. This card will populate once
+						the collector (#302) ships and starts reporting selector health here.
+					</Alert.Description>
+				</Alert.Root>
+			</Card.Content>
+		</Card.Root>
+	</div>
+</PageContainer>
+
+{#if dirty}
+	<div
+		class="fixed bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 rounded-lg border bg-background px-4 py-2 shadow-lg"
+		transition:fly={{ y: 20, duration: 150 }}
+	>
+		<span class="text-sm">You have unsaved changes</span>
+		<Button variant="outline" size="sm" onclick={discard}>Discard</Button>
+		<Button size="sm" onclick={save} disabled={saving}>Save</Button>
+	</div>
+{/if}

--- a/web/tests/linkedin-assist-settings.test.ts
+++ b/web/tests/linkedin-assist-settings.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it, beforeEach, afterAll } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, getPool, schema } from '@pitchbox/shared/db';
+import { hashPassword, createSession } from '@pitchbox/shared/auth';
+import {
+  ASSIST_COMMENT_CAP_CEILING,
+  ASSIST_POST_CAP_CEILING,
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+  loadLinkedInAssistDeviceState,
+} from '@pitchbox/shared/linkedin-assist';
+import { GET, POST } from '../src/routes/api/settings/linkedin-assist/+server.js';
+import { GET as deviceGet } from '../src/routes/api/extension/linkedin-assist/+server.js';
+import { type CookieJar, runThroughHandle } from './helpers/handle-harness.js';
+
+// LI-19 (#316): the off switch and owner for the in-page LinkedIn assistant.
+// Two boundaries to defend, per docs/linkedin-integration-design.md: the API
+// (not the settings page) is the enforcement boundary for who may write it,
+// and there is no cache between a save and the extension's next read, so a
+// kill switch actually stops something "immediately" rather than at the next
+// alarm.
+
+const PASSWORD = 'correct-horse-battery';
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+  await db.execute(
+    sql`TRUNCATE extension_devices, projects, memberships, users RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function seedOrg(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug })
+    .returning();
+  return { orgId: org.id, projectId: project.id };
+}
+
+function ev(orgId: number, role: string, method: 'GET' | 'POST', body?: unknown): RequestEvent {
+  return {
+    locals: { org: { id: orgId, slug: 'x', role } },
+    request: new Request('http://x/', {
+      method,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    }),
+  } as unknown as RequestEvent;
+}
+
+async function statusOf(fn: () => Promise<Response>): Promise<number> {
+  try {
+    return (await fn()).status;
+  } catch (e) {
+    return (e as { status?: number }).status ?? 500;
+  }
+}
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({ organizationId, tokenHash: tokenHash(token), label: 'test' });
+}
+
+function deviceRequest(token: string | null): Request {
+  return new Request('http://x/api/extension/linkedin-assist', {
+    method: 'GET',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+}
+
+describe('GET /api/settings/linkedin-assist', () => {
+  beforeEach(reset);
+
+  it('a member is forbidden (403)', async () => {
+    const { orgId } = await seedOrg('la-member');
+    expect(await statusOf(() => GET(ev(orgId, 'member', 'GET')))).toBe(403);
+  });
+
+  it('an admin reads the defaults (off, unbound, capped at the ceiling)', async () => {
+    const { orgId } = await seedOrg('la-admin-get');
+    const res = await GET(ev(orgId, 'admin', 'GET'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      enabled: false,
+      projectId: null,
+      collectorEnabled: false,
+      dailyCommentCap: ASSIST_COMMENT_CAP_CEILING,
+      dailyPostCap: ASSIST_POST_CAP_CEILING,
+      killSwitch: false,
+    });
+  });
+});
+
+describe('POST /api/settings/linkedin-assist', () => {
+  beforeEach(reset);
+
+  it('a member cannot write the setting (403), and nothing is saved', async () => {
+    const { orgId, projectId } = await seedOrg('la-member-write');
+    const attempt = {
+      enabled: true,
+      projectId,
+      collectorEnabled: true,
+      dailyCommentCap: 1,
+      dailyPostCap: 1,
+      killSwitch: false,
+    };
+    expect(await statusOf(() => POST(ev(orgId, 'member', 'POST', attempt)))).toBe(403);
+    const state = await loadLinkedInAssistDeviceState(getDb(), orgId);
+    expect(state.enabled).toBe(false);
+  });
+
+  it('an admin can write the setting and it persists', async () => {
+    const { orgId, projectId } = await seedOrg('la-admin-write');
+    const body = {
+      enabled: true,
+      projectId,
+      collectorEnabled: true,
+      dailyCommentCap: 3,
+      dailyPostCap: 1,
+      killSwitch: false,
+    };
+    const res = await POST(ev(orgId, 'admin', 'POST', body));
+    expect(res.status).toBe(200);
+    const state = await loadLinkedInAssistDeviceState(getDb(), orgId);
+    expect(state).toMatchObject({
+      enabled: true,
+      collectorEnabled: true,
+      projectId,
+      dailyCommentCap: 3,
+      dailyPostCap: 1,
+    });
+  });
+
+  it('refuses a comment cap above the code ceiling (400)', async () => {
+    const { orgId, projectId } = await seedOrg('la-comment-ceiling');
+    const body = {
+      ...defaultLinkedInAssistSettings(),
+      projectId,
+      dailyCommentCap: ASSIST_COMMENT_CAP_CEILING + 1,
+    };
+    expect(await statusOf(() => POST(ev(orgId, 'admin', 'POST', body)))).toBe(400);
+  });
+
+  it('refuses a post cap above the code ceiling (400)', async () => {
+    const { orgId, projectId } = await seedOrg('la-post-ceiling');
+    const body = {
+      ...defaultLinkedInAssistSettings(),
+      projectId,
+      dailyPostCap: ASSIST_POST_CAP_CEILING + 1,
+    };
+    expect(await statusOf(() => POST(ev(orgId, 'admin', 'POST', body)))).toBe(400);
+  });
+
+  it('allows lowering a cap below the ceiling', async () => {
+    const { orgId, projectId } = await seedOrg('la-lower-cap');
+    const body = {
+      ...defaultLinkedInAssistSettings(),
+      projectId,
+      dailyCommentCap: 1,
+      dailyPostCap: 0,
+    };
+    expect(await statusOf(() => POST(ev(orgId, 'admin', 'POST', body)))).toBe(200);
+  });
+
+  it('refuses enabling assist without a bound project (400)', async () => {
+    const { orgId } = await seedOrg('la-unbound');
+    const body = { ...defaultLinkedInAssistSettings(), enabled: true, projectId: null };
+    expect(await statusOf(() => POST(ev(orgId, 'admin', 'POST', body)))).toBe(400);
+  });
+
+  it("refuses binding another organization's project (400)", async () => {
+    const { orgId } = await seedOrg('la-cross-org-a');
+    const { projectId: otherProjectId } = await seedOrg('la-cross-org-b');
+    const body = { ...defaultLinkedInAssistSettings(), enabled: true, projectId: otherProjectId };
+    expect(await statusOf(() => POST(ev(orgId, 'admin', 'POST', body)))).toBe(400);
+  });
+});
+
+describe('GET /api/extension/linkedin-assist (device read path)', () => {
+  beforeEach(reset);
+
+  it('rejects a request with no bearer token (401)', async () => {
+    expect(await statusOf(() => deviceGet({ request: deviceRequest(null) }))).toBe(401);
+  });
+
+  it('rejects an unknown token (401)', async () => {
+    expect(await statusOf(() => deviceGet({ request: deviceRequest('not-a-real-token') }))).toBe(
+      401,
+    );
+  });
+
+  it('a device sees only its own organization, never a sibling org', async () => {
+    const { orgId: orgA, projectId: projectA } = await seedOrg('la-device-a');
+    const { orgId: orgB, projectId: projectB } = await seedOrg('la-device-b');
+    await saveLinkedInAssistSettings(getDb(), orgA, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId: projectA,
+    });
+    await saveLinkedInAssistSettings(getDb(), orgB, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId: projectB,
+    });
+
+    const token = 'device-token-a';
+    await mintDevice(orgA, token);
+    const res = await deviceGet({ request: deviceRequest(token) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.assist.projectId).toBe(projectA);
+    expect(body.assist.projectId).not.toBe(projectB);
+  });
+
+  it('the kill switch is visible on the very next read, with no caching', async () => {
+    const { orgId, projectId } = await seedOrg('la-kill-switch');
+    await saveLinkedInAssistSettings(getDb(), orgId, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId,
+      collectorEnabled: true,
+    });
+    const token = 'device-token-kill';
+    await mintDevice(orgId, token);
+
+    const before = await (await deviceGet({ request: deviceRequest(token) })).json();
+    expect(before.assist.enabled).toBe(true);
+    expect(before.assist.collectorEnabled).toBe(true);
+
+    // Flip the kill switch the same way the settings page does - through the
+    // save path, not a direct DB write - then read again with no delay and
+    // no cache invalidation step of any kind.
+    await POST(
+      ev(orgId, 'admin', 'POST', {
+        enabled: true,
+        projectId,
+        collectorEnabled: true,
+        dailyCommentCap: ASSIST_COMMENT_CAP_CEILING,
+        dailyPostCap: ASSIST_POST_CAP_CEILING,
+        killSwitch: true,
+      }),
+    );
+
+    const after = await (await deviceGet({ request: deviceRequest(token) })).json();
+    expect(after.assist.killSwitch).toBe(true);
+    expect(after.assist.enabled).toBe(false);
+    expect(after.assist.collectorEnabled).toBe(false);
+  });
+
+  it('treats a deleted bound project as unbound rather than leaking a dangling id', async () => {
+    const { orgId, projectId } = await seedOrg('la-deleted-project');
+    await saveLinkedInAssistSettings(getDb(), orgId, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId,
+    });
+    await getDb().delete(schema.projects).where(eq(schema.projects.id, projectId));
+
+    const token = 'device-token-deleted-project';
+    await mintDevice(orgId, token);
+    const body = await (await deviceGet({ request: deviceRequest(token) })).json();
+    expect(body.assist.projectId).toBeNull();
+    expect(body.assist.enabled).toBe(false);
+  });
+});
+
+// The role gate is exactly the kind of bug ISO-1 (#132) hid: a hand-injected
+// locals.org (as above) can't catch a hooks.server.ts wiring mistake, because
+// the hook never runs. Drive these through the real handle() hook instead
+// (see helpers/handle-harness.ts).
+describe('role gate (real handle() path)', () => {
+  async function sessionFor(username: string, role: 'member' | 'admin'): Promise<CookieJar> {
+    const hash = await hashPassword(PASSWORD);
+    await getDb()
+      .insert(schema.users)
+      .values({ username, passwordHash: hash })
+      .onConflictDoNothing();
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(sql`username = ${username}`);
+    let [org] = await getDb()
+      .select()
+      .from(schema.organizations)
+      .where(sql`slug = 'default'`);
+    if (!org) {
+      [org] = await getDb()
+        .insert(schema.organizations)
+        .values({ slug: 'default', name: 'Default' })
+        .returning();
+    }
+    await getDb()
+      .insert(schema.memberships)
+      .values({ organizationId: org.id, userId: user.id, role })
+      .onConflictDoUpdate({
+        target: [schema.memberships.organizationId, schema.memberships.userId],
+        set: { role },
+      });
+    const session = await createSession(getDb(), user.id);
+    return { store: new Map([['pitchbox_session', { value: session.id }]]) };
+  }
+
+  it('a member session is forbidden (403)', async () => {
+    const jar = await sessionFor('la-rg-member', 'member');
+    const req = new Request('http://localhost/api/settings/linkedin-assist');
+    await expect(runThroughHandle(req, jar, GET as any)).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('an admin session can read the settings (200)', async () => {
+    const jar = await sessionFor('la-rg-admin', 'admin');
+    const req = new Request('http://localhost/api/settings/linkedin-assist');
+    const res = await runThroughHandle(req, jar, GET as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect('enabled' in body).toBe(true);
+  });
+});
+
+afterAll(async () => {
+  await getPool().end();
+});


### PR DESCRIPTION
Closes #316

## What this adds

The off switch and owner for the in-page LinkedIn assistant. Until this existed, #302's collector and #314's panel had no legitimate way to know whether they should be running or which project they write as.

- A new org-scoped settings page, `settings/linkedin-assist` (eighth entry in the flat rail): assist on/off, the project a suggestion writes as, the observation collector on/off, daily caps (clamped to the code ceiling, 8 comments/day and 1 post/day, matching `QUOTA_DEFAULTS.linkedin`), and a kill switch. Off by default (a fresh install does not start collecting).
- Stored in `app_config` under a new `linkedin_assist` key, one blob keyed by organization id inside it - the same shape `quota_defaults` already uses, just keyed by org instead of platform, since this is per-org where quota defaults are instance-wide. No migration.
- The role gate is enforced in the page's own loader (`requireRole(event, 'admin')`, throws for a member, same class as Retention/Security rather than narrowing like Quota - this is org structural config a member shouldn't even view) and again on the API (`GET`/`POST /api/settings/linkedin-assist`), which is the real boundary regardless of what the UI hides.
- A new device read path, `GET /api/extension/linkedin-assist`, that an already-authenticated extension device polls. There is no cache between it and `app_config`, so a flipped kill switch is visible on the device's very next read, not at the next alarm.
- Selector health (LI-6/#303) gets a card on the page, currently always "No reports yet": #303 shipped the client-side detection and local activity-log surfacing, but nothing posts a report to the server yet, and building that ingest pipeline is an extension-side change outside this lane's file scope. The card is real UI, wired to a real (currently empty) read, ready for whichever of #302/#303's follow-up wires the writer.

## The device read path contract (frozen for #302 and #314)

```
GET /api/extension/linkedin-assist
Authorization: Bearer <device token>

200 OK
{
  "assist": {
    "enabled": boolean,          // effective: true only if the stored flag is on, a live project is bound, and killSwitch is false
    "collectorEnabled": boolean, // effective: same preconditions as enabled, AND the stored collector flag is on
    "killSwitch": boolean,       // raw flag, exposed separately so a consumer can render "stopped by an admin" distinctly from "never turned on"
    "projectId": number | null,  // null when unbound, or when the stored project id no longer resolves in this org (e.g. deleted)
    "dailyCommentCap": number,
    "dailyPostCap": number
  }
}
401  no/invalid bearer token
429  device polled past its rate limit (12/min)
404  device's organization cannot be resolved (should not happen for a device minted by /api/extension/auto-pair)
```

`enabled` and `collectorEnabled` are pre-derived (kill switch and live-project-binding already folded in) so #302 and #314 don't each need to reimplement that boolean logic differently. `killSwitch` is exposed raw in case a future UI wants to distinguish "an admin stopped this" from "nobody turned it on".

## Verified

- `pnpm -F web check`: 0 errors, 0 warnings.
- `pnpm -F @pitchbox/shared typecheck`: clean.
- `npx vitest run web/tests/linkedin-assist-settings.test.ts`: 16/16 passing. Covers: a member is forbidden on both GET and POST (403); an admin can read/write and it persists; a POST is refused (400) for a comment cap or post cap above the code ceiling, for enabling without a bound project, and for binding another organization's project; lowering a cap below the ceiling is allowed; the device read path 401s with no/invalid token; a device sees only its own org's bound project, never a sibling org's; the kill switch is visible on the very next device read with no caching, driven through the real save path; a deleted bound project reads back as unbound rather than a dangling id; and a role-gate pair driven through the real `handle()` hook (not hand-injected `locals.org`), the same defense #132/ISO-1 needed.
- Proved the tests actually bite: temporarily removed `requireRole` from the API (the 3 role-gate tests failed, nothing else did, restored); dropped the kill-switch and live-project checks from the shared module's effective-state calc (the 2 corresponding tests failed, nothing else did, restored); removed the `.max()` ceiling from the zod schema (the 2 ceiling tests failed, nothing else did, restored). Diffed each file back to identical after restoring.
- Manual, against the worktree's own dev server (`pnpm run dev:web`, auth off): created a project and a device row directly in the test DB, then drove the real HTTP endpoints with curl - saved settings with `enabled:true`, confirmed the device read reflected it, flipped `killSwitch:true` through the same save path, and confirmed the very next device read (no restart, no delay) showed `enabled:false`, `collectorEnabled:false`, `killSwitch:true`. This is the acceptance criterion "flip the kill switch and confirm the collector stops without a reload" exercised end to end against the real route, not just the vitest fakes.
- `eslint`/`prettier` clean on every non-`.svelte` file I touched or added. Prettier cannot parse `.svelte` at all in this repo today (no `prettier-plugin-svelte`, no per-workspace override) - confirmed this is pre-existing by running it against an untouched file (`settings/quota/+page.svelte`), which fails identically. `pnpm -F web check` (svelte-check) is the real gate for my two `.svelte` files and is clean.
- `docs/permissions.md` updated and confirmed in my worktree: it now lists `settings/linkedin-assist` GET+POST under the admin route table, the #254 rail paragraph mentions the eighth route and why it throws instead of narrowing, and the rail-hiding sentence includes it alongside retention/security.
- `uishot` against the running dev server, desktop 1440x900, both themes (this app's dark mode is class-based via `mode-watcher` with `localStorage` persistence, not the OS `prefers-color-scheme` media query, so the light capture forces the class off before shooting - otherwise both come back dark). Contact sheets:
  - `artifact://` not needed, local paths: `/tmp/uishot-pb316/sheet.png` (dark, default) and `/tmp/uishot-pb316-light/sheet.png` (light, forced) and `/tmp/uishot-pb316-killed/sheet.png` (dark, kill switch engaged, showing the destructive banner and a bound project).
  - `--axe` flagged two pre-existing issues in both themes (`.border-border/60` contrast on the sidebar's `SystemStatusCard.svelte` version footer, and an `.sr-only` element outside a landmark) - both are global app-shell chrome that exists on every page, not introduced by this change; confirmed by grepping for the class and finding it only in `SystemStatusCard.svelte`, unrelated to my new files.

## Not verified / deliberately out of scope

- The extension side of any of this (the collector actually honoring `collectorEnabled`, the panel actually honoring `enabled`, #302's or #303's "post selector health to the dashboard" half) - none of that exists yet per the wave's own dependency note, and wiring it is #302/#314's job, or whichever follow-up lands #303's dashboard-reporting half. I did not touch `extension/src/lib/api.ts` or the i18n dicts.
- I did not touch `web/src/routes/api/extension/suggest/+server.ts` or `.../observations/+server.ts` to make them defensively re-check the kill switch server-side. The read path exists for the client to honor; adding server-side enforcement to those two routes felt like scope beyond "build the settings surface and the read path", and both routes' own lanes/issues are better positioned to decide whether that's belt-and-suspenders or redundant with the client check. Flagging it explicitly in case Main wants it folded into this PR or filed separately.
- No migration - confirmed unnecessary and none added, per the wave's constraint.
