### PR TITLE
security(web): enforce the assist switch and kill switch on the server, not only in the panel

### DIFF
--- a/web/src/routes/api/extension/observations/+server.ts
+++ b/web/src/routes/api/extension/observations/+server.ts
@@ -8,6 +8,7 @@ import {
   ingestObservedTargets,
   MAX_OBSERVED_TARGETS_BATCH,
 } from '@pitchbox/shared/observed-targets';
+import { loadLinkedInAssistDeviceState } from '@pitchbox/shared/linkedin-assist';
 
 // Server side of the observation buffer (#301): the extension's content
 // script watches linkedin.com passively and posts what it saw here, on a
@@ -72,6 +73,26 @@ export async function POST({ request }: { request: Request }) {
     .where(eq(schema.platforms.slug, body.platform))
     .limit(1);
   if (!platform) throw error(404, 'unknown platform');
+
+  // Same reason as the suggest route: #316 shipped the collector switch and
+  // the kill switch, and the collector is supposed to be off by default, but
+  // nothing here refused a post that ignored either. An extension build that
+  // never polls the read path, or a tab whose content script predates the
+  // flip, would keep filling the buffer with third-party post text an admin
+  // has explicitly said not to collect. Gated on the LinkedIn switch only,
+  // since `linkedin_assist` is what the setting names.
+  if (platform.slug === 'linkedin') {
+    const assist = await loadLinkedInAssistDeviceState(db, project.organizationId);
+    if (!assist.collectorEnabled) {
+      // 403 rather than the suggest route's renderable 200: this caller is a
+      // background collector with no human waiting on a rendered answer, and
+      // a hard refusal is what makes it stop.
+      throw error(403, assist.killSwitch ? 'kill_switch' : 'collector_disabled');
+    }
+    if (assist.projectId !== project.id) {
+      throw error(403, 'project_not_bound');
+    }
+  }
 
   // Delegate the write and the dedup entirely to LI-3's ingest service - no
   // hand-rolled insert here. `body.items` is passed through unvalidated:

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -10,6 +10,7 @@ import { loadActiveTemplates } from '@pitchbox/shared/templates';
 import { getAccountUsage, checkQuota, loadQuotaLimits } from '@pitchbox/shared/quota';
 import { mapDraftKindToQuotaKind } from '@pitchbox/shared/quota-types';
 import { MAX_POST_CHARS, type SuggestionKind } from '@pitchbox/shared/assist/suggest-prompt';
+import { loadLinkedInAssistDeviceState } from '@pitchbox/shared/linkedin-assist';
 
 // The real-time plane. What makes the in-page assistant a separate subsystem
 // rather than a view onto campaigns:
@@ -127,6 +128,39 @@ export async function POST(event: RequestEvent) {
         limit: day.limit,
         used: day.used,
         boundBy: day.kind,
+      });
+    }
+  }
+
+  // The kill switch has to be enforced here, not only honoured by the panel
+  // (#316 shipped the switch and the device read path; nothing refused a call
+  // that ignored them). This route's own header says the API is the
+  // enforcement boundary and not the panel, and a switch a client can decline
+  // to read is not a switch: a stolen device token, a stale content script or
+  // a tab left open across the flip all reach this code with the org's
+  // assistant explicitly turned off.
+  //
+  // Scoped to the platform the switch actually names. `linkedin_assist` is a
+  // LinkedIn setting, so gating every platform on it would silently block a
+  // future Mastodon or Reddit assist that nobody ever wired to it.
+  if (platform.slug === 'linkedin') {
+    const assist = await loadLinkedInAssistDeviceState(db, project.organizationId);
+    if (!assist.enabled) {
+      // Same posture as the quota refusal above: a 200 with a body the panel
+      // can render. Nothing went wrong, an admin turned it off.
+      return json({
+        refused: assist.killSwitch ? 'kill_switch' : 'assist_disabled',
+        platform: platform.slug,
+      });
+    }
+    // A suggestion is written as the bound project's voice, so a request
+    // naming a different project of the same org is not a narrower case of
+    // the binding, it bypasses it.
+    if (assist.projectId !== project.id) {
+      return json({
+        refused: 'project_not_bound',
+        platform: platform.slug,
+        boundProjectId: assist.projectId,
       });
     }
   }

