### PR TITLE
perf(web): the assist path asks for a fast model unless an operator pinned one

### DIFF
--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { getDb } from './db.js';
 import { createAgentRunner } from '@pitchbox/shared/agents/registry';
 import type { AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
-import { loadRunnerConfig } from '@pitchbox/shared/agents/config';
+import { loadRunnerConfig, type RunnerConfig } from '@pitchbox/shared/agents/config';
 import {
   buildSuggestionPrompt,
   type ObservedPost,
@@ -46,6 +46,34 @@ export interface SuggestionHandle {
 /** A suggestion the human is waiting on has a much shorter patience than a
  * campaign run. Past this the answer is not worth having. */
 const SUGGESTION_TIMEOUT_MS = 90_000;
+
+/**
+ * The model a suggestion asks for when an operator has not pinned one for
+ * this runner. A campaign run is unattended and can afford the most capable
+ * model; a suggestion has a human staring at an empty panel, and the wait is
+ * dominated by how long the model deliberates before its first text token,
+ * not by the spawn.
+ *
+ * Measured on an idle devbox, same prompt (3043 chars), claude-code, n=3 each
+ * (see #360 for the full table):
+ *
+ *   unpinned (session default)  median 16.8s to first token, 19.8s total
+ *   sonnet                      median 10.4s to first token, 12.9s total
+ *
+ * Spawn plus `session/new` is 2.2s of either, which is why this is the lever
+ * and a pool of warm processes is not (#318).
+ */
+export const ASSIST_DEFAULT_MODEL = 'sonnet';
+
+/**
+ * An explicit runner config wins: an operator who pinned a model for this
+ * runner meant it, including for suggestions. Everything else, including an
+ * empty string from a cleared form field, falls back to the fast default.
+ */
+export function resolveAssistRunnerConfig(config: RunnerConfig): RunnerConfig {
+  const pinned = config.model?.trim();
+  return pinned ? config : { ...config, model: ASSIST_DEFAULT_MODEL };
+}
 
 export function runSuggestion(args: {
   kind: SuggestionKind;
@@ -90,7 +118,7 @@ export function runSuggestion(args: {
     if (cancelled) throw new Cancelled();
     const config = await loadRunnerConfig(db, args.runnerSlug as AgentRunnerSlug);
     if (cancelled) throw new Cancelled();
-    const runner = createAgentRunner(args.runnerSlug, config);
+    const runner = createAgentRunner(args.runnerSlug, resolveAssistRunnerConfig(config));
 
     // The agent still gets a working directory, and it must not be the repo:
     // this session has no tools attached, but a cwd it could read is a cwd it

--- a/web/tests/extension-suggest.test.ts
+++ b/web/tests/extension-suggest.test.ts
@@ -3,6 +3,7 @@ import { sql, eq } from 'drizzle-orm';
 import { createHash } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
 import type { AgentRunHandle, AgentRunOptions, AgentRunner } from '@pitchbox/shared/agents';
+import { saveRunnerConfig, type RunnerConfig } from '@pitchbox/shared/agents/config';
 import {
   defaultLinkedInAssistSettings,
   saveLinkedInAssistSettings,
@@ -21,15 +22,20 @@ import {
 
 const chunks = ['A specific ', 'thing that ', 'happened.'];
 let lastOptions: AgentRunOptions | null = null;
+/** The runner config the route actually handed to the registry, so a test can
+ * assert which model a suggestion asks for rather than trusting the resolver
+ * in isolation. */
+let lastConfig: RunnerConfig | null = null;
 let cancelCalls = 0;
 /** Set by a test to hold the fake agent open so a disconnect can be observed. */
 let hangForever = false;
 
 vi.mock('@pitchbox/shared/agents/registry', () => ({
-  createAgentRunner: (): AgentRunner => ({
+  createAgentRunner: (_slug: string, config: RunnerConfig): AgentRunner => ({
     slug: 'fake',
     run(opts: AgentRunOptions): AgentRunHandle {
       lastOptions = opts;
+      lastConfig = config;
       let stop: (() => void) | null = null;
       const result = new Promise<never>((_resolve, reject) => {
         stop = () => reject(new Error('cancelled'));
@@ -69,7 +75,8 @@ vi.mock('@pitchbox/shared/agents/registry', () => ({
 }));
 
 const { POST: suggest } = await import('../src/routes/api/extension/suggest/+server.js');
-const { runSuggestion } = await import('../src/lib/server/suggest.js');
+const { runSuggestion, resolveAssistRunnerConfig, ASSIST_DEFAULT_MODEL } =
+  await import('../src/lib/server/suggest.js');
 
 function tokenHash(token: string): string {
   return createHash('sha256').update(token).digest('hex');
@@ -81,7 +88,9 @@ async function reset() {
   );
   await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
   await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'runner_configs'`);
   lastOptions = null;
+  lastConfig = null;
   cancelCalls = 0;
   hangForever = false;
 }
@@ -348,5 +357,55 @@ describe('POST /api/extension/suggest', () => {
     } as never);
     expect(ok.headers.get('content-type')).toContain('text/event-stream');
     await ok.text();
+  });
+
+  // #360: the wait a human sees is dominated by how long the model deliberates
+  // before its first text token, so this path asks for a fast model unless an
+  // operator pinned one. Asserted against the config the route actually handed
+  // the registry, not against the resolver in isolation: the resolver being
+  // correct and never called is the failure mode worth catching.
+  it('asks for the fast assist model when no operator pinned one', async () => {
+    const { org, project } = await seedOrgProject('org-model-default');
+    await mintDevice(org.id, 'tokModel');
+
+    const res = await suggest({
+      request: request('tokModel', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    await res.text();
+    expect(lastConfig).toMatchObject({ model: ASSIST_DEFAULT_MODEL });
+  });
+
+  it('leaves an operator-pinned model alone, including for suggestions', async () => {
+    const { org, project } = await seedOrgProject('org-model-pinned');
+    await mintDevice(org.id, 'tokPinned');
+    await saveRunnerConfig(getDb(), 'claude-code', { model: 'opus', maxTurns: 3 });
+
+    const res = await suggest({
+      request: request('tokPinned', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    await res.text();
+    expect(lastConfig).toMatchObject({ model: 'opus', maxTurns: 3 });
+  });
+});
+
+describe('resolveAssistRunnerConfig', () => {
+  it('defaults an unpinned config to the fast model', () => {
+    expect(resolveAssistRunnerConfig({})).toEqual({ model: ASSIST_DEFAULT_MODEL });
+  });
+
+  it('keeps every other setting while defaulting the model', () => {
+    expect(resolveAssistRunnerConfig({ maxTurns: 2, extraArgs: ['--x'] })).toEqual({
+      maxTurns: 2,
+      extraArgs: ['--x'],
+      model: ASSIST_DEFAULT_MODEL,
+    });
+  });
+
+  it('treats a blank pinned model as unpinned, since a cleared form field is not a choice', () => {
+    expect(resolveAssistRunnerConfig({ model: '   ' })).toEqual({ model: ASSIST_DEFAULT_MODEL });
+  });
+
+  it('respects an explicit pin', () => {
+    expect(resolveAssistRunnerConfig({ model: 'haiku' })).toEqual({ model: 'haiku' });
   });
 });


### PR DESCRIPTION
Closes #360.

A suggestion resolved the runner config for the project's runner and handed it straight to the registry, so the model a human waits on in a panel was the model an unattended campaign run uses. #318 assumed that wait was process spawn. It is not, and the measurement is in #360: spawn plus `session/new` is 2.2 to 3.1 seconds of an 18-second wait, and the ten seconds of silence after that is the model deliberating before its first text token.

| model | to first token | total | reply length |
|---|---|---|---|
| unpinned (session default) | 16.8s | 19.8s | 834 chars |
| `sonnet` | 10.4s | 12.9s | 516 chars |

Medians of n=3 each, same 3043-char prompt, idle box. So this is 1.6x on the number a human experiences, for a one-line resolution and no new configuration surface. The shorter reply is a bonus rather than the point, though for a LinkedIn comment 516 chars reads better than 834.

**Precedence, which is the only real decision here.** An explicit `runner_configs` model wins, including for suggestions: an operator who pinned one meant it, and silently overriding it on this path would be the kind of surprise that takes an hour to find. A blank or whitespace-only string counts as unpinned, since a cleared form field is not a choice.

**Not a setting.** A knob whose only defensible value is "fast" is not a decision to hand an operator, and `runner_configs` is already the escape hatch for anyone who disagrees.

## Verified

Six tests, and the two that matter are asserted against the config the route actually handed the registry rather than against the resolver in isolation, because a correct resolver that is never called is the failure mode worth catching. Proven to bite:

- Unwiring the resolver from `runSuggestion` (leaving it correct but uncalled): `asks for the fast assist model when no operator pinned one` fails, 1 failed / 16 passed.
- Making the resolver clobber a pin: `leaves an operator-pinned model alone` and `respects an explicit pin` both fail, 2 failed / 15 passed.
- Restored: 17 passed.

`pnpm -F web check` clean (5850 files, 0 errors), eslint and prettier clean on both touched files.

## Not verified

The measurement in #360 came from the real `claude-code` runner on this box, not from CI, and the numbers move with provider load: I re-ran the whole set on an idle box after finding that a concurrent six-agent wave inflated first-token time by nearly 4x. The ordering between the two models held in every run; treat the absolute figures as this box, this day.