### PR TITLE
feat(extension): passive LinkedIn observation collector content script

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -12,6 +12,7 @@ import { logEvent } from './lib/activity.js';
 import { getSettings as getExtensionSettings } from './lib/settings.js';
 import { hasLinkedInPermission } from './lib/permissions.js';
 import linkedinCommentScriptPath from './content/linkedin-comment.ts?script';
+import linkedinObserveScriptPath from './content/linkedin-observe.ts?script';
 
 const ALARM = 'pitchbox:dm-sync';
 
@@ -256,6 +257,58 @@ export async function syncLinkedInContentScript(): Promise<void> {
   }
 }
 
+const LINKEDIN_OBSERVE_CONTENT_SCRIPT_ID = 'pitchbox-linkedin-observe';
+
+/**
+ * Same gating as syncLinkedInContentScript above, for the passive
+ * observation collector (LI-5, #302). A second dynamic registration rather
+ * than folded into the same chrome.scripting.registerContentScripts call:
+ * the two scripts run on different (overlapping but not identical) match
+ * sets and have independent lifecycles, and the linkedin-compliance rule 2
+ * check derives its LinkedIn content-script scan set per registration
+ * entry, so keeping them separate keeps that derivation legible file-by-file.
+ */
+export async function syncLinkedInObserveContentScript(): Promise<void> {
+  try {
+    const [granted, existing] = await Promise.all([
+      hasLinkedInPermission(),
+      chrome.scripting.getRegisteredContentScripts({ ids: [LINKEDIN_OBSERVE_CONTENT_SCRIPT_ID] }),
+    ]);
+    if (granted && existing.length === 0) {
+      await chrome.scripting.registerContentScripts([
+        {
+          id: LINKEDIN_OBSERVE_CONTENT_SCRIPT_ID,
+          js: [linkedinObserveScriptPath],
+          matches: [
+            'https://www.linkedin.com/feed*',
+            'https://www.linkedin.com/posts/*',
+            'https://www.linkedin.com/in/*/recent-activity*',
+          ],
+          runAt: 'document_idle',
+        },
+      ]);
+    } else if (!granted && existing.length > 0) {
+      await chrome.scripting.unregisterContentScripts({
+        ids: [LINKEDIN_OBSERVE_CONTENT_SCRIPT_ID],
+      });
+    }
+  } catch (err) {
+    console.warn('[pitchbox] syncLinkedInObserveContentScript failed:', err);
+  }
+}
+
+/**
+ * Registers/unregisters every LinkedIn content script this extension owns,
+ * gated on the same on-demand host permission (#317). One wrapper instead
+ * of a growing list of individual calls at each of the four trigger sites
+ * below (onInstalled, onStartup, permissions.onAdded/onRemoved) - a future
+ * LinkedIn content script (see #307's reply/DM ingest, landing separately)
+ * has exactly one place to add its own sync call.
+ */
+export async function syncLinkedInContentScripts(): Promise<void> {
+  await Promise.all([syncLinkedInContentScript(), syncLinkedInObserveContentScript()]);
+}
+
 // #203: exported so tests can drive the install/update branch directly
 // without going through chrome.runtime.onInstalled's listener plumbing.
 export async function handleInstalled(details: chrome.runtime.InstalledDetails): Promise<void> {
@@ -268,7 +321,7 @@ export async function handleInstalled(details: chrome.runtime.InstalledDetails):
     console.warn('[pitchbox] sidePanel.setPanelBehavior failed:', err);
   }
   await applyAlarms();