--- a/web/tests/extension-observations.test.ts
+++ b/web/tests/extension-observations.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it, beforeEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { createHash } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
 import { POST as observationsPost } from '../src/routes/api/extension/observations/+server.js';
 
 /**
@@ -20,6 +24,7 @@ async function reset() {
   // colliding in the same in-memory bucket for the limiter's 60s window. A
   // monotonically increasing id keeps every test's device in its own bucket.
   await getDb().execute(sql`DELETE FROM extension_devices`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
 }
 
 function bearer(token: string | null, body: unknown): Request {
@@ -30,13 +35,28 @@ function bearer(token: string | null, body: unknown): Request {
   });
 }
 
-async function seedOrgWithProject(slug: string) {
+/**
+ * Seeds an org and a project, and by default binds the LinkedIn assistant to
+ * that project with the collector on. That binding is a precondition of the
+ * route now, not decoration: the collector is off by default (#316), and the
+ * route refuses a post an admin never switched on. Pass `assist: false` to
+ * seed the default off state.
+ */
+async function seedOrgWithProject(slug: string, opts: { assist?: boolean } = {}) {
   const db = getDb();
   const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
   const [project] = await db
     .insert(schema.projects)
     .values({ organizationId: org.id, slug: `p-${slug}`, name: slug })
     .returning();
+  if (opts.assist ?? true) {
+    await saveLinkedInAssistSettings(db, org.id, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      collectorEnabled: true,
+      projectId: project.id,
+    });
+  }
   return { org, project };
 }
 
