### PR TITLE
fix(tests): stop truncating the seeded default organization

### DIFF
--- a/shared/tests/observed-targets.test.ts
+++ b/shared/tests/observed-targets.test.ts
@@ -56,9 +56,15 @@ describe('ingestObservedTargets', () => {
   let projectBId: number;
 
   beforeEach(async () => {
-    await getDb().execute(
-      sql`TRUNCATE observed_targets, projects, organizations RESTART IDENTITY CASCADE`,
-    );
+    // Never truncate `organizations`: the seeded `default` org is created once
+    // by tests/global-setup.ts and several suites resolve it by slug, so
+    // dropping it here fails whichever file happens to run next. Measured:
+    // running this file immediately before web/tests/extension-sent-comment-id
+    // took that suite from 6 passing to 6 failing, and it is why the full run
+    // failed a different unrelated file each time. Every other suite in the
+    // repo uses the delete-except-default form below.
+    await getDb().execute(sql`TRUNCATE observed_targets, projects RESTART IDENTITY CASCADE`);
+    await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
     linkedinId = await platformId('linkedin');
     orgAId = await ensureOrg('obs-targets-org-a');
     orgBId = await ensureOrg('obs-targets-org-b');
@@ -260,9 +266,9 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
   let projectBId: number;
 
   beforeEach(async () => {
-    await getDb().execute(
-      sql`TRUNCATE observed_targets, projects, organizations RESTART IDENTITY CASCADE`,
-    );
+    // Same reason as the reset above: the seeded `default` org has to survive.
+    await getDb().execute(sql`TRUNCATE observed_targets, projects RESTART IDENTITY CASCADE`);
+    await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
     linkedinId = await platformId('linkedin');
     orgAId = await ensureOrg('recent-obs-org-a');
     orgBId = await ensureOrg('recent-obs-org-b');


### PR DESCRIPTION
Found by the dependency-bump lane (#372) while trying to establish a clean baseline, and worth its own PR because it is not a dependency problem: a full `pnpm test` run was failing a different unrelated file each time, which reads exactly like devbox load and is not.

`shared/tests/observed-targets.test.ts` truncated the `organizations` table in both of its `beforeEach` hooks. That takes out the `default` org, which `tests/global-setup.ts` seeds once per run and which several suites resolve by slug, so whichever file ran next paid for it. Vitest does not guarantee file order, hence a different victim each run.

Measured rather than reasoned about:

| run | result |
|---|---|
| `observed-targets` then `extension-sent-comment-id` | the second suite went from 6 passing to **6 failing** |
| after this fix, same order | 22 passed |
| after this fix, reversed order | 22 passed |

The fix is the form 59 other test files already use: truncate this suite's own tables, then `DELETE FROM organizations WHERE slug != 'default'`.

`shared/tests/auth.test.ts` also truncates `organizations`, and I checked it rather than assuming: it recreates a default org as part of its own assertions, so it restores the invariant it breaks. I left it alone.

What I did not do: add a guard that makes this impossible to reintroduce. A static check over test files (no truncate of `organizations` without a restore) is the obvious candidate, and it belongs in its own change with its own argument, since the honest alternative is a shared reset helper that every suite calls.