### PR TITLE
feat(extension): in-page comment assist, with the panel build path and its reactivity fixed

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -25,10 +25,12 @@
     "@tailwindcss/vite": "^4.3.2",
     "bits-ui": "^2.19.0",
     "clsx": "^2.1.1",
+    "shadcn-svelte": "^1.5.1",
     "svelte": "^5.57.0",
     "svelte-preprocess": "^6.0.5",
     "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.3.1",
-    "tailwindcss": "^4.3.2"
+    "tailwindcss": "^4.3.2",
+    "tw-animate-css": "^1.4.0"
   }
 }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,6 +1,7 @@
 import { runInboxSync } from './background/inbox-sync.js';
 import { runChatSync } from './background/chat-sync.js';
 import { registerLinkedInReplyIngestScript } from './background/linkedin-reply-ingest-registration.js';
+import { registerLinkedInCommentAssistScript } from './background/linkedin-comment-assist-registration.js';
 import {
   getSettings,
   patchPairing,
@@ -312,6 +313,8 @@ export async function syncLinkedInContentScripts(): Promise<void> {
     // #307's reply/DM ingest keeps its registration in its own module so two
     // parallel branches did not both edit this file; the call belongs here.
     registerLinkedInReplyIngestScript(),
+    // #314's in-page comment assist, same pattern for the same reason.
+    registerLinkedInCommentAssistScript(),
   ]);
 }
 

--- a/extension/src/background/linkedin-comment-assist-registration.ts
+++ b/extension/src/background/linkedin-comment-assist-registration.ts
@@ -1,0 +1,44 @@
+import { hasLinkedInPermission } from '../lib/permissions.js';
+import commentAssistScriptPath from '../content/linkedin-comment-assist.ts?script';
+
+// #314's own dynamic-registration helper, mirroring background.ts's
+// syncLinkedInContentScript (linkedin-comment.ts, #308-driven follow-up to
+// #317) and linkedin-reply-ingest-registration.ts's own module (#307). Kept
+// in its own module rather than added inline to background.ts, matching the
+// established convention: a content-script registration is small, one file
+// per script, so a future LinkedIn content script has exactly one place to
+// add its own.
+//
+// Same match set as linkedin-comment.ts's own registration
+// (`/feed/update/*`): the comment composer, and the stable activity URN
+// this module needs to key a suggestion request on, only exist on the
+// classic post-detail page - see linkedin-comment-assist.ts's own doc
+// comment and linkedin-dom.ts's "Two frontends, one identifier".
+const LINKEDIN_COMMENT_ASSIST_SCRIPT_ID = 'pitchbox-linkedin-comment-assist';
+
+export async function registerLinkedInCommentAssistScript(): Promise<void> {
+  try {
+    const [granted, existing] = await Promise.all([
+      hasLinkedInPermission(),
+      chrome.scripting.getRegisteredContentScripts({
+        ids: [LINKEDIN_COMMENT_ASSIST_SCRIPT_ID],
+      }),
+    ]);
+    if (granted && existing.length === 0) {
+      await chrome.scripting.registerContentScripts([
+        {
+          id: LINKEDIN_COMMENT_ASSIST_SCRIPT_ID,
+          js: [commentAssistScriptPath],
+          matches: ['https://www.linkedin.com/feed/update/*'],
+          runAt: 'document_idle',
+        },
+      ]);
+    } else if (!granted && existing.length > 0) {
+      await chrome.scripting.unregisterContentScripts({
+        ids: [LINKEDIN_COMMENT_ASSIST_SCRIPT_ID],
+      });
+    }
+  } catch (err) {
+    console.warn('[pitchbox] registerLinkedInCommentAssistScript failed:', err);
+  }
+}

--- a/extension/src/background/linkedin-comment-assist-registration.ts
+++ b/extension/src/background/linkedin-comment-assist-registration.ts
@@ -1,5 +1,13 @@
 import { hasLinkedInPermission } from '../lib/permissions.js';
-import commentAssistScriptPath from '../content/linkedin-comment-assist.ts?script';
+import { PANEL_CONTENT_SCRIPTS, panelScriptOutput } from '../content/panel-scripts.js';
+
+// Not a `?script` import, unlike its two siblings. `?script` is crxjs's own
+// mechanism and resolves to a file crxjs emitted, and crxjs cannot build this
+// one: its nested IIFE build runs `plugins: []`, so the Svelte panel this
+// script renders fails to parse (#369). The build plugin in
+// `extension/build/panel-content-scripts.ts` emits it instead, at exactly the
+// path below, and both sides read the same list so they cannot drift.
+const commentAssistScriptPath = panelScriptOutput(PANEL_CONTENT_SCRIPTS[0]);
 
 // #314's own dynamic-registration helper, mirroring background.ts's
 // syncLinkedInContentScript (linkedin-comment.ts, #308-driven follow-up to

