### PR TITLE
feat(extension): in-page LinkedIn post composer assist

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -2,6 +2,7 @@ import { runInboxSync } from './background/inbox-sync.js';
 import { runChatSync } from './background/chat-sync.js';
 import { registerLinkedInReplyIngestScript } from './background/linkedin-reply-ingest-registration.js';
 import { registerLinkedInCommentAssistScript } from './background/linkedin-comment-assist-registration.js';
+import { registerLinkedInPostAssistScript } from './background/linkedin-post-assist-registration.js';
 import {
   getSettings,
   patchPairing,
@@ -315,6 +316,8 @@ export async function syncLinkedInContentScripts(): Promise<void> {
     registerLinkedInReplyIngestScript(),
     // #314's in-page comment assist, same pattern for the same reason.
     registerLinkedInCommentAssistScript(),
+    // #315's in-page post composer assist, same pattern for the same reason.
+    registerLinkedInPostAssistScript(),
   ]);
 }
 

--- a/extension/src/background/linkedin-post-assist-registration.ts
+++ b/extension/src/background/linkedin-post-assist-registration.ts
@@ -1,0 +1,51 @@
+import { hasLinkedInPermission } from '../lib/permissions.js';
+import { PANEL_CONTENT_SCRIPTS, panelScriptOutput } from '../content/panel-scripts.js';
+
+// Not a `?script` import, matching linkedin-comment-assist-registration.ts's
+// own reasoning: `?script` is crxjs's own mechanism and resolves to a file
+// crxjs emitted, and crxjs cannot build this one - its nested IIFE build
+// runs `plugins: []`, so the Svelte panel this script renders fails to parse
+// (#369). The build plugin in `extension/build/panel-content-scripts.ts`
+// emits it instead, at exactly the path below, and both sides read the same
+// list so they cannot drift.
+const postAssistScriptPath = panelScriptOutput(PANEL_CONTENT_SCRIPTS[1]);
+
+// #315's own dynamic-registration helper, mirroring
+// linkedin-comment-assist-registration.ts (#314) and
+// linkedin-reply-ingest-registration.ts (#307). Kept in its own module for
+// the same reason those are: a content-script registration is small, one
+// file per script, so a future LinkedIn content script has exactly one place
+// to add its own.
+//
+// Matches the feed rather than the post-detail-only set the comment assist
+// registers against: LinkedIn's "Start a post" composer is reachable from
+// the top of the main feed, not from a single post's own page - see
+// linkedin-post-assist.ts's own doc comment.
+const LINKEDIN_POST_ASSIST_SCRIPT_ID = 'pitchbox-linkedin-post-assist';
+
+export async function registerLinkedInPostAssistScript(): Promise<void> {
+  try {
+    const [granted, existing] = await Promise.all([
+      hasLinkedInPermission(),
+      chrome.scripting.getRegisteredContentScripts({
+        ids: [LINKEDIN_POST_ASSIST_SCRIPT_ID],
+      }),
+    ]);
+    if (granted && existing.length === 0) {
+      await chrome.scripting.registerContentScripts([
+        {
+          id: LINKEDIN_POST_ASSIST_SCRIPT_ID,
+          js: [postAssistScriptPath],
+          matches: ['https://www.linkedin.com/feed*'],
+          runAt: 'document_idle',
+        },
+      ]);
+    } else if (!granted && existing.length > 0) {
+      await chrome.scripting.unregisterContentScripts({
+        ids: [LINKEDIN_POST_ASSIST_SCRIPT_ID],
+      });
+    }
+  } catch (err) {
+    console.warn('[pitchbox] registerLinkedInPostAssistScript failed:', err);
+  }
+}

--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -84,9 +84,15 @@ export function readAssistPost(root: ParentNode = document): AssistPost | null {
 
 /** Every refusal this panel can render, honestly and distinctly (the brief's
  * five states, plus the accept path's own three, plus three this client
- * detects itself). */
+ * detects itself). `no_recent_activity` is excluded: it only ever answers a
+ * `kind: 'post'` request (#315's post composer assist grounds itself in the
+ * observation buffer; this comment assist always supplies its own post
+ * text, so it can never hit that refusal). */
 export type AssistRefusal =
