### PR TITLE
ci: three-tier CI, Tests (Postgres) to main-only plus preflight

### DIFF
--- a/.github/preflight.json
+++ b/.github/preflight.json
@@ -1,0 +1,26 @@
+{
+  "base": "origin/main",
+  "jobs": 4,
+  "checks": [
+    {
+      "id": "test-postgres",
+      "run": "DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5490/pitchbox_test_preflight ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef PITCHBOX_ROOT=$(pwd) pnpm test",
+      "when": [
+        "web/**",
+        "cli/**",
+        "daemon/**",
+        "extension/**",
+        "shared/**",
+        "tests/**",
+        "package.json",
+        "pnpm-lock.yaml",
+        "vitest.config.ts"
+      ],
+      "setup": "docker compose -f docker-compose.preflight.yml up -d --wait",
+      "teardown": "docker compose -f docker-compose.preflight.yml down -v",
+      "serial": true,
+      "lock": "postgres",
+      "why": "Tests (Postgres) moved off the PR path to main-only (5.2m job); this is its local-tier replacement, against its own disposable Postgres on 5490 so it never touches the dev DB on 5434"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Job-level permissions REPLACE the workflow-level block rather than
+    # merging with it: dorny/paths-filter lists the PR's files through the
+    # API (that's the whole point of needing no checkout), which needs
+    # pull-requests: read on top of contents: read. Every other job stays on
+    # the workflow-level contents: read only.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       app: ${{ steps.filter.outputs.app }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,51 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
-# One in-flight run per ref; new pushes cancel the old run.
+# One in-flight run per ref per event; new pushes cancel the old run.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
+  # PR-only. dorny/paths-filter answers from the API on a pull_request, so
+  # this job needs no checkout. Not used on push: main always runs everything.
+  changes:
+    name: changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'web/**'
+              - 'cli/**'
+              - 'daemon/**'
+              - 'extension/**'
+              - 'shared/**'
+              - 'tests/**'
+              - 'package.json'
+              - 'pnpm-workspace.yaml'
+              - 'pnpm-lock.yaml'
+              - 'tsconfig.base.json'
+              - 'eslint.config.js'
+              - 'vitest*.config.ts'
+
+  # Tier 2: cheap, scoped, runs on a PR and again on main. Skipped entirely
+  # for a diff that can't touch it (docs, playbooks, README).
   quality:
     name: Lint · Typecheck · Build
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -35,8 +71,12 @@ jobs:
       - name: Build (web + extension)
         run: pnpm run build
 
+  # Tier 3: heavy (5.2m), main only. Its PR-path replacement is the
+  # `test-postgres` preflight check (.github/preflight.json) against a local,
+  # disposable Postgres.
   test:
     name: Tests (Postgres)
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:
@@ -70,3 +110,21 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Test (vitest, full suite)
         run: pnpm test
+
+  # The single required status check. Never rename it: it is the one context
+  # in the ruleset, so the job names above it can change forever without
+  # touching a ruleset again.
+  ci:
+    name: ci
+    if: always()
+    needs: [changes, quality, test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: A needed job failed or was cancelled
+        run: |
+          printf '%s\n' '${{ toJSON(needs) }}'
+          printf '%s' '${{ toJSON(needs) }}' | jq -e '
+            to_entries
+            | map(select(.value.result == "failure" or .value.result == "cancelled"))
+            | length == 0'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,11 +112,16 @@ checker (#350).
 
 ### Local verification: run the minimal covering subset
 
-CI (`.github/workflows/ci.yml`) runs the full lint + typecheck + build + test
-matrix on every push and PR - that's the gate at merge. Locally, don't re-run
-the whole matrix; run just enough to catch an obviously broken PR in the code
-you touched. Scope by **amount** (narrow to your diff), never by **category**
-(don't skip a check CI runs - e.g. typecheck or a sub-workspace's own `check`):
+CI (`.github/workflows/ci.yml`) now has three tiers. On a PR it runs a single
+scoped `quality` job (lint + typecheck + build) - skipped entirely when the
+diff can't touch it, per the `changes` filter job. `Tests (Postgres)` no
+longer runs on a PR at all: it moved to `push: main`, since it's the heaviest
+job (5.2m) and doesn't need to block a review. The `ci` job aggregates all of
+the above (skips count as passing) and is the one required status check.
+Locally, don't try to reproduce the whole matrix; run just enough to catch an
+obviously broken PR in the code you touched. Scope by **amount** (narrow to
+your diff), never by **category** (don't skip a check CI runs - e.g.
+typecheck or a sub-workspace's own `check`):
 
 ```bash
 # Tests - filter to the file(s)/pattern you touched, not the full suite
@@ -136,7 +141,9 @@ pnpm -F web check                     # or @pitchbox/extension check
 
 Run the full `pnpm run lint`, `pnpm run typecheck`, and `pnpm test` only for
 release-critical changes (migrations, auth, the runner protocol) or when the
-change is genuinely repo-wide.
+change is genuinely repo-wide. `pnpm test` is also what `preflight` runs
+locally (see "CI and preflight" below) against its own disposable Postgres,
+so a green `preflight` run before you push already covers it.
 
 ## Working in a worktree, next to other agents
 
@@ -210,6 +217,17 @@ above only calls out lint/typecheck/test. `deploy-preview.yml` (on every CI
 success on `main`) and `deploy-prod.yml` (on a `v*` tag) both run on
 `[self-hosted, prodbox]` and rsync into `/opt/apps/pitchbox{-preview}/`: nothing
 local reproduces either, so don't report them as verified.
+
+**CI and preflight.** The one required status check on `main` is `ci`, an
+aggregate job that needs every other job in `.github/workflows/ci.yml` and
+treats a `skipped` dependency as passing - that's what lets a docs-only PR go
+green without paying for `quality` or `Tests (Postgres)`. `Tests (Postgres)`
+only runs on `push: main` now; its PR-path replacement is `preflight`
+(`.github/preflight.json`), which runs `pnpm test` locally against a
+disposable Postgres on `127.0.0.1:5490` (`docker-compose.preflight.yml`,
+its own compose project so it can never touch the dev Postgres on 5434).
+Run `preflight` (or let the installed `pre-push` hook run it) before you
+push; `preflight --list` shows what it would run for your current diff.
 
 **Merging requires a PR, squash-only, and cleans up after itself.** Two active
 rulesets (`gh api repos/fiorelorenzo/pitchbox/rulesets`) protect `main`:

--- a/docker-compose.preflight.yml
+++ b/docker-compose.preflight.yml
@@ -1,0 +1,28 @@
+# Postgres for `preflight`'s local Tests (Postgres) check only. Deliberately its
+# own stack rather than docker-compose.yml's shared dev container: preflight runs
+# unattended (setup, run, teardown) and must not depend on, or disturb, a Postgres
+# a developer already has up for `pnpm run dev`. `name:` gives this its own
+# compose project so `up`/`down -v` here can never touch, recreate, or delete the
+# dev stack's "postgres" service or its `pitchbox-pg-data` volume - without it
+# both files share the directory-derived "pitchbox" project and collide on the
+# service key, which destroyed and replaced the live dev container the first
+# time this was tested. Port 5490 and the tmpfs data directory keep this stack
+# disposable and off every other repo's port range (dev + CI already use 5434).
+name: pitchbox-preflight
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: pitchbox-preflight-postgres
+    environment:
+      POSTGRES_USER: pitchbox
+      POSTGRES_PASSWORD: pitchbox
+      POSTGRES_DB: pitchbox_test_preflight
+    ports:
+      - '127.0.0.1:5490:5432'
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U pitchbox -d pitchbox_test_preflight']
+      interval: 2s
+      timeout: 3s
+      retries: 20


### PR DESCRIPTION
Moves pitchbox onto the estate's three-tier CI shape (measured audit, 2026-09-06).

**Before:** 208 runs/30d, PR CI median 5.0 min. Two jobs on every push and pull_request, no path filtering: `Lint · Typecheck · Build` (1.8m) and `Tests (Postgres)` (5.2m). A docs-only PR paid for both.

**PR path now:** a `changes` job (dorny/paths-filter, no checkout) scopes `quality` (`Lint · Typecheck · Build`) to diffs that can actually break it - skipped on a docs/playbooks-only PR. `Tests (Postgres)` no longer runs on `pull_request` at all.

**Main-only:** `Tests (Postgres)` moves to `push: main` - it's the heaviest job (5.2m) and the deploy gate is what should pay for it, not every review.

**Moved into preflight:** `.github/preflight.json`'s `test-postgres` check runs the identical `pnpm test` locally, against a disposable Postgres on `127.0.0.1:5490` (`docker-compose.preflight.yml`, its own compose project - confirmed this doesn't collide with the dev Postgres on 5434 after an early manifest mistake did exactly that on this machine, see commit history). `serial: true` + `lock: postgres` so it queues behind any other Postgres-bound preflight check on a shared box instead of colliding on host state.

The single required status check becomes `ci`, an aggregate job (`needs: [changes, quality, test]`, `if: always()`) that treats `skipped` as passing.

`deploy-preview.yml`'s `workflow_run: workflows: ['CI']` gate is unaffected - the workflow's top-level `name: CI` didn't change.

**This PR's own CI run** (workflow-only diff, so `quality`/`test` correctly skip): [run 34025291214](https://github.com/fiorelorenzo/pitchbox/actions/runs/34025291214), total wall clock ~12s.

| job | result | started | completed |
| --- | --- | --- | --- |
| changes | success | 09:40:00Z | 09:40:04Z |
| Lint · Typecheck · Build | skipped | 09:40:04Z | 09:40:04Z |
| Tests (Postgres) | skipped | 09:39:58Z | 09:39:58Z |
| ci | success | 09:40:06Z | 09:40:08Z |

`quality`'s own runtime is unchanged from the 1.8m baseline (only its trigger condition changed); this run demonstrates the skip path, which is the new behaviour.

A follow-up commit adds `pull-requests: read` to the `changes` job (job-level permissions replace the workflow-level block, and `dorny/paths-filter` lists a PR's files through the API) after the estate found repos where the default token scope didn't cover it; this run happened to succeed without it, but the fix is now in for safety - see the second CI run on this PR for confirmation.

**Preflight, real:** `preflight --list` on this diff correctly reports `skip test-postgres` (none of the changed paths are in its `when` list). Ran for real against the disposable Postgres on 5490 (forced by id, since this diff doesn't touch app code): **PASS in 433.7s** (~7.2 min). Slower than CI's own 5.2m baseline purely from shared-devbox contention while 8 other agents ran their own repos' suites concurrently (two earlier attempts were killed `-9` by that load before `serial` + `lock: postgres` had something to actually serialize against once the box calmed down). Migrate, seed, full vitest suite and teardown all completed cleanly.