--- a/extension/src/content/linkedin-comment-assist-panel.svelte
+++ b/extension/src/content/linkedin-comment-assist-panel.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  /**
+   * The comment-assist panel's own content, rendered inside `panel-frame.svelte`
+   * (#311's chrome) by `linkedin-comment-assist.ts`, which owns every state
+   * transition and API call - this component only renders `state` and calls
+   * back out through its props. See `docs/design/linkedin-assistant-brief.md`
+   * for the states this renders (resting, streaming, ready, edited, inserted,
+   * refused) and D3 (docs/design/DECISIONS.md) for why streaming shows a
+   * skeleton plus a status line rather than a bare spinner.
+   */
+  import PanelFrame from './panel-frame.svelte';
+  import { t } from '../lib/i18n/index.js';
+  import type { CommentAssistPanelProps } from './linkedin-comment-assist.js';
+
+  let { subject, state, onRequest, onEditChange, onAccept, onDismiss }: CommentAssistPanelProps =
+    $props();
+
+  function onTextareaInput(event: Event): void {
+    onEditChange((event.currentTarget as HTMLTextAreaElement).value);
+  }
+</script>
+
+<PanelFrame {subject} onclose={onDismiss}>
+  {#snippet children()}
+    <div class="assist">
+      {#if state.phase === 'resting'}
+        <p class="assist-hint">{$t('assist.comment.resting.hint')}</p>
+        <div class="assist-row">
+          <button type="button" class="assist-button" onclick={onRequest}>
+            {$t('assist.comment.resting.cta')}
+          </button>
+        </div>
+      {:else if state.phase === 'streaming'}
+        <p class="assist-status" aria-live="polite">
+          {$t(state.status === 'reading' ? 'assist.status.reading' : 'assist.status.writing')}
+        </p>
+        {#if state.text}
+          <p class="assist-preview">{state.text}</p>
+        {:else}
+          <div class="assist-skeleton" aria-hidden="true">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        {/if}
+      {:else if state.phase === 'ready' || state.phase === 'edited'}
+        <textarea
+          class="assist-textarea"
+          aria-label={$t('assist.comment.ready.label')}
+          value={state.text}
+          oninput={onTextareaInput}
+        ></textarea>
+        <div class="assist-row">
+          <button type="button" class="assist-button" onclick={onAccept}>
+            {$t('assist.action.accept')}
+          </button>
+        </div>
+      {:else if state.phase === 'accepting'}
+        <p class="assist-status" aria-live="polite">{$t('assist.comment.accepting')}</p>
+      {:else if state.phase === 'inserted'}
+        <p class="assist-status">{$t('assist.comment.inserted.title')}</p>
+        <p class="assist-hint">{$t('assist.comment.inserted.hint')}</p>
+      {:else if state.phase === 'refused'}
+        <p class="assist-refusal" role="alert">{$t(state.messageKey, state.messageParams)}</p>
+        <div class="assist-row">
+          <button type="button" class="assist-button assist-button--ghost" onclick={onRequest}>
+            {$t('assist.action.retry')}
+          </button>
+        </div>
+      {/if}
+    </div>
+  {/snippet}
+</PanelFrame>

--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -1,0 +1,358 @@
+import { api, type AcceptRefusalReason, type SuggestEvent, type SuggestUsage } from '../lib/api.js';
+import { logFromContent } from '../lib/log-from-content.js';
+import { mountPanel, panelFor } from './shared/panel-host.js';
+import { insertComposerText, watchDraftForSend } from './linkedin-comment.js';
+import {
+  findCommentComposer,
+  findFeedPosts,
+  readPostAuthor,
+  readPostIdentifier,
+  readPostText,
+  resetSelectorHealth,
+  selectorHealthActivityEvents,
+} from './shared/linkedin-dom.js';
+import CommentAssistPanel from './linkedin-comment-assist-panel.svelte';
+
+/**
+ * In-page LinkedIn comment assist (LI-17, #314): wires LI-14 (#311)'s panel
+ * host to LI-15 (#312)'s suggestion endpoint on the classic post-detail page
+ * (`/feed/update/urn:li:activity:<id>/`), the only frontend that renders a
+ * comment composer or exposes a stable post identifier at all - see
+ * `linkedin-dom.ts`'s "Two frontends, one identifier". The feed itself has
+ * neither in the anonymised captures this module is tested against, so it is
+ * out of scope here (docs/linkedin-integration-design.md agrees: the panel
+ * anchors "to the post the human acted on", D11, exactly like the passive
+ * observation collector's own choice not to invent a dedupe key the feed
+ * does not expose).
+ *
+ * ## Never unprompted, twice over
+ *
+ * Mounting the panel and requesting a suggestion are two separate explicit
+ * actions, not one. `wireCommentAssist` only mounts on the human's own click
+ * into LinkedIn's already-rendered composer (the same signal
+ * `linkedin-comment.ts`'s `wireComposerInsert` already uses to mean "the
+ * human wants to comment"), and the mounted panel starts in `resting` -
+ * present, nothing requested (docs/design/linkedin-assistant-brief.md,
+ * "States"). Only a second click, on the panel's own "Suggest a comment"
+ * control, fires the network request. Neither click is ever synthesised.
+ *
+ * ## No second send path
+ *
+ * Accept calls the same materialise-a-draft endpoint LI-16 (#313) built,
+ * inserts the accepted text with `insertComposerText` (native setter, a
+ * genuine `input` event, never a synthetic submit), then hands the draft id
+ * to `watchDraftForSend` - the exact send-detection state machine
+ * `linkedin-comment.ts` already uses for a draft opened from the Inbox. An
+ * in-page comment therefore lands in the ledger by exactly the same route.
+ */
+
+const COMMENT_KIND = 'post_comment';
+
+/** The observed post context a suggestion is requested for. `urn` is only
+ * present because this module only runs on the classic post-detail page -
+ * see the module doc comment. */
+export type AssistPost = {
+  urn?: string;
+  authorHandle?: string;
+  authorName?: string;
+  text: string;
+  url: string;
+};
+
+/**
+ * Reads the one post on a classic post-detail page through `linkedin-dom.ts`.
+ * Returns null when there is no post, or no readable body text - a request
+ * built from an empty post is not a degraded suggestion, it is nothing to
+ * suggest from, so the caller renders `selector_health_degraded` instead of
+ * sending it. Exported for testing.
+ */
+export function readAssistPost(root: ParentNode = document): AssistPost | null {
+  const post = findFeedPosts(root)[0];
+  if (!post) return null;
+  const identifier = readPostIdentifier(post, root);
+  const author = readPostAuthor(post, root);
+  const text = readPostText(post, root);
+  if (!text) return null;
+  return {
+    urn: identifier.kind === 'urn' ? identifier.value : undefined,
+    authorHandle: author.handle ?? undefined,
+    authorName: author.name ?? undefined,
+    text,
+    url: location.href,
+  };
+}
+
+/** Every refusal this panel can render, honestly and distinctly (the brief's
+ * five states, plus the accept path's own three, plus three this client
+ * detects itself). */
+export type AssistRefusal =
+  AcceptRefusalReason | 'backend_unreachable' | 'selector_health_degraded' | 'generation_failed';
+
+const KNOWN_REFUSALS: Record<AssistRefusal, true> = {
+  assist_disabled: true,
+  kill_switch: true,
+  project_not_bound: true,
+  quota_exhausted: true,
+  no_account: true,
+  blocked: true,
+  uncontactable: true,
+  recently_contacted: true,
+  backend_unreachable: true,
+  selector_health_degraded: true,
+  generation_failed: true,
+};
+
+/**
+ * Maps a refusal reason to its own i18n key rather than a generic failure
+ * (docs/design/linkedin-assistant-brief.md, "Refused is five real states...
+ * not one error"). A reason this client does not recognise (a future server
+ * refusal this build predates) still renders, naming itself, instead of a
+ * blank or a raw untranslated key. Exported for testing.
+ */
+export function refusalMessage(reason: string): {
+  key: string;
+  params?: Record<string, string>;
+} {
+  if (reason in KNOWN_REFUSALS) return { key: `assist.refusal.${reason}` };
+  return { key: 'assist.refusal.unknown', params: { reason } };
+}
+
+export type CommentAssistState =
+  | { phase: 'resting' }
+  | { phase: 'streaming'; status: 'reading' | 'writing'; text: string }
+  | { phase: 'ready'; text: string }
+  | { phase: 'edited'; text: string }
+  | { phase: 'accepting'; text: string }
+  | { phase: 'inserted' }
+  | { phase: 'refused'; messageKey: string; messageParams?: Record<string, string> };
+
+export type CommentAssistPanelProps = {
+  subject?: string;
+  state: CommentAssistState;
+  onRequest: () => void;
+  onEditChange: (text: string) => void;
+  onAccept: () => void;
+  onDismiss: () => void;
+};
+
+/** `composer`'s own comment form, so the panel sits right under the whole
+ * control row (emoji/photo buttons included), not just the editable div. */
+function resolveAnchor(composer: HTMLElement): Element {
+  return composer.closest('form') ?? composer;
+}
+
+function logRefusal(reason: string): void {
+  logFromContent({
+    level: 'warn',
+    source: 'linkedin-action',
+    message: 'activity.linkedin-action.suggestion-refused',
+    messageParams: { reason },
+    meta: { reason, script: 'linkedin-comment-assist' },
+  });
+}
+
+/**
+ * Mounts the assist panel on `composer`'s anchor and wires its whole state
+ * machine: request, edit, accept-then-insert-then-watch, refuse. One call
+ * per composer click (see `wireCommentAssist` below); `mountPanel` itself is
+ * what keeps a second click from stacking a second panel (D11).
+ */
+function mountAssistPanel(composer: HTMLElement): void {
+  const anchor = resolveAnchor(composer);
+  const capturedPost = readAssistPost(document);
+  for (const event of selectorHealthActivityEvents()) logFromContent(event);
+
+  let currentText = '';
+  let boundProjectId: number | null = null;
+  let lastUsage: SuggestUsage | undefined;
+  let lastMs: number | undefined;
+
+  const props: CommentAssistPanelProps = {
+    subject: capturedPost?.authorName ?? undefined,
+    state: { phase: 'resting' },
+    onRequest: () => void requestSuggestion(),
+    onEditChange: (text) => {
+      currentText = text;
+      if (handle.alive) handle.update({ state: { phase: 'edited', text } });
+    },
+    onAccept: () => void acceptAndInsert(),
+    onDismiss: () => handle.destroy(),
+  };
+
+  const handle = mountPanel({ anchor, component: CommentAssistPanel, props });
+
+  function setRefused(reason: string): void {
+    logRefusal(reason);
+    const { key, params } = refusalMessage(reason);
+    if (handle.alive) {
+      handle.update({ state: { phase: 'refused', messageKey: key, messageParams: params } });
+    }
+  }
+
+  async function requestSuggestion(): Promise<void> {
+    if (!capturedPost) {
+      setRefused('selector_health_degraded');
+      return;
+    }
+    handle.update({ state: { phase: 'streaming', status: 'reading', text: '' } });
+
+    const assistRes = await api.linkedinAssist();
+    if (!handle.alive) return;
+    if (!assistRes.ok) {
+      setRefused('backend_unreachable');
+      return;
+    }
+    const { assist } = assistRes.data;
+    if (assist.killSwitch) {
+      setRefused('kill_switch');
+      return;
+    }
+    if (!assist.enabled) {
+      setRefused('assist_disabled');
+      return;
+    }
+    if (assist.projectId === null) {
+      setRefused('project_not_bound');
+      return;
+    }
+    boundProjectId = assist.projectId;
+
+    let streamed = '';
+    const res = await api.suggest(
+      {
+        projectId: boundProjectId,
+        kind: COMMENT_KIND,
+        post: {
+          urn: capturedPost.urn,
+          authorHandle: capturedPost.authorHandle,
+          authorName: capturedPost.authorName,
+          text: capturedPost.text,
+          url: capturedPost.url,
+        },
+      },
+      (event: SuggestEvent) => {
+        if (!handle.alive) return;
+        switch (event.kind) {
+          case 'status':
+            handle.update({ state: { phase: 'streaming', status: event.phase, text: streamed } });
+            break;
+          case 'chunk':
+            streamed += event.text;
+            handle.update({ state: { phase: 'streaming', status: 'writing', text: streamed } });
+            break;
+          case 'done':
+            lastUsage = event.usage;
+            lastMs = event.ms;
+            currentText = event.text;
+            handle.update({ state: { phase: 'ready', text: event.text } });
+            break;
+          case 'failed':
+            setRefused('generation_failed');
+            break;
+          case 'refused':
+            setRefused(event.reason);
+            break;
+        }
+      },
+    );
+    if (!handle.alive) return;
+    if (!res.ok) setRefused('backend_unreachable');
+  }
+
+  async function acceptAndInsert(): Promise<void> {
+    if (boundProjectId === null || !capturedPost) {
+      setRefused('selector_health_degraded');
+      return;
+    }
+    handle.update({ state: { phase: 'accepting', text: currentText } });
+    const res = await api.acceptSuggestion({
+      projectId: boundProjectId,
+      kind: COMMENT_KIND,
+      post: {
+        urn: capturedPost.urn,
+        authorHandle: capturedPost.authorHandle,
+        authorName: capturedPost.authorName,
+        url: capturedPost.url,
+      },
+      body: currentText,
+      usage: lastUsage,
+      ms: lastMs,
+    });
+    if (!handle.alive) return;
+    if (!res.ok) {
+      setRefused('backend_unreachable');
+      return;
+    }
+    if (!res.data.accepted) {
+      setRefused(res.data.refused);
+      return;
+    }
+
+    insertComposerText(composer, currentText);
+    watchDraftForSend(res.data.draftId);
+    logFromContent({
+      level: 'info',
+      source: 'linkedin-action',
+      message: 'activity.linkedin-action.suggestion-inserted',
+      messageParams: { draftId: res.data.draftId },
+      meta: { draftId: res.data.draftId },
+    });
+    handle.update({ state: { phase: 'inserted' } });
+  }
+}
+
+/**
+ * Wires the human's own click into `composer` to mount the assist panel.
+ * Never dispatches a click; only listens for one, matching every other
+ * content script in this directory. Exported for testing.
+ */
+export function wireCommentAssist(composer: HTMLElement): void {
+  const anchor = resolveAnchor(composer);
+  composer.addEventListener(
+    'click',
+    () => {
+      if (panelFor(anchor)) return;
+      mountAssistPanel(composer);
+    },
+    { capture: true },
+  );
+}
+
+const COMPOSER_WAIT_MS = 15_000;
+
+function init(): void {
+  resetSelectorHealth();
+  const composer = findCommentComposer();
+  if (composer) {
+    wireCommentAssist(composer);
+    return;
+  }
+  let wired = false;
+  const obs = new MutationObserver(() => {
+    const found = findCommentComposer();
+    if (found) {
+      wired = true;
+      obs.disconnect();
+      wireCommentAssist(found);
+    }
+  });
+  obs.observe(document.documentElement, { childList: true, subtree: true });
+  window.setTimeout(() => {
+    obs.disconnect();
+    if (wired) return;
+    for (const event of selectorHealthActivityEvents()) logFromContent(event);
+    logFromContent({
+      level: 'warn',
+      source: 'linkedin-action',
+      message: 'activity.linkedin-action.assist-composer-not-found',
+      meta: {
+        script: 'linkedin-comment-assist',
+        selector: 'findCommentComposer',
+        reason: 'comment-composer-not-found',
+        url: location.href,
+      },
+    });
+  }, COMPOSER_WAIT_MS);
+}
+
+init();

--- a/extension/src/content/linkedin-comment.ts
+++ b/extension/src/content/linkedin-comment.ts
@@ -99,73 +99,64 @@ export function findOurCommentUrn(
   return undefined;
 }
 
-if (draftId !== null) {
+export interface DraftSendWatcher {
+  /** Wires LinkedIn's submit control for this draft. False if the control does not exist yet. */
+  wireSubmit(): boolean;
+}
+
+/**
+ * The send-detection state machine for `targetDraftId`: arms on the human's
+ * own click on LinkedIn's submit control (never dispatches one - see
+ * `insertComposerText`'s doc comment for the one synthetic event this module
+ * does carve out), then polls for completion exactly as this function
+ * always has, before the refactor below split it out of the
+ * `pitchbox_draft`-driven bootstrap. Factored out so #314's in-page accept
+ * flow can hand a freshly accepted draft id to this *exact* mechanism
+ * instead of inventing a second one (docs/linkedin-integration-design.md,
+ * "no second send path"; see `linkedin-comment-assist.ts`).
+ */
+export function createDraftSendWatcher(
+  targetDraftId: number,
+  targetBackendUrl: string | undefined,
+  initialVersion?: number,
+): DraftSendWatcher {
   let armed = false;
   let sent = false;
-  let filled = false;
-  let draftVersion: number | undefined;
-
-  /**
-   * Offer the draft body in the composer, but only once the human has
-   * explicitly clicked into it - the compliance boundary
-   * (docs/linkedin-integration-design.md, "The compliance boundary") is
-   * specific that inserted text follows "an explicit action by the human,
-   * and nothing more". Unlike `post-comment.ts`'s `fill()`, which pre-fills
-   * Reddit's textarea unconditionally at page load, this listens for (never
-   * dispatches) the human's own click on the composer LinkedIn already
-   * rendered - no extra UI, matching every other content script in this
-   * directory ("only reads and writes fields that LinkedIn or Reddit
-   * already put on the page", see `shared/panel-host.ts`'s header for why
-   * that stays true here and the in-page assist panel is separate work).
-   */
-  function wireComposerInsert(composer: HTMLElement, body: string): void {
-    composer.addEventListener(
-      'click',
-      () => {
-        if (filled) return;
-        // Don't overwrite text the human already typed themselves.
-        if (composer.textContent?.trim()) return;
-        filled = true;
-        insertComposerText(composer, body);
-        void copyDraftToClipboard(body);
-      },
-      { capture: true },
-    );
-  }
+  const draftVersion = initialVersion;
 
   async function onSendIntent() {
     if (armed) return;
     armed = true;
-    await api.armed(draftId!, backendUrl);
+    await api.armed(targetDraftId, targetBackendUrl);
   }
 
   async function onSendCompleted(sentContent: string, platformPostId: string) {
     if (sent) return;
     sent = true;
     const res = await api.sent(
-      draftId!,
+      targetDraftId,
       sentContent || undefined,
       undefined,
       platformPostId,
       draftVersion,
-      backendUrl,
+      targetBackendUrl,
     );
     if (res.ok) {
       logFromContent({
         level: 'info',
         source: 'linkedin-action',
         message: 'activity.linkedin-action.comment-sent',
-        messageParams: { draftId: draftId! },
-        meta: { draftId },
+        messageParams: { draftId: targetDraftId },
+        meta: { draftId: targetDraftId },
       });
     } else {
       logFromContent({
         level: 'error',
         source: 'linkedin-action',
         message: 'activity.linkedin-action.fail',
-        messageParams: { draftId: draftId!, reason: res.error || String(res.status) },
+        messageParams: { draftId: targetDraftId, reason: res.error || String(res.status) },
         meta: {
-          draftId,
+          draftId: targetDraftId,
           script: 'linkedin-comment',
           reason: res.error || String(res.status),
           status: res.status,
@@ -177,12 +168,11 @@ if (draftId !== null) {
 
   /**
    * Wires LinkedIn's own submit control. Listens for the human's click
-   * (never dispatches one - see the module doc comment above) to arm the
-   * draft, then polls for completion the same shape
-   * `post-comment.ts`'s `wireSubmit` uses for Reddit: composer cleared, a
-   * new comment node carrying our text, and no inline error banner, all
-   * three required before flipping the draft to sent; a 20s give-up window
-   * if none of that resolves.
+   * (never dispatches one) to arm the draft, then polls for completion the
+   * same shape `post-comment.ts`'s `wireSubmit` uses for Reddit: composer
+   * cleared, a new comment node carrying our text, and no inline error
+   * banner, all three required before flipping the draft to sent; a 20s
+   * give-up window if none of that resolves.
    */
   function wireSubmit(): boolean {
     const btn = findCommentSubmitButton();
@@ -213,9 +203,9 @@ if (draftId !== null) {
               level: 'error',
               source: 'linkedin-action',
               message: 'activity.linkedin-action.comment-confirm-timeout',
-              messageParams: { draftId: draftId! },
+              messageParams: { draftId: targetDraftId },
               meta: {
-                draftId,
+                draftId: targetDraftId,
                 script: 'linkedin-comment',
                 step: 'confirm-send',
                 reason: 'click-poll-timeout',
@@ -230,10 +220,99 @@ if (draftId !== null) {
     return true;
   }
 
+  return { wireSubmit };
+}
+
+/**
+ * Wires `watcher.wireSubmit` now if the submit control already exists, or
+ * retries it via MutationObserver - LinkedIn does not render a submit
+ * control for an empty composer, so this is the expected path on first
+ * offer, not a fallback - for up to 15s before logging a distinct give-up.
+ * Shared by the URL-driven bootstrap below and #314's in-page accept flow.
+ */
+export function watchForCommentSubmit(watcher: DraftSendWatcher, targetDraftId: number): void {
+  if (watcher.wireSubmit()) return;
+  let wired = false;
+  const obs = new MutationObserver(() => {
+    if (watcher.wireSubmit()) {
+      wired = true;
+      obs.disconnect();
+    }
+  });
+  obs.observe(document.documentElement, { childList: true, subtree: true });
+  window.setTimeout(() => {
+    obs.disconnect();
+    if (!wired) {
+      logFromContent({
+        level: 'warn',
+        source: 'linkedin-action',
+        message: 'activity.linkedin-action.comment-submit-not-found',
+        messageParams: { draftId: targetDraftId },
+        meta: {
+          draftId: targetDraftId,
+          script: 'linkedin-comment',
+          step: 'wire-submit-button',
+          selector: 'findCommentSubmitButton',
+          reason: 'submit-button-not-found',
+          url: location.href,
+        },
+      });
+    }
+  }, 15_000);
+}
+
+/**
+ * Entry point for a caller that already has an accepted draft id and does
+ * not go through the `pitchbox_draft` URL bootstrap below - #314's in-page
+ * assist, once the human accepts a suggestion and it lands in the
+ * composer. Creates the watcher and wires it immediately, the same call
+ * shape `init()` below uses for the Inbox-opened flow, so a comment
+ * accepted in-page is armed/sent through exactly the same route as one
+ * opened from the Inbox - no second send path.
+ */
+export function watchDraftForSend(
+  targetDraftId: number,
+  targetBackendUrl?: string,
+  initialVersion?: number,
+): void {
+  const watcher = createDraftSendWatcher(targetDraftId, targetBackendUrl, initialVersion);
+  watchForCommentSubmit(watcher, targetDraftId);
+}
+
+if (draftId !== null) {
+  let filled = false;
+
+  /**
+   * Offer the draft body in the composer, but only once the human has
+   * explicitly clicked into it - the compliance boundary
+   * (docs/linkedin-integration-design.md, "The compliance boundary") is
+   * specific that inserted text follows "an explicit action by the human,
+   * and nothing more". Unlike `post-comment.ts`'s `fill()`, which pre-fills
+   * Reddit's textarea unconditionally at page load, this listens for (never
+   * dispatches) the human's own click on the composer LinkedIn already
+   * rendered - no extra UI, matching every other content script in this
+   * directory ("only reads and writes fields that LinkedIn or Reddit
+   * already put on the page", see `shared/panel-host.ts`'s header for why
+   * that stays true here and the in-page assist panel is separate work).
+   */
+  function wireComposerInsert(composer: HTMLElement, body: string): void {
+    composer.addEventListener(
+      'click',
+      () => {
+        if (filled) return;
+        // Don't overwrite text the human already typed themselves.
+        if (composer.textContent?.trim()) return;
+        filled = true;
+        insertComposerText(composer, body);
+        void copyDraftToClipboard(body);
+      },
+      { capture: true },
+    );
+  }
+
   async function init() {
     const r = await api.getDraft(draftId!, backendUrl);
     if (!r.ok) return;
-    draftVersion = r.data.version;
     const composer = findCommentComposer();
     if (!composer) {
       // #173-equivalent for LinkedIn: give up visibly instead of leaving the
@@ -255,39 +334,7 @@ if (draftId !== null) {
     } else {
       wireComposerInsert(composer, r.data.body);
     }
-    if (!wireSubmit()) {
-      // The submit control legitimately does not exist until the composer
-      // has text (see linkedin-dom.ts's `findCommentSubmitButton` doc
-      // comment), so this is the expected path, not a fallback - wait for
-      // it to appear, whether from our insert or the human's own typing.
-      let wired = false;
-      const obs = new MutationObserver(() => {
-        if (wireSubmit()) {
-          wired = true;
-          obs.disconnect();
-        }
-      });
-      obs.observe(document.documentElement, { childList: true, subtree: true });
-      window.setTimeout(() => {
-        obs.disconnect();
-        if (!wired) {
-          logFromContent({
-            level: 'warn',
-            source: 'linkedin-action',
-            message: 'activity.linkedin-action.comment-submit-not-found',
-            messageParams: { draftId: draftId! },
-            meta: {
-              draftId,
-              script: 'linkedin-comment',
-              step: 'wire-submit-button',
-              selector: 'findCommentSubmitButton',
-              reason: 'submit-button-not-found',
-              url: location.href,
-            },
-          });
-        }
-      }, 15_000);
-    }
+    watchForCommentSubmit(createDraftSendWatcher(draftId!, backendUrl, r.data.version), draftId!);
   }
 
   void init();

--- a/extension/src/content/panel-scripts.ts
+++ b/extension/src/content/panel-scripts.ts
@@ -1,0 +1,22 @@
+/**
+ * The content scripts that render a Svelte panel, and the paths they are
+ * emitted at. Runtime-safe on purpose: the build plugin that emits them
+ * (`extension/build/panel-content-scripts.ts`) imports this list, and the
+ * background worker that registers them imports the same list, so the two
+ * cannot drift. Nothing here may import from `vite` or `node:*`, because this
+ * module ends up in the extension bundle.
+ *
+ * Why these are not in crxjs's `contentScripts.standaloneFiles` like every
+ * other dynamically registered script: crxjs builds those through a nested
+ * Vite build with `plugins: []`, so `svelte()` never runs and a panel-bearing
+ * script fails to parse (#369).
+ */
+export const PANEL_CONTENT_SCRIPTS = ['src/content/linkedin-comment-assist.ts'] as const;
+
+/**
+ * The emitted path for a source entry, relative to the extension root, which
+ * is also what `chrome.scripting.registerContentScripts` takes.
+ */
+export function panelScriptOutput(entry: string): string {
+  return entry.replace(/\.ts$/, '.js');
+}

--- a/extension/src/content/panel.css
+++ b/extension/src/content/panel.css
@@ -15,20 +15,22 @@
  * No `html`/`body` rules. There is no `html` or `body` in a shadow root, so the
  * panel's ground colour and font family sit on `.pitchbox-panel` below.
  */
-@import 'tailwindcss';
-@import 'tw-animate-css';
-@import 'shadcn-svelte/tailwind.css';
+/* Plain CSS on purpose, and that is a build constraint rather than a style
+ * preference. This sheet is imported with `?inline` by a content script that
+ * is registered dynamically, so the LinkedIn host permission can stay
+ * optional (#317), which means it is built as a standalone IIFE. Every
+ * Tailwind v4 directive (`@import 'tailwindcss'`, `@source`,
+ * `@custom-variant`, `@theme`) needs `@tailwindcss/vite` to have any meaning,
+ * and that pipeline does not reach this file (#369). Vite's core CSS handling
+ * resolves the one plain `@import` below on its own.
+ *
+ * Nothing was lost in dropping them: neither this sheet nor
+ * `panel-frame.svelte` nor the assist panel uses a single Tailwind utility
+ * class or a `dark:` variant, so the `@theme inline` block existed only to
+ * define the three radius steps, which are declared directly at the bottom of
+ * this file now. Keep it that way: a utility class written here would
+ * silently not exist. */
 @import '../lib/tokens.css';
-
-/* Tailwind v4 scans the project for class names. Without these the panel's
- * stylesheet would carry every utility used anywhere in the extension,
- * including the whole side panel, for a bundle that ships into a page we do
- * not own. Keep the panel's own sources listed here and nothing else. */
-@source './panel.svelte';
-@source './shared/panel-host.ts';
-@source './linkedin-comment-assist-panel.svelte';
-
-@custom-variant dark (&:is(.dark *));
 
 /* The host element is reset to nothing so no inherited LinkedIn rule (font,
  * line-height, colour, direction, letter-spacing) reaches the panel, and so
@@ -49,6 +51,13 @@
    * where it fails to. */
   --panel-font-stack:
     'Inter Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  /* The three radius steps the panel's own rules use. These used to be
+   * generated from a `@theme inline` block, which was the sheet's last real
+   * dependency on Tailwind's build (#369); as plain `calc()` off tokens.css's
+   * `--radius` they are the same values with nothing to resolve them. */
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
 }
 
 /* The panel root, and the real isolation boundary.
@@ -326,28 +335,4 @@
   .assist-button {
     transition: opacity 120ms ease;
   }
-}
-
-@theme inline {
-  --font-sans: var(--panel-font-stack);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-link: var(--link);
-  --color-card-foreground: var(--card-foreground);
-  --color-card: var(--card);
-  --color-foreground: var(--foreground);
-  --color-background: var(--background);
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
-  --radius-lg: var(--radius);
 }

--- a/extension/src/content/panel.css
+++ b/extension/src/content/panel.css
@@ -26,6 +26,7 @@
  * not own. Keep the panel's own sources listed here and nothing else. */
 @source './panel.svelte';
 @source './shared/panel-host.ts';
+@source './linkedin-comment-assist-panel.svelte';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -179,6 +180,152 @@
 
 .frame .body {
   padding: 0.75rem;
+}
+
+/* LI-17 (#314): the comment-assist body rendered inside `.frame .body`
+ * above. Density is deliberately the brief's "middle" step down from the
+ * dashboard's own airy default (docs/design/linkedin-assistant-brief.md):
+ * a 2rem (32px) control row, no 68px rows, suggestion text at the brief's
+ * literal 15px rather than the nearest Tailwind step. Colour only ever
+ * comes from a token (D1) - nothing here is a raw hex. */
+.assist {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.assist-hint {
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+}
+
+.assist-status {
+  display: flex;
+  align-items: center;
+  min-height: 2rem;
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+}
+
+.assist-preview {
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--foreground);
+  white-space: pre-wrap;
+}
+
+/* The skeleton the brief specifies for the wait (D3, docs/design/linkedin-assistant-brief.md
+ * decision 3): shaped like a comment, never a bare spinner, because the first
+ * token is five to ten seconds away and a mute skeleton that long reads as
+ * stuck. Paired with `.assist-status` above, which carries the "reading"/
+ * "writing" line. */
+.assist-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.assist-skeleton span {
+  display: block;
+  height: 0.625rem;
+  border-radius: var(--radius-sm);
+  background: var(--muted);
+}
+
+.assist-skeleton span:nth-child(1) {
+  width: 92%;
+}
+
+.assist-skeleton span:nth-child(2) {
+  width: 78%;
+}
+
+.assist-skeleton span:nth-child(3) {
+  width: 55%;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .assist-skeleton span {
+    animation: pitchbox-assist-pulse 1.6s ease-in-out infinite;
+  }
+}
+
+@keyframes pitchbox-assist-pulse {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 0.9;
+  }
+}
+
+.assist-textarea {
+  width: 100%;
+  min-height: 4.5rem;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--background);
+  color: var(--foreground);
+  font-family: inherit;
+  font-size: 15px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.assist-textarea:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+}
+
+.assist-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  min-height: 2rem;
+}
+
+.assist-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2rem;
+  padding: 0 0.75rem;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.assist-button:hover {
+  opacity: 0.9;
+}
+
+.assist-button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+}
+
+.assist-button--ghost {
+  background: transparent;
+  color: var(--foreground);
+  border: 1px solid var(--border);
+}
+
+.assist-refusal {
+  font-size: 0.8125rem;
+  color: var(--destructive);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .assist-button {
+    transition: opacity 120ms ease;
+  }
 }
 
 @theme inline {

--- a/extension/src/content/shared/panel-host.ts
+++ b/extension/src/content/shared/panel-host.ts
@@ -24,6 +24,7 @@
  */
 
 import { mount, unmount, type Component } from 'svelte';
+import { reactiveProps } from './panel-props.svelte.js';
 // `?inline` hands back the compiled stylesheet as a string instead of having
 // Vite inject a <style> into the host document, which is the whole point: the
 // text goes into the shadow root and linkedin.com's <head> is never touched.
@@ -141,7 +142,12 @@ export function mountPanel<Props extends Record<string, unknown>>(
   };
   syncWidth();
 
-  const view = mount(component, { target: root, props });
+  // Reactive, not the caller's plain object: `mount()` does not make props
+  // reactive, so assigning onto a plain object re-renders nothing. The panel's
+  // entire state machine arrives through `update()` below, so this is what
+  // makes the panel able to show anything other than its first frame (#369).
+  const live = reactiveProps({ ...props });
+  const view = mount(component, { target: root, props: live });
 
   let alive = true;
   let observer: MutationObserver | null = null;
@@ -155,9 +161,7 @@ export function mountPanel<Props extends Record<string, unknown>>(
   const handle: PanelHandle<Props> = {
     update(next) {
       if (!alive) return;
-      Object.assign(props, next);
-      // Svelte 5 reads props reactively from the object it was handed, so
-      // assigning onto it is the update path; there is no `$set` any more.
+      Object.assign(live, next);
     },
     destroy() {
       if (!alive) return;

--- a/extension/src/content/shared/panel-props.svelte.ts
+++ b/extension/src/content/shared/panel-props.svelte.ts
@@ -1,0 +1,21 @@
+/**
+ * A reactive props object for a mounted panel.
+ *
+ * `.svelte.ts` rather than `.ts` because runes only compile in a module the
+ * Svelte plugin processes, and this needs `$state`: Svelte 5's `mount()` does
+ * **not** make the props object it is handed reactive, so assigning onto a
+ * plain object notifies nothing and the component never re-renders. That is
+ * exactly how `panel-host.ts`'s `update()` shipped as a silent no-op (#369),
+ * with the in-page assistant unable to leave its resting state.
+ *
+ * Kept as its own module so `panel-host.ts` stays a plain `.ts` file that any
+ * suite can import, and so the reason for the file extension has somewhere to
+ * be written down.
+ *
+ * `$state` has to initialise a variable declaration rather than be returned
+ * directly, which is why this reads the way it does.
+ */
+export function reactiveProps<Props extends Record<string, unknown>>(initial: Props): Props {
+  const live = $state(initial);
+  return live;
+}

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -22,6 +22,62 @@ export type LinkedInAssistState = {
   dailyPostCap: number;
 };
 
+// #314's in-page assist: POST /api/extension/suggest (SSE) and its accept
+// half, POST /api/extension/suggest/accept. Types mirror the server's own
+// zod schemas (web/src/routes/api/extension/suggest{,/accept}/+server.ts)
+// rather than importing them - the extension has no dependency on the web
+// workspace, matching every other api.ts shape on this file.
+
+export type SuggestionKind = 'post_comment' | 'post';
+
+/** The observed post context /suggest drafts from. `urn` is absent for a
+ * feed sighting - see linkedin-dom.ts's "Two frontends, one identifier". */
+export type SuggestPost = {
+  urn?: string;
+  authorHandle?: string;
+  authorName?: string;
+  text: string;
+  url?: string;
+};
+
+/** What /suggest/accept sends back: the same post context, minus `text` -
+ * the accepted body travels separately, as whatever the human edited it to. */
+export type SuggestPostRef = Omit<SuggestPost, 'text'>;
+
+export type SuggestUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+  costUsd?: number | null;
+};
+
+/** Every `refused` value POST /api/extension/suggest can answer with, ahead of the stream. */
+export type SuggestRefusalReason =
+  'assist_disabled' | 'kill_switch' | 'project_not_bound' | 'quota_exhausted';
+
+/** Every `refused` value POST /api/extension/suggest/accept can answer with: the same
+ * assist gate as /suggest, plus shared/src/assist-accept.ts's own refusals for a
+ * suggestion that cannot be materialised into a draft. */
+export type AcceptRefusalReason =
+  SuggestRefusalReason | 'no_account' | 'blocked' | 'uncontactable' | 'recently_contacted';
+
+/**
+ * One event out of /suggest, folded to one shape regardless of whether the
+ * server answered a plain `200 {refused}` ahead of the stream or an actual
+ * `text/event-stream` frame - a caller switches on `kind` either way.
+ */
+export type SuggestEvent =
+  | { kind: 'status'; phase: 'reading' | 'writing' }
+  | { kind: 'chunk'; text: string }
+  | { kind: 'done'; text: string; usage?: SuggestUsage; ms: number }
+  | { kind: 'failed'; message: string }
+  | { kind: 'refused'; reason: SuggestRefusalReason; detail: Record<string, unknown> };
+
+export type AcceptOutcome =
+  | { accepted: true; draftId: number; runId: number }
+  | { accepted: false; refused: AcceptRefusalReason; detail: Record<string, unknown> };
+
 /**
  * Resolve which pairing a single-backend op should target. Compose-time
  * content scripts pass the explicit `backendUrl` the dashboard tags onto the
@@ -106,6 +162,53 @@ export type DmSyncFanout = Array<DmSyncResult & { backendUrl: string }>;
 /** Turn a Promise.allSettled rejection reason into a plain error string. */
 function describeRejection(reason: unknown): string {
   return reason instanceof Error ? reason.message : String(reason);
+}
+
+/**
+ * Parses one `event: <kind>\ndata: <json>` frame (the text between two
+ * `\n\n`-separated chunks of /suggest's stream) into a SuggestEvent. Pure
+ * and exported so the chunk-boundary logic inside `api.suggest` below is
+ * testable without a real ReadableStream. Returns null for the leading
+ * `: <padding>` comment line the endpoint sends first, or for a frame this
+ * client does not recognise, rather than throwing - a forward-compatible
+ * unknown event kind should degrade silently, not crash a stream the human
+ * is watching.
+ */
+export function parseSuggestSseFrame(frame: string): SuggestEvent | null {
+  let eventKind = '';
+  let dataLine = '';
+  for (const line of frame.split('\n')) {
+    if (line.startsWith('event:')) eventKind = line.slice(6).trim();
+    else if (line.startsWith('data:')) dataLine += line.slice(5).trim();
+  }
+  if (!eventKind || !dataLine) return null;
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(dataLine) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  switch (eventKind) {
+    case 'status':
+      return data.phase === 'reading' || data.phase === 'writing'
+        ? { kind: 'status', phase: data.phase }
+        : null;
+    case 'chunk':
+      return typeof data.text === 'string' ? { kind: 'chunk', text: data.text } : null;
+    case 'done':
+      return typeof data.text === 'string'
+        ? {
+            kind: 'done',
+            text: data.text,
+            usage: data.usage as SuggestUsage | undefined,
+            ms: typeof data.ms === 'number' ? data.ms : 0,
+          }
+        : null;
+    case 'failed':
+      return typeof data.message === 'string' ? { kind: 'failed', message: data.message } : null;
+    default:
+      return null;
+  }
 }
 
 export const api = {
@@ -354,5 +457,126 @@ export const api = {
     const p = await pickPairing(backendUrl);
     if (!p) return { ok: false, status: 0, error: 'not configured' };
     return postJson(p, '/api/extension/observations', { platform: 'linkedin', projectId, items });
+  },
+
+  /**
+   * POST /api/extension/suggest (LI-15, #312): streams a suggested comment
+   * or post for `params.post` as `onEvent` receives it, so the panel can
+   * render a partial answer instead of a spinner for the five-to-ten-second
+   * (measured: 10-14s, #360) wait before the first token. The server can
+   * also answer a plain `200 {refused}` ahead of the stream (kill switch,
+   * quota, an unbound project) - both shapes fold into the same `onEvent`
+   * calls, so the caller has one place to switch on `event.kind`.
+   *
+   * The outer `ApiResult` reports only transport-level success: a network
+   * failure or non-2xx status short-circuits before `onEvent` ever fires.
+   * Every application-level outcome (a chunk, `done`, a mid-stream
+   * `failed`, or a pre-stream `refused`) arrives through `onEvent` instead,
+   * because the SSE contract has no single "final value" to return - by
+   * the time the promise below resolves, every event has already been
+   * delivered.
+   */
+  suggest: async (
+    params: {
+      projectId: number;
+      kind: SuggestionKind;
+      post: SuggestPost;
+      hint?: string;
+      platform?: string;
+    },
+    onEvent: (event: SuggestEvent) => void,
+    backendUrl?: string,
+  ): Promise<ApiResult<{ ok: true }>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    try {
+      const res = await fetch(`${p.backendUrl}/api/extension/suggest`, {
+        method: 'POST',
+        headers: authHeaders(p),
+        body: JSON.stringify({ platform: 'linkedin', ...params }),
+      });
+      if (!res.ok) return { ok: false, status: res.status, error: await res.text() };
+      const contentType = res.headers.get('content-type') ?? '';
+      if (contentType.includes('application/json')) {
+        // A pre-stream refusal: killSwitch/disabled/unbound/quota all answer
+        // a renderable 200 rather than an error status (see the route's own
+        // doc comment on why - a refusal is the system working, not a defect).
+        const data = (await res.json()) as { refused?: SuggestRefusalReason } & Record<
+          string,
+          unknown
+        >;
+        if (data.refused) {
+          const { refused, ...detail } = data;
+          onEvent({ kind: 'refused', reason: refused, detail });
+        } else {
+          onEvent({ kind: 'failed', message: 'unexpected response from the suggestion endpoint' });
+        }
+        return { ok: true, data: { ok: true } };
+      }
+      const reader = res.body?.getReader();
+      if (!reader) {
+        onEvent({ kind: 'failed', message: 'the suggestion endpoint returned no body' });
+        return { ok: true, data: { ok: true } };
+      }
+      const decoder = new TextDecoder();
+      let buffer = '';
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let sep = buffer.indexOf('\n\n');
+        while (sep >= 0) {
+          const event = parseSuggestSseFrame(buffer.slice(0, sep));
+          if (event) onEvent(event);
+          buffer = buffer.slice(sep + 2);
+          sep = buffer.indexOf('\n\n');
+        }
+      }
+      return { ok: true, data: { ok: true } };
+    } catch (e) {
+      return { ok: false, status: 0, error: (e as Error).message };
+    }
+  },
+
+  /**
+   * POST /api/extension/suggest/accept (LI-16, #313): materialises the
+   * human's edited suggestion into a real draft. Unlike `suggest` above,
+   * this is a plain request/response - there is one outcome to report, so it
+   * comes back as the resolved value rather than through a callback. The
+   * inner `AcceptOutcome.accepted` distinguishes a real refusal (quota, no
+   * bound account, blocklisted, ...) from the outer `ApiResult.ok`, which
+   * only reports whether the HTTP round trip itself succeeded.
+   */
+  acceptSuggestion: async (
+    params: {
+      projectId: number;
+      kind: SuggestionKind;
+      post: SuggestPostRef;
+      body: string;
+      usage?: SuggestUsage;
+      ms?: number;
+      platform?: string;
+    },
+    backendUrl?: string,
+  ): Promise<ApiResult<AcceptOutcome>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    const res = await postJson<Record<string, unknown>>(p, '/api/extension/suggest/accept', {
+      platform: 'linkedin',
+      ...params,
+    });
+    if (!res.ok) return res;
+    const data = res.data;
+    if (typeof data.refused === 'string') {
+      const { refused, ...detail } = data;
+      return {
+        ok: true,
+        data: { accepted: false, refused: refused as AcceptRefusalReason, detail },
+      };
+    }
+    return {
+      ok: true,
+      data: { accepted: true, draftId: data.draftId as number, runId: data.runId as number },
+    };
   },
 };

--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -133,6 +133,11 @@ export const en = {
     'Could not find the LinkedIn comment submit button for draft {draftId} within 15s; posting will not be tracked automatically.',
   'activity.linkedin-action.comment-confirm-timeout':
     'Could not confirm draft {draftId} was posted within 20s after clicking submit; check its status manually.',
+  'activity.linkedin-action.assist-composer-not-found':
+    'Could not find the LinkedIn comment composer; the suggestion assistant was not offered.',
+  'activity.linkedin-action.suggestion-refused': 'LinkedIn assist suggestion refused: {reason}',
+  'activity.linkedin-action.suggestion-inserted':
+    'Inserted an accepted suggestion into the LinkedIn composer for draft {draftId}.',
   'activity.linkedin-dom.selector-miss':
     'LinkedIn selector "{selector}" is not matching on the {pageKind} page ({misses} misses, {matches} matches) - this reading may be stale or missing.',
   'activity.linkedin-collector.batch-sent':
@@ -215,6 +220,38 @@ export const en = {
   // translated; everything else on this surface is.
   'panel.title': 'Pitchbox',
   'panel.close': 'Close',
+
+  // In-page LinkedIn comment assist (LI-17, #314): the panel that offers a
+  // suggested comment next to LinkedIn's own composer. Shared with #315's
+  // post-composer assist wherever a key names no particular kind.
+  'assist.comment.resting.hint': 'Get a Pitchbox-suggested reply for this post.',
+  'assist.comment.resting.cta': 'Suggest a comment',
+  'assist.status.reading': 'Reading the post…',
+  'assist.status.writing': 'Writing…',
+  'assist.comment.ready.label': 'Suggested comment (editable)',
+  'assist.action.accept': 'Insert',
+  'assist.action.retry': 'Try again',
+  'assist.comment.accepting': 'Saving…',
+  'assist.comment.inserted.title': 'Inserted',
+  'assist.comment.inserted.hint': "Press LinkedIn's own Comment button to send it.",
+  // Refused is five states in the brief plus three the accept path can also
+  // answer with (no_account, blocked, uncontactable, recently_contacted) and
+  // three this client detects itself (backend_unreachable, selector health,
+  // a mid-stream generation failure) - each real, each with its own remedy,
+  // never a generic failure.
+  'assist.refusal.assist_disabled': 'The Pitchbox assistant is turned off for this workspace.',
+  'assist.refusal.kill_switch': 'An admin stopped the assistant.',
+  'assist.refusal.project_not_bound': 'No project is bound to the assistant yet.',
+  'assist.refusal.quota_exhausted': "Today's comment quota is used up.",
+  'assist.refusal.no_account': 'No LinkedIn account is linked to this project yet.',
+  'assist.refusal.blocked': 'This person is on the blocklist.',
+  'assist.refusal.uncontactable': 'This person was marked uncontactable.',
+  'assist.refusal.recently_contacted': 'Already contacted recently, so this is being skipped.',
+  'assist.refusal.backend_unreachable': 'Could not reach the Pitchbox backend.',
+  'assist.refusal.selector_health_degraded':
+    "LinkedIn's layout changed and Pitchbox could not read this post reliably.",
+  'assist.refusal.generation_failed': 'Something went wrong while writing the suggestion.',
+  'assist.refusal.unknown': 'The assistant refused this request ({reason}).',
 
   // Language names are endonyms (each language's own name for itself) and
   // are intentionally identical across every locale dictionary; a language

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -138,6 +138,11 @@ export const it = {
     'Impossibile trovare il pulsante di invio del commento LinkedIn per il draft {draftId} entro 15s; la pubblicazione non verrà tracciata automaticamente.',
   'activity.linkedin-action.comment-confirm-timeout':
     'Impossibile confermare che il draft {draftId} sia stato pubblicato entro 20s dal clic su invio; verifica manualmente lo stato.',
+  'activity.linkedin-action.assist-composer-not-found':
+    "Impossibile trovare il box del commento LinkedIn; l'assistente non è stato offerto.",
+  'activity.linkedin-action.suggestion-refused': 'Suggerimento LinkedIn assist rifiutato: {reason}',
+  'activity.linkedin-action.suggestion-inserted':
+    'Suggerimento accettato inserito nel box del commento LinkedIn per il draft {draftId}.',
   'activity.linkedin-dom.selector-miss':
     'Il selettore LinkedIn "{selector}" non trova corrispondenze nella pagina {pageKind} ({misses} mancate, {matches} trovate) - questa lettura potrebbe essere obsoleta o mancante.',
   'activity.linkedin-collector.batch-sent':
@@ -220,6 +225,32 @@ export const it = {
   // translated; everything else on this surface is.
   'panel.title': 'Pitchbox',
   'panel.close': 'Chiudi',
+
+  // In-page LinkedIn comment assist (LI-17, #314), see the comment in dict-en.ts.
+  'assist.comment.resting.hint': 'Ottieni una risposta suggerita da Pitchbox per questo post.',
+  'assist.comment.resting.cta': 'Suggerisci un commento',
+  'assist.status.reading': 'Lettura del post in corso…',
+  'assist.status.writing': 'Scrittura in corso…',
+  'assist.comment.ready.label': 'Commento suggerito (modificabile)',
+  'assist.action.accept': 'Inserisci',
+  'assist.action.retry': 'Riprova',
+  'assist.comment.accepting': 'Salvataggio in corso…',
+  'assist.comment.inserted.title': 'Inserito',
+  'assist.comment.inserted.hint': 'Premi il pulsante Commenta di LinkedIn per inviarlo.',
+  'assist.refusal.assist_disabled': "L'assistente Pitchbox è disattivato per questo workspace.",
+  'assist.refusal.kill_switch': "Un amministratore ha fermato l'assistente.",
+  'assist.refusal.project_not_bound': "Nessun progetto è collegato all'assistente.",
+  'assist.refusal.quota_exhausted': 'La quota commenti di oggi è esaurita.',
+  'assist.refusal.no_account': 'Nessun account LinkedIn è collegato a questo progetto.',
+  'assist.refusal.blocked': 'Questa persona è nella blocklist.',
+  'assist.refusal.uncontactable': 'Questa persona è stata segnata come non contattabile.',
+  'assist.refusal.recently_contacted': 'Contattata di recente, quindi viene saltata.',
+  'assist.refusal.backend_unreachable': 'Impossibile raggiungere il backend di Pitchbox.',
+  'assist.refusal.selector_health_degraded':
+    'Il layout di LinkedIn è cambiato e Pitchbox non è riuscito a leggere questo post in modo affidabile.',
+  'assist.refusal.generation_failed':
+    'Qualcosa è andato storto durante la scrittura del suggerimento.',
+  'assist.refusal.unknown': "L'assistente ha rifiutato questa richiesta ({reason}).",
 
   // Language names are endonyms, see the comment in dict-en.ts.
   'settings.language.option.en': 'English',

--- a/extension/tests/content/linkedin-comment-assist.test.ts
+++ b/extension/tests/content/linkedin-comment-assist.test.ts
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * The in-page comment assist (#314), against the real Svelte panel rather than
+ * a stand-in: what the human sees is the whole feature, and the panel's states
+ * arrive through `panel-host`'s `update()`, which shipped as a silent no-op
+ * until #369. So every assertion here reads the rendered shadow tree.
+ *
+ * The API layer is the only thing faked. The DOM is the real captured
+ * post-detail fixture, the panel is the real component, and the composer the
+ * text lands in is the fixture's own.
+ */
+
+import POST_DETAIL_HTML from './fixtures/linkedin/post-detail.html?raw';
+
+const linkedinAssist = vi.fn();
+const suggest = vi.fn();
+const acceptSuggestion = vi.fn();
+const armed = vi.fn(async () => ({ ok: true as const, data: {} }));
+const sent = vi.fn(async () => ({ ok: true as const, data: {} }));
+
+vi.mock('../../src/lib/api.js', () => ({
+  api: {
+    linkedinAssist: () => linkedinAssist(),
+    suggest: (body: unknown, onEvent: unknown) => suggest(body, onEvent),
+    acceptSuggestion: (body: unknown) => acceptSuggestion(body),
+    armed: () => armed(),
+    sent: () => sent(),
+  },
+}));
+
+const logged: Array<Record<string, unknown>> = [];
+vi.mock('../../src/lib/log-from-content.js', () => ({
+  logFromContent: (entry: Record<string, unknown>) => {
+    logged.push(entry);
+  },
+}));
+
+const { wireCommentAssist, refusalMessage } =
+  await import('../../src/content/linkedin-comment-assist.js');
+
+const ASSIST_ON = {
+  ok: true as const,
+  data: {
+    assist: {
+      enabled: true,
+      collectorEnabled: true,
+      killSwitch: false,
+      projectId: 2,
+      dailyCommentCap: 8,
+      dailyPostCap: 1,
+    },
+  },
+};
+
+/**
+ * The shape the fixture's classic post-detail page has, reduced to what the
+ * selector module reads: an activity URN, an author link, the post text, and a
+ * contenteditable comment composer.
+ */
+function renderPost(): HTMLElement {
+  // The real captured page, not hand-written markup: the selectors this feature
+  // depends on are the reason the fixture exists (see its README).
+  document.body.innerHTML = POST_DETAIL_HTML;
+  const composer = document.querySelector<HTMLElement>('[contenteditable="true"][role="textbox"]');
+  if (!composer) throw new Error('fixture has no comment composer');
+  return composer;
+}
+
+function shadow(): ShadowRoot {
+  const host = [...document.querySelectorAll('*')].find((e) => e.shadowRoot);
+  if (!host?.shadowRoot) throw new Error('no panel mounted');
+  return host.shadowRoot;
+}
+
+function panelText(): string {
+  return (shadow().textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+/** Lets the panel's mount, the awaited API calls and Svelte's flush settle. */
+async function settle(times = 6): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+/** A suggestion delivered as the route delivers it: chunks, then done. */
+function streamingSuggest(text: string) {
+  return async (_body: unknown, onEvent: (event: Record<string, unknown>) => void) => {
+    onEvent({ kind: 'status', phase: 'writing' });
+    onEvent({ kind: 'chunk', text: text.slice(0, 20) });
+    onEvent({ kind: 'chunk', text: text.slice(20) });
+    onEvent({ kind: 'done', text, ms: 900 });
+    return { ok: true as const, data: { text } };
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  logged.length = 0;
+  vi.clearAllMocks();
+  Reflect.deleteProperty(globalThis as Record<string, unknown>, 'FontFace');
+  linkedinAssist.mockResolvedValue(ASSIST_ON);
+});
+
+describe('the panel never appears unprompted', () => {
+  it('mounts nothing until the human clicks into the composer', async () => {
+    const composer = renderPost();
+    wireCommentAssist(composer);
+    await settle();
+
+    expect([...document.querySelectorAll('*')].some((e) => e.shadowRoot)).toBe(false);
+    expect(linkedinAssist).not.toHaveBeenCalled();
+    expect(suggest).not.toHaveBeenCalled();
+  });
+
+  it('mounts on the click, and still asks for nothing until the human asks', async () => {
+    const composer = renderPost();
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(panelText()).toContain('Giulia Bianchi');
+    expect(suggest).not.toHaveBeenCalled();
+  });
+
+  it('mounts one panel per anchor however many times the human clicks', async () => {
+    const composer = renderPost();
+    wireCommentAssist(composer);
+    for (let i = 0; i < 3; i++) composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(1);
+  });
+});
+
+describe('the suggestion, as it arrives', () => {
+  it('renders partial text while the stream is still open, not just at the end', async () => {
+    const composer = renderPost();
+    const seen: string[] = [];
+    suggest.mockImplementation(
+      async (
+        _body: unknown,
+        onEvent: (e: Record<string, unknown>) => void,
+      ): Promise<{ ok: true; data: { text: string } }> => {
+        onEvent({ kind: 'status', phase: 'writing' });
+        onEvent({ kind: 'chunk', text: 'First half. ' });
+        await settle(2);
+        seen.push(panelText());
+        onEvent({ kind: 'chunk', text: 'Second half.' });
+        onEvent({ kind: 'done', text: 'First half. Second half.', ms: 900 });
+        return { ok: true, data: { text: 'First half. Second half.' } };
+      },
+    );
+
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    // Mid-stream the panel already showed the first chunk and nothing of the second.
+    expect(seen[0]).toContain('First half.');
+    expect(seen[0]).not.toContain('Second half.');
+    // And when it finishes, the human gets an editable copy of the whole thing.
+    expect(shadow().querySelector('textarea')?.value).toBe('First half. Second half.');
+  });
+});
+
+describe('accept, insert, and the button the human presses', () => {
+  it('writes the text into LinkedIn own composer and dispatches no click or submit', async () => {
+    const composer = renderPost();
+    const text = 'We saw the same thing, but the cause was PR size.';
+    suggest.mockImplementation(streamingSuggest(text));
+    acceptSuggestion.mockResolvedValue({
+      ok: true,
+      data: { accepted: true, draftId: 4242, runId: 7 },
+    });
+
+    const clicks: string[] = [];
+    const submits: string[] = [];
+    const realClick = HTMLElement.prototype.click;
+    HTMLElement.prototype.click = function patched(this: HTMLElement) {
+      // The panel's own controls are the human's clicks in this test; what the
+      // boundary forbids is a click on LinkedIn's send control.
+      if (!this.closest('pitchbox-panel-host') && !this.getRootNode().toString().includes('Shadow'))
+        clicks.push(this.tagName);
+      return realClick.call(this);
+    };
+    document.addEventListener('submit', (e) => submits.push(String(e.type)), true);
+
+    try {
+      wireCommentAssist(composer);
+      composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle();
+      shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+      await settle();
+      shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+      await settle();
+    } finally {
+      HTMLElement.prototype.click = realClick;
+    }
+
+    expect(composer.textContent).toContain('PR size');
+    expect(acceptSuggestion).toHaveBeenCalledTimes(1);
+    expect(clicks).toEqual([]);
+    expect(submits).toEqual([]);
+    expect(panelText()).toMatch(/Comment button|Inserted/i);
+  });
+});
+
+describe('every refusal says which one it is', () => {
+  it('maps each server reason to its own message key', () => {
+    const keys = [
+      'assist_disabled',
+      'kill_switch',
+      'project_not_bound',
+      'quota_exhausted',
+      'backend_unreachable',
+      'selector_health_degraded',
+    ].map((reason) => refusalMessage(reason).key);
+
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(refusalMessage('a_reason_nobody_has_written_yet').key).toBe('assist.refusal.unknown');
+  });
+
+  it('renders the kill switch distinctly from never having been turned on', async () => {
+    const composer = renderPost();
+    linkedinAssist.mockResolvedValue({
+      ok: true,
+      data: { assist: { ...ASSIST_ON.data.assist, enabled: false, killSwitch: true } },
+    });
+
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    const killed = panelText();
+    expect(suggest).not.toHaveBeenCalled();
+
+    document.body.innerHTML = '';
+    const second = renderPost();
+    linkedinAssist.mockResolvedValue({
+      ok: true,
+      data: { assist: { ...ASSIST_ON.data.assist, enabled: false, killSwitch: false } },
+    });
+    wireCommentAssist(second);
+    second.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    expect(panelText()).not.toBe(killed);
+  });
+});
+
+describe('single-page navigation', () => {
+  it('leaves no panel behind when LinkedIn replaces the post node', async () => {
+    const composer = renderPost();
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(1);
+
+    document.body.innerHTML = '';
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(0);
+  });
+});

--- a/extension/tests/content/panel-host-reactivity.test.ts
+++ b/extension/tests/content/panel-host-reactivity.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mountPanel } from '../../src/content/shared/panel-host.js';
+import PanelFrame from '../../src/content/panel-frame.svelte';
+
+/**
+ * `panel-host.ts`'s `update()` against a real compiled component, which is the
+ * only way to see whether a panel actually re-renders.
+ *
+ * This exists because it did not. `update()` shipped as
+ * `Object.assign(props, next)` on a plain object, with a comment asserting
+ * that Svelte 5 reads props reactively from the object it was handed. It does
+ * not: mutating a plain props object notifies nothing. The panel's whole state
+ * machine (streaming, ready, refused) is delivered through this call, so the
+ * in-page assistant could never leave its resting state (#369).
+ *
+ * `panel-host.test.ts` could not have caught it. Its stand-in component is a
+ * hand-written function that renders once, so re-rendering is unobservable
+ * there, and its only assertion about `update` is that it does not throw,
+ * which a no-op satisfies perfectly.
+ */
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+  // jsdom has no FontFace, and the host treats that as cosmetic.
+  Reflect.deleteProperty(globalThis as Record<string, unknown>, 'FontFace');
+});
+
+function anchorEl(): HTMLElement {
+  const el = document.createElement('article');
+  document.body.append(el);
+  return el;
+}
+
+function panelText(shadow: ShadowRoot): string {
+  return (shadow.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+describe('panel-host update, against a real component', () => {
+  it('re-renders the component when a prop changes', async () => {
+    const anchor = anchorEl();
+    const handle = mountPanel({
+      anchor,
+      component: PanelFrame,
+      props: { subject: 'Giulia Bianchi' },
+    });
+
+    expect(panelText(handle.shadow)).toContain('Giulia Bianchi');
+
+    handle.update({ subject: 'Marco Rossi' });
+    await Promise.resolve();
+
+    expect(panelText(handle.shadow)).toContain('Marco Rossi');
+    expect(panelText(handle.shadow)).not.toContain('Giulia Bianchi');
+  });
+
+  it('keeps re-rendering across several updates, so a state machine can drive it', async () => {
+    const anchor = anchorEl();
+    const handle = mountPanel({
+      anchor,
+      component: PanelFrame,
+      props: { subject: 'first' },
+    });
+
+    for (const subject of ['second', 'third', 'fourth']) {
+      handle.update({ subject });
+      await Promise.resolve();
+      expect(panelText(handle.shadow)).toContain(subject);
+    }
+  });
+
+  it('still refuses to update once destroyed, and leaves no host behind', async () => {
+    const anchor = anchorEl();
+    const handle = mountPanel({
+      anchor,
+      component: PanelFrame,
+      props: { subject: 'before' },
+    });
+    handle.destroy();
+
+    expect(() => handle.update({ subject: 'after' })).not.toThrow();
+    expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(0);
+  });
+});

--- a/extension/tests/lib/api-suggest.test.ts
+++ b/extension/tests/lib/api-suggest.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { parseSuggestSseFrame, type SuggestEvent } from '../../src/lib/api.js';
+
+// Minimal chrome.storage.local mock so api.ts's getSettings()/patchPairing() resolve,
+// matching api-fanout.test.ts's own setup.
+(globalThis as any).chrome = {
+  storage: {
+    local: {
+      _s: {} as Record<string, unknown>,
+      async get(keys: string[] | string) {
+        const k = Array.isArray(keys) ? keys : [keys];
+        const out: Record<string, unknown> = {};
+        for (const x of k) if (x in this._s) out[x] = this._s[x];
+        return out;
+      },
+      async set(patch: Record<string, unknown>) {
+        Object.assign(this._s, patch);
+      },
+      async remove(keys: string[] | string) {
+        const k = Array.isArray(keys) ? keys : [keys];
+        for (const x of k) delete this._s[x];
+      },
+    },
+  },
+};
+
+const BACKEND = 'https://backend.example';
+
+function seed() {
+  (globalThis as any).chrome.storage.local._s = {
+    pairings: [{ backendUrl: BACKEND, token: 't'.repeat(40) }],
+  };
+}
+
+beforeEach(() => {
+  (globalThis as any).chrome.storage.local._s = {};
+  vi.restoreAllMocks();
+});
+
+describe('parseSuggestSseFrame', () => {
+  it('parses a status frame', () => {
+    expect(parseSuggestSseFrame('event: status\ndata: {"phase":"reading"}')).toEqual({
+      kind: 'status',
+      phase: 'reading',
+    });
+  });
+
+  it('parses a chunk frame', () => {
+    expect(parseSuggestSseFrame('event: chunk\ndata: {"text":"Great post"}')).toEqual({
+      kind: 'chunk',
+      text: 'Great post',
+    });
+  });
+
+  it('parses a done frame with usage', () => {
+    expect(
+      parseSuggestSseFrame(
+        'event: done\ndata: {"text":"Great post!","usage":{"outputTokens":12},"ms":2200}',
+      ),
+    ).toEqual({
+      kind: 'done',
+      text: 'Great post!',
+      usage: { outputTokens: 12 },
+      ms: 2200,
+    });
+  });
+
+  it('parses a failed frame', () => {
+    expect(parseSuggestSseFrame('event: failed\ndata: {"message":"agent crashed"}')).toEqual({
+      kind: 'failed',
+      message: 'agent crashed',
+    });
+  });
+
+  it('returns null for the leading padding comment line', () => {
+    expect(parseSuggestSseFrame(`: ${' '.repeat(2048)}`)).toBeNull();
+  });
+
+  it('returns null for an unrecognised event kind, rather than throwing', () => {
+    expect(parseSuggestSseFrame('event: mystery\ndata: {"whatever":1}')).toBeNull();
+  });
+
+  it('returns null for malformed JSON, rather than throwing', () => {
+    expect(parseSuggestSseFrame('event: chunk\ndata: {not json')).toBeNull();
+  });
+});
+
+function sseStream(frames: string[], chunkBoundaryInsideFrame = false): ReadableStream {
+  const encoder = new TextEncoder();
+  const full = frames.map((f) => `${f}\n\n`).join('');
+  return new ReadableStream({
+    start(controller) {
+      if (chunkBoundaryInsideFrame) {
+        // Split arbitrarily in the middle of the encoded bytes, proving the
+        // frame parser reassembles a frame split across two reader.read() calls.
+        const bytes = encoder.encode(full);
+        const mid = Math.floor(bytes.length / 2);
+        controller.enqueue(bytes.slice(0, mid));
+        controller.enqueue(bytes.slice(mid));
+      } else {
+        controller.enqueue(encoder.encode(full));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe('api.suggest', () => {
+  it('streams status, chunk, and done events in order as they arrive', async () => {
+    seed();
+    const { api } = await import('../../src/lib/api.js');
+    const frames = [
+      'event: status\ndata: {"phase":"reading"}',
+      'event: status\ndata: {"phase":"writing"}',
+      'event: chunk\ndata: {"text":"Great "}',
+      'event: chunk\ndata: {"text":"post!"}',
+      'event: done\ndata: {"text":"Great post!","ms":2200}',
+    ];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(sseStream(frames), { headers: { 'content-type': 'text/event-stream' } }),
+      ),
+    );
+
+    const events: SuggestEvent[] = [];
+    const res = await api.suggest(
+      { projectId: 1, kind: 'post_comment', post: { text: 'a post' } },
+      (e) => events.push(e),
+    );
+
+    expect(res.ok).toBe(true);
+    expect(events).toEqual([
+      { kind: 'status', phase: 'reading' },
+      { kind: 'status', phase: 'writing' },
+      { kind: 'chunk', text: 'Great ' },
+      { kind: 'chunk', text: 'post!' },
+      { kind: 'done', text: 'Great post!', usage: undefined, ms: 2200 },
+    ]);
+  });
+
+  it('reassembles a frame split across two reader chunks', async () => {
+    seed();
+    const { api } = await import('../../src/lib/api.js');
+    const frames = ['event: chunk\ndata: {"text":"a fairly long chunk of streamed text here"}'];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(sseStream(frames, true), {
+            headers: { 'content-type': 'text/event-stream' },
+          }),
+      ),
+    );
+
+    const events: SuggestEvent[] = [];
+    await api.suggest({ projectId: 1, kind: 'post_comment', post: { text: 'a post' } }, (e) =>
+      events.push(e),
+    );
+
+    expect(events).toEqual([{ kind: 'chunk', text: 'a fairly long chunk of streamed text here' }]);
+  });
+
+  it('maps a pre-stream JSON refusal to a refused event, not an error result', async () => {
+    seed();
+    const { api } = await import('../../src/lib/api.js');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              refused: 'quota_exhausted',
+              kind: 'comment',
+              window: 'day',
+              limit: 8,
+              used: 8,
+            }),
+            { headers: { 'content-type': 'application/json' }, status: 200 },
+          ),
+      ),
+    );
+
+    const events: SuggestEvent[] = [];
+    const res = await api.suggest(
+      { projectId: 1, kind: 'post_comment', post: { text: 'a post' } },
+      (e) => events.push(e),
+    );
+
+    expect(res.ok).toBe(true);
+    expect(events).toEqual([
+      {
+        kind: 'refused',
+        reason: 'quota_exhausted',
+        detail: { kind: 'comment', window: 'day', limit: 8, used: 8 },
+      },
+    ]);
+  });
+
+  it('reports a non-2xx status as a transport failure, without calling onEvent', async () => {
+    seed();
+    const { api } = await import('../../src/lib/api.js');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('too many requests', { status: 429 })),
+    );
+
+    const onEvent = vi.fn();
+    const res = await api.suggest(
+      { projectId: 1, kind: 'post_comment', post: { text: 'a post' } },
+      onEvent,
+    );
+
+    expect(res.ok).toBe(false);
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('api.acceptSuggestion', () => {
+  it('returns the created draft and run id on success', async () => {
+    seed();
+    const { api } = await import('../../src/lib/api.js');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ ok: true, draftId: 42, runId: 7 }), { status: 200 }),
+      ),
+    );
+
+    const res = await api.acceptSuggestion({
+      projectId: 1,
+      kind: 'post_comment',
+      post: { authorHandle: 'jane' },
+      body: 'edited text',
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data).toEqual({ accepted: true, draftId: 42, runId: 7 });
+  });
+
+  it('surfaces a refusal distinctly from a transport error', async () => {
+    seed();
+    const { api } = await import('../../src/lib/api.js');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ refused: 'no_account' }), { status: 200 })),
+    );
+
+    const res = await api.acceptSuggestion({
+      projectId: 1,
+      kind: 'post_comment',
+      post: {},
+      body: 'edited text',
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data).toEqual({ accepted: false, refused: 'no_account', detail: {} });
+  });
+});

--- a/extension/vite-plugins/panel-content-scripts.ts
+++ b/extension/vite-plugins/panel-content-scripts.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { build, type Plugin, type ResolvedConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+/**
+ * Builds the content scripts that render a Svelte panel, because crxjs cannot.
+ *
+ * `@crxjs/vite-plugin` builds every `contentScripts.standaloneFiles` entry
+ * through its own nested Vite build (`createIifeConfig`, `dist/index.mjs:1397`),
+ * and that build hardcodes `plugins: []`: it inherits `root`, `mode`,
+ * `resolve`, `define` and `esbuild` from the outer config and nothing else. So
+ * `svelte()` never runs on that path, and a script that imports a `.svelte`
+ * component fails with a JSX parse error (#369).
+ *
+ * That path is not optional for us. A dynamically registered MV3 content
+ * script cannot be an ES module, so it has to be a standalone IIFE, and
+ * registering dynamically is what keeps the LinkedIn host permission optional
+ * (#317). So the panel-bearing scripts are built here instead, with the same
+ * IIFE shape, the same output path, and the real Svelte plugin behind them.
+ *
+ * Two consequences worth knowing before touching this:
+ *
+ *  - The script's path is a plain string at every call site rather than a
+ *    `?script` import, because `?script` is crxjs's own mechanism and resolves
+ *    to a file crxjs emitted. `PANEL_CONTENT_SCRIPTS` below is the single list
+ *    both this build and `chrome.scripting.registerContentScripts` read.
+ *  - `panel.css` has to stay plain CSS. Vite's core CSS pipeline resolves its
+ *    `@import` and its `?inline` query here, but `@tailwindcss/vite` is
+ *    deliberately not in this build: a Tailwind directive in that sheet would
+ *    silently produce nothing. `assertNoTailwindDirectives` fails the build
+ *    rather than letting that ship.
+ */
+
+// The list lives in a runtime-safe module because the background worker reads
+// it too, and this file imports vite and node:fs.
+export { PANEL_CONTENT_SCRIPTS, panelScriptOutput } from '../src/content/panel-scripts.js';
+import { PANEL_CONTENT_SCRIPTS, panelScriptOutput } from '../src/content/panel-scripts.js';
+
+const TAILWIND_DIRECTIVE = /^\s*@(?:tailwind|theme|source|custom-variant|apply|plugin|utility)\b/m;
+const TAILWIND_IMPORT = /^\s*@import\s+['"](?:tailwindcss|tw-animate-css|.*\/tailwind\.css)['"]/m;
+
+/**
+ * The regression guard #369 asks for. A Tailwind directive in a stylesheet this
+ * build touches is not a style mistake, it is a rule that will not exist at
+ * runtime, and the symptom is an unstyled panel on somebody else's page rather
+ * than an error.
+ */
+export function assertNoTailwindDirectives(cssPath: string): void {
+  const css = readFileSync(cssPath, 'utf8');
+  const directive = TAILWIND_DIRECTIVE.exec(css) ?? TAILWIND_IMPORT.exec(css);
+  if (directive) {
+    throw new Error(
+      `${path.relative(process.cwd(), cssPath)} carries a Tailwind directive (${directive[0].trim()}), ` +
+        'but the panel content-script build runs no Tailwind plugin (#369), so it would resolve to nothing. ' +
+        'Write plain CSS here, or move the rule to a surface Tailwind actually builds.',
+    );
+  }
+}
+
+function safeVarName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_$]/g, '_');
+}
+
+/**
+ * Runs after the main build, so crxjs has already written the manifest and its
+ * own chunks and we only add files. `enforce: 'post'` plus `closeBundle` is the
+ * one ordering that holds: crxjs emits during `generateBundle`/`writeBundle`,
+ * and an IIFE built here during those hooks would be overwritten.
+ */
+export function panelContentScripts(): Plugin {
+  let config: ResolvedConfig;
+  return {
+    name: 'pitchbox:panel-content-scripts',
+    apply: 'build',
+    enforce: 'post',
+    configResolved(resolved) {
+      config = resolved;
+    },
+    async closeBundle() {
+      assertNoTailwindDirectives(path.resolve(config.root, 'src/content/panel.css'));
+      for (const entry of PANEL_CONTENT_SCRIPTS) {
+        const outputFile = panelScriptOutput(entry);
+        await build({
+          configFile: false,
+          root: config.root,
+          mode: config.mode,
+          logLevel: 'warn',
+          // The only plugin the plugin-less path was missing. Tailwind stays
+          // out on purpose: see the doc comment.
+          plugins: [svelte()],
+          resolve: config.resolve,
+          define: config.define,
+          build: {
+            outDir: config.build.outDir,
+            emptyOutDir: false,
+            minify: config.build.minify,
+            sourcemap: config.build.sourcemap,
+            target: config.build.target,
+            lib: {
+              entry: path.resolve(config.root, entry),
+              formats: ['iife'],
+              name: safeVarName(path.basename(outputFile, '.js')),
+              fileName: () => outputFile,
+            },
+            rollupOptions: {
+              output: { entryFileNames: outputFile, inlineDynamicImports: true },
+            },
+          },
+        });
+      }
+    },
+  };
+}

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -4,6 +4,7 @@ import { crx } from '@crxjs/vite-plugin';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import tailwindcss from '@tailwindcss/vite';
 import manifest from './manifest.config';
+import { panelContentScripts } from './build/panel-content-scripts';
 import pkg from './package.json' with { type: 'json' };
 
 export default defineConfig({
@@ -25,12 +26,17 @@ export default defineConfig({
       contentScripts: {
         standaloneFiles: [
           'src/content/linkedin-comment.ts',
-          'src/content/linkedin-comment-assist.ts',
           'src/content/linkedin-observe.ts',
           'src/content/linkedin-reply-ingest.ts',
         ],
       },
     }),
+    // The panel-bearing scripts cannot go in the list above: crxjs builds
+    // those with `plugins: []`, so a Svelte component in one fails to parse
+    // (#369). They are built with the same IIFE shape by this plugin instead,
+    // which does run svelte(). PANEL_CONTENT_SCRIPTS is the single list it and
+    // background.ts's registration both read.
+    panelContentScripts(),
   ],
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version),

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       contentScripts: {
         standaloneFiles: [
           'src/content/linkedin-comment.ts',
+          'src/content/linkedin-comment-assist.ts',
           'src/content/linkedin-observe.ts',
           'src/content/linkedin-reply-ingest.ts',
         ],

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -4,7 +4,7 @@ import { crx } from '@crxjs/vite-plugin';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import tailwindcss from '@tailwindcss/vite';
 import manifest from './manifest.config';
-import { panelContentScripts } from './build/panel-content-scripts';
+import { panelContentScripts } from './vite-plugins/panel-content-scripts';
 import pkg from './package.json' with { type: 'json' };
 
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "typescript": "^6.0.3",
     "vite": "^8.2.2",
     "vitepress": "^1.6.4",
-    "vitest": "4.1.9"
+    "vitest": "4.1.9",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "svelte": "^5.57.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      shadcn-svelte:
+        specifier: ^1.5.1
+        version: 1.5.1(svelte@5.57.0(@typescript-eslint/types@8.62.1))
       svelte:
         specifier: ^5.57.0
         version: 5.57.0(@typescript-eslint/types@8.62.1)
@@ -141,6 +144,9 @@ importers:
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
     devDependencies:
       '@crxjs/vite-plugin':
         specifier: ^2.7.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.9.1(jiti@2.7.0))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.1.2
+        version: 7.1.2(svelte@5.57.0(@typescript-eslint/types@8.62.1))(vite@8.2.2(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13))
       '@types/node':
         specifier: ^26.1.0
         version: 26.1.0
@@ -40,6 +43,9 @@ importers:
       sharp:
         specifier: 0.35.4
         version: 0.35.4(@types/node@26.1.0)
+      svelte:
+        specifier: ^5.57.0
+        version: 5.57.0(@typescript-eslint/types@8.62.1)
       tsx:
         specifier: ^4.23.13
         version: 4.23.13

--- a/tests/compliance/linkedin-boundary.ts
+++ b/tests/compliance/linkedin-boundary.ts
@@ -223,7 +223,11 @@ export async function linkedinContentScriptFiles(
     if (!isLinkedIn) continue;
     for (const js of entry.js ?? []) files.add(path.resolve(dir, js));
   }
-  for (const file of dynamicallyRegisteredLinkedinScripts(sourceRoot ?? path.join(dir, 'src'))) {
+  const src = sourceRoot ?? path.join(dir, 'src');
+  for (const file of dynamicallyRegisteredLinkedinScripts(src)) {
+    files.add(file);
+  }
+  for (const file of declaredPanelScripts(path.dirname(src))) {
     files.add(file);
   }
   return [...files];
@@ -303,6 +307,43 @@ function resolveScriptReference(
     if (namedHere) resolved = fromSpecifier(node.moduleSpecifier.text);
   });
   return resolved;
+}
+
+/**
+ * The panel-bearing LinkedIn content scripts, read from the registry module
+ * that declares them (`extension/src/content/panel-scripts.ts`).
+ *
+ * These are registered by a plain path string rather than through a `?script`
+ * import, because crxjs cannot build them: its nested IIFE build runs
+ * `plugins: []`, so a Svelte panel in one fails to parse (#369). The registry
+ * module is what the build plugin and the background worker both read, so it
+ * is also the honest place for this checker to read: a script that reaches
+ * linkedin.com must be in the scan set no matter which mechanism registers it.
+ */
+function declaredPanelScripts(extensionRoot: string): string[] {
+  const registry = path.join(extensionRoot, 'src/content/panel-scripts.ts');
+  if (!fs.existsSync(registry)) return [];
+  const sf = parseSource(registry);
+  const out: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === 'PANEL_CONTENT_SCRIPTS' &&
+      node.initializer
+    ) {
+      const arr = unwrap(node.initializer);
+      const elements = ts.isArrayLiteralExpression(arr) ? arr.elements : [];
+      for (const el of elements) {
+        if (!ts.isStringLiteral(el)) continue;
+        const resolved = path.join(extensionRoot, el.text);
+        if (fs.existsSync(resolved)) out.push(resolved);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return out;
 }
 
 export async function checkContentScriptStorageReads(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { configDefaults, defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 // Point tests at the dedicated test DB. Allow a per-run override ONLY when it names
 // an isolated `pitchbox_test[_suffix]` database (used by parallel worktree agents so
@@ -39,6 +40,13 @@ export default defineConfig({
         return null;
       },
     },
+    // Compile real Svelte components in tests. Without this a test can only
+    // exercise the panel host against a hand-written stand-in, which is how
+    // `panel-host.ts`'s `update()` shipped as a silent no-op: the only
+    // assertion it had was `not.toThrow()`, and a hand-written probe cannot
+    // show whether a real component re-rendered (#369). The extension's own
+    // config has had this since #339; CI runs this one, so it needs it too.
+    svelte(),
   ],
   // SvelteKit's `$lib` alias so tests can import server route handlers
   // (`web/src/routes/**/+server.ts`) that resolve `$lib/server/...` at module load.


### PR DESCRIPTION
Closes #314.
Closes #369.

The human experience this adds: reading a LinkedIn post, clicking into its comment box, getting a suggested reply written in the project's voice, editing it, and pressing LinkedIn's own Comment button. The draft lands in the ledger through the same path an Inbox-opened draft takes.

Two defects stood between the logic and a working feature, and neither was visible from a green test suite. That is the interesting half of this PR.

## The build path did not exist

crxjs builds every dynamically registered content script through a nested Vite build that hardcodes `plugins: []` (`@crxjs/vite-plugin@2.7.1`, `dist/index.mjs:1397`, inheriting only `root`, `mode`, `resolve`, `define` and `esbuild`). So `svelte()` never ran on that path and the panel failed to parse. That path is not optional: a dynamically registered MV3 script cannot be an ES module, and registering dynamically is exactly what keeps the LinkedIn host permission optional (#317).

`extension/build/panel-content-scripts.ts` now builds those entries with the same IIFE shape, the same output path, and the real Svelte plugin behind them. `extension/src/content/panel-scripts.ts` is the single registry the build plugin and the background worker both read, so the emitted path and the registered path cannot drift.

Tailwind is deliberately not in that build, which is why `panel.css` is plain CSS now. Nothing was lost: neither `panel-frame.svelte` nor the assist panel uses a single utility class or a `dark:` variant, so the `@theme inline` block existed only to define three radius steps, which are declared directly. `assertNoTailwindDirectives` fails the build if a directive comes back, because the symptom would be an unstyled panel on somebody else's page rather than an error.

## The panel could not re-render

`panel-host.ts`'s `update()` did `Object.assign(props, next)` on a plain object, with a comment asserting that Svelte 5 reads props reactively from the object it was handed. It does not. Every state the panel has (streaming, ready, refused) arrives through that call, so the assistant was structurally unable to leave its resting state.

#311's tests could not have caught it. Their stand-in component is a hand-written function that renders once, so re-rendering is unobservable there, and the only assertion about `update` was `not.toThrow()`, which a no-op passes perfectly. So the root vitest config now compiles Svelte (the extension's own config has since #339), and three new tests mount a real component and read the rendered shadow tree. Props are a `$state` object in a `.svelte.ts` module, with the file extension explained in the file.

## Verified by rendering, because compiling was already true

A harness mounts the built IIFE over the captured `post-detail.html` fixture with the minimum `chrome` surface the script touches and a fetch stub that serves the suggestion as a real SSE stream. A genuine CDP mouse click opens the panel, since it deliberately mounts only on the human's own click.

| state | what rendered |
|---|---|
| resting | `Pitchbox / Giulia Bianchi`, the hint, one `Suggest a comment` control |
| streaming | `Writing...` plus the partial text, growing as chunks arrive |
| ready | an editable textarea holding the whole suggestion, plus `Insert` |
| inserted | `Press LinkedIn's own Comment button to send it.` |

And the boundary assertion, instrumented in the page rather than read off the source: after `Insert`, LinkedIn's own composer holds the text, `__clicks` is `[]` and `__submits` is `[]`. Zero synthetic clicks, zero submit events. Screenshots in `/tmp/pb-li/harness/panel-light.webp` and `panel-dark.webp`; they are identical on purpose, since D10 says the panel is always dark so it reads as a Pitchbox surface rather than part of LinkedIn.

- Root suite: **1527 passed** (219 files), which is the check that adding the Svelte plugin to the root config broke nothing.
- `pnpm run test:linkedin-compliance`: **15/15**, after teaching rule 2 the new registration mechanism. Proven it still bites: a planted `localStorage.getItem('li_at')` in the panel script fails the check by name, and removing it goes green.
- `pnpm -F @pitchbox/extension check`: 0 errors, 0 warnings (753 files).
- `pnpm run build:extension`: `dist/src/content/` lists all four LinkedIn scripts; the panel one is an IIFE with no top-level `import`/`export`, carries the resolved `--radius-sm:calc(...)` custom properties and the Svelte runtime, and contains no Tailwind directive.
- Eight new assist tests, each proven to bite by breaking production code: mounting on load instead of on click, dropping the mid-stream update, firing a synthetic click after insert, and reverting the `panel-host` fix. Each broke exactly the expected test and nothing else.

## Not verified

No signed-in LinkedIn session exists here, so the real end-to-end (request, stream, edit, accept, insert, press Comment, draft `sent` with `contact_history` written and quota moved) is a human's to run: load `extension/dist/` unpacked in `chrome://extensions`, grant the LinkedIn permission from the side panel, turn the assistant on and bind a project, open a real post permalink, and watch the Inbox and the quota badge afterwards.

The harness fakes the API layer, so the panel's behaviour against the live routes is covered by reading them plus the server-side tests in #359, not by this render. And the fixture is the classic post-detail frontend, which is the only one that carries an activity URN (#365), so the feed remains out of scope for this surface.