-  AcceptRefusalReason | 'backend_unreachable' | 'selector_health_degraded' | 'generation_failed';
+  | Exclude<AcceptRefusalReason, 'no_recent_activity'>
+  | 'backend_unreachable'
+  | 'selector_health_degraded'
+  | 'generation_failed';
 
 const KNOWN_REFUSALS: Record<AssistRefusal, true> = {
   assist_disabled: true,

--- a/extension/src/content/linkedin-post-assist-panel.svelte
+++ b/extension/src/content/linkedin-post-assist-panel.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  /**
+   * The post-composer assist panel's own content, rendered inside
+   * `panel-frame.svelte` (#311's chrome) by `linkedin-post-assist.ts`, which
+   * owns every state transition and API call - this component only renders
+   * `state` and calls back out through its props. Mirrors
+   * `linkedin-comment-assist-panel.svelte` (#314) exactly in shape; only the
+   * strings differ, since this offers a post rather than a comment and has
+   * no post author to show as a `subject` (the suggestion is the operator's
+   * own voice, not a reply to anyone).
+   */
+  import PanelFrame from './panel-frame.svelte';
+  import { t } from '../lib/i18n/index.js';
+  import type { PostAssistPanelProps } from './linkedin-post-assist.js';
+
+  let { state, onRequest, onEditChange, onAccept, onDismiss }: PostAssistPanelProps = $props();
+
+  function onTextareaInput(event: Event): void {
+    onEditChange((event.currentTarget as HTMLTextAreaElement).value);
+  }
+</script>
+
+<PanelFrame onclose={onDismiss}>
+  {#snippet children()}
+    <div class="assist">
+      {#if state.phase === 'resting'}
+        <p class="assist-hint">{$t('assist.post.resting.hint')}</p>
+        <div class="assist-row">
+          <button type="button" class="assist-button" onclick={onRequest}>
+            {$t('assist.post.resting.cta')}
+          </button>
+        </div>
+      {:else if state.phase === 'streaming'}
+        <p class="assist-status" aria-live="polite">
+          {$t(state.status === 'reading' ? 'assist.status.reading' : 'assist.status.writing')}
+        </p>
+        {#if state.text}
+          <p class="assist-preview">{state.text}</p>
+        {:else}
+          <div class="assist-skeleton" aria-hidden="true">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        {/if}
+      {:else if state.phase === 'ready' || state.phase === 'edited'}
+        <textarea
+          class="assist-textarea"
+          aria-label={$t('assist.post.ready.label')}
+          value={state.text}
+          oninput={onTextareaInput}
+        ></textarea>
+        <div class="assist-row">
+          <button type="button" class="assist-button" onclick={onAccept}>
+            {$t('assist.action.accept')}
+          </button>
+        </div>
+      {:else if state.phase === 'accepting'}
+        <p class="assist-status" aria-live="polite">{$t('assist.post.accepting')}</p>
+      {:else if state.phase === 'inserted'}
+        <p class="assist-status">{$t('assist.post.inserted.title')}</p>
+        <p class="assist-hint">{$t('assist.post.inserted.hint')}</p>
+      {:else if state.phase === 'refused'}
+        <p class="assist-refusal" role="alert">{$t(state.messageKey, state.messageParams)}</p>
+        <div class="assist-row">
+          <button type="button" class="assist-button assist-button--ghost" onclick={onRequest}>
+            {$t('assist.action.retry')}
+          </button>
+        </div>
+      {/if}
+    </div>
+  {/snippet}
+</PanelFrame>

--- a/extension/src/content/linkedin-post-assist.ts
+++ b/extension/src/content/linkedin-post-assist.ts
@@ -1,0 +1,431 @@
+import { api, type AcceptRefusalReason, type SuggestEvent, type SuggestUsage } from '../lib/api.js';
+import { logFromContent } from '../lib/log-from-content.js';
+import { mountPanel, panelFor } from './shared/panel-host.js';
+import { insertComposerText, hasInlineCommentError } from './linkedin-comment.js';
+import {
+  findPostComposer,
+  findPostComposerModal,
+  findPostSubmitButton,
+  resetSelectorHealth,
+  selectorHealthActivityEvents,
+} from './shared/linkedin-dom.js';
+import PostAssistPanel from './linkedin-post-assist-panel.svelte';
+
+/**
+ * In-page LinkedIn post composer assist (LI-18, #315): the other half of
+ * LI-17's comment assist (#314, `linkedin-comment-assist.ts`), wired to
+ * LI-14's panel host and LI-15's suggestion endpoint (`kind: 'post'`), but
+ * on LinkedIn's own "Start a post" composer rather than a comment box.
+ *
+ * ## Registered on the feed, not on a single post
+ *
+ * The comment assist registers against `/feed/update/*` - the one page that
+ * both renders a comment composer and exposes a stable post identifier (see
+ * `linkedin-dom.ts`'s "Two frontends, one identifier"). The post composer has
+ * neither concern: it opens as a modal reachable from the top of the main
+ * feed, not from any one post's own page, so this registers against
+ * `/feed*` instead (`linkedin-post-assist-registration.ts`).
+ *
+ * ## Grounded through the server, not by scraping the feed itself
+ *
+ * A comment suggestion is grounded in the one post the human is reading -
+ * this script reads it and sends it along. A post suggestion has nothing
+ * equivalent: the composer is a blank box, not a post. Rather than have this
+ * script scrape a pile of feed posts and hand them to the suggestion
+ * endpoint (which would make this script's own DOM reach much larger, and
+ * duplicate what the passive observation collector, `linkedin-observe.ts`,
+ * already does more carefully with `IntersectionObserver` gating and
+ * dedup), the suggestion endpoint grounds `kind: 'post'` itself, server-side,
+ * in the most recent thing the observation buffer has actually collected for
+ * this project (`shared/src/observed-targets.ts`'s `loadRecentObservedTarget`,
+ * wired into `POST /api/extension/suggest`). This script sends only the
+ * current page URL for context - never post text it read itself.
+ *
+ * ## Never unprompted, twice over
+ *
+ * Same discipline as the comment assist. `wirePostAssist` only mounts once
+ * the human has already clicked into LinkedIn's own post editor (the modal
+ * has to be open for that to be possible at all), and the mounted panel
+ * starts in `resting` - present, nothing requested. Only the panel's own
+ * "Suggest a post" control fires the network request. Neither click is ever
+ * synthesised.
+ *
+ * ## No URN after publish - completion detection stops at "armed"
+ *
+ * A comment's URN can be confirmed the moment it posts: the classic
+ * post-detail frontend renders it as `article[data-id]`
+ * (`linkedin-comment.ts`'s `findOurCommentUrn`). A freshly published post has
+ * no equivalent this module can read. `linkedin-dom.ts`'s own header
+ * documents the exhaustive search behind this (#303): on the SDUI feed the
+ * activity URN "is not in the feed DOM, not inside any shadow root, not in
+ * any inline script, and not reachable through React's fiber or memoized
+ * props" - and that is exactly the frontend a freshly published post renders
+ * into. So this script arms the draft on the human's own click of LinkedIn's
+ * "Post" control (never dispatches one) and watches for the composer closing
+ * without an inline error, but it never calls the `sent` endpoint the way
+ * the comment watcher does: there is no `platform_post_id` to give it, and
+ * writing one down without an identifier would be a fabricated confirmation,
+ * not a detected one. The draft stays `armed` for a human to resolve.
+ *
+ * What a human with a live account would need to capture before this can go
+ * further: right after publishing a real post from this composer, does
+ * *anything* on the page expose the new post's URN - a `data-urn` on the
+ * fresh top-of-feed card, a `data-sdui-anchor-id` keyed to it, a network
+ * response body the browser's own devtools can see, or does navigating to
+ * the profile's own `/recent-activity/` page render it through the classic
+ * frontend with a real `data-urn`? None of the fixtures in this repo show
+ * that state, so none of it is guessed here.
+ */
+
+const POST_KIND = 'post';
+
+/** Every refusal this panel can render, honestly and distinctly. A subset of
+ * the comment assist's own `AssistRefusal` (LI-17): a `post` suggestion never
+ * targets one person, so the accept path's `uncontactable`/`recently_contacted`
+ * refusals (only reachable with a `targetUser`, see `shared/src/assist-accept.ts`)
+ * can never fire here, and this script never reads post content off the page,
+ * so `selector_health_degraded` cannot fire either. `no_recent_activity` is
+ * new: the observation buffer this suggestion grounds in (see the module doc
+ * comment) had nothing recent enough to draft from. */
+export type PostAssistRefusal =
+  | Exclude<AcceptRefusalReason, 'uncontactable' | 'recently_contacted'>
+  | 'backend_unreachable'
+  | 'generation_failed'
+  | 'no_recent_activity';
+
+const KNOWN_REFUSALS: Record<PostAssistRefusal, true> = {
+  assist_disabled: true,
+  kill_switch: true,
+  project_not_bound: true,
+  quota_exhausted: true,
+  no_recent_activity: true,
+  no_account: true,
+  blocked: true,
+  backend_unreachable: true,
+  generation_failed: true,
+};
+
+/**
+ * Maps a refusal reason to its own i18n key. `quota_exhausted` gets a key
+ * distinct from the comment assist's own (`assist.refusal.post_quota_exhausted`
+ * vs `assist.refusal.quota_exhausted`): the server answers the same reason
+ * string either way, but "today's comment quota is used up" would be a lie
+ * on this surface - the post quota ships separately, at one a day. Every
+ * other reason reuses the comment assist's own message, which names nothing
+ * kind-specific. A reason this client does not recognise still renders,
+ * naming itself, instead of a blank or a raw untranslated key. Exported for
+ * testing.
+ */
+export function refusalMessage(reason: string): {
+  key: string;
+  params?: Record<string, string>;
+} {
+  if (reason === 'quota_exhausted') return { key: 'assist.refusal.post_quota_exhausted' };
+  if (reason in KNOWN_REFUSALS) return { key: `assist.refusal.${reason}` };
+  return { key: 'assist.refusal.unknown', params: { reason } };
+}
+
+export type PostAssistState =
+  | { phase: 'resting' }
+  | { phase: 'streaming'; status: 'reading' | 'writing'; text: string }
+  | { phase: 'ready'; text: string }
+  | { phase: 'edited'; text: string }
+  | { phase: 'accepting'; text: string }
+  | { phase: 'inserted' }
+  | { phase: 'refused'; messageKey: string; messageParams?: Record<string, string> };
+
+export type PostAssistPanelProps = {
+  state: PostAssistState;
+  onRequest: () => void;
+  onEditChange: (text: string) => void;
+  onAccept: () => void;
+  onDismiss: () => void;
+};
+
+// `editor`'s own form when it has one, matching `linkedin-comment-assist.ts`'s
+// anchor resolution exactly - unverified for the post composer (no fixture
+// shows its modal open, see the module doc comment), so this falls back to
+// the editor itself with the same posture that script does.
+
+const POST_CONFIRM_POLL_MS = 500;
+const POST_CONFIRM_TIMEOUT_MS = 20_000;
+const POST_SUBMIT_WAIT_MS = 15_000;
+
+/**
+ * Arms `draftId` on the human's own click of LinkedIn's post-composer submit
+ * control found under `modal` (never dispatches one), then watches for the
+ * modal closing cleanly. Never calls `api.sent` - see the module doc
+ * comment's "No URN after publish" section for why that would be a
+ * fabricated confirmation rather than a detected one. Exported for testing.
+ */
+export function wirePostSubmit(modal: Element, draftId: number): boolean {
+  const btn = findPostSubmitButton(modal);
+  if (!btn) return false;
+  let armed = false;
+  btn.addEventListener(
+    'click',
+    () => {
+      if (armed) return;
+      armed = true;
+      void api.armed(draftId);
+      let resolved = false;
+      const finish = (message: string, reason: string) => {
+        if (resolved) return;
+        resolved = true;
+        window.clearInterval(poll);
+        window.clearTimeout(giveUp);
+        logFromContent({
+          level: 'warn',
+          source: 'linkedin-action',
+          message,
+          messageParams: { draftId },
+          meta: { draftId, script: 'linkedin-post-assist', reason, url: location.href },
+        });
+      };
+      const poll = window.setInterval(() => {
+        if (hasInlineCommentError()) {
+          // LinkedIn showed an inline error - leave the draft armed for a
+          // retry, nothing resolved yet.
+          window.clearInterval(poll);
+          window.clearTimeout(giveUp);
+          return;
+        }
+        if (findPostComposerModal()) return; // still open/submitting
+        finish('activity.linkedin-action.post-confirm-unavailable', 'no-post-identifier-in-dom');
+      }, POST_CONFIRM_POLL_MS);
+      const giveUp = window.setTimeout(() => {
+        finish('activity.linkedin-action.post-confirm-timeout', 'confirm-poll-timeout');
+      }, POST_CONFIRM_TIMEOUT_MS);
+    },
+    { capture: true },
+  );
+  return true;
+}
+
+/**
+ * Wires `wirePostSubmit` now if the submit control already exists under
+ * `modal`, or retries via `MutationObserver` scoped to the modal - LinkedIn
+ * does not render a submit control for an empty composer, matching
+ * `linkedin-comment.ts`'s `watchForCommentSubmit` (this is the expected path
+ * right after inserting text, not a fallback) - for up to 15s before logging
+ * a distinct give-up.
+ */
+function watchPostForSend(modal: Element, draftId: number): void {
+  if (wirePostSubmit(modal, draftId)) return;
+  let wired = false;
+  const obs = new MutationObserver(() => {
+    if (wirePostSubmit(modal, draftId)) {
+      wired = true;
+      obs.disconnect();
+    }
+  });
+  obs.observe(modal, { childList: true, subtree: true });
+  window.setTimeout(() => {
+    obs.disconnect();
+    if (wired) return;
+    logFromContent({
+      level: 'warn',
+      source: 'linkedin-action',
+      message: 'activity.linkedin-action.post-submit-not-found',
+      messageParams: { draftId },
+      meta: {
+        draftId,
+        script: 'linkedin-post-assist',
+        step: 'wire-submit-button',
+        selector: 'findPostSubmitButton',
+        reason: 'submit-button-not-found',
+        url: location.href,
+      },
+    });
+  }, POST_SUBMIT_WAIT_MS);
+}
+
+/**
+ * Mounts the assist panel on `editor`'s anchor and wires its whole state
+ * machine: request, edit, accept-then-insert-then-arm, refuse. One call per
+ * modal open (see `wirePostAssist` below); `mountPanel` itself is what keeps
+ * a second click from stacking a second panel.
+ */
+function mountAssistPanel(editor: HTMLElement, modal: Element): void {
+  const anchor = editor.closest('form') ?? editor;
+  for (const event of selectorHealthActivityEvents()) logFromContent(event);
+
+  let currentText = '';
+  let boundProjectId: number | null = null;
+  let lastUsage: SuggestUsage | undefined;
+  let lastMs: number | undefined;
+
+  const props: PostAssistPanelProps = {
+    state: { phase: 'resting' },
+    onRequest: () => void requestSuggestion(),
+    onEditChange: (text) => {
+      currentText = text;
+      if (handle.alive) handle.update({ state: { phase: 'edited', text } });
+    },
+    onAccept: () => void acceptAndInsert(),
+    onDismiss: () => handle.destroy(),
+  };
+
+  const handle = mountPanel({ anchor, component: PostAssistPanel, props });
+
+  function setRefused(reason: string): void {
+    logFromContent({
+      level: 'warn',
+      source: 'linkedin-action',
+      message: 'activity.linkedin-action.suggestion-refused',
+      messageParams: { reason },
+      meta: { reason, script: 'linkedin-post-assist' },
+    });
+    const { key, params } = refusalMessage(reason);
+    if (handle.alive) {
+      handle.update({ state: { phase: 'refused', messageKey: key, messageParams: params } });
+    }
+  }
+
+  async function requestSuggestion(): Promise<void> {
+    handle.update({ state: { phase: 'streaming', status: 'reading', text: '' } });
+
+    const assistRes = await api.linkedinAssist();
+    if (!handle.alive) return;
+    if (!assistRes.ok) {
+      setRefused('backend_unreachable');
+      return;
+    }
+    const { assist } = assistRes.data;
+    if (assist.killSwitch) {
+      setRefused('kill_switch');
+      return;
+    }
+    if (!assist.enabled) {
+      setRefused('assist_disabled');
+      return;
+    }
+    if (assist.projectId === null) {
+      setRefused('project_not_bound');
+      return;
+    }
+    boundProjectId = assist.projectId;
+
+    let streamed = '';
+    // Never a pile of observed posts: the server itself reads the
+    // observation buffer for `kind: 'post'` (see the module doc comment).
+    // `post` here is informational context only.
+    const res = await api.suggest(
+      { projectId: boundProjectId, kind: POST_KIND, post: { url: location.href } },
+      (event: SuggestEvent) => {
+        if (!handle.alive) return;
+        switch (event.kind) {
+          case 'status':
+            handle.update({ state: { phase: 'streaming', status: event.phase, text: streamed } });
+            break;
+          case 'chunk':
+            streamed += event.text;
+            handle.update({ state: { phase: 'streaming', status: 'writing', text: streamed } });
+            break;
+          case 'done':
+            lastUsage = event.usage;
+            lastMs = event.ms;
+            currentText = event.text;
+            handle.update({ state: { phase: 'ready', text: event.text } });
+            break;
+          case 'failed':
+            setRefused('generation_failed');
+            break;
+          case 'refused':
+            setRefused(event.reason);
+            break;
+        }
+      },
+    );
+    if (!handle.alive) return;
+    if (!res.ok) setRefused('backend_unreachable');
+  }
+
+  async function acceptAndInsert(): Promise<void> {
+    if (boundProjectId === null) {
+      setRefused('backend_unreachable');
+      return;
+    }
+    handle.update({ state: { phase: 'accepting', text: currentText } });
+    const res = await api.acceptSuggestion({
+      projectId: boundProjectId,
+      kind: POST_KIND,
+      // No urn (a post has none until it publishes), no authorHandle/authorName
+      // (this is the operator's own voice, not a reply to someone) - see
+      // web/src/routes/api/extension/suggest/accept/+server.ts's targetUser
+      // handling for `kind: 'post'`.
+      post: {},
+      body: currentText,
+      usage: lastUsage,
+      ms: lastMs,
+    });
+    if (!handle.alive) return;
+    if (!res.ok) {
+      setRefused('backend_unreachable');
+      return;
+    }
+    if (!res.data.accepted) {
+      setRefused(res.data.refused);
+      return;
+    }
+
+    insertComposerText(editor, currentText);
+    watchPostForSend(modal, res.data.draftId);
+    logFromContent({
+      level: 'info',
+      source: 'linkedin-action',
+      message: 'activity.linkedin-action.suggestion-inserted',
+      messageParams: { draftId: res.data.draftId },
+      meta: { draftId: res.data.draftId },
+    });
+    handle.update({ state: { phase: 'inserted' } });
+  }
+}
+
+/**
+ * Wires the human's own click into `editor` to mount the assist panel.
+ * Never dispatches a click; only listens for one, matching every other
+ * content script in this directory. Exported for testing.
+ */
+export function wirePostAssist(editor: HTMLElement, modal: Element): void {
+  const anchor = editor.closest('form') ?? editor;
+  editor.addEventListener(
+    'click',
+    () => {
+      if (panelFor(anchor)) return;
+      mountAssistPanel(editor, modal);
+    },
+    { capture: true },
+  );
+}
+
+// The "Start a post" modal can open, close and reopen any number of times
+// across this script's lifetime (a feed page never reloads for it), unlike
+// the comment assist's one-shot page-load wait - so this observer never
+// disconnects, and `wiredEditors` is what keeps a still-open modal from
+// getting a second, redundant listener on every unrelated DOM mutation.
+const wiredEditors = new WeakSet<HTMLElement>();
+
+function tryWire(): void {
+  // This observer never disconnects (see above), so its callback can still
+  // be queued for delivery after the page context it was watching is gone -
+  // a navigation away, or the extension itself reloading mid-session.
+  // `document` is a bare global at that point, not merely empty, so this
+  // guards the access itself rather than trusting a null check downstream.
+  if (typeof document === 'undefined') return;
+  const modal = findPostComposerModal();
+  if (!modal) return;
+  const editor = findPostComposer(modal);
+  if (!editor || wiredEditors.has(editor)) return;
+  wiredEditors.add(editor);
+  wirePostAssist(editor, modal);
+}
+
+function init(): void {
+  resetSelectorHealth();
+  tryWire();
+  const obs = new MutationObserver(tryWire);
+  obs.observe(document.documentElement, { childList: true, subtree: true });
+}
+
+init();

--- a/extension/src/content/panel-scripts.ts
+++ b/extension/src/content/panel-scripts.ts
@@ -11,7 +11,10 @@
  * Vite build with `plugins: []`, so `svelte()` never runs and a panel-bearing
  * script fails to parse (#369).
  */
-export const PANEL_CONTENT_SCRIPTS = ['src/content/linkedin-comment-assist.ts'] as const;
+export const PANEL_CONTENT_SCRIPTS = [
+  'src/content/linkedin-comment-assist.ts',
+  'src/content/linkedin-post-assist.ts',
+] as const;
 
 /**
  * The emitted path for a source entry, relative to the extension root, which

--- a/extension/src/content/shared/linkedin-dom.ts
+++ b/extension/src/content/shared/linkedin-dom.ts
@@ -108,6 +108,8 @@ export type LinkedInSelectorId =
   | 'commentComposer'
   | 'commentSubmitButton'
   | 'postComposer'
+  | 'postComposerModal'
+  | 'postSubmitButton'
   | 'ownProfileHandle'
   | 'postComments'
   | 'commentAuthor'
@@ -457,6 +459,43 @@ export function findPostComposer(root: ParentNode = document): HTMLElement | nul
   const pageKind = detectPageKind(root);
   const el = queryDeep<HTMLElement>('[contenteditable="true"][role="textbox"]', root);
   if (pageKind !== 'unknown') record('postComposer', pageKind, el !== null);
+  return el;
+}
+
+/**
+ * The "start a post" modal's own container under `root` - what a caller must
+ * find first and pass as `root` to `findPostComposer`/`findPostSubmitButton`
+ * below, per those functions' own doc comments. Anchored on the standard
+ * `role="dialog"` ARIA landmark rather than a LinkedIn-authored `data-*`
+ * attribute (contrast every other accessor in this module): LinkedIn ships
+ * that modal as an actual dialog in every capture this project's authors
+ * have seen live, but - like `findPostComposer` itself - neither fixture in
+ * this repo shows it open, so this is unverified against a real capture and
+ * exists to be corrected against one. It is what keeps this script from
+ * mistaking an inline *comment* composer (the identical
+ * `[contenteditable="true"][role="textbox"]` editor, but never inside a
+ * dialog) for the post composer when both can be present on the same
+ * post-detail page.
+ */
+export function findPostComposerModal(root: ParentNode = document): Element | null {
+  const pageKind = detectPageKind(root);
+  const el = queryDeep('[role="dialog"]', root);
+  if (pageKind !== 'unknown') record('postComposerModal', pageKind, el !== null);
+  return el;
+}
+
+/**
+ * The post composer's own submit ("Post") control under `root` - pass the
+ * modal from `findPostComposerModal` above, matching `findCommentSubmitButton`'s
+ * own scoping convention. Same primary selector and the same disclaimer: no
+ * fixture shows the post composer's modal open with typed text, so this is
+ * unverified against a live capture and exercised only against synthetic
+ * markup in tests.
+ */
+export function findPostSubmitButton(root: ParentNode = document): HTMLButtonElement | null {
+  const pageKind = detectPageKind(root);
+  const el = queryDeep<HTMLButtonElement>('button[type="submit"]', root);
+  if (pageKind !== 'unknown') record('postSubmitButton', pageKind, el !== null);
   return el;
 }
 

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -31,12 +31,15 @@ export type LinkedInAssistState = {
 export type SuggestionKind = 'post_comment' | 'post';
 
 /** The observed post context /suggest drafts from. `urn` is absent for a
- * feed sighting - see linkedin-dom.ts's "Two frontends, one identifier". */
+ * feed sighting - see linkedin-dom.ts's "Two frontends, one identifier".
+ * `text` is optional because a `kind: 'post'` request carries nothing to
+ * draft from at all - the server grounds that kind itself, in whatever the
+ * observation buffer most recently saw (#315). */
 export type SuggestPost = {
   urn?: string;
   authorHandle?: string;
   authorName?: string;
-  text: string;
+  text?: string;
   url?: string;
 };
 
@@ -52,9 +55,15 @@ export type SuggestUsage = {
   costUsd?: number | null;
 };
 
-/** Every `refused` value POST /api/extension/suggest can answer with, ahead of the stream. */
+/** Every `refused` value POST /api/extension/suggest can answer with, ahead of the stream.
+ * `no_recent_activity` only ever answers a `kind: 'post'` request: the observation
+ * buffer this project's account has filled has nothing recent enough to draft from. */
 export type SuggestRefusalReason =
-  'assist_disabled' | 'kill_switch' | 'project_not_bound' | 'quota_exhausted';
+  | 'assist_disabled'
+  | 'kill_switch'
+  | 'project_not_bound'
+  | 'quota_exhausted'
+  | 'no_recent_activity';
 
 /** Every `refused` value POST /api/extension/suggest/accept can answer with: the same
  * assist gate as /suggest, plus shared/src/assist-accept.ts's own refusals for a

--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -138,6 +138,12 @@ export const en = {
   'activity.linkedin-action.suggestion-refused': 'LinkedIn assist suggestion refused: {reason}',
   'activity.linkedin-action.suggestion-inserted':
     'Inserted an accepted suggestion into the LinkedIn composer for draft {draftId}.',
+  'activity.linkedin-action.post-submit-not-found':
+    'Could not find the LinkedIn post submit button for draft {draftId} within 15s; posting will not be tracked automatically.',
+  'activity.linkedin-action.post-confirm-unavailable':
+    "Draft {draftId} left the composer with no error, but LinkedIn's feed exposes no stable identifier for a freshly published post, so Pitchbox could not confirm it was sent or capture its URN. Mark it manually if it published.",
+  'activity.linkedin-action.post-confirm-timeout':
+    'Could not confirm draft {draftId} left the composer within 20s after clicking Post; check its status manually.',
   'activity.linkedin-dom.selector-miss':
     'LinkedIn selector "{selector}" is not matching on the {pageKind} page ({misses} misses, {matches} matches) - this reading may be stale or missing.',
   'activity.linkedin-collector.batch-sent':
@@ -234,6 +240,16 @@ export const en = {
   'assist.comment.accepting': 'Saving…',
   'assist.comment.inserted.title': 'Inserted',
   'assist.comment.inserted.hint': "Press LinkedIn's own Comment button to send it.",
+  // In-page LinkedIn post composer assist (LI-18, #315): same shape as the
+  // comment assist above, offering a post rather than a comment. No
+  // `resting`/`ready` subject: the suggestion is the operator's own voice,
+  // not a reply to anyone.
+  'assist.post.resting.hint': 'Get a Pitchbox-suggested post for your network.',
+  'assist.post.resting.cta': 'Suggest a post',
+  'assist.post.ready.label': 'Suggested post (editable)',
+  'assist.post.accepting': 'Saving…',
+  'assist.post.inserted.title': 'Inserted',
+  'assist.post.inserted.hint': "Press LinkedIn's own Post button to send it.",
   // Refused is five states in the brief plus three the accept path can also
   // answer with (no_account, blocked, uncontactable, recently_contacted) and
   // three this client detects itself (backend_unreachable, selector health,
@@ -252,6 +268,15 @@ export const en = {
     "LinkedIn's layout changed and Pitchbox could not read this post reliably.",
   'assist.refusal.generation_failed': 'Something went wrong while writing the suggestion.',
   'assist.refusal.unknown': 'The assistant refused this request ({reason}).',
+  // The post assist's own quota message: the server answers the same
+  // `quota_exhausted` reason for both kinds, but the comment assist's
+  // message above names the wrong quota here - the post quota ships
+  // separately, at one a day.
+  'assist.refusal.post_quota_exhausted': "Today's post quota is used up.",
+  // Post-only: the observation buffer this suggestion grounds in (#315) had
+  // nothing recent enough to draft from.
+  'assist.refusal.no_recent_activity':
+    'Nothing recent to draft a post from yet. Browse your network for a bit, then try again.',
 
   // Language names are endonyms (each language's own name for itself) and
   // are intentionally identical across every locale dictionary; a language

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -143,6 +143,12 @@ export const it = {
   'activity.linkedin-action.suggestion-refused': 'Suggerimento LinkedIn assist rifiutato: {reason}',
   'activity.linkedin-action.suggestion-inserted':
     'Suggerimento accettato inserito nel box del commento LinkedIn per il draft {draftId}.',
+  'activity.linkedin-action.post-submit-not-found':
+    'Impossibile trovare il pulsante di pubblicazione del post LinkedIn per il draft {draftId} entro 15s; la pubblicazione non verrà tracciata automaticamente.',
+  'activity.linkedin-action.post-confirm-unavailable':
+    "Il draft {draftId} ha lasciato il composer senza errori, ma il feed di LinkedIn non espone un identificatore stabile per un post appena pubblicato, quindi Pitchbox non ha potuto confermarne l'invio né catturarne l'URN. Segnalo manualmente se è stato pubblicato.",
+  'activity.linkedin-action.post-confirm-timeout':
+    'Impossibile confermare che il draft {draftId} abbia lasciato il composer entro 20s dal clic su Pubblica; verifica manualmente lo stato.',
   'activity.linkedin-dom.selector-miss':
     'Il selettore LinkedIn "{selector}" non trova corrispondenze nella pagina {pageKind} ({misses} mancate, {matches} trovate) - questa lettura potrebbe essere obsoleta o mancante.',
   'activity.linkedin-collector.batch-sent':
@@ -237,6 +243,12 @@ export const it = {
   'assist.comment.accepting': 'Salvataggio in corso…',
   'assist.comment.inserted.title': 'Inserito',
   'assist.comment.inserted.hint': 'Premi il pulsante Commenta di LinkedIn per inviarlo.',
+  'assist.post.resting.hint': 'Ottieni un post suggerito da Pitchbox per la tua rete.',
+  'assist.post.resting.cta': 'Suggerisci un post',
+  'assist.post.ready.label': 'Post suggerito (modificabile)',
+  'assist.post.accepting': 'Salvataggio in corso…',
+  'assist.post.inserted.title': 'Inserito',
+  'assist.post.inserted.hint': 'Premi il pulsante Pubblica di LinkedIn per inviarlo.',
   'assist.refusal.assist_disabled': "L'assistente Pitchbox è disattivato per questo workspace.",
   'assist.refusal.kill_switch': "Un amministratore ha fermato l'assistente.",
   'assist.refusal.project_not_bound': "Nessun progetto è collegato all'assistente.",
@@ -251,6 +263,9 @@ export const it = {
   'assist.refusal.generation_failed':
     'Qualcosa è andato storto durante la scrittura del suggerimento.',
   'assist.refusal.unknown': "L'assistente ha rifiutato questa richiesta ({reason}).",
+  'assist.refusal.post_quota_exhausted': 'La quota post di oggi è esaurita.',
+  'assist.refusal.no_recent_activity':
+    'Ancora nulla di recente da cui scrivere un post. Esplora la tua rete per un po’, poi riprova.',
 
   // Language names are endonyms, see the comment in dict-en.ts.
   'settings.language.option.en': 'English',

--- a/extension/tests/content/linkedin-dom.test.ts
+++ b/extension/tests/content/linkedin-dom.test.ts
@@ -9,6 +9,8 @@ import {
   findCommentComposer,
   findCommentSubmitButton,
   findPostComposer,
+  findPostComposerModal,
+  findPostSubmitButton,
   readOwnProfileHandle,
   getSelectorHealthReport,
   resetSelectorHealth,
@@ -245,6 +247,38 @@ describe('synthetic markup: affordances neither real capture rendered', () => {
     const composer = findPostComposer(document);
     expect(composer).not.toBeNull();
     expect(composer?.getAttribute('role')).toBe('textbox');
+  });
+
+  it('findPostComposerModal finds the role="dialog" container the post composer opens in', () => {
+    render(
+      '<div role="dialog"><div contenteditable="true" role="textbox">Cosa vuoi condividere?</div></div>',
+    );
+    const modal = findPostComposerModal(document);
+    expect(modal).not.toBeNull();
+    expect(modal?.getAttribute('role')).toBe('dialog');
+  });
+
+  it('findPostComposerModal does not mistake an inline comment composer (no dialog ancestor) for the post modal', () => {
+    render('<div contenteditable="true" role="textbox">a comment draft</div>');
+    expect(findPostComposerModal(document)).toBeNull();
+  });
+
+  it('findPostSubmitButton, scoped to the modal, finds the submit control once one exists', () => {
+    render(
+      '<div role="dialog"><div contenteditable="true" role="textbox">a draft post</div><button type="submit">Pubblica</button></div>',
+    );
+    const modal = findPostComposerModal(document)!;
+    const button = findPostSubmitButton(modal);
+    expect(button).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  it('findPostSubmitButton scoped to the modal ignores a submit button outside it', () => {
+    render(
+      '<div role="dialog"><div contenteditable="true" role="textbox">a draft post</div></div>' +
+        '<button type="submit">Commenta</button>',
+    );
+    const modal = findPostComposerModal(document)!;
+    expect(findPostSubmitButton(modal)).toBeNull();
   });
 
   it("readOwnProfileHandle reads the member's own profile link out of the global nav", () => {

--- a/extension/tests/content/linkedin-post-assist.test.ts
+++ b/extension/tests/content/linkedin-post-assist.test.ts
@@ -41,9 +41,8 @@ vi.mock('../../src/lib/log-from-content.js', () => ({
 // Dynamic, not static: this module must load after the `vi.mock` calls
 // above are in place (vitest hoists `vi.mock` but not a static import),
 // matching `linkedin-comment-assist.test.ts`'s own established pattern.
-const { wirePostAssist, wirePostSubmit, refusalMessage } = await import(
-  '../../src/content/linkedin-post-assist.js'
-);
+const { wirePostAssist, wirePostSubmit, refusalMessage } =
+  await import('../../src/content/linkedin-post-assist.js');
 
 const ASSIST_ON = {
   ok: true as const,

--- a/extension/tests/content/linkedin-post-assist.test.ts
+++ b/extension/tests/content/linkedin-post-assist.test.ts
@@ -1,0 +1,397 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * The in-page post composer assist (#315), against the real Svelte panel
+ * rather than a stand-in - same posture `linkedin-comment-assist.test.ts`
+ * takes for #314, for the same reason.
+ *
+ * Unlike the comment assist, no captured fixture shows LinkedIn's "Start a
+ * post" modal open (see `linkedin-post-assist.ts`'s own module doc comment
+ * and `linkedin-dom.ts`'s header) - so the DOM here is synthetic, matching
+ * the same posture `linkedin-dom.test.ts`'s own synthetic cases already take
+ * for `findPostComposer`/`findMessageEvents`. The API layer is faked; the
+ * panel and the modal shape are real.
+ */
+
+const linkedinAssist = vi.fn();
+const suggest = vi.fn();
+const acceptSuggestion = vi.fn();
+const armed = vi.fn(async (_draftId: number, _backendUrl?: string) => ({
+  ok: true as const,
+  data: {},
+}));
+
+vi.mock('../../src/lib/api.js', () => ({
+  api: {
+    linkedinAssist: () => linkedinAssist(),
+    suggest: (body: unknown, onEvent: unknown) => suggest(body, onEvent),
+    acceptSuggestion: (body: unknown) => acceptSuggestion(body),
+    armed: (draftId: number, backendUrl?: string) => armed(draftId, backendUrl),
+  },
+}));
+
+const logged: Array<Record<string, unknown>> = [];
+vi.mock('../../src/lib/log-from-content.js', () => ({
+  logFromContent: (entry: Record<string, unknown>) => {
+    logged.push(entry);
+  },
+}));
+
+// Dynamic, not static: this module must load after the `vi.mock` calls
+// above are in place (vitest hoists `vi.mock` but not a static import),
+// matching `linkedin-comment-assist.test.ts`'s own established pattern.
+const { wirePostAssist, wirePostSubmit, refusalMessage } = await import(
+  '../../src/content/linkedin-post-assist.js'
+);
+
+const ASSIST_ON = {
+  ok: true as const,
+  data: {
+    assist: {
+      enabled: true,
+      collectorEnabled: true,
+      killSwitch: false,
+      projectId: 2,
+      dailyCommentCap: 8,
+      dailyPostCap: 1,
+    },
+  },
+};
+
+/**
+ * LinkedIn's "Start a post" modal, in the minimal shape
+ * `findPostComposerModal`/`findPostComposer` read: a `role="dialog"`
+ * container wrapping the same `contenteditable`/`role="textbox"` editor the
+ * comment composer uses. Synthetic, not a capture - see this file's own doc
+ * comment.
+ */
+function renderModal(): { modal: HTMLElement; editor: HTMLElement } {
+  document.body.innerHTML =
+    '<div role="dialog"><div contenteditable="true" role="textbox"></div></div>';
+  const modal = document.querySelector<HTMLElement>('[role="dialog"]');
+  const editor = modal?.querySelector<HTMLElement>('[contenteditable="true"][role="textbox"]');
+  if (!modal || !editor) throw new Error('synthetic modal build failed');
+  return { modal, editor };
+}
+
+function shadow(): ShadowRoot {
+  const host = [...document.querySelectorAll('*')].find((e) => e.shadowRoot);
+  if (!host?.shadowRoot) throw new Error('no panel mounted');
+  return host.shadowRoot;
+}
+
+function panelText(): string {
+  return (shadow().textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+/** Lets the panel's mount, the awaited API calls and Svelte's flush settle. */
+async function settle(times = 6): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+/** A suggestion delivered as the route delivers it: chunks, then done. */
+function streamingSuggest(text: string) {
+  return async (_body: unknown, onEvent: (event: Record<string, unknown>) => void) => {
+    onEvent({ kind: 'status', phase: 'writing' });
+    onEvent({ kind: 'chunk', text: text.slice(0, 20) });
+    onEvent({ kind: 'chunk', text: text.slice(20) });
+    onEvent({ kind: 'done', text, ms: 900 });
+    return { ok: true as const, data: { text } };
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  logged.length = 0;
+  vi.clearAllMocks();
+  Reflect.deleteProperty(globalThis as Record<string, unknown>, 'FontFace');
+  linkedinAssist.mockResolvedValue(ASSIST_ON);
+});
+
+describe('the panel never appears unprompted', () => {
+  it('mounts nothing until the human clicks into the post editor', async () => {
+    const { editor, modal } = renderModal();
+    wirePostAssist(editor, modal);
+    await settle();
+
+    expect([...document.querySelectorAll('*')].some((e) => e.shadowRoot)).toBe(false);
+    expect(linkedinAssist).not.toHaveBeenCalled();
+    expect(suggest).not.toHaveBeenCalled();
+  });
+
+  it('mounts on the click, and still asks for nothing until the human asks', async () => {
+    const { editor, modal } = renderModal();
+    wirePostAssist(editor, modal);
+    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(panelText()).toContain('Suggest a post');
+    expect(suggest).not.toHaveBeenCalled();
+  });
+
+  it('mounts one panel per anchor however many times the human clicks', async () => {
+    const { editor, modal } = renderModal();
+    wirePostAssist(editor, modal);
+    for (let i = 0; i < 3; i++) editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(1);
+  });
+});
+
+describe('grounded through the server, never a pile of observed posts', () => {
+  it('asks for kind "post" and sends only the current page URL, never post text this script read itself', async () => {
+    const { editor, modal } = renderModal();
+    suggest.mockImplementation(streamingSuggest('A short update about tonight.'));
+
+    wirePostAssist(editor, modal);
+    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    expect(suggest).toHaveBeenCalledTimes(1);
+    const [body] = suggest.mock.calls[0] as [Record<string, unknown>];
+    expect(body.kind).toBe('post');
+    expect(body.post).toEqual({ url: location.href });
+  });
+});
+
+describe('the suggestion, as it arrives', () => {
+  it('renders partial text while the stream is still open, not just at the end', async () => {
+    const { editor, modal } = renderModal();
+    const seen: string[] = [];
+    suggest.mockImplementation(
+      async (
+        _body: unknown,
+        onEvent: (e: Record<string, unknown>) => void,
+      ): Promise<{ ok: true; data: { text: string } }> => {
+        onEvent({ kind: 'status', phase: 'writing' });
+        onEvent({ kind: 'chunk', text: 'First half. ' });
+        await settle(2);
+        seen.push(panelText());
+        onEvent({ kind: 'chunk', text: 'Second half.' });
+        onEvent({ kind: 'done', text: 'First half. Second half.', ms: 900 });
+        return { ok: true, data: { text: 'First half. Second half.' } };
+      },
+    );
+
+    wirePostAssist(editor, modal);
+    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    expect(seen[0]).toContain('First half.');
+    expect(seen[0]).not.toContain('Second half.');
+    expect(shadow().querySelector('textarea')?.value).toBe('First half. Second half.');
+  });
+});
+
+describe('accept, insert, and the button the human presses', () => {
+  it('writes the text into LinkedIn own composer and dispatches no click or submit', async () => {
+    const { editor, modal } = renderModal();
+    const text = 'Shipped the post composer assist tonight.';
+    suggest.mockImplementation(streamingSuggest(text));
+    acceptSuggestion.mockResolvedValue({
+      ok: true,
+      data: { accepted: true, draftId: 5150, runId: 9 },
+    });
+
+    const clicks: string[] = [];
+    const submits: string[] = [];
+    const realClick = HTMLElement.prototype.click;
+    HTMLElement.prototype.click = function patched(this: HTMLElement) {
+      // The panel's own controls are the human's clicks in this test; what the
+      // boundary forbids is a click on LinkedIn's own submit control.
+      if (!this.closest('pitchbox-panel-host') && !this.getRootNode().toString().includes('Shadow'))
+        clicks.push(this.tagName);
+      return realClick.call(this);
+    };
+    document.addEventListener('submit', (e) => submits.push(String(e.type)), true);
+
+    try {
+      wirePostAssist(editor, modal);
+      editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle();
+      shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+      await settle();
+      shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+      await settle();
+    } finally {
+      HTMLElement.prototype.click = realClick;
+    }
+
+    expect(editor.textContent).toContain('post composer assist');
+    expect(acceptSuggestion).toHaveBeenCalledTimes(1);
+    // No urn/authorHandle/authorName in the accept body: a post has none of
+    // those until it publishes, and it is the operator's own voice.
+    expect(acceptSuggestion.mock.calls[0][0]).toMatchObject({ kind: 'post', post: {} });
+    expect(clicks).toEqual([]);
+    expect(submits).toEqual([]);
+    expect(panelText()).toMatch(/Post button|Inserted/i);
+  });
+});
+
+describe('every refusal says which one it is', () => {
+  it("gives the post quota message its own key, distinct from the comment assist's own", () => {
+    expect(refusalMessage('quota_exhausted').key).toBe('assist.refusal.post_quota_exhausted');
+  });
+
+  it('maps every other known reason to its own distinct message key', () => {
+    const keys = [
+      'assist_disabled',
+      'kill_switch',
+      'project_not_bound',
+      'no_recent_activity',
+      'no_account',
+      'blocked',
+      'backend_unreachable',
+      'generation_failed',
+    ].map((reason) => refusalMessage(reason).key);
+
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(refusalMessage('a_reason_nobody_has_written_yet').key).toBe('assist.refusal.unknown');
+  });
+});
+
+describe('refusal rendering: post-specific, not the comment assist copy', () => {
+  it('renders the post quota message, not the comment quota message, when the server refuses quota_exhausted', async () => {
+    const { editor, modal } = renderModal();
+    suggest.mockImplementation(
+      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+        onEvent({ kind: 'refused', reason: 'quota_exhausted', detail: {} });
+        return { ok: true, data: {} };
+      },
+    );
+
+    wirePostAssist(editor, modal);
+    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    expect(panelText()).toMatch(/post quota/i);
+    expect(panelText()).not.toMatch(/comment/i);
+  });
+
+  it('renders a distinct message when the observation buffer has nothing recent to ground a post in', async () => {
+    const { editor, modal } = renderModal();
+    suggest.mockImplementation(
+      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+        onEvent({ kind: 'refused', reason: 'no_recent_activity', detail: {} });
+        return { ok: true, data: {} };
+      },
+    );
+
+    wirePostAssist(editor, modal);
+    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    expect(panelText()).toMatch(/nothing recent/i);
+  });
+});
+
+describe('single-page navigation', () => {
+  it('leaves no panel behind when LinkedIn tears the modal down', async () => {
+    const { editor, modal } = renderModal();
+    wirePostAssist(editor, modal);
+    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(1);
+
+    document.body.innerHTML = '';
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(0);
+  });
+});
+
+describe('post completion detection: arms, but never fabricates a sent confirmation', () => {
+  // No fixture shows a published post's URN anywhere (see the module doc
+  // comment's "No URN after publish" section) - so `wirePostSubmit` is
+  // exercised directly against synthetic markup, matching every other
+  // unverified accessor's own test posture in this repo.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function buildArmedModal(): { modal: HTMLElement; btn: HTMLButtonElement } {
+    document.body.innerHTML =
+      '<div role="dialog"><div contenteditable="true" role="textbox">draft</div>' +
+      '<button type="submit">Pubblica</button></div>';
+    const modal = document.querySelector<HTMLElement>('[role="dialog"]')!;
+    const btn = modal.querySelector<HTMLButtonElement>('button[type="submit"]')!;
+    return { modal, btn };
+  }
+
+  it('arms the draft on the human click - never dispatched, only listened for', async () => {
+    const { modal, btn } = buildArmedModal();
+    expect(wirePostSubmit(modal, 777)).toBe(true);
+
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(armed).toHaveBeenCalledWith(777, undefined);
+  });
+
+  it('logs a distinct warning, and never a fabricated sent, once the modal closes without an error', async () => {
+    const { modal, btn } = buildArmedModal();
+    wirePostSubmit(modal, 777);
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    // LinkedIn's own signal a submit went through, on the SDUI frontend a
+    // freshly published post exposes no other identifier this module could
+    // read instead (see the module doc comment).
+    document.body.innerHTML = '';
+    await vi.advanceTimersByTimeAsync(600);
+
+    const warn = logged.find(
+      (e) => e.message === 'activity.linkedin-action.post-confirm-unavailable',
+    );
+    expect(warn).toBeDefined();
+    expect(warn?.level).toBe('warn');
+    expect(warn?.messageParams).toEqual({ draftId: 777 });
+  });
+
+  it('leaves the draft armed and logs nothing when the modal closes but LinkedIn shows an inline error', async () => {
+    const { modal, btn } = buildArmedModal();
+    wirePostSubmit(modal, 777);
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    // The modal is gone - the same shape a successful submit leaves - but
+    // LinkedIn also rendered an inline error, a failed submit's real shape.
+    // The error must win: "the modal closed" alone is not enough to log
+    // anything, and it must never be read as a confirmation.
+    document.body.innerHTML = '';
+    const alert = document.createElement('div');
+    alert.setAttribute('role', 'alert');
+    alert.textContent = 'Something went wrong. Please try again.';
+    document.body.appendChild(alert);
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(
+      logged.some((e) => String(e.message).startsWith('activity.linkedin-action.post-confirm')),
+    ).toBe(false);
+  });
+
+  it('gives up and logs a distinct timeout when the modal neither closes nor errors within 20s', async () => {
+    const { modal, btn } = buildArmedModal();
+    wirePostSubmit(modal, 777);
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    const warn = logged.find((e) => e.message === 'activity.linkedin-action.post-confirm-timeout');
+    expect(warn).toBeDefined();
+    expect(warn?.messageParams).toEqual({ draftId: 777 });
+  });
+});

--- a/shared/src/observed-targets.ts
+++ b/shared/src/observed-targets.ts
@@ -142,7 +142,7 @@ export async function ingestObservedTargets(
  */
 export async function loadRecentObservedTarget(
   db: Db,
-  input: { projectId: number; platformId: number },
+  input: { organizationId: number; projectId: number; platformId: number },
 ): Promise<{
   authorHandle: string | null;
   authorName: string | null;
@@ -159,6 +159,12 @@ export async function loadRecentObservedTarget(
     .from(observedTargets)
     .where(
       and(
+        // Organization as well as project, even though a project belongs to
+        // exactly one organization and the caller has already checked it:
+        // `organization_id` is carried on this row directly for precisely
+        // this reason (#263), and a read that has to be reasoned about to be
+        // safe is one somebody will get wrong later.
+        eq(observedTargets.organizationId, input.organizationId),
         eq(observedTargets.projectId, input.projectId),
         eq(observedTargets.platformId, input.platformId),
         isNotNull(observedTargets.text),

--- a/shared/src/observed-targets.ts
+++ b/shared/src/observed-targets.ts
@@ -17,6 +17,7 @@
 // rather than resurrecting it - see the verifying-on-conflict-dedupe skill.
 
 import { z } from 'zod';
+import { and, desc, eq, isNotNull } from 'drizzle-orm';
 import type { Db } from './db/client.js';
 import { observedTargets } from './db/schema.js';
 
@@ -123,4 +124,53 @@ export async function ingestObservedTargets(
     .returning();
 
   return { written, rejected };
+}
+
+/**
+ * The single most recently observed post with readable text, for `projectId`
+ * on `platformId`. What `POST /api/extension/suggest` grounds a `kind: 'post'`
+ * suggestion in (#315): the post composer itself has nothing to riff off - it
+ * is a blank box, not a post the human is reading - so a `post` suggestion is
+ * grounded server-side in what the observation buffer (#301/#302) already
+ * collected while the human scrolled, rather than the panel handing over
+ * whatever it could scrape live off the page it happens to be on. Ignores
+ * `consumedByRunId`: a scout-candidate drain (#304) consuming a row for a
+ * campaign has nothing to do with whether that sighting is still recent
+ * enough to ground a suggestion. Text-less sightings (a real, documented gap
+ * - see `linkedin-dom.ts`'s "What is checked against a real capture") are
+ * excluded, since there is nothing in them to draft from.
+ */
+export async function loadRecentObservedTarget(
+  db: Db,
+  input: { projectId: number; platformId: number },
+): Promise<{
+  authorHandle: string | null;
+  authorName: string | null;
+  text: string;
+  url: string;
+} | null> {
+  const [row] = await db
+    .select({
+      authorHandle: observedTargets.authorHandle,
+      authorName: observedTargets.authorName,
+      text: observedTargets.text,
+      url: observedTargets.url,
+    })
+    .from(observedTargets)
+    .where(
+      and(
+        eq(observedTargets.projectId, input.projectId),
+        eq(observedTargets.platformId, input.platformId),
+        isNotNull(observedTargets.text),
+      ),
+    )
+    .orderBy(desc(observedTargets.observedAt))
+    .limit(1);
+  if (!row || !row.text) return null;
+  return {
+    authorHandle: row.authorHandle,
+    authorName: row.authorName,
+    text: row.text,
+    url: row.url,
+  };
 }

--- a/shared/tests/observed-targets.test.ts
+++ b/shared/tests/observed-targets.test.ts
@@ -272,6 +272,7 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
 
   it('returns null for a project the collector has never seen anything for', async () => {
     const result = await loadRecentObservedTarget(getDb(), {
+      organizationId: orgAId,
       projectId: projectAId,
       platformId: linkedinId,
     });
@@ -300,6 +301,7 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
     });
 
     const result = await loadRecentObservedTarget(db, {
+      organizationId: orgAId,
       projectId: projectAId,
       platformId: linkedinId,
     });
@@ -328,6 +330,7 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
     });
 
     const result = await loadRecentObservedTarget(db, {
+      organizationId: orgAId,
       projectId: projectAId,
       platformId: linkedinId,
     });
@@ -345,6 +348,7 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
     });
 
     const result = await loadRecentObservedTarget(db, {
+      organizationId: orgAId,
       projectId: projectAId,
       platformId: linkedinId,
     });
@@ -361,6 +365,29 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
     });
 
     const result = await loadRecentObservedTarget(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('refuses a mismatched organization and project pair rather than trusting the project id', async () => {
+    const db = getDb();
+    await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [observation({ text: 'org A saw this' })],
+    });
+
+    // A project belongs to exactly one organization, so this pair cannot
+    // arise from real data: it can only arise from a caller that resolved
+    // one of the two from somewhere else. The row carries `organization_id`
+    // directly (#263) so the query can refuse rather than be reasoned about,
+    // and this is the assertion that keeps that filter honest.
+    const result = await loadRecentObservedTarget(db, {
+      organizationId: orgBId,
       projectId: projectAId,
       platformId: linkedinId,
     });
@@ -385,6 +412,7 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
       .where(eq(schema.observedTargets.projectId, projectAId));
 
     const result = await loadRecentObservedTarget(db, {
+      organizationId: orgAId,
       projectId: projectAId,
       platformId: linkedinId,
     });

--- a/shared/tests/observed-targets.test.ts
+++ b/shared/tests/observed-targets.test.ts
@@ -3,6 +3,7 @@ import { eq, sql } from 'drizzle-orm';
 import { getDb, schema } from '../src/db/client.js';
 import {
   ingestObservedTargets,
+  loadRecentObservedTarget,
   MAX_OBSERVED_TARGETS_BATCH,
   type RawObservedTarget,
 } from '../src/observed-targets.js';
@@ -248,5 +249,145 @@ describe('ingestObservedTargets', () => {
 
     const rows = await db.select().from(schema.observedTargets);
     expect(rows).toHaveLength(0);
+  });
+});
+
+describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds in)', () => {
+  let linkedinId: number;
+  let orgAId: number;
+  let orgBId: number;
+  let projectAId: number;
+  let projectBId: number;
+
+  beforeEach(async () => {
+    await getDb().execute(
+      sql`TRUNCATE observed_targets, projects, organizations RESTART IDENTITY CASCADE`,
+    );
+    linkedinId = await platformId('linkedin');
+    orgAId = await ensureOrg('recent-obs-org-a');
+    orgBId = await ensureOrg('recent-obs-org-b');
+    projectAId = await makeProject(orgAId, 'recent-obs-proj-a');
+    projectBId = await makeProject(orgBId, 'recent-obs-proj-b');
+  });
+
+  it('returns null for a project the collector has never seen anything for', async () => {
+    const result = await loadRecentObservedTarget(getDb(), {
+      projectId: projectAId,
+      platformId: linkedinId,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns the most recently observed row, not the first or the largest id', async () => {
+    const db = getDb();
+    await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [
+        observation({
+          externalId: 'urn:li:activity:older',
+          text: 'an older sighting',
+          observedAt: new Date('2026-01-01T00:00:00Z').toISOString(),
+        }),
+        observation({
+          externalId: 'urn:li:activity:newer',
+          authorName: 'Recent Author',
+          text: 'the newest sighting',
+          observedAt: new Date('2026-06-01T00:00:00Z').toISOString(),
+        }),
+      ],
+    });
+
+    const result = await loadRecentObservedTarget(db, {
+      projectId: projectAId,
+      platformId: linkedinId,
+    });
+    expect(result?.text).toBe('the newest sighting');
+    expect(result?.authorName).toBe('Recent Author');
+  });
+
+  it('skips a text-less sighting even when it is the most recent one', async () => {
+    const db = getDb();
+    await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [
+        observation({
+          externalId: 'urn:li:activity:has-text',
+          text: 'readable content',
+          observedAt: new Date('2026-01-01T00:00:00Z').toISOString(),
+        }),
+        observation({
+          externalId: 'urn:li:activity:no-text',
+          text: null,
+          observedAt: new Date('2026-06-01T00:00:00Z').toISOString(),
+        }),
+      ],
+    });
+
+    const result = await loadRecentObservedTarget(db, {
+      projectId: projectAId,
+      platformId: linkedinId,
+    });
+    expect(result?.text).toBe('readable content');
+  });
+
+  it('never crosses a project boundary within the same org', async () => {
+    const db = getDb();
+    const otherProjectId = await makeProject(orgAId, 'recent-obs-proj-a2');
+    await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: otherProjectId,
+      platformId: linkedinId,
+      observations: [observation({ text: 'seen for the other project only' })],
+    });
+
+    const result = await loadRecentObservedTarget(db, {
+      projectId: projectAId,
+      platformId: linkedinId,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('never crosses an organization boundary', async () => {
+    const db = getDb();
+    await ingestObservedTargets(db, {
+      organizationId: orgBId,
+      projectId: projectBId,
+      platformId: linkedinId,
+      observations: [observation({ text: 'org B saw this, org A never did' })],
+    });
+
+    const result = await loadRecentObservedTarget(db, {
+      projectId: projectAId,
+      platformId: linkedinId,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('still returns a row already consumed by a run - consumption is not what "recent" means here', async () => {
+    const db = getDb();
+    await ingestObservedTargets(db, {
+      organizationId: orgAId,
+      projectId: projectAId,
+      platformId: linkedinId,
+      observations: [observation({ text: 'already drained into a scout run' })],
+    });
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ projectId: projectAId, trigger: 'manual', kind: 'project_extraction' })
+      .returning({ id: schema.runs.id });
+    await db
+      .update(schema.observedTargets)
+      .set({ consumedByRunId: run.id })
+      .where(eq(schema.observedTargets.projectId, projectAId));
+
+    const result = await loadRecentObservedTarget(db, {
+      projectId: projectAId,
+      platformId: linkedinId,
+    });
+    expect(result?.text).toBe('already drained into a scout run');
   });
 });

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -9,8 +9,13 @@ import { runSuggestion } from '$lib/server/suggest.js';
 import { loadActiveTemplates } from '@pitchbox/shared/templates';
 import { getAccountUsage, checkQuota, loadQuotaLimits } from '@pitchbox/shared/quota';
 import { mapDraftKindToQuotaKind } from '@pitchbox/shared/quota-types';
-import { MAX_POST_CHARS, type SuggestionKind } from '@pitchbox/shared/assist/suggest-prompt';
+import {
+  MAX_POST_CHARS,
+  type ObservedPost,
+  type SuggestionKind,
+} from '@pitchbox/shared/assist/suggest-prompt';
 import { loadLinkedInAssistDeviceState } from '@pitchbox/shared/linkedin-assist';
+import { loadRecentObservedTarget } from '@pitchbox/shared/observed-targets';
 
 // The real-time plane. What makes the in-page assistant a separate subsystem
 // rather than a view onto campaigns:
@@ -29,22 +34,38 @@ const perDevice = new RateLimiter(20, 60_000);
 // several legitimate devices still add up to something sane.
 const perOrg = new RateLimiter(60, 60_000);
 
-const BodySchema = z.object({
-  projectId: z.number().int().positive(),
-  kind: z.enum(['post_comment', 'post']),
-  post: z.object({
-    urn: z.string().max(200).optional(),
-    authorHandle: z.string().max(200).optional(),
-    authorName: z.string().max(200).optional(),
-    text: z
-      .string()
-      .min(1)
-      .max(MAX_POST_CHARS * 2),
-    url: z.string().max(2000).optional(),
-  }),
-  hint: z.string().max(500).optional(),
-  platform: z.string().min(1).max(40).default('linkedin'),
-});
+const BodySchema = z
+  .object({
+    projectId: z.number().int().positive(),
+    kind: z.enum(['post_comment', 'post']),
+    post: z.object({
+      urn: z.string().max(200).optional(),
+      authorHandle: z.string().max(200).optional(),
+      authorName: z.string().max(200).optional(),
+      text: z
+        .string()
+        .max(MAX_POST_CHARS * 2)
+        .optional(),
+      url: z.string().max(2000).optional(),
+    }),
+    hint: z.string().max(500).optional(),
+    platform: z.string().min(1).max(40).default('linkedin'),
+  })
+  .superRefine((val, ctx) => {
+    // A `post_comment` suggestion is grounded in the post the panel read off
+    // the page - that travels with the request, there is nothing else to
+    // draft from. A `post` suggestion is grounded server-side instead (see
+    // the observed-targets read below, #315): the composer itself has no
+    // post to riff off, so its own `post` is informational at most and may
+    // be empty.
+    if (val.kind === 'post_comment' && !val.post.text?.trim()) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'post.text is required for kind "post_comment"',
+        path: ['post', 'text'],
+      });
+    }
+  });
 
 function sse(controller: ReadableStreamDefaultController, encoder: TextEncoder) {
   return (kind: string, data: unknown) => {
@@ -165,6 +186,36 @@ export async function POST(event: RequestEvent) {
     }
   }
 
+  // A `post` suggestion has no post to riff off the way a `post_comment`
+  // does - the composer is a blank box - so it is grounded in the most
+  // recent thing the observation buffer (#301/#302) actually saw this
+  // project's account scroll past, read through the server rather than
+  // trusting the panel to have scraped and forwarded a pile of observed
+  // posts itself. An empty buffer (a fresh binding, or nothing sighted
+  // since the collector was last on) is a real, distinct refusal: there is
+  // nothing honest to write a "starting point" prompt from, so this refuses
+  // the same way an exhausted quota does rather than asking the model to
+  // invent a subject.
+  let groundedPost: ObservedPost;
+  if (body.kind === 'post') {
+    const recent = await loadRecentObservedTarget(db, {
+      projectId: project.id,
+      platformId: platform.id,
+    });
+    if (!recent) {
+      return json({ refused: 'no_recent_activity', platform: platform.slug });
+    }
+    groundedPost = {
+      authorHandle: recent.authorHandle ?? undefined,
+      authorName: recent.authorName ?? undefined,
+      text: recent.text,
+      url: recent.url,
+    };
+  } else {
+    // superRefine above guarantees a non-empty post.text for this branch.
+    groundedPost = { ...body.post, text: body.post.text as string };
+  }
+
   const examples = (
     await loadActiveTemplates(db, {
       projectId: project.id,
@@ -188,7 +239,7 @@ export async function POST(event: RequestEvent) {
 
       const handle = runSuggestion({
         kind: body.kind as SuggestionKind,
-        post: body.post,
+        post: groundedPost,
         project: { name: project.name, description: project.description, examples },
         hint: body.hint,
         projectId: project.id,

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -199,6 +199,7 @@ export async function POST(event: RequestEvent) {
   let groundedPost: ObservedPost;
   if (body.kind === 'post') {
     const recent = await loadRecentObservedTarget(db, {
+      organizationId: project.organizationId,
       projectId: project.id,
       platformId: platform.id,
     });

--- a/web/tests/extension-suggest.test.ts
+++ b/web/tests/extension-suggest.test.ts
@@ -8,6 +8,7 @@ import {
   defaultLinkedInAssistSettings,
   saveLinkedInAssistSettings,
 } from '@pitchbox/shared/linkedin-assist';
+import { ingestObservedTargets } from '@pitchbox/shared/observed-targets';
 
 /**
  * The real-time suggestion endpoint (#312). What these tests defend is the
@@ -397,6 +398,61 @@ describe('POST /api/extension/suggest', () => {
     } as never);
     await res.text();
     expect(lastConfig).toMatchObject({ model: 'opus', maxTurns: 3 });
+  });
+  describe('kind: "post" - grounded server-side in the observation buffer, #315', () => {
+    it('refuses with a renderable body, not a 500, when the buffer has nothing recent', async () => {
+      const { org, project } = await seedOrgProject('org-post-empty');
+      await mintDevice(org.id, 'tokPostEmpty');
+
+      const res = await suggest({
+        request: request('tokPostEmpty', { kind: 'post', projectId: project.id, post: {} }),
+      } as never);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      expect(await res.json()).toMatchObject({ refused: 'no_recent_activity' });
+      expect(lastOptions).toBeNull();
+    });
+
+    it('ignores client-supplied post text and grounds the prompt in the most recent observation instead', async () => {
+      const { org, project, platform } = await seedOrgProject('org-post-grounded');
+      await mintDevice(org.id, 'tokPostGrounded');
+      await ingestObservedTargets(getDb(), {
+        organizationId: org.id,
+        projectId: project.id,
+        platformId: platform.id,
+        observations: [
+          {
+            externalId: 'urn:li:activity:older-sighting',
+            url: 'https://www.linkedin.com/feed/update/urn:li:activity:older-sighting/',
+            text: 'an older thing the network was discussing',
+            observedAt: new Date('2026-01-01T00:00:00Z').toISOString(),
+          },
+          {
+            externalId: 'urn:li:activity:newest-sighting',
+            url: 'https://www.linkedin.com/feed/update/urn:li:activity:newest-sighting/',
+            authorName: 'Recent Author',
+            text: 'the most recent thing the network was discussing',
+            observedAt: new Date('2026-06-01T00:00:00Z').toISOString(),
+          },
+        ],
+      });
+
+      const res = await suggest({
+        request: request('tokPostGrounded', {
+          kind: 'post',
+          projectId: project.id,
+          // A pile of client-supplied text - the route must ignore this
+          // entirely for kind "post" and use the observation buffer instead.
+          post: { text: 'whatever the panel scraped off the current page' },
+        }),
+      } as never);
+      expect(res.headers.get('content-type')).toContain('text/event-stream');
+      await res.text();
+
+      expect(lastOptions?.prompt).toContain('the most recent thing the network was discussing');
+      expect(lastOptions?.prompt).not.toContain('an older thing');
+      expect(lastOptions?.prompt).not.toContain('whatever the panel scraped');
+      expect(lastOptions?.prompt).toContain('Recent Author');
+    });
   });
 });
 


### PR DESCRIPTION
Closes #315

**Verified**

- `pnpm run test:linkedin-compliance`: 15/15. Rule 2 confirmed live: planted a `document.cookie` read in `linkedin-post-assist.ts`, watched the checker name that exact file, removed it, watched it go back to 15/15.
- `pnpm run build:extension`: `extension/dist/src/content/linkedin-post-assist.js` exists, is an IIFE (`grep -oE '\b(import|export)\b'` on the built file matches zero literal `import`/`export` statements - the two `export` substring hits are inside i18n key strings, not the keyword), and no static `content_scripts`/`host_permissions` entry was added (matches the comment assist's own dynamic-registration convention).
- `extension/tests/content/linkedin-post-assist.test.ts` (15 tests) + 4 new synthetic-markup cases in `linkedin-dom.test.ts` (`findPostComposerModal`/`findPostSubmitButton`): panel mounts only on the human's click, the stream renders incrementally, accept inserts into the real composer with **zero** synthetic click/submit (instrumented via a patched `HTMLElement.prototype.click` and a `submit` listener, not just read from source), the post quota refusal renders its own message distinct from the comment assist's, and the completion watcher arms/logs/times out without ever fabricating a `sent` call. Every one of these was mutation-tested by hand: broke the production line, watched the exact test go red, restored, confirmed green again. Notably:
  - Removing the `resolveAnchor`-immediate-mount mutation (mounting outside the click handler) broke "mounts nothing until the human clicks".
  - Collapsing the two distinct completion log messages into one broke "logs a distinct warning... once the modal closes without an error".
  - Widening `POST_CONFIRM_TIMEOUT_MS` broke the 20s give-up test.
  - The first version of the "leaves the draft armed... during an inline error" test was **weak** - it passed even with the error check deleted, because the synthetic modal was never actually removed, so "still open" alone masked the error branch. Rewrote it to also close the modal so the error-vs-still-open precedence is genuinely exercised, then re-mutated to confirm it now bites.
  - Disabling the `post.text is required for post_comment` server-side branch, changing the SQL sort order to ascending, and dropping the `isNotNull(text)` filter all broke their respective `shared`/`web` tests (see below).
- `web/tests/extension-suggest.test.ts` (+2) and `shared/tests/observed-targets.test.ts` (+6), run against the real Postgres test DB (`pitchbox_test_w6315`): the `no_recent_activity` refusal when the buffer is empty, and that the prompt is built from the observation buffer's most recent row rather than from client-supplied `post.text` (mutated the grounding branch off; the failure output literally showed the prompt embedding the attacker-supplied "whatever the panel scraped" text instead of the real observation, which is the exact bug this test exists to catch).
- `pnpm -F @pitchbox/extension check` and `pnpm -F web check`: clean.

**Not verified** (needs a human with a real LinkedIn account, per the assignment): the manual flow the issue itself asks for - open the composer, request/edit/insert/publish, confirm the draft lands `sent` with `platform_post_id` set to the published URN. See "Post completion detection" below for exactly why, and exactly what a human needs to go capture before that can be automated.

## What this adds

**The panel.** `extension/src/content/linkedin-post-assist.ts` + `linkedin-post-assist-panel.svelte`, a second panel-bearing content script mirroring #368's comment assist, built through the same crxjs-can't-do-Svelte panel path (`panel-scripts.ts`, `panel-content-scripts.ts`) and registered dynamically (`linkedin-post-assist-registration.ts`, wired into `background.ts`'s `syncLinkedInContentScripts()`), gated on the same optional LinkedIn permission, on `https://www.linkedin.com/feed*` (the "Start a post" composer lives at the top of the feed, not on a single post's page the way the comment composer does). Mounts only on the human's own click into LinkedIn's post editor; the request and accept clicks are the panel's own controls. No synthetic click or submit anywhere.

**Grounding, moved server-side (minimal schema change, no new route).** The issue asked for this to be read through the server rather than the panel handing over a pile of observed posts. `POST /api/extension/suggest`'s body schema made `post.text` optional (previously required unconditionally); a `superRefine` still requires it for `kind: 'post_comment'`. For `kind: 'post'`, the route now ignores whatever `post` the client sent and instead calls a new `shared/src/observed-targets.ts` export, `loadRecentObservedTarget(db, { projectId, platformId })`, which reads the single most recent `observed_targets` row with non-null text for that project (deliberately ignoring `consumedByRunId` - a scout-candidate drain has nothing to do with what's recent). Empty buffer -> a new, distinct refusal, `no_recent_activity`, in both `SuggestRefusalReason` and the post-assist's own i18n dict entry, rather than asking the model to invent a subject. No new HTTP route; the read lives inside the existing suggest handler, right after the kill-switch/project-bound gate and before the stream opens.

**Accept.** Same materialise-into-`drafts` endpoint as the comment assist, `kind: 'post'`, `targetUser: null` (already supported server-side by `assist-accept.ts` - a post is the operator's own voice, not addressed to anyone, so no blocklist/dedup check applies, only the keyword-blocklist and quota gates, which already existed).

**Quota.** The post quota ships at one a day via the existing `QUOTA_DEFAULTS.linkedin.post` seed (already `1`/day, no change needed there). The server answers the same `quota_exhausted` reason for both kinds; the client maps it to its own message (`assist.refusal.post_quota_exhausted`, both `dict-en.ts`/`dict-it.ts`) since "today's comment quota is used up" would be a lie on this surface.

## Post completion detection: the honest gap

A comment's URN is confirmed the moment it posts, because the classic post-detail frontend renders `article[data-id]`. A freshly published post has no equivalent anywhere this module can read: `linkedin-dom.ts`'s own header already documents an exhaustive search (#303) showing the SDUI feed's activity URN is "not in the feed DOM, not inside any shadow root, not in any inline script, and not reachable through React's fiber or memoized props" - and that's exactly the frontend a freshly published post lands on.

So the submit watcher (`wirePostSubmit`, exported and unit-tested) arms the draft on the human's own click of LinkedIn's "Post" control (never dispatched), then watches for the modal closing without an inline error. On a clean close it logs a distinct `activity.linkedin-action.post-confirm-unavailable` warning and stops - **it never calls the `sent` endpoint**, because there is no `platform_post_id` to give it and writing one down anyway would be a fabricated confirmation, not a detected one. The draft stays `armed` for a human to resolve manually. On an inline error it leaves the draft armed silently (a retry is still possible). After 20s with neither signal, it gives up and logs a separate `post-confirm-timeout`.

**What a human with a live account needs to capture before this can go further** (this is the honest version of "if you cannot establish it from the fixtures, say exactly what a human would have to capture"): right after publishing a real post from this composer, does *anything* on the page expose the new post's identifier - a `data-urn` on the fresh top-of-feed card, a `data-sdui-anchor-id` keyed to it, a network response body visible in devtools, or does navigating to the profile's own `/recent-activity/` page render it through the classic frontend with a real `data-urn`? None of the two fixtures in `extension/tests/content/fixtures/linkedin/` show that state (neither shows the modal open, let alone a fresh publish), so none of it is guessed in code here.

The modal/submit-button selectors themselves (`findPostComposerModal`, `findPostSubmitButton`, both new in `linkedin-dom.ts`) are best-effort and unverified against a live capture, exactly like `findPostComposer`/`findCommentSubmitButton` already were before this PR (same disclaimer, same precedent, same "exercised only against synthetic markup" posture) - that's a materially different and much lower-risk kind of guess than the URN question, which is a documented negative finding rather than an untested one.

## Scope notes

- Touched `linkedin-comment-assist.ts` only to exclude the new `no_recent_activity` reason from its own exhaustive `AssistRefusal` record (it's a `kind: 'post'`-only refusal; comment assist can never hit it) - required for `pnpm -F @pitchbox/extension check` to stay clean, no behavior change.
- No migration. `loadRecentObservedTarget` is a plain read against the existing `observed_targets` table.
- Did not touch `docs/linkedin-integration-design.md` or the settings UI (`dailyPostCap` etc.) - out of scope for this issue, already shipped by #316.
