### PR TITLE
feat(web,shared): materialise an accepted in-page suggestion into the ledger

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -55,7 +55,8 @@
     "./scheduler/backoff": "./src/scheduler/backoff.ts",
     "./scheduler/dispatch-lock": "./src/scheduler/dispatch-lock.ts",
     "./project-extraction": "./src/project-extraction/index.ts",
-    "./linkedin-assist": "./src/linkedin-assist.ts"
+    "./linkedin-assist": "./src/linkedin-assist.ts",
+    "./assist-accept": "./src/assist-accept.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",

--- a/shared/src/assist-accept.ts
+++ b/shared/src/assist-accept.ts
@@ -1,0 +1,245 @@
+// Materialises an accepted in-page suggestion (LI-16, #313) into the same
+// ledger a campaign draft lands in. A suggestion is ephemeral until the human
+// accepts it (web/src/lib/server/suggest.ts): no runs row, no draft. This is
+// the other half - the accept path - and it deliberately walks the same
+// checks `cli/src/commands/drafts.ts`'s `createDrafts` applies to a campaign
+// draft (blocklist, contact dedup, `checkUncontactable`), so a suggestion
+// Pitchbox helped write is never invisible to quota, contact history or
+// analytics (docs/linkedin-integration-design.md, "Bookkeeping").
+//
+// `drafts.run_id` is NOT NULL, so rather than making that column nullable
+// this creates a `runs` row of kind = 'assist' (project-targeted, no
+// campaign) to hang the draft off - see the `runs_kind_target_chk` migration
+// (shared/src/db/migrations/0013_assist_run_kind.sql) and
+// shared/src/runlog/contract.ts (an assist run has no playbook and no finish
+// tool, so it is written already terminal, in the same transaction as the
+// draft, and is deliberately absent from `PLAYBOOK_FINISH_TOOL`).
+import { and, eq } from 'drizzle-orm';
+import { schema, type Db } from './db/client.js';
+import { isBlocklisted, isKeywordBlocklisted, isSubredditBlocklisted } from './blocklist.js';
+import {
+  checkContactDedup,
+  checkUncontactable,
+  parseDedupPolicy,
+  DEFAULT_DEDUP_POLICY,
+} from './contact-dedup.js';
+import { checkQuota, getAccountUsage, loadQuotaLimits, mapDraftKindToQuotaKind } from './quota.js';
+import type { DraftKind } from './quota-types.js';
+
+export interface AcceptSuggestionUsage {
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  cacheReadTokens?: number | null;
+  cacheCreationTokens?: number | null;
+  costUsd?: number | null;
+}
+
+export interface AcceptSuggestionInput {
+  projectId: number;
+  organizationId: number;
+  platformId: number;
+  kind: DraftKind;
+  /** Null for a kind whose audience is public rather than one person (e.g. a
+   * top-level `post`), so no blocklist/dedup/contact-history check applies. */
+  targetUser: string | null;
+  body: string;
+  sourceRef?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  agentRunner: string;
+  usage?: AcceptSuggestionUsage | null;
+  /** Extra context recorded on the `runs.params` jsonb, for analytics/debugging. */
+  runParams?: Record<string, unknown>;
+}
+
+export type AcceptSuggestionRefusal =
+  | { reason: 'no_account' }
+  | { reason: 'blocked'; detail: string | null }
+  | { reason: 'uncontactable'; detail: string | null }
+  | { reason: 'recently_contacted'; priorContactedAt: string }
+  | { reason: 'quota_exhausted'; window: 'day'; limit: number; used: number };
+
+export type AcceptSuggestionResult =
+  | { ok: true; draftId: number; runId: number; dedupWarning: string | null }
+  | { ok: false; refusal: AcceptSuggestionRefusal };
+
+/**
+ * Validate an accepted suggestion against the same gates a campaign draft
+ * goes through, then write the `runs` + `drafts` (+ `draft_events`) rows in
+ * one transaction. Every check below runs before the transaction opens, so a
+ * refusal leaves neither row behind - "no partial write" from #313's
+ * acceptance criteria.
+ */
+export async function acceptSuggestionIntoDraft(
+  db: Db,
+  input: AcceptSuggestionInput,
+): Promise<AcceptSuggestionResult> {
+  const [account] = await db
+    .select()
+    .from(schema.accounts)
+    .where(
+      and(
+        eq(schema.accounts.projectId, input.projectId),
+        eq(schema.accounts.platformId, input.platformId),
+        eq(schema.accounts.active, true),
+      ),
+    )
+    .limit(1);
+  if (!account) return { ok: false, refusal: { reason: 'no_account' } };
+
+  if (input.targetUser) {
+    const r = await isBlocklisted(db, {
+      platformId: input.platformId,
+      projectId: input.projectId,
+      targetUser: input.targetUser,
+    });
+    if (r.blocked) return { ok: false, refusal: { reason: 'blocked', detail: r.reason } };
+  }
+
+  // Subreddit blocklist: mirrors createDrafts for parity, though LinkedIn
+  // metadata never carries `subreddit` - this only ever fires for a future
+  // platform that reuses this path and does.
+  const subreddit = typeof input.metadata?.subreddit === 'string' ? input.metadata.subreddit : null;
+  if ((input.kind === 'post' || input.kind === 'post_comment') && subreddit) {
+    const r = await isSubredditBlocklisted(db, {
+      platformId: input.platformId,
+      projectId: input.projectId,
+      subreddit,
+    });
+    if (r.blocked) return { ok: false, refusal: { reason: 'blocked', detail: r.reason } };
+  }
+
+  if (input.body.trim()) {
+    const r = await isKeywordBlocklisted(db, {
+      platformId: input.platformId,
+      projectId: input.projectId,
+      text: input.body,
+    });
+    if (r.blocked) return { ok: false, refusal: { reason: 'blocked', detail: r.reason } };
+  }
+
+  let dedupWarning: string | null = null;
+  if (input.targetUser) {
+    // #335: a DM target already known to reject message requests is skipped
+    // outright, ahead of the ordinary dedup window below. LinkedIn never
+    // produces a `dm` suggestion (quota ships at zero, no scenario), but this
+    // keeps the accept path a genuine superset of createDrafts rather than a
+    // LinkedIn-only special case.
+    if (input.kind === 'dm') {
+      const uncontactableCheck = await checkUncontactable(db, {
+        platformId: input.platformId,
+        targetUser: input.targetUser,
+        organizationId: input.organizationId,
+      });
+      if (uncontactableCheck.uncontactable) {
+        return {
+          ok: false,
+          refusal: { reason: 'uncontactable', detail: uncontactableCheck.reason },
+        };
+      }
+    }
+
+    const [policyRow] = await db
+      .select()
+      .from(schema.appConfig)
+      .where(eq(schema.appConfig.key, 'dedup_policy'));
+    const dedupPolicy = policyRow ? parseDedupPolicy(policyRow.value) : { ...DEFAULT_DEDUP_POLICY };
+    const dedup = await checkContactDedup(db, {
+      platformId: input.platformId,
+      targetUser: input.targetUser,
+      windowDays: dedupPolicy.windowDays,
+      organizationId: input.organizationId,
+    });
+    if (dedup.withinWindow && dedup.priorContactedAt) {
+      if (dedupPolicy.mode === 'skip') {
+        return {
+          ok: false,
+          refusal: {
+            reason: 'recently_contacted',
+            priorContactedAt: dedup.priorContactedAt.toISOString(),
+          },
+        };
+      }
+      dedupWarning = `Previously contacted on ${dedup.priorContactedAt.toISOString()} (within ${dedupPolicy.windowDays}d window).`;
+    }
+  }
+
+  // Quota: a precondition here for the same reason it is one for /suggest -
+  // accepting what cannot be sent wastes the human's edit and the draft would
+  // just sit blocked at send time. Only the day window: /suggest's own
+  // precondition checks day only, and the week window still gates at send
+  // through evaluateDraftSend.
+  const [platform] = await db
+    .select({ slug: schema.platforms.slug })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.id, input.platformId));
+  const [limits, usage] = await Promise.all([
+    loadQuotaLimits(db, platform?.slug ?? 'reddit'),
+    getAccountUsage(db, account.id),
+  ]);
+  const quotaKind = mapDraftKindToQuotaKind(input.kind);
+  const day = checkQuota({
+    platformLimit: limits[quotaKind].perDay,
+    accountLimit: account.dailyLimit,
+    used: usage[quotaKind].day,
+  });
+  if (day.remaining <= 0) {
+    return {
+      ok: false,
+      refusal: { reason: 'quota_exhausted', window: 'day', limit: day.limit, used: day.used },
+    };
+  }
+
+  const costUsd = input.usage?.costUsd != null ? input.usage.costUsd.toFixed(4) : null;
+
+  const written = await db.transaction(async (tx) => {
+    const [run] = await tx
+      .insert(schema.runs)
+      .values({
+        kind: 'assist',
+        campaignId: null,
+        projectId: input.projectId,
+        agentRunner: input.agentRunner,
+        trigger: 'manual',
+        // Terminal on write: an assist run has no agent that could call a
+        // finish tool (shared/src/runlog/contract.ts), so it must never sit
+        // in `running` waiting for one, or it reads as `playbook_incomplete`.
+        status: 'success',
+        finishedAt: new Date(),
+        inputTokens: input.usage?.inputTokens ?? null,
+        outputTokens: input.usage?.outputTokens ?? null,
+        cacheReadTokens: input.usage?.cacheReadTokens ?? null,
+        cacheCreationTokens: input.usage?.cacheCreationTokens ?? null,
+        costUsd,
+        params: input.runParams ?? {},
+      })
+      .returning({ id: schema.runs.id });
+
+    const [draft] = await tx
+      .insert(schema.drafts)
+      .values({
+        runId: run.id,
+        projectId: input.projectId,
+        platformId: input.platformId,
+        accountId: account.id,
+        kind: input.kind,
+        state: 'pending_review',
+        targetUser: input.targetUser,
+        body: input.body,
+        sourceRef: input.sourceRef ?? {},
+        metadata: input.metadata ?? {},
+        dedupWarning,
+      })
+      .returning({ id: schema.drafts.id });
+
+    await tx.insert(schema.draftEvents).values({
+      draftId: draft.id,
+      event: 'created',
+      actor: 'system',
+      details: {},
+    });
+
+    return { runId: run.id, draftId: draft.id };
+  });
+
+  return { ok: true, draftId: written.draftId, runId: written.runId, dedupWarning };
+}