@@ -232,5 +252,82 @@ describe('POST /api/extension/observations', () => {
     expect(passedThrough).toBe(30);
     expect(throttled).toBe(1);
     expect(passedThrough + throttled).toBe(statuses.length);
+  });
+
+  // #316 shipped the collector switch, the kill switch and the device read
+  // path, but nothing on the server refused a post that ignored them. These
+  // three fail on the code as #357 left it: measured before the gate landed,
+  // every one of them returned 200 and wrote the row.
+  it('refuses a collector that an admin never switched on, which is the default state', async () => {
+    const { org, project } = await seedOrgWithProject('obs-collector-off', { assist: false });
+    await mintDevice(org.id, 'tokOff');
+
+    await expect(
+      observationsPost({
+        request: bearer('tokOff', {
+          platform: 'linkedin',
+          projectId: project.id,
+          items: [observation()],
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 403 });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.observedTargets)
+      .where(eq(schema.observedTargets.projectId, project.id));
+    expect(rows).toEqual([]);
+  });
+
+  it('refuses while the kill switch is engaged, even with the collector flag left on', async () => {
+    const { org, project } = await seedOrgWithProject('obs-killed', { assist: false });
+    await saveLinkedInAssistSettings(getDb(), org.id, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      collectorEnabled: true,
+      projectId: project.id,
+      killSwitch: true,
+    });
+    await mintDevice(org.id, 'tokKilled');
+
+    await expect(
+      observationsPost({
+        request: bearer('tokKilled', {
+          platform: 'linkedin',
+          projectId: project.id,
+          items: [observation()],
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('refuses a project of the same org that is not the bound one', async () => {
+    const { org, project } = await seedOrgWithProject('obs-other-project');
+    const [other] = await getDb()
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'p-obs-other', name: 'other' })
+      .returning();
+    await mintDevice(org.id, 'tokOther');
+
+    await expect(
+      observationsPost({
+        request: bearer('tokOther', {
+          platform: 'linkedin',
+          projectId: other.id,
+          items: [observation()],
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 403 });
+
+    // The bound project still works from the same device, so this is the
+    // binding being enforced and not the device being broken.
+    const res = await observationsPost({
+      request: bearer('tokOther', {
+        platform: 'linkedin',
+        projectId: project.id,
+        items: [observation()],
+      }),
+    } as never);
+    expect(res.status).toBe(200);
   });
 });

--- a/web/tests/extension-suggest.test.ts
+++ b/web/tests/extension-suggest.test.ts
@@ -3,6 +3,10 @@ import { sql, eq } from 'drizzle-orm';
 import { createHash } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
 import type { AgentRunHandle, AgentRunOptions, AgentRunner } from '@pitchbox/shared/agents';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
 
 /**
  * The real-time suggestion endpoint (#312). What these tests defend is the
@@ -76,12 +80,20 @@ async function reset() {
     sql`TRUNCATE drafts, runs, campaigns, accounts, projects, contact_history, extension_devices RESTART IDENTITY CASCADE`,
   );
   await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
   lastOptions = null;
   cancelCalls = 0;
   hangForever = false;
 }
 
-async function seedOrgProject(slug: string) {
+/**
+ * Seeds an org and a project, and by default binds the LinkedIn assistant to
+ * that project. The binding is a precondition of the route now: the assistant
+ * is off until an admin turns it on (#316), and the route refuses rather than
+ * trusting the panel to have read the switch. Pass `assist: false` for the
+ * default off state.
+ */
+async function seedOrgProject(slug: string, opts: { assist?: boolean } = {}) {
   const db = getDb();
   const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
   const [project] = await db
@@ -92,6 +104,13 @@ async function seedOrgProject(slug: string) {
     .select()
     .from(schema.platforms)
     .where(eq(schema.platforms.slug, 'linkedin'));
+  if (opts.assist ?? true) {
+    await saveLinkedInAssistSettings(db, org.id, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId: project.id,
+    });
+  }
   return { org, project, platform };
 }
 
@@ -271,5 +290,63 @@ describe('POST /api/extension/suggest', () => {
     await reader.cancel();
 
     await vi.waitFor(() => expect(cancelCalls).toBeGreaterThan(0));
+  });
+
+  // The switch #316 shipped was only ever read by a client that chose to read
+  // it. All three of these returned a full streamed suggestion on the code as
+  // #357 left it, with the org's assistant off.
+  it('refuses to suggest for an org that never turned the assistant on', async () => {
+    const { org, project } = await seedOrgProject('org-off', { assist: false });
+    await mintDevice(org.id, 'tokOff');
+
+    const res = await suggest({
+      request: request('tokOff', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    expect(await res.json()).toMatchObject({ refused: 'assist_disabled' });
+    // No model call at all, which is the point: a refusal that still spawns an
+    // agent has only moved the cost.
+    expect(lastOptions).toBeNull();
+  });
+
+  it('names the kill switch distinctly, so the panel can say who stopped it', async () => {
+    const { org, project } = await seedOrgProject('org-killed', { assist: false });
+    await saveLinkedInAssistSettings(getDb(), org.id, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId: project.id,
+      killSwitch: true,
+    });
+    await mintDevice(org.id, 'tokKilled');
+
+    const res = await suggest({
+      request: request('tokKilled', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    expect(await res.json()).toMatchObject({ refused: 'kill_switch' });
+    expect(lastOptions).toBeNull();
+  });
+
+  it('refuses to write as a project of the same org that is not the bound one', async () => {
+    const { org, project } = await seedOrgProject('org-bound');
+    const [other] = await getDb()
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'p-other', name: 'other', description: 'other' })
+      .returning();
+    await mintDevice(org.id, 'tokBound');
+
+    const res = await suggest({
+      request: request('tokBound', { ...POST_BODY, projectId: other.id }),
+    } as never);
+    expect(await res.json()).toMatchObject({
+      refused: 'project_not_bound',
+      boundProjectId: project.id,
+    });
+    expect(lastOptions).toBeNull();
+
+    // The bound project still streams from the same device.
+    const ok = await suggest({
+      request: request('tokBound', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    expect(ok.headers.get('content-type')).toContain('text/event-stream');
+    await ok.text();
   });
 });


### PR DESCRIPTION
Closes #358.

#316 shipped the org-level assist switch, the collector switch, the kill switch and the device read path. Nothing on the server refused a call that ignored them, so the switch was only ever honoured by a client that chose to honour it.

## What I measured on main first

With an org whose assistant is off (which is the default state of a fresh install) and a valid device token:

| call | on main | with this PR |
|---|---|---|
| `POST /api/extension/suggest` | streams a full suggestion, spawns a real agent | `200 {refused: "assist_disabled"}`, no agent spawned |
| same, with `killSwitch: true` | streams a full suggestion | `200 {refused: "kill_switch"}` |
| `POST /api/extension/observations` | `200`, rows written | `403 collector_disabled` |
| same, with `killSwitch: true` | `200`, rows written | `403 kill_switch` |
| either, naming another project of the same org | accepted | refused, `project_not_bound` |

The strongest evidence is not in that table though: the two existing suites for these routes were green with the assistant switched off, and had to be taught to seed the binding once the gate landed. A test that passes with the feature disabled was not testing the feature's gate.

## Decisions in here

**The refusal shapes differ on purpose.** `suggest` answers with a renderable 200, exactly as it already does for an exhausted quota, and for the same reason its code gives there: a 500 would look like a defect, and this is the system working. `observations` gets a hard 403, because its caller is a background collector with no human waiting on a rendered answer, and a hard refusal is what makes it stop.

**`kill_switch` is named distinctly from `assist_disabled`,** so the panel can say "an admin stopped this" rather than "you never turned it on". The device read path already exposes `killSwitch` separately for that reason; this keeps the two surfaces consistent.

**The bound project is enforced, not just read.** A suggestion is written as the bound project's voice, so a request naming a different project of the same org does not narrow the binding, it bypasses it. Same for an observation, whose whole value is being attributed to the right project's candidate pool.

**Gated on the LinkedIn switch only.** `linkedin_assist` is a LinkedIn setting. Gating every platform on it would silently block a future Mastodon or Reddit assist that nobody ever wired to it, which is the kind of coupling that gets found six months later by somebody debugging why their new platform is quiet.

## Verified

- Six new tests, all six proven to fail with the gate removed and to pass with it restored (`Tests 6 failed | 14 passed` -> `20 passed`).
- The refusal happens before any agent spawn (`expect(lastOptions).toBeNull()`), so a refused call has not merely moved the cost.
- The bound project still works from the same device in both suites, so this is the binding being enforced rather than the device being broken.
- `pnpm -F web check` clean (5850 files, 0 errors). `web/tests/extension-suggest.test.ts`, `extension-observations.test.ts` and `linkedin-assist-settings.test.ts`: 36 passed. eslint and prettier clean on every touched file.

## Not verified

No live extension run against a real LinkedIn page: the collector (#302) and the panel (#314) do not exist yet, so there is no client to observe honouring or ignoring this. That is also why the gate matters now rather than later, since both will be written against a server that already refuses.