-  await syncLinkedInContentScript();
+  await syncLinkedInContentScripts();
   if (details.reason === 'update') {
     await logEvent({
       level: 'info',
@@ -293,11 +346,11 @@ chrome.runtime.onInstalled.addListener(handleInstalled);
 chrome.runtime.onStartup.addListener(async () => {
   await logEvent({ level: 'info', source: 'system', message: 'activity.system.boot' });
   await applyAlarms();
-  await syncLinkedInContentScript();
+  await syncLinkedInContentScripts();
 });
 
-chrome.permissions.onAdded.addListener(() => void syncLinkedInContentScript());
-chrome.permissions.onRemoved.addListener(() => void syncLinkedInContentScript());
+chrome.permissions.onAdded.addListener(() => void syncLinkedInContentScripts());
+chrome.permissions.onRemoved.addListener(() => void syncLinkedInContentScripts());
 
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area !== 'local') return;

--- a/extension/src/content/linkedin-observe.ts
+++ b/extension/src/content/linkedin-observe.ts
@@ -1,0 +1,288 @@
+import { api } from '../lib/api.js';
+import { logFromContent } from '../lib/log-from-content.js';
+import {
+  findFeedPosts,
+  readPostAuthor,
+  readPostIdentifier,
+  readPostText,
+  resetSelectorHealth,
+  selectorHealthActivityEvents,
+} from './shared/linkedin-dom.js';
+
+/**
+ * The passive observation collector (LI-5, #302): fills `observed_targets`
+ * from what the human's own scrolling already rendered on the feed, a post
+ * page, or a profile's recent activity, so an async LinkedIn campaign has
+ * candidates without a discovery API
+ * (docs/linkedin-integration-design.md, "Observation collection").
+ *
+ * ## Off by default, and the server is the actual authority
+ *
+ * This script fetches `GET /api/extension/linkedin-assist` before touching
+ * the DOM at all, and does nothing - no `MutationObserver`, no
+ * `IntersectionObserver`, no timer - unless that read says both the
+ * assistant and the collector are on for a bound project (LI-19, #316).
+ * `POST /api/extension/observations` also enforces this server-side (#358)
+ * and answers 403 (`collector_disabled` | `kill_switch` | `project_not_bound`)
+ * otherwise, so this script's own gate is a courtesy that saves a request,
+ * not the actual boundary - a 403 is treated as authoritative below
+ * (`stopCollecting`), never retried into, and turns the collector off for
+ * the rest of this script's lifetime (a full page load/navigation; there is
+ * no "resume" without one).
+ *
+ * ## Poll cadence
+ *
+ * `ASSIST_POLL_MS` (60s) only runs while the collector is actually active -
+ * a disabled collector makes zero requests, matching "does nothing until
+ * enabled" literally, and there is nothing running that a poll would need to
+ * stop. While active, 60s means an admin's kill switch is visible within a
+ * minute even on a long-idle tab with nothing to flush, well inside the read
+ * path's own `RateLimiter(12, 60_000)`. The hard floor underneath that is
+ * `POST /api/extension/observations`'s own 403: even if this tab's poll
+ * timer is throttled (backgrounded tab, MV3 considerations), the very next
+ * batch attempt gets refused and stops the collector regardless of how
+ * stale the last poll was - "a kill switch that only stops at the next poll
+ * is not a kill switch" (docs/linkedin-integration-design.md). This script
+ * deliberately does not use the alarms API for either the poll or the flush
+ * timer: the compliance boundary (LI-11, #308) forbids an alarms job
+ * reachable from LinkedIn code, and an in-page timer needs no such job - it
+ * simply stops running once the tab closes or navigates away.
+ *
+ * ## Batching, not per post
+ *
+ * Every rendered post is queued locally (`queue`) and flushed on a
+ * debounce: `FLUSH_IDLE_MS` after the last new post seen, or at
+ * `FLUSH_MAX_WAIT_MS` since the oldest still-pending item, whichever comes
+ * first, so continuous scrolling still flushes periodically instead of
+ * debouncing forever. `MAX_BATCH_SIZE` mirrors
+ * `shared/src/observed-targets.ts`'s `MAX_OBSERVED_TARGETS_BATCH` (not
+ * imported - the extension has no dependency on `@pitchbox/shared`) and
+ * forces an immediate flush if reached, matching the server's own cap.
+ * `seenExternalIds` dedupes within this script's lifetime so a post
+ * scrolled past twice is queued once.
+ *
+ * ## Only a post the human opened is dedupable
+ *
+ * `linkedin-dom.ts`'s "Two frontends, one identifier" is the reason this
+ * matters: the feed's own `readPostIdentifier` returns a `render-anchor`,
+ * a per-render token, never a `urn`. Only `kind: 'urn'` (the classic
+ * post-detail frontend - a permalink, or one card in a recent-activity
+ * list) is a stable, dedupable identifier, so only those posts are queued.
+ * A feed sighting with no `urn` is read (for selector health) and then
+ * dropped, not queued - `observed_targets.external_id` is `NOT NULL`, so
+ * there is nothing honest to send for it, and inventing one would silently
+ * violate the server's own dedup key.
+ *
+ * ## Viewport only
+ *
+ * `IntersectionObserver` gates every post: a `MutationObserver` over the
+ * document notices new post elements as they render (including whatever a
+ * virtual list adds while scrolling), but each one is only read once it
+ * actually intersects the viewport, not the moment it lands in the DOM -
+ * "read only posts that actually rendered in the viewport, not what a
+ * virtual list is holding offscreen" (design doc, "Observation collection").
+ */
+
+// Matches shared/src/observed-targets.ts's MAX_OBSERVED_TARGETS_BATCH.
+const MAX_BATCH_SIZE = 200;
+
+const ASSIST_POLL_MS = 60_000;
+const FLUSH_IDLE_MS = 3_000;
+const FLUSH_MAX_WAIT_MS = 15_000;
+
+type QueuedObservation = {
+  externalId: string;
+  url: string;
+  authorHandle: string | null;
+  authorName: string | null;
+  text: string | null;
+  observedAt: string;
+};
+
+let collectorEnabled = false;
+let boundProjectId: number | null = null;
+// Once true, this script instance never collects again - see the module
+// doc comment's "off by default" section.
+let stopped = false;
+
+const seenExternalIds = new Set<string>();
+const observedElements = new WeakSet<Element>();
+let pending: QueuedObservation[] = [];
+let idleTimer: number | undefined;
+let maxWaitTimer: number | undefined;
+let assistPollTimer: number | undefined;
+let mutationObserver: MutationObserver | undefined;
+let intersectionObserver: IntersectionObserver | undefined;
+
+function reportSelectorHealth(): void {
+  for (const event of selectorHealthActivityEvents()) logFromContent(event);
+}
+
+function clearFlushTimers(): void {
+  if (idleTimer !== undefined) {
+    window.clearTimeout(idleTimer);
+    idleTimer = undefined;
+  }
+  if (maxWaitTimer !== undefined) {
+    window.clearTimeout(maxWaitTimer);
+    maxWaitTimer = undefined;
+  }
+}
+
+function stopCollecting(reason: string): void {
+  if (stopped) return;
+  stopped = true;
+  mutationObserver?.disconnect();
+  intersectionObserver?.disconnect();
+  if (assistPollTimer !== undefined) {
+    window.clearInterval(assistPollTimer);
+    assistPollTimer = undefined;
+  }
+  clearFlushTimers();
+  pending = [];
+  logFromContent({
+    level: 'warn',
+    source: 'linkedin-collector',
+    message: 'activity.linkedin-collector.stopped',
+    messageParams: { reason },
+    meta: { reason, url: location.href },
+  });
+}
+
+function scheduleFlush(): void {
+  if (idleTimer !== undefined) window.clearTimeout(idleTimer);
+  idleTimer = window.setTimeout(() => void flush(), FLUSH_IDLE_MS);
+  if (maxWaitTimer === undefined) {
+    maxWaitTimer = window.setTimeout(() => void flush(), FLUSH_MAX_WAIT_MS);
+  }
+}
+
+async function flush(): Promise<void> {
+  clearFlushTimers();
+  if (stopped || pending.length === 0 || boundProjectId === null) return;
+  const items = pending;
+  pending = [];
+  const res = await api.observeLinkedIn(boundProjectId, items);
+  if (res.ok) {
+    logFromContent({
+      level: 'info',
+      source: 'linkedin-collector',
+      message: 'activity.linkedin-collector.batch-sent',
+      messageParams: {
+        inserted: res.data.inserted,
+        duplicates: res.data.duplicates,
+        dropped: res.data.dropped,
+      },
+    });
+    return;
+  }
+  if (res.status === 403) {
+    let reason = 'refused';
+    try {
+      const parsed = JSON.parse(res.error) as { message?: string };
+      if (parsed.message) reason = parsed.message;
+    } catch {
+      // Non-JSON body: keep the generic reason above.
+    }
+    stopCollecting(reason);
+    return;
+  }
+  // Transient failure (network error, 429, 5xx): put the batch back for the
+  // next flush rather than losing it silently. Bounded by MAX_BATCH_SIZE so
+  // a long outage can't grow this without limit while the human keeps
+  // scrolling.
+  pending = [...items, ...pending].slice(0, MAX_BATCH_SIZE);
+  logFromContent({
+    level: 'warn',
+    source: 'linkedin-collector',
+    message: 'activity.linkedin-collector.batch-failed',
+    messageParams: { reason: res.error || String(res.status) },
+  });
+}
+
+function queue(observation: QueuedObservation): void {
+  if (stopped) return;
+  if (seenExternalIds.has(observation.externalId)) return;
+  seenExternalIds.add(observation.externalId);
+  pending.push(observation);
+  if (pending.length >= MAX_BATCH_SIZE) {
+    void flush();
+    return;
+  }
+  scheduleFlush();
+}
+
+function processPost(post: Element): void {
+  if (stopped) return;
+  const identifier = readPostIdentifier(post);
+  const author = readPostAuthor(post);
+  const text = readPostText(post);
+  if (identifier.kind !== 'urn') {
+    // Feed sighting: read for selector health, not dedupable, not queued -
+    // see the module doc comment's "Only a post the human opened" section.
+    return;
+  }
+  queue({
+    externalId: identifier.value,
+    url: location.href,
+    authorHandle: author.handle,
+    authorName: author.name,
+    text,
+    observedAt: new Date().toISOString(),
+  });
+}
+
+function onIntersect(entries: IntersectionObserverEntry[]): void {
+  if (stopped) return;
+  for (const entry of entries) {
+    if (!entry.isIntersecting) continue;
+    intersectionObserver?.unobserve(entry.target);
+    processPost(entry.target);
+  }
+  reportSelectorHealth();
+}
+
+function scanForNewPosts(): void {
+  if (stopped || !intersectionObserver) return;
+  for (const post of findFeedPosts()) {
+    if (observedElements.has(post)) continue;
+    observedElements.add(post);
+    intersectionObserver.observe(post);
+  }
+}
+
+function startObserving(): void {
+  if (mutationObserver) return; // already running
+  intersectionObserver = new IntersectionObserver(onIntersect, { threshold: 0.25 });
+  mutationObserver = new MutationObserver(() => scanForNewPosts());
+  mutationObserver.observe(document.documentElement, { childList: true, subtree: true });
+  scanForNewPosts();
+}
+
+async function pollAssistState(): Promise<void> {
+  if (stopped) return;
+  const res = await api.linkedinAssist();
+  // A transient read failure keeps whatever state this script already has -
+  // a real, current refusal still surfaces authoritatively on the next
+  // POST /api/extension/observations (see the module doc comment).
+  if (!res.ok) return;
+  const { assist } = res.data;
+  const wasEnabled = collectorEnabled;
+  collectorEnabled = assist.collectorEnabled;
+  boundProjectId = assist.projectId;
+  if (!collectorEnabled) {
+    if (wasEnabled) stopCollecting(assist.killSwitch ? 'kill_switch' : 'collector_disabled');
+    return;
+  }
+  if (!wasEnabled) startObserving();
+}
+
+async function init(): Promise<void> {
+  resetSelectorHealth();
+  await pollAssistState();
+  if (collectorEnabled && !stopped) {
+    assistPollTimer = window.setInterval(() => void pollAssistState(), ASSIST_POLL_MS);
+  }
+}
+
+void init();

--- a/extension/src/lib/activity.ts
+++ b/extension/src/lib/activity.ts
@@ -9,6 +9,7 @@ export type ActivitySource =
   | 'reddit-action'
   | 'linkedin-dom'
   | 'linkedin-action'
+  | 'linkedin-collector'
   | 'settings'
   | 'system';
 

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -12,6 +12,16 @@ type DraftSummary = {
   version?: number;
 };
 
+/** The exact shape served by GET /api/extension/linkedin-assist (LI-19, #316). */
+export type LinkedInAssistState = {
+  enabled: boolean;
+  collectorEnabled: boolean;
+  killSwitch: boolean;
+  projectId: number | null;
+  dailyCommentCap: number;
+  dailyPostCap: number;
+};
+
 /**
  * Resolve which pairing a single-backend op should target. Compose-time
  * content scripts pass the explicit `backendUrl` the dashboard tags onto the
@@ -310,5 +320,39 @@ export const api = {
     } catch (e) {
       return { ok: false, status: 0, error: (e as Error).message };
     }
+  },
+
+  /**
+   * GET /api/extension/linkedin-assist (#316): whether the org has turned
+   * on the assistant/collector and which project a suggestion or an
+   * observation writes as. #302's passive collector polls this - see
+   * content/linkedin-observe.ts's own doc comment for the poll cadence it
+   * defends. No backendUrl-targeted variant beyond the single-pairing
+   * default: unlike armed/sent, this call never carries a compose-time
+   * draft URL to resolve a specific backend from.
+   */
+  linkedinAssist: async (
+    backendUrl?: string,
+  ): Promise<ApiResult<{ assist: LinkedInAssistState }>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    return getJson(p, '/api/extension/linkedin-assist');
+  },
+
+  /**
+   * POST /api/extension/observations (#301): a debounced batch of posts the
+   * passive collector (#302) saw actually render in the viewport on
+   * linkedin.com. `platform` is a body field (matching dm-sync's own
+   * shape) rather than baked into the path, in case a second observed
+   * platform ever needs the same buffer.
+   */
+  observeLinkedIn: async (
+    projectId: number,
+    items: unknown[],
+    backendUrl?: string,
+  ): Promise<ApiResult<{ ok: true; inserted: number; duplicates: number; dropped: number }>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    return postJson(p, '/api/extension/observations', { platform: 'linkedin', projectId, items });
   },
 };