--- a/shared/src/db/migrations/0013_assist_run_kind.sql
+++ b/shared/src/db/migrations/0013_assist_run_kind.sql
@@ -1,0 +1,21 @@
+-- LI-16 (#313): the in-page LinkedIn assistant's accept path materialises an
+-- accepted suggestion into a real drafts row. drafts.run_id is NOT NULL, so
+-- rather than making that column nullable, accept creates a runs row of a
+-- new kind = 'assist' (project-targeted, no campaign) to hang the draft off.
+--
+-- runs_kind_target_chk is not tracked by drizzle (schema.ts declares no
+-- check() for it - see the historical-constraint-name warning in AGENTS.md),
+-- so `migrate:generate` cannot diff it; this is hand-authored, following the
+-- same DROP/ADD-with-the-real-name shape as every prior change to this
+-- constraint (migrations_archive/0010, 0011, 0045-0048).
+ALTER TABLE "runs" DROP CONSTRAINT IF EXISTS "runs_kind_target_chk";
+ALTER TABLE "runs" ADD CONSTRAINT "runs_kind_target_chk"
+  CHECK (
+    (kind = 'campaign' AND campaign_id IS NOT NULL)
+    OR (kind = 'project_extraction' AND project_id IS NOT NULL)
+    OR (kind = 'campaign_skill_generation' AND campaign_id IS NOT NULL)
+    OR (kind = 'draft_regeneration' AND project_id IS NOT NULL)
+    OR (kind = 'reply_drafting' AND project_id IS NOT NULL)
+    OR (kind = 'project_insights' AND project_id IS NOT NULL)
+    OR (kind = 'assist' AND project_id IS NOT NULL)
+  );

--- a/shared/src/db/migrations/meta/0013_snapshot.json
+++ b/shared/src/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,3483 @@
+{
+  "id": "84f87067-a44d-4024-a32d-c8459a998ce2",
+  "prevId": "7d63b2d6-6c39-49d1-bae4-7e4593b0081d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cookie_session": {
+          "name": "cookie_session",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_limit": {
+          "name": "weekly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_project_id_projects_id_fk": {
+          "name": "accounts_project_id_projects_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_platform_id_platforms_id_fk": {
+          "name": "accounts_platform_id_platforms_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_failures": {
+      "name": "auth_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login_attempt'"
+        }
+      },
+      "indexes": {
+        "auth_failures_identifier_idx": {
+          "name": "auth_failures_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist": {
+      "name": "blocklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocklist_platform_id_platforms_id_fk": {
+          "name": "blocklist_platform_id_platforms_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocklist_project_id_projects_id_fk": {
+          "name": "blocklist_project_id_projects_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_recommendations": {
+      "name": "campaign_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_slug": {
+          "name": "scenario_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_recommendations_project_idx": {
+          "name": "campaign_recommendations_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_recommendations_project_id_projects_id_fk": {
+          "name": "campaign_recommendations_project_id_projects_id_fk",
+          "tableFrom": "campaign_recommendations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_slug": {
+          "name": "skill_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_attempts": {
+          "name": "failure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_due_to_failures": {
+          "name": "paused_due_to_failures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_post": {
+          "name": "auto_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_platform_id_platforms_id_fk": {
+          "name": "campaigns_platform_id_platforms_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_history": {
+      "name": "contact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_handle": {
+          "name": "account_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_checked_at": {
+          "name": "reply_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_room_id": {
+          "name": "chat_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_context_url": {
+          "name": "platform_context_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uncontactable": {
+          "name": "uncontactable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uncontactable_reason": {
+          "name": "uncontactable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_history_target_idx": {
+          "name": "contact_history_target_idx",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_target_idx": {
+          "name": "messages_account_target_idx",
+          "columns": [
+            {
+              "expression": "account_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_org_idx": {
+          "name": "contact_history_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_contacted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_history_platform_id_platforms_id_fk": {
+          "name": "contact_history_platform_id_platforms_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contact_history_draft_id_drafts_id_fk": {
+          "name": "contact_history_draft_id_drafts_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_history_organization_id_organizations_id_fk": {
+          "name": "contact_history_organization_id_organizations_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_heartbeats": {
+      "name": "daemon_heartbeats",
+      "schema": "",
+      "columns": {
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tick_at": {
+          "name": "tick_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_events": {
+      "name": "draft_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_events_kind_created_idx": {
+          "name": "draft_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_events_draft_id_drafts_id_fk": {
+          "name": "draft_events_draft_id_drafts_id_fk",
+          "tableFrom": "draft_events",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_regeneration_hints": {
+      "name": "draft_regeneration_hints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint_text": {
+          "name": "hint_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_regeneration_hints_draft_id_drafts_id_fk": {
+          "name": "draft_regeneration_hints_draft_id_drafts_id_fk",
+          "tableFrom": "draft_regeneration_hints",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "fit_score": {
+          "name": "fit_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_url": {
+          "name": "compose_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_content": {
+          "name": "sent_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_comment_id": {
+          "name": "platform_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dedup_warning": {
+          "name": "dedup_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_edited": {
+          "name": "body_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_send_after": {
+          "name": "scheduled_send_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerating_run_id": {
+          "name": "regenerating_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drafting_run_id": {
+          "name": "drafting_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_reason": {
+          "name": "quality_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_model": {
+          "name": "quality_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_id": {
+          "name": "variant_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undeliverable_reason": {
+          "name": "undeliverable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drafts_state_idx": {
+          "name": "drafts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_project_idx": {
+          "name": "drafts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_run_idx": {
+          "name": "drafts_state_run_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_campaign_created_idx": {
+          "name": "drafts_state_campaign_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_variant_group_idx": {
+          "name": "drafts_variant_group_idx",
+          "columns": [
+            {
+              "expression": "variant_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_run_id_runs_id_fk": {
+          "name": "drafts_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_project_id_projects_id_fk": {
+          "name": "drafts_project_id_projects_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_platform_id_platforms_id_fk": {
+          "name": "drafts_platform_id_platforms_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_accounts_id_fk": {
+          "name": "drafts_account_id_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_regenerating_run_id_runs_id_fk": {
+          "name": "drafts_regenerating_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "regenerating_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drafts_drafting_run_id_runs_id_fk": {
+          "name": "drafts_drafting_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "drafting_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_devices": {
+      "name": "extension_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unnamed device'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "extension_devices_token_hash_unique": {
+          "name": "extension_devices_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extension_devices_organization_id_organizations_id_fk": {
+          "name": "extension_devices_organization_id_organizations_id_fk",
+          "tableFrom": "extension_devices",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_pairings": {
+      "name": "extension_pairings",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extension_pairings_organization_id_organizations_id_fk": {
+          "name": "extension_pairings_organization_id_organizations_id_fk",
+          "tableFrom": "extension_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_watches": {
+      "name": "keyword_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_field": {
+          "name": "match_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keyword_watches_campaign_idx": {
+          "name": "keyword_watches_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_watches_project_idx": {
+          "name": "keyword_watches_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_watches_project_id_projects_id_fk": {
+          "name": "keyword_watches_project_id_projects_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keyword_watches_campaign_id_campaigns_id_fk": {
+          "name": "keyword_watches_campaign_id_campaigns_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_org_user_unique": {
+          "name": "memberships_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_from_us": {
+          "name": "is_from_us",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_platform": {
+          "name": "created_at_platform",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_contact_idx": {
+          "name": "messages_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_platform_message_unique": {
+          "name": "messages_platform_message_unique",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_contact_id_contact_history_id_fk": {
+          "name": "messages_contact_id_contact_history_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "contact_history",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_draft_id_drafts_id_fk": {
+          "name": "messages_draft_id_drafts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_platform_id_platforms_id_fk": {
+          "name": "messages_platform_id_platforms_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_unread_idx": {
+          "name": "notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_idx": {
+          "name": "notifications_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organization_id_organizations_id_fk": {
+          "name": "notifications_organization_id_organizations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observed_targets": {
+      "name": "observed_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_by_run_id": {
+          "name": "consumed_by_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "observed_targets_dedup_idx": {
+          "name": "observed_targets_dedup_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "observed_targets_project_unconsumed_idx": {
+          "name": "observed_targets_project_unconsumed_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_by_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "observed_targets_organization_id_organizations_id_fk": {
+          "name": "observed_targets_organization_id_organizations_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_project_id_projects_id_fk": {
+          "name": "observed_targets_project_id_projects_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_platform_id_platforms_id_fk": {
+          "name": "observed_targets_platform_id_platforms_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observed_targets_consumed_by_run_id_runs_id_fk": {
+          "name": "observed_targets_consumed_by_run_id_runs_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "consumed_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invites": {
+      "name": "org_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_invites_org_idx": {
+          "name": "org_invites_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invites_organization_id_organizations_id_fk": {
+          "name": "org_invites_organization_id_organizations_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invites_created_by_user_id_users_id_fk": {
+          "name": "org_invites_created_by_user_id_users_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invites_token_unique": {
+          "name": "org_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_run_budget_usd": {
+          "name": "monthly_run_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platforms": {
+      "name": "platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platforms_slug_unique": {
+          "name": "platforms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playbooks": {
+      "name": "playbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playbooks_slug_unique": {
+          "name": "playbooks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_insights": {
+      "name": "project_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary_md": {
+          "name": "summary_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_insights_project_idx": {
+          "name": "project_insights_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_insights_project_id_projects_id_fk": {
+          "name": "project_insights_project_id_projects_id_fk",
+          "tableFrom": "project_insights",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_runner": {
+          "name": "default_agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_unique": {
+          "name": "projects_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_events_run_idx": {
+          "name": "run_events_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_events_kind_created_idx": {
+          "name": "run_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'campaign'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout_log_path": {
+          "name": "stdout_log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playbook_body": {
+          "name": "playbook_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_project_kind_idx": {
+          "name": "runs_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_campaign_id_campaigns_id_fk": {
+          "name": "runs_campaign_id_campaigns_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_scout_candidates": {
+      "name": "staging_scout_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staging_scout_candidates_run_id_runs_id_fk": {
+          "name": "staging_scout_candidates_run_id_runs_id_fk",
+          "tableFrom": "staging_scout_candidates",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_project_kind_idx": {
+          "name": "templates_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_project_id_projects_id_fk": {
+          "name": "templates_project_id_projects_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_instance_admin": {
+          "name": "is_instance_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recent_idx": {
+          "name": "webhook_deliveries_recent_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_org_idx": {
+          "name": "webhook_deliveries_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_organization_id_organizations_id_fk": {
+          "name": "webhook_deliveries_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1788551298729,
       "tag": "0012_mature_lila_cheney",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1788960000000,
+      "tag": "0013_assist_run_kind",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -241,7 +241,7 @@ export const runs = pgTable(
   'runs',
   {
     id: bigserial('id', { mode: 'number' }).primaryKey(),
-    kind: text('kind').notNull().default('campaign'), // 'campaign' | 'project_extraction' | 'campaign_skill_generation' | 'draft_regeneration' | 'reply_drafting' | 'project_insights'
+    kind: text('kind').notNull().default('campaign'), // 'campaign' | 'project_extraction' | 'campaign_skill_generation' | 'draft_regeneration' | 'reply_drafting' | 'project_insights' | 'assist'
     campaignId: integer('campaign_id').references(() => campaigns.id, { onDelete: 'cascade' }),
     projectId: integer('project_id').references(() => projects.id, { onDelete: 'cascade' }),
     params: jsonb('params').notNull().default({}),

--- a/shared/src/runlog/contract.ts
+++ b/shared/src/runlog/contract.ts
@@ -17,6 +17,15 @@ import * as schema from '../db/schema.js';
  * `run_finish` only closes the run. A campaign run that drafted something did
  * its job even if it forgot the bookkeeping call, so that case is checked
  * against the drafts, not against the run status.
+ *
+ * `assist` (#313) is deliberately absent, not merely unmentioned: an assist
+ * run has no playbook, no MCP session and no agent that could call a finish
+ * tool at all - it is created by `shared/src/assist-accept.ts` already
+ * terminal (`status: 'success'`), in the same transaction as the draft it
+ * produced. This map is only consulted for a run still `running` after its
+ * agent process exits, which never happens for `assist` (there is no
+ * process), so `playbookContractError` below returns null for it via the
+ * `if (!tool) return null` fallthrough rather than a special case.
  */
 export const PLAYBOOK_FINISH_TOOL: Record<string, string> = {
   campaign: 'run_finish',

--- a/shared/tests/assist-run-kind.test.ts
+++ b/shared/tests/assist-run-kind.test.ts
@@ -1,0 +1,48 @@
+// #313: runs_kind_target_chk (shared/src/db/migrations/0013_assist_run_kind.sql)
+// gains the 'assist' kind. Modelled on insights-run-kind.test.ts, the same
+// pattern used to pin the constraint's acceptance of project_insights.
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+
+async function reset() {
+  await getDb().execute(sql`TRUNCATE runs, campaigns, projects RESTART IDENTITY CASCADE`);
+}
+
+describe('runs_kind_target_chk: the assist run kind', () => {
+  beforeEach(reset);
+
+  it('accepts an assist run with a project_id', async () => {
+    const db = getDb();
+    const [org] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(sql`slug = 'default'`);
+    const [proj] = await db
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'assist-chk', name: 'assist-chk' })
+      .returning();
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ kind: 'assist', projectId: proj.id, trigger: 'manual', status: 'success' })
+      .returning();
+    expect(run.kind).toBe('assist');
+    expect(run.projectId).toBe(proj.id);
+  });
+
+  it('rejects an assist run without a project_id', async () => {
+    const db = getDb();
+    await expect(
+      db.insert(schema.runs).values({ kind: 'assist', trigger: 'manual', status: 'success' }),
+    ).rejects.toThrow();
+  });
+
+  // The constraint change is additive (an OR'd clause); this pins that the
+  // pre-existing malformed pairings it already rejected still are.
+  it('still rejects a malformed pairing on an unrelated kind (campaign with no campaign_id)', async () => {
+    const db = getDb();
+    await expect(
+      db.insert(schema.runs).values({ kind: 'campaign', trigger: 'manual', status: 'running' }),
+    ).rejects.toThrow();
+  });
+});

--- a/shared/tests/runlog/contract.test.ts
+++ b/shared/tests/runlog/contract.test.ts
@@ -130,6 +130,21 @@ describe('playbookContractError', () => {
     const { db } = await fixtures();
     expect(await playbookContractError(db, { id: 1, kind: 'something_else' })).toBeNull();
   });
+
+  // #313: an assist run has no playbook and no agent that could call a finish
+  // tool at all, unlike every other kind above. It is deliberately absent
+  // from PLAYBOOK_FINISH_TOOL rather than mapped to one, so this exercises the
+  // real row shape (kind: 'assist', a bare project, no campaign) rather than
+  // the synthetic 'something_else' case above.
+  it('an assist run is never classified playbook_incomplete', async () => {
+    const { db, project } = await fixtures();
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ kind: 'assist', projectId: project.id, trigger: 'manual', status: 'running' })
+      .returning();
+
+    expect(await playbookContractError(db, run)).toBeNull();
+  });
 });
 
 afterAll(async () => {

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -34,6 +34,13 @@ export interface SuggestionResult {
   usage?: {
     inputTokens: number;
     outputTokens: number;
+    // A suggestion's prompt is served from the provider's cache (issue #313
+    // comment): `inputTokens` alone reads as ~2 tokens for an ~800-token
+    // prompt because the cached remainder arrives as these two counts
+    // instead. Carried through so a caller that writes them down (the
+    // accept path's `runs` row) doesn't read as broken accounting.
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
     costUsd: number | null;
   };
 }
@@ -176,6 +183,8 @@ export function runSuggestion(args: {
           ? {
               inputTokens: run.usage.inputTokens,
               outputTokens: run.usage.outputTokens,
+              cacheReadTokens: run.usage.cacheReadTokens,
+              cacheCreationTokens: run.usage.cacheCreationTokens,
               costUsd: run.usage.costUsd,
             }
           : undefined,

--- a/web/src/routes/api/extension/draft/[id]/sent/+server.ts
+++ b/web/src/routes/api/extension/draft/[id]/sent/+server.ts
@@ -130,7 +130,16 @@ export async function POST({ params, request }: { params: { id: string }; reques
   // unresolvable org here is a bug worth naming rather than a DB error.
   const orgId = await requireDraftOrgId(db, id);
 
-  if (draft.kind === 'dm' && draft.targetUser) {
+  // Was `draft.kind === 'dm' && draft.targetUser` until #313: the dashboard's
+  // own manual-send route (web/src/routes/inbox/[id]/+server.ts) has always
+  // gated this purely on `draft.targetUser`, and the LinkedIn assist accept
+  // path (shared/src/assist-accept.ts) deliberately sets `targetUser` on a
+  // `post_comment` draft (the post's author - real-time, one known target,
+  // unlike the campaign commenter convention of leaving it null) precisely
+  // so a sent assist draft gets a contact_history row. Every other kind's
+  // `targetUser` was already null in practice, so this only widens what was
+  // dead code for them.
+  if (draft.targetUser) {
     const [account] = await db
       .select()
       .from(schema.accounts)

--- a/web/src/routes/api/extension/suggest/accept/+server.ts
+++ b/web/src/routes/api/extension/suggest/accept/+server.ts
@@ -1,0 +1,156 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import { getDb, schema } from '$lib/server/db.js';
+import { requireExtensionAuth } from '$lib/server/extension-auth.js';
+import { RateLimiter } from '$lib/server/rate-limit.js';
+import { emit } from '$lib/server/events.js';
+import { loadLinkedInAssistDeviceState } from '@pitchbox/shared/linkedin-assist';
+import { acceptSuggestionIntoDraft } from '@pitchbox/shared/assist-accept';
+
+// The other half of the real-time plane (#313): `POST /api/extension/suggest`
+// produces text nobody has committed to anything yet; this endpoint is what
+// turns the human's accept - the suggestion plus whatever they edited - into
+// a real `drafts` row, through the same blocklist/dedup/quota gates a
+// campaign draft goes through (`shared/src/assist-accept.ts`). See
+// docs/linkedin-integration-design.md, "Bookkeeping, which is where the two
+// planes touch."
+//
+// There is no suggestion registry to reference by id - `/suggest` writes
+// nothing down - so the accept body carries the full context the panel
+// already holds in memory: the post, the kind, the final text and the usage
+// block `/suggest`'s `done` event reported.
+
+// Same shape as /suggest's own limiter: an accept is one human decision per
+// suggestion, so it is rarer than a suggestion request, but sized the same to
+// avoid a second magic number.
+const perDevice = new RateLimiter(20, 60_000);
+const perOrg = new RateLimiter(60, 60_000);
+
+const BodySchema = z.object({
+  projectId: z.number().int().positive(),
+  kind: z.enum(['post_comment', 'post']),
+  post: z.object({
+    urn: z.string().max(200).optional(),
+    authorHandle: z.string().max(200).optional(),
+    authorName: z.string().max(200).optional(),
+    url: z.string().max(2000).optional(),
+  }),
+  body: z.string().min(1).max(10000),
+  platform: z.string().min(1).max(40).default('linkedin'),
+  usage: z
+    .object({
+      inputTokens: z.number().nonnegative().optional(),
+      outputTokens: z.number().nonnegative().optional(),
+      cacheReadTokens: z.number().nonnegative().optional(),
+      cacheCreationTokens: z.number().nonnegative().optional(),
+      costUsd: z.number().nullable().optional(),
+    })
+    .optional(),
+  ms: z.number().nonnegative().optional(),
+});
+
+export async function POST(event: RequestEvent) {
+  const auth = await requireExtensionAuth(event.request);
+
+  if (!perDevice.consume(`device:${auth.deviceId}`)) throw error(429, 'too many accepts');
+  if (auth.organizationId != null && !perOrg.consume(`org:${auth.organizationId}`)) {
+    throw error(429, 'too many accepts for this organization');
+  }
+
+  const parsed = BodySchema.safeParse(await event.request.json());
+  if (!parsed.success) throw error(400, parsed.error.issues[0]?.message ?? 'invalid body');
+  const body = parsed.data;
+
+  const db = getDb();
+
+  // Org scoping, same posture as /suggest and /observations: an id that
+  // doesn't resolve for this org 404s rather than 403s, leaking nothing
+  // about other tenants' ids.
+  const [project] = await db
+    .select()
+    .from(schema.projects)
+    .where(
+      auth.organizationId == null
+        ? eq(schema.projects.id, body.projectId)
+        : and(
+            eq(schema.projects.id, body.projectId),
+            eq(schema.projects.organizationId, auth.organizationId),
+          ),
+    )
+    .limit(1);
+  if (!project) throw error(404, 'project not found');
+
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, body.platform))
+    .limit(1);
+  if (!platform) throw error(400, `unknown platform: ${body.platform}`);
+
+  // The assist gate (#359's enforcement pattern, applied here too): an org
+  // whose assistant is off, whose kill switch is engaged, or that names a
+  // project other than the bound one must be refused just as firmly as a
+  // suggestion is - a suggestion that cannot be produced but can still be
+  // accepted is a hole in the same switch. Scoped to `linkedin` for the same
+  // reason /suggest scopes it: `linkedin_assist` is a LinkedIn-only setting.
+  if (platform.slug === 'linkedin') {
+    const assist = await loadLinkedInAssistDeviceState(db, project.organizationId);
+    if (!assist.enabled) {
+      return json({
+        refused: assist.killSwitch ? 'kill_switch' : 'assist_disabled',
+        platform: platform.slug,
+      });
+    }
+    if (assist.projectId !== project.id) {
+      return json({
+        refused: 'project_not_bound',
+        platform: platform.slug,
+        boundProjectId: assist.projectId,
+      });
+    }
+  }
+
+  // Convention shared with the linkedin-commenter playbook (sourceRef holds
+  // the post's own identifiers; see playbooks/linkedin-commenter.md).
+  const sourceRef: Record<string, unknown> = {};
+  if (body.post.urn) sourceRef.externalId = body.post.urn;
+  if (body.post.url) sourceRef.url = body.post.url;
+
+  // Unlike the campaign commenter playbook (targetUser always null - "the
+  // audience is whoever reads the post, not one person"), the assist accept
+  // path knows exactly which member's post the human is engaging in real
+  // time, so a `post_comment` carries that author as its target: it is what
+  // lets the blocklist and contact-history ledger see it at all. A `post`
+  // has no target - it is the human's own content, merely inspired by
+  // something they read.
+  const targetUser =
+    body.kind === 'post_comment' && body.post.authorHandle ? body.post.authorHandle : null;
+
+  const result = await acceptSuggestionIntoDraft(db, {
+    projectId: project.id,
+    organizationId: project.organizationId,
+    platformId: platform.id,
+    kind: body.kind,
+    targetUser,
+    body: body.body,
+    sourceRef,
+    metadata: {
+      ...(body.post.authorHandle ? { authorHandle: body.post.authorHandle } : {}),
+      ...(body.post.authorName ? { authorName: body.post.authorName } : {}),
+    },
+    agentRunner: project.defaultAgentRunner,
+    usage: body.usage ?? null,
+    runParams: { suggestionKind: body.kind, ms: body.ms ?? null },
+  });
+
+  if (!result.ok) {
+    const { reason, ...rest } = result.refusal;
+    return json({ refused: reason, ...rest });
+  }
+
+  emit('drafts:changed', { id: result.draftId, state: 'pending_review' }, project.organizationId);
+
+  return json({ ok: true, draftId: result.draftId, runId: result.runId });
+}

--- a/web/tests/extension-suggest-accept.test.ts
+++ b/web/tests/extension-suggest-accept.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+import { getAccountUsage } from '@pitchbox/shared/quota';
+import { updateDraftWithVersion } from '../src/lib/server/draft-state.js';
+import { POST as accept } from '../src/routes/api/extension/suggest/accept/+server.js';
+import { POST as markSent } from '../src/routes/api/extension/draft/[id]/sent/+server.js';
+
+/**
+ * The other half of the real-time plane (#313): `/suggest` produces text
+ * nobody has committed to anything yet, and this is what turns an accepted
+ * suggestion into a real, ledgered `drafts` row - through the same
+ * blocklist/dedup/quota gates a campaign draft goes through, so accepting
+ * something Pitchbox helped write is never invisible to quota, contact
+ * history or analytics.
+ */
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, draft_events, contact_history, blocklist, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'dedup_policy'`);
+}
+
+async function seedOrgProject(slug: string, opts: { assist?: boolean } = {}) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug, description: `about ${slug}` })
+    .returning();
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'));
+  if (opts.assist ?? true) {
+    await saveLinkedInAssistSettings(db, org.id, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId: project.id,
+    });
+  }
+  return { org, project, platform };
+}
+
+async function seedAccount(
+  projectId: number,
+  platformId: number,
+  overrides: Partial<typeof schema.accounts.$inferInsert> = {},
+) {
+  const [account] = await getDb()
+    .insert(schema.accounts)
+    .values({ projectId, platformId, handle: 'lorenzo', active: true, ...overrides })
+    .returning();
+  return account;
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({
+      organizationId,
+      tokenHash: createHash('sha256').update(token).digest('hex'),
+      label: 'test',
+    });
+}
+
+function request(token: string | null, body: unknown) {
+  return new Request('http://x/api/extension/suggest/accept', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+const POST_BODY = {
+  kind: 'post_comment' as const,
+  post: {
+    urn: 'urn:li:activity:7000000000000000001',
+    authorHandle: 'jane-doe',
+    authorName: 'Jane Doe',
+    url: 'https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000001/',
+  },
+  body: 'We hit the same wall and cut p99 in half by batching the writes.',
+  usage: {
+    inputTokens: 2,
+    outputTokens: 41,
+    cacheReadTokens: 812,
+    cacheCreationTokens: 0,
+    costUsd: 0.0091,
+  },
+  ms: 8123,
+};
+
+describe('POST /api/extension/suggest/accept', () => {
+  beforeEach(reset);
+
+  it('refuses a request with no bearer token', async () => {
+    await expect(
+      accept({ request: request(null, { ...POST_BODY, projectId: 1 }) } as never),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('404s a project outside the device org, so it leaks no other tenant ids', async () => {
+    const { project: bProject } = await seedOrgProject('acc-org-b');
+    const { org: orgA } = await seedOrgProject('acc-org-a');
+    await mintDevice(orgA.id, 'tokA');
+
+    await expect(
+      accept({ request: request('tokA', { ...POST_BODY, projectId: bProject.id }) } as never),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('refuses for an org that never turned the assistant on', async () => {
+    const { org, project, platform } = await seedOrgProject('acc-off', { assist: false });
+    await seedAccount(project.id, platform.id);
+    await mintDevice(org.id, 'tokOff');
+
+    const res = await accept({
+      request: request('tokOff', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    expect(await res.json()).toMatchObject({ refused: 'assist_disabled' });
+    expect(await getDb().select().from(schema.drafts)).toHaveLength(0);
+    expect(await getDb().select().from(schema.runs)).toHaveLength(0);
+  });
+
+  it('names the kill switch distinctly', async () => {
+    const { org, project, platform } = await seedOrgProject('acc-killed', { assist: false });
+    await seedAccount(project.id, platform.id);
+    await saveLinkedInAssistSettings(getDb(), org.id, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId: project.id,
+      killSwitch: true,
+    });
+    await mintDevice(org.id, 'tokKilled');
+
+    const res = await accept({
+      request: request('tokKilled', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    expect(await res.json()).toMatchObject({ refused: 'kill_switch' });
+  });
+
+  it('refuses to write as a project of the same org that is not the bound one', async () => {
+    const { org, project, platform } = await seedOrgProject('acc-bound');
+    await seedAccount(project.id, platform.id);
+    const [other] = await getDb()
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'p-other', name: 'other', description: 'other' })
+      .returning();
+    await mintDevice(org.id, 'tokBound');
+
+    const res = await accept({
+      request: request('tokBound', { ...POST_BODY, projectId: other.id }),
+    } as never);
+    expect(await res.json()).toMatchObject({
+      refused: 'project_not_bound',
+      boundProjectId: project.id,
+    });
+  });
+
+  it('materialises exactly one draft and one terminal assist run, carrying cache tokens through honestly', async () => {
+    const { org, project, platform } = await seedOrgProject('acc-happy');
+    const account = await seedAccount(project.id, platform.id);
+    await mintDevice(org.id, 'tokHappy');
+
+    const res = await accept({
+      request: request('tokHappy', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    const body = (await res.json()) as { ok: boolean; draftId: number; runId: number };
+    expect(body.ok).toBe(true);
+
+    const runs = await getDb().select().from(schema.runs);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      id: body.runId,
+      kind: 'assist',
+      campaignId: null,
+      projectId: project.id,
+      status: 'success',
+      inputTokens: 2,
+      outputTokens: 41,
+      cacheReadTokens: 812,
+      cacheCreationTokens: 0,
+    });
+    expect(runs[0].costUsd).toBe('0.0091');
+    expect(runs[0].finishedAt).not.toBeNull();
+
+    const drafts = await getDb().select().from(schema.drafts);
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]).toMatchObject({
+      runId: body.runId,
+      projectId: project.id,
+      accountId: account.id,
+      kind: 'post_comment',
+      state: 'pending_review',
+      targetUser: 'jane-doe',
+      body: POST_BODY.body,
+      version: 0,
+    });
+    expect(drafts[0].sourceRef).toMatchObject({ externalId: POST_BODY.post.urn });
+  });
+
+  it('refuses no_account when the project has no active LinkedIn account, with no partial write', async () => {
+    const { org, project } = await seedOrgProject('acc-noacct');
+    await mintDevice(org.id, 'tokNoAcct');
+
+    const res = await accept({
+      request: request('tokNoAcct', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    expect(await res.json()).toMatchObject({ refused: 'no_account' });
+    expect(await getDb().select().from(schema.drafts)).toHaveLength(0);
+    expect(await getDb().select().from(schema.runs)).toHaveLength(0);
+  });
+
+  it('refuses a blocklisted target with no partial write', async () => {
+    const { org, project, platform } = await seedOrgProject('acc-blocked');
+    await seedAccount(project.id, platform.id);
+    await mintDevice(org.id, 'tokBlocked');
+    await getDb()
+      .insert(schema.blocklist)
+      .values({ platformId: platform.id, kind: 'user', value: 'jane-doe', scope: 'global' });
+
+    const res = await accept({
+      request: request('tokBlocked', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    expect(await res.json()).toMatchObject({ refused: 'blocked' });
+    expect(await getDb().select().from(schema.drafts)).toHaveLength(0);
+    expect(await getDb().select().from(schema.runs)).toHaveLength(0);
+  });
+
+  it('refuses an exhausted daily quota with no partial write', async () => {
+    const { org, project, platform } = await seedOrgProject('acc-quota');
+    await seedAccount(project.id, platform.id, { dailyLimit: 0 });
+    await mintDevice(org.id, 'tokQuota');
+
+    const res = await accept({
+      request: request('tokQuota', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    expect(await res.json()).toMatchObject({ refused: 'quota_exhausted', window: 'day' });
+    expect(await getDb().select().from(schema.drafts)).toHaveLength(0);
+    expect(await getDb().select().from(schema.runs)).toHaveLength(0);
+  });
+
+  it('an accepted draft flows through send exactly like a campaign draft: one quota decrement, one contact_history row', async () => {
+    const { org, project, platform } = await seedOrgProject('acc-send');
+    const account = await seedAccount(project.id, platform.id);
+    await mintDevice(org.id, 'tokSend');
+
+    const acceptRes = await accept({
+      request: request('tokSend', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    const { draftId } = (await acceptRes.json()) as { draftId: number };
+
+    const sentReq = new Request(`http://x/api/extension/draft/${draftId}/sent`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer tokSend' },
+      body: JSON.stringify({}),
+    });
+    const sentRes = await markSent({ params: { id: String(draftId) }, request: sentReq } as never);
+    expect(sentRes.status).toBe(200);
+    expect(await sentRes.json()).toMatchObject({ ok: true });
+
+    const [draft] = await getDb().select().from(schema.drafts).where(eq(schema.drafts.id, draftId));
+    expect(draft.state).toBe('sent');
+    expect(draft.sentAt).not.toBeNull();
+
+    const contacts = await getDb()
+      .select()
+      .from(schema.contactHistory)
+      .where(eq(schema.contactHistory.draftId, draftId));
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0]).toMatchObject({
+      platformId: platform.id,
+      accountHandle: account.handle,
+      targetUser: 'jane-doe',
+      organizationId: org.id,
+    });
+
+    // Quota decrement: getAccountUsage now counts this sent draft against
+    // the account's comment usage for the day.
+    const usage = await getAccountUsage(getDb(), account.id);
+    expect(usage.comment.day).toBe(1);
+  });
+
+  it('holds optimistic locking on the created draft: a stale version is rejected, the current one succeeds', async () => {
+    const { org, project, platform } = await seedOrgProject('acc-version');
+    await seedAccount(project.id, platform.id);
+    await mintDevice(org.id, 'tokVersion');
+
+    const acceptRes = await accept({
+      request: request('tokVersion', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    const { draftId } = (await acceptRes.json()) as { draftId: number };
+
+    const [fresh] = await getDb().select().from(schema.drafts).where(eq(schema.drafts.id, draftId));
+    expect(fresh.version).toBe(0);
+
+    const stale = await updateDraftWithVersion(draftId, fresh.version + 1, { state: 'approved' });
+    expect(stale.kind).toBe('conflict');
+    const [afterStale] = await getDb()
+      .select()
+      .from(schema.drafts)
+      .where(eq(schema.drafts.id, draftId));
+    expect(afterStale.state).toBe('pending_review');
+
+    const ok = await updateDraftWithVersion(draftId, fresh.version, { state: 'approved' });
+    expect(ok.kind).toBe('ok');
+    const [afterOk] = await getDb()
+      .select()
+      .from(schema.drafts)
+      .where(eq(schema.drafts.id, draftId));
+    expect(afterOk.state).toBe('approved');
+    expect(afterOk.version).toBe(1);
+  });
+});

--- a/web/tests/extension-suggest.test.ts
+++ b/web/tests/extension-suggest.test.ts
@@ -58,9 +58,13 @@ vi.mock('@pitchbox/shared/agents/registry', () => ({
           exitCode: 0,
           logPath: '/dev/null',
           usage: {
-            inputTokens: 1200,
+            // Modelled on the real measurement in #313's comment: the prompt
+            // is served from the provider's cache, so almost none of it shows
+            // up as `inputTokens` and the rest arrives as the two cache
+            // counts instead.
+            inputTokens: 2,
             outputTokens: 40,
-            cacheReadTokens: 0,
+            cacheReadTokens: 780,
             cacheCreationTokens: 0,
             costUsd: 0.004,
             costReported: true,
@@ -194,9 +198,17 @@ describe('POST /api/extension/suggest', () => {
     expect(kinds).toContain('status');
     expect(kinds[kinds.length - 1]).toBe('done');
 
-    const done = events.at(-1)!.data as { text: string; usage?: { outputTokens: number } };
+    const done = events.at(-1)!.data as {
+      text: string;
+      usage?: { outputTokens: number; cacheReadTokens: number; cacheCreationTokens: number };
+    };
     expect(done.text).toBe(chunks.join(''));
     expect(done.usage?.outputTokens).toBe(40);
+    // #313 comment: `inputTokens` alone reads as ~2 tokens for a cached
+    // prompt, so the cache counts have to reach the caller for the accept
+    // path's `runs` row to not read as broken accounting.
+    expect(done.usage?.cacheReadTokens).toBe(780);
+    expect(done.usage?.cacheCreationTokens).toBe(0);
   });
 
   it('attaches no MCP server and passes a prompt rather than a playbook', async () => {


### PR DESCRIPTION
Closes #313

## What

`POST /api/extension/suggest/accept` turns an accepted in-page LinkedIn suggestion (the post, the kind, the human's final text, and the usage block `/suggest`'s `done` event reported - there is no suggestion registry to reference by id, `/suggest` writes nothing down) into a real `drafts` row, through the exact same blocklist/contact-dedup/`checkUncontactable`/quota gates `cli/src/commands/drafts.ts`'s `createDrafts` applies to a campaign draft. That shared logic lives in `shared/src/assist-accept.ts`.

- `drafts.run_id` stays `NOT NULL`: the accept path creates a `runs` row of a new `kind = 'assist'` (project-targeted, no campaign) in the same transaction as the draft, already terminal (`status: 'success'`). An assist run has no agent that could call a finish tool, so it's deliberately absent from `PLAYBOOK_FINISH_TOOL` (documented in `shared/src/runlog/contract.ts`) rather than mapped to one, and is never left `running`.
- `runs_kind_target_chk` gains the `assist` kind. The constraint isn't drizzle-tracked (no `check()` in `schema.ts`, confirmed by grep), so migration `0013_assist_run_kind.sql` is hand-authored against the real historical constraint name (`runs_kind_target_chk`, verified against the live DB, not trusted from a generated diff), following the exact `DROP CONSTRAINT IF EXISTS` / `ADD CONSTRAINT` shape every prior change to it used.
- `SuggestionResult.usage` now carries `cacheReadTokens`/`cacheCreationTokens` through (`web/src/lib/server/suggest.ts`), per the issue's own comment: the prompt is served from the provider's cache, so `inputTokens` alone reads as ~2 tokens for an ~800-token prompt.
- The assist gate (`loadLinkedInAssistDeviceState`) is enforced on accept the same way #359 enforces it on `/suggest` and `/observations`: off, killed, or unbound all refuse with `{ refused: ... }` before any write.
- Unlike the campaign `linkedin-commenter` playbook's convention (`targetUser` always null on a `post_comment` - "the audience is whoever reads the post, not one person"), the assist accept path knows exactly which member's post the human is engaging in real time, so a `post_comment` sets `targetUser` to the post's author. That's what makes the blocklist and contact-history ledger see it at all - so `web/src/routes/api/extension/draft/[id]/sent/+server.ts`'s contact_history condition widens from `kind === 'dm'` to any draft with a `targetUser` (matching the dashboard's own manual-send route, `web/src/routes/inbox/[id]/+server.ts`, which was already this permissive).

## Verified

- `pnpm -F @pitchbox/shared typecheck` - clean.
- `pnpm -F web check` (svelte-check) - clean, 0 errors/warnings.
- `npx eslint` on every file added/changed - clean (only a JSON-file "no config" warning on `shared/package.json`, expected).
- `npx prettier --check` on every file added/changed - clean.
- New/changed test files, run against my own worktree's test DB (`pitchbox_test_w4313`, migrated with `pnpm run migrate` using this worktree's `.env`):
  - `web/tests/extension-suggest-accept.test.ts` (new, 11 tests): auth, org scoping, all three assist-gate refusals, the happy path (exactly one `drafts` row + one terminal `assist` `runs` row with the cache token counts carried through honestly), `no_account`, blocklist refusal with no partial write, quota-exhausted refusal with no partial write, the full accept-then-send pipeline (one `contact_history` row, one quota-counted send), and optimistic locking on `drafts.version`.
  - `web/tests/extension-suggest.test.ts` (updated): the streamed `done` event now asserts `cacheReadTokens`/`cacheCreationTokens` are carried through.
  - `shared/tests/runlog/contract.test.ts` (updated): an `assist` run is never classified `playbook_incomplete`.
  - `shared/tests/assist-run-kind.test.ts` (new): `runs_kind_target_chk` accepts `assist` with a `project_id`, rejects it without one, and still rejects an unrelated malformed pairing (`campaign` with no `campaign_id`).
  - `web/tests/extension-sent-comment-id.test.ts`, `extension-draft-org-scope.test.ts`, `extension-draft-state-gate.test.ts`, `extension-observations.test.ts`, `linkedin-assist-settings.test.ts` - re-run to confirm the widened `sent` route condition and the accept endpoint introduce no regression.
  - All of the above: 57 tests, all green together in one run.
- Migration applied against my own test database with `pnpm run migrate` (this worktree's `DATABASE_URL`), and the real constraint name/definition verified directly against the live DB (`pg_get_constraintdef`), not assumed from the generated SQL.
- **Every new/changed test proven to bite**, by breaking the production code first, confirming the test goes red, then restoring and confirming green again:
  - Disabling the assist-gate check in the accept route -> exactly the 3 gate tests fail, the other 8 stay green.
  - Disabling the `no_account`/blocklist/quota checks in `assist-accept.ts` simultaneously -> exactly those 3 refusal tests fail (the `no_account` case surfaces as a thrown `TypeError` reaching an undefined account, which still correctly fails the test).
  - Nulling out the cache-token fields written to the `runs` row -> the happy-path test's `toMatchObject` fails on `cacheReadTokens`/`cacheCreationTokens`.
  - Reverting the `sent` route's contact_history condition back to `kind === 'dm'` -> the send-pipeline test's `contacts` assertion drops from length 1 to 0.
  - Dropping the version check out of `updateDraftWithVersion`'s WHERE clause -> the optimistic-locking test's "stale write" assertion flips from `conflict` to `ok`.
  - Mapping `assist` to a (nonexistent) finish tool in `PLAYBOOK_FINISH_TOOL` -> the new contract test fails with a non-null "saved nothing" error.
  - Dropping the `assist` clause from the live DB constraint (and, separately, dropping the whole constraint) -> the corresponding accept/reject assertions in `assist-run-kind.test.ts` fail as expected; restored via the migration file's own SQL each time.
  - Reverting the `SuggestionResult` cache-token carry-through in `suggest.ts` -> the updated `extension-suggest.test.ts` assertion fails.
  - All sabotage was reverted (`diff` confirmed byte-identical to the pre-sabotage backup) before the final commit; `grep -rn "TEMP SABOTAGE"` across `shared/` and `web/` finds nothing.

## Not verified

- CI's `pnpm run test:linkedin-compliance`, `pnpm run lint`, `pnpm run typecheck` (repo-wide), `pnpm test` (repo-wide), `pnpm run version:check`, and the two deploy workflows - out of scope per this task's validation instructions (own-diff only; no extension file was touched, so the compliance check should be unaffected, but I did not run it).
- No UI was touched (no extension, no dashboard component), so no visual verification applies.