--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -133,6 +133,12 @@ export const en = {
     'Could not find the LinkedIn comment submit button for draft {draftId} within 15s; posting will not be tracked automatically.',
   'activity.linkedin-action.comment-confirm-timeout':
     'Could not confirm draft {draftId} was posted within 20s after clicking submit; check its status manually.',
+  'activity.linkedin-dom.selector-miss':
+    'LinkedIn selector "{selector}" is not matching on the {pageKind} page ({misses} misses, {matches} matches) - this reading may be stale or missing.',
+  'activity.linkedin-collector.batch-sent':
+    'LinkedIn observations sent - {inserted} new, {duplicates} duplicate, {dropped} dropped.',
+  'activity.linkedin-collector.batch-failed': 'LinkedIn observation batch failed: {reason}',
+  'activity.linkedin-collector.stopped': 'LinkedIn observation collector stopped: {reason}',
   'activity.settings.changed': 'Settings updated.',
   'activity.system.boot': 'Service worker started.',
   'activity.system.alarms-applied': 'Alarms re-applied ({interval} min).',

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -138,6 +138,13 @@ export const it = {
     'Impossibile trovare il pulsante di invio del commento LinkedIn per il draft {draftId} entro 15s; la pubblicazione non verrà tracciata automaticamente.',
   'activity.linkedin-action.comment-confirm-timeout':
     'Impossibile confermare che il draft {draftId} sia stato pubblicato entro 20s dal clic su invio; verifica manualmente lo stato.',
+  'activity.linkedin-dom.selector-miss':
+    'Il selettore LinkedIn "{selector}" non trova corrispondenze nella pagina {pageKind} ({misses} mancate, {matches} trovate) - questa lettura potrebbe essere obsoleta o mancante.',
+  'activity.linkedin-collector.batch-sent':
+    'Osservazioni LinkedIn inviate - {inserted} nuove, {duplicates} duplicate, {dropped} scartate.',
+  'activity.linkedin-collector.batch-failed':
+    'Invio del batch di osservazioni LinkedIn fallito: {reason}',
+  'activity.linkedin-collector.stopped': 'Collettore di osservazioni LinkedIn fermato: {reason}',
   'activity.settings.changed': 'Impostazioni aggiornate.',
   'activity.system.boot': 'Service worker avviato.',
   'activity.system.alarms-applied': 'Alarms riapplicati ({interval} min).',

--- a/extension/tests/content/linkedin-observe.test.ts
+++ b/extension/tests/content/linkedin-observe.test.ts
@@ -1,0 +1,395 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import linkedinObserveSource from '../../src/content/linkedin-observe.ts?raw';
+// Real, anonymised captures - see fixtures/linkedin/README.md. feed.html is
+// the SDUI frontend (no dedupable identifier anywhere); post-detail.html is
+// the classic frontend with exactly one urn-bearing post.
+import FEED_HTML from './fixtures/linkedin/feed.html?raw';
+import POST_DETAIL_HTML from './fixtures/linkedin/post-detail.html?raw';
+
+const BACKEND = 'https://backend.example';
+const PAIRING = { backendUrl: BACKEND, token: 't'.repeat(40) };
+const PROJECT_ID = 7;
+
+type AssistState = {
+  enabled: boolean;
+  collectorEnabled: boolean;
+  killSwitch: boolean;
+  projectId: number | null;
+  dailyCommentCap: number;
+  dailyPostCap: number;
+};
+
+function assistState(overrides: Partial<AssistState> = {}): AssistState {
+  return {
+    enabled: true,
+    collectorEnabled: true,
+    killSwitch: false,
+    projectId: PROJECT_ID,
+    dailyCommentCap: 8,
+    dailyPostCap: 1,
+    ...overrides,
+  };
+}
+
+/** jsdom has no IntersectionObserver - stand-in that lets a test fire
+ * intersection entries on demand, the same way the real one would once a
+ * post it is watching actually scrolls into the viewport. */
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+  observed = new Set<Element>();
+  constructor(
+    public callback: IntersectionObserverCallback,
+    public options?: IntersectionObserverInit,
+  ) {
+    FakeIntersectionObserver.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observed.add(el);
+  }
+  unobserve(el: Element) {
+    this.observed.delete(el);
+  }
+  disconnect() {
+    this.observed.clear();
+  }
+  takeRecords() {
+    return [];
+  }
+  /** Test helper: report an intersection for `target`, whether or not it is
+   * still tracked in `observed` - mirrors a real IntersectionObserver batch
+   * that can report the same target more than once in its lifetime. */
+  fire(target: Element, isIntersecting = true) {
+    this.callback(
+      [{ target, isIntersecting } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+function installChromeMock() {
+  (globalThis as any).chrome = {
+    storage: {
+      local: {
+        _s: {} as Record<string, unknown>,
+        async get(keys: string[] | string) {
+          const k = Array.isArray(keys) ? keys : [keys];
+          const out: Record<string, unknown> = {};
+          for (const x of k) if (x in (this._s as any)) out[x] = (this._s as any)[x];
+          return out;
+        },
+        async set(patch: Record<string, unknown>) {
+          Object.assign(this._s as any, patch);
+        },
+        async remove(keys: string[] | string) {
+          const k = Array.isArray(keys) ? keys : [keys];
+          for (const x of k) delete (this._s as any)[x];
+        },
+      },
+    },
+    runtime: { sendMessage: vi.fn() },
+  };
+}
+
+function seedPairing() {
+  ((globalThis as any).chrome.storage.local as any)._s = { pairings: [PAIRING] };
+}
+
+function loggedEvents(): Array<Record<string, any>> {
+  const fn = (globalThis as any).chrome.runtime.sendMessage as ReturnType<typeof vi.fn>;
+  return fn.mock.calls.map((args: any[]) => args[0]?.event);
+}
+
+/** Flush pending promise microtasks without depending on real/fake timers. */
+async function flushMicrotasks(times = 15) {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+function render(html: string) {
+  document.body.innerHTML = html;
+}
+
+type ObservationsBody = { platform: string; projectId: number; items: unknown[] };
+type ObservationsHandler = (body: ObservationsBody) => { status: number; body: unknown };
+
+function installFetchMock(opts: { assist: AssistState; onObservations?: ObservationsHandler }) {
+  let assist = opts.assist;
+  const observationCalls: ObservationsBody[] = [];
+  const mock = vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    if (url.endsWith('/api/extension/linkedin-assist')) {
+      return new Response(JSON.stringify({ assist }), { status: 200 });
+    }
+    if (url.endsWith('/api/extension/observations')) {
+      const body = JSON.parse(String(init?.body)) as ObservationsBody;
+      observationCalls.push(body);
+      const result = opts.onObservations
+        ? opts.onObservations(body)
+        : {
+            status: 200,
+            body: { ok: true, inserted: body.items.length, duplicates: 0, dropped: 0 },
+          };
+      return new Response(JSON.stringify(result.body), { status: result.status });
+    }
+    throw new Error(`unexpected fetch url: ${url}`);
+  });
+  vi.stubGlobal('fetch', mock);
+  return { mock, observationCalls, setAssist: (next: AssistState) => (assist = next) };
+}
+
+async function importModule() {
+  return await import('../../src/content/linkedin-observe.js');
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  installChromeMock();
+  seedPairing();
+  FakeIntersectionObserver.instances = [];
+  (globalThis as any).IntersectionObserver = FakeIntersectionObserver;
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('off by default: the collector does nothing until enabled and bound', () => {
+  it('never observes the DOM and never posts when the server says the collector is disabled', async () => {
+    render(POST_DETAIL_HTML);
+    const { mock, observationCalls } = installFetchMock({
+      assist: assistState({ enabled: false, collectorEnabled: false, projectId: null }),
+    });
+    await importModule();
+    await flushMicrotasks();
+
+    expect(FakeIntersectionObserver.instances).toHaveLength(0);
+    expect(observationCalls).toHaveLength(0);
+    // The only fetch made is the read path itself, never observations.
+    expect(mock.mock.calls.every((c) => String(c[0]).endsWith('/linkedin-assist'))).toBe(true);
+  });
+});
+
+describe('feed.html (SDUI frontend, real capture): no dedupable identifier anywhere', () => {
+  it('reads every rendered post but never queues or sends an observation for it', async () => {
+    render(FEED_HTML);
+    const { observationCalls } = installFetchMock({ assist: assistState() });
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+
+    const io = FakeIntersectionObserver.instances[0];
+    expect(io.observed.size).toBeGreaterThan(0);
+    for (const post of Array.from(io.observed)) io.fire(post, true);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(20_000);
+    await flushMicrotasks();
+
+    expect(observationCalls).toHaveLength(0);
+  });
+});
+
+describe('post-detail.html (classic frontend, real capture): the one urn-bearing post', () => {
+  it('is queued and sent as exactly one observation with the read urn, author, text and url', async () => {
+    render(POST_DETAIL_HTML);
+    const { observationCalls } = installFetchMock({ assist: assistState() });
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+
+    const io = FakeIntersectionObserver.instances[0];
+    expect(io.observed.size).toBe(1);
+    const [post] = Array.from(io.observed);
+    io.fire(post, true);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(3_000);
+    await flushMicrotasks();
+
+    expect(observationCalls).toHaveLength(1);
+    expect(observationCalls[0].platform).toBe('linkedin');
+    expect(observationCalls[0].projectId).toBe(PROJECT_ID);
+    expect(observationCalls[0].items).toHaveLength(1);
+    const item = observationCalls[0].items[0] as Record<string, unknown>;
+    expect(item.externalId).toBe('urn:li:activity:7000000000000000001');
+    expect(item.authorHandle).toBe('example-person');
+    expect(item.authorName).toBe('Giulia Bianchi');
+    expect(item.text).toMatch(/ingest path/);
+    expect(item.url).toBe(window.location.href);
+    expect(typeof item.observedAt).toBe('string');
+    expect(Number.isNaN(Date.parse(item.observedAt as string))).toBe(false);
+  });
+
+  it('a post seen twice yields one observation (session-level dedupe)', async () => {
+    render(POST_DETAIL_HTML);
+    const { observationCalls } = installFetchMock({ assist: assistState() });
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+
+    const io = FakeIntersectionObserver.instances[0];
+    const [post] = Array.from(io.observed);
+    // Fired twice for the same target before the batch flushes - the same
+    // shape a real IntersectionObserver produces for a post that scrolled
+    // out and back into view before this script's own unobserve() lands.
+    io.fire(post, true);
+    io.fire(post, true);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(3_000);
+    await flushMicrotasks();
+
+    expect(observationCalls).toHaveLength(1);
+    expect(observationCalls[0].items).toHaveLength(1);
+  });
+});
+
+describe('a 403 is authoritative: it stops the collector, not just the batch', () => {
+  it('never posts again this session once the server refuses with kill_switch', async () => {
+    render(POST_DETAIL_HTML);
+    const { observationCalls } = installFetchMock({
+      assist: assistState(),
+      onObservations: () => ({ status: 403, body: { message: 'kill_switch' } }),
+    });
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+
+    const io = FakeIntersectionObserver.instances[0];
+    const [post] = Array.from(io.observed);
+    io.fire(post, true);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(3_000);
+    await flushMicrotasks();
+
+    expect(observationCalls).toHaveLength(1);
+    const events = loggedEvents();
+    expect(
+      events.some(
+        (e) =>
+          e.source === 'linkedin-collector' &&
+          e.message === 'activity.linkedin-collector.stopped' &&
+          e.messageParams?.reason === 'kill_switch',
+      ),
+    ).toBe(true);
+
+    // A further intersection report after the stop must produce no request.
+    io.fire(post, true);
+    await vi.advanceTimersByTimeAsync(20_000);
+    await flushMicrotasks();
+    expect(observationCalls).toHaveLength(1);
+  });
+
+  it('maps collector_disabled and project_not_bound the same way', async () => {
+    for (const reason of ['collector_disabled', 'project_not_bound']) {
+      document.body.innerHTML = '';
+      installChromeMock();
+      seedPairing();
+      FakeIntersectionObserver.instances = [];
+      vi.resetModules();
+      render(POST_DETAIL_HTML);
+      const { observationCalls } = installFetchMock({
+        assist: assistState(),
+        onObservations: () => ({ status: 403, body: { message: reason } }),
+      });
+      vi.useFakeTimers();
+      await importModule();
+      await flushMicrotasks();
+      const io = FakeIntersectionObserver.instances[0];
+      const [post] = Array.from(io.observed);
+      io.fire(post, true);
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(3_000);
+      await flushMicrotasks();
+
+      expect(observationCalls).toHaveLength(1);
+      const events = loggedEvents();
+      expect(
+        events.some(
+          (e) =>
+            e.message === 'activity.linkedin-collector.stopped' &&
+            e.messageParams?.reason === reason,
+        ),
+      ).toBe(true);
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('poll cadence: an already-active collector notices a kill switch flip on its own', () => {
+  it('stops after the next assist poll, without needing a batch attempt at all', async () => {
+    render(POST_DETAIL_HTML);
+    const { observationCalls, setAssist } = installFetchMock({ assist: assistState() });
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+
+    setAssist(assistState({ enabled: false, collectorEnabled: false, killSwitch: true }));
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flushMicrotasks();
+
+    const events = loggedEvents();
+    expect(
+      events.some(
+        (e) =>
+          e.message === 'activity.linkedin-collector.stopped' &&
+          e.messageParams?.reason === 'kill_switch',
+      ),
+    ).toBe(true);
+    // Never even attempted a batch - the poll caught it first.
+    expect(observationCalls).toHaveLength(0);
+  });
+});
+
+describe('selector health: forwarded through logFromContent, not swallowed', () => {
+  it('logs an activity.linkedin-dom.selector-miss event when the author selector breaks', async () => {
+    // readPostAuthor's classic-frontend selector (`a[href] [aria-hidden="true"]`)
+    // falls through to whichever `[aria-hidden="true"]` element inside the
+    // byline anchor it finds first - the fixture's byline anchor nests
+    // three of them (name, connection-degree marker, and a visually-hidden
+    // duplicate of the post text), so clearing only the name span's
+    // attribute still leaves the selector matching the next one. Strip the
+    // attribute everywhere, leaving the urn-bearing article (and so
+    // findFeedPosts/readPostIdentifier) untouched.
+    const broken = POST_DETAIL_HTML.replaceAll('aria-hidden="true"', 'data-hidden-decoy="true"');
+    expect(broken).not.toBe(POST_DETAIL_HTML);
+    render(broken);
+    installFetchMock({ assist: assistState() });
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+
+    const io = FakeIntersectionObserver.instances[0];
+    const [post] = Array.from(io.observed);
+    io.fire(post, true);
+    await flushMicrotasks();
+
+    const events = loggedEvents();
+    expect(
+      events.some(
+        (e) =>
+          e.source === 'linkedin-dom' &&
+          e.message === 'activity.linkedin-dom.selector-miss' &&
+          e.messageParams?.selector === 'postAuthor',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('compliance boundary: this content script never crosses the line', () => {
+  // Mirrors linkedin-dom.test.ts's and linkedin-comment.test.ts's own
+  // boundary checks over their own source text.
+  const source = linkedinObserveSource;
+
+  it('never fetches linkedin.com or reads its cookies/storage', () => {
+    expect(source).not.toMatch(/fetch\s*\(\s*['"`]https?:\/\/[^'"`]*linkedin\.com/);
+    expect(source).not.toMatch(/document\.cookie/);
+    expect(source).not.toMatch(/localStorage|sessionStorage/);
+    expect(source).not.toMatch(/chrome\.alarms/);
+  });
+
+  it('never dispatches a synthetic click or submit, and never calls .click()/.submit()', () => {
+    expect(source).not.toMatch(/\.click\s*\(/);
+    expect(source).not.toMatch(/\.submit\s*\(/);
+    expect(source).not.toMatch(/dispatchEvent/);
+  });
+});

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       // https://crxjs.dev/concepts/content and the `contentScripts` option
       // in @crxjs/vite-plugin).
       contentScripts: {
-        standaloneFiles: ['src/content/linkedin-comment.ts'],
+        standaloneFiles: ['src/content/linkedin-comment.ts', 'src/content/linkedin-observe.ts'],
       },
     }),
   ],


### PR DESCRIPTION
Closes #302

## What this does

Adds `extension/src/content/linkedin-observe.ts`, the passive observation collector (LI-5): a `MutationObserver` notices posts as they render on the LinkedIn feed, a post/permalink page, or a profile's recent-activity list; each post is only read once it actually intersects the viewport (`IntersectionObserver`), never what a virtual list is holding offscreen. Only a post with a stable identifier (the classic frontend's `urn:li:activity:...`, per `linkedin-dom.ts`'s "Two frontends, one identifier") is queued; an SDUI feed sighting has only a per-render token and is read (for selector health) but never queued or sent, matching the design's explicit decision. Queued items are deduped within the script's lifetime and flushed in batches (debounced, capped at the server's `MAX_OBSERVED_TARGETS_BATCH`) to `POST /api/extension/observations`.

Registered dynamically (`chrome.scripting.registerContentScripts`), gated on the same on-demand `*://*.linkedin.com/*` permission `linkedin-comment.ts` already uses (#317 stays optional; no static `content_scripts` entry, no `host_permissions` addition). `background.ts` gains `syncLinkedInObserveContentScript` plus a `syncLinkedInContentScripts()` wrapper now called at all four trigger sites (`onInstalled`, `onStartup`, `permissions.onAdded`/`onRemoved`) - `ReplyIngest` (#307) should add its own registration call inside that same wrapper rather than a fifth call site.

Off by default: reads `GET /api/extension/linkedin-assist` before touching the DOM at all and does nothing unless the read says the collector is enabled for a bound project. A 403 from `POST /api/extension/observations` (`collector_disabled` / `kill_switch` / `project_not_bound`) is treated as authoritative and stops the collector for the rest of the page's lifetime - never retried into. It also polls the read path every 60s while active (not via `chrome.alarms` - an in-page timer that dies with the tab, per the compliance boundary) so a kill switch is visible without waiting for a scroll to trigger a batch; the 403 on the next `POST` is the actual floor regardless of poll timing.

`extension/src/lib/api.ts` gains `linkedinAssist()` and `observeLinkedIn()`. `extension/src/lib/activity.ts` gains the `linkedin-collector` `ActivitySource`. Both i18n dicts gain the collector's own activity keys, plus `activity.linkedin-dom.selector-miss` - the key `linkedin-dom.ts` (#303) has referenced since it landed but never had a translation for, since nothing consumed `selectorHealthActivityEvents()` until now. `vite.config.ts` gains the new script in `standaloneFiles`.

## Verified

- `pnpm -F @pitchbox/extension check` - 0 errors, 0 warnings (741 files).
- `pnpm run build:extension` - builds cleanly; `dist/manifest.json` carries no static LinkedIn `content_scripts` entry and no LinkedIn `host_permissions`; `dist/src/content/linkedin-observe.js` is emitted as a standalone IIFE alongside `linkedin-comment.js`.
- `pnpm run test:linkedin-compliance` - 15/15 pass, including the real-repo "zero violations" check and rule 2's "scans the real repo, and the file it scans is the dynamically registered one" assertion.
- **Proved the compliance check actually bites**: planted `const __tmpComplianceProbe = document.cookie;` in `linkedin-observe.ts`, reran `pnpm run test:linkedin-compliance` - it failed, naming `extension/src/content/linkedin-observe.ts` and quoting the exact `document.cookie` read, on both the aggregate "zero violations" test and rule 2's own test. Removed the probe; suite is green again (15/15).
- New test file `extension/tests/content/linkedin-observe.test.ts` (10 tests, all passing) over the real anonymised fixtures in `extension/tests/content/fixtures/linkedin/`:
  - `feed.html` (SDUI): every rendered post is read but none is queued or sent (no dedupable identifier anywhere on that frontend).
  - `post-detail.html` (classic): the one urn-bearing post produces exactly one observation with the correct `externalId`/`authorHandle`/`authorName`/`text`/`url`.
  - The same post reported twice by the (faked) `IntersectionObserver` before a batch flushes still yields exactly one observation (session dedupe).
  - The collector makes zero requests beyond the initial read when the server says it's disabled.
  - A 403 (each of `kill_switch`, `collector_disabled`, `project_not_bound`) stops the collector; a further intersection report afterward produces no further request.
  - An already-active collector notices a kill-switch flip on its own next poll, without needing a batch attempt at all.
  - A deliberately broken selector (author markup) produces a forwarded `activity.linkedin-dom.selector-miss` event, proving the selector-health wiring isn't just imported but actually used.
  - Source-text compliance self-check (no fetch/XHR toward linkedin.com, no cookie/storage read, no synthetic click/submit/dispatchEvent, no alarms).
- **Each new test proven to bite**: reran the suite three times with the production logic separately broken - (1) removed the `identifier.kind !== 'urn'` guard so feed sightings would also queue, and watched the "no dedupable identifier" feed test go red (`observationCalls` had 1 entry instead of 0); (2) removed the `seenExternalIds` dedupe check in `queue()`, and watched the "seen twice" test go red (2 items instead of 1); (3) disabled the `res.status === 403` branch, and watched the kill-switch test go red (never called `stopCollecting`). Reverted each mutation individually and confirmed the suite is green again after each; final `git diff` is empty (the file matches the committed version exactly).
- Scoped lint: `npx eslint` and `npx prettier --check` clean on every file this PR touches (`extension/src/background.ts`, `extension/src/content/linkedin-observe.ts`, `extension/src/lib/activity.ts`, `extension/src/lib/api.ts`, `extension/src/lib/i18n/dict-en.ts`, `extension/src/lib/i18n/dict-it.ts`, `extension/vite.config.ts`, `extension/tests/content/linkedin-observe.test.ts`).
- Scoped test run: `extension/tests/content`, `extension/tests/background`, `extension/tests/lib/i18n.test.ts` - 184/184 passing, no regressions (existing `handleInstalled`/lifecycle tests still pass with the new `syncLinkedInContentScripts()` wrapper in place, since their `chrome.permissions.contains` mock defaults to `false`, exercising both registrations as no-ops the same way it did for the single one before).

## Not verified

There is no automated way to drive a real, signed-in linkedin.com page in this environment (same limitation every other LinkedIn content script in this codebase documents). Unverified here, matching that existing disclaimer:

- That the real feed's `MutationObserver` actually notices posts a virtualized list adds while scrolling, and that `IntersectionObserver` fires when they cross into the real viewport, the way the faked implementation in the test suite models.
- That `GET /api/extension/linkedin-assist` and `POST /api/extension/observations` behave against a live backend exactly as the fixture-driven fetch mocks assume (status codes, body shapes) - covered instead by reading the actual route source (`web/src/routes/api/extension/observations/+server.ts`, `web/src/routes/api/extension/linkedin-assist/+server.ts`) and matching its contract.
- That `/posts/*` and `/in/*/recent-activity*` render as the classic frontend (assumed from the URL patterns and `detectPageKind`'s general handling, not captured/measured - only `/feed/` and `/feed/update/urn:.../` have real captures per `extension/tests/content/fixtures/linkedin/README.md`).

To verify manually: load `extension/dist/` unpacked in `chrome://extensions`, grant the LinkedIn permission from the side panel, turn on the assistant + collector + bind a project for the test org, browse a real signed-in feed and a real post permalink, and confirm from the side panel's Activity view that observations were collected (and, on a deliberately-disabled or kill-switched org, that nothing is) and from the network panel that the extension never makes a request whose destination is linkedin.com or licdn.com.