### PR TITLE
ci: fix quality cascade-skipping on every push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,12 @@ jobs:
   quality:
     name: Lint · Typecheck · Build
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.app == 'true'
+    # !cancelled() (not always()) defeats needs-cascade-skip: a job with
+    # `needs` is skipped whenever the dependency was skipped, regardless of
+    # its own `if`, unless that `if` contains a status-check function. changes
+    # is always skipped on push, so without this, quality silently skipped on
+    # every push:main too - the exact tier this change moved coverage onto.
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.app == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Follow-up to #374. `quality` had `needs: changes` with an `if` that never referenced a status-check function, so GitHub's needs-cascade-skip applied on top regardless: `changes` is always skipped on push (PR-only by design), so `quality` (Lint · Typecheck · Build) silently skipped on the push:main run right after #374 merged - confirmed on the real run (https://github.com/fiorelorenzo/pitchbox/actions/runs/34025939433, `Lint · Typecheck · Build: skipped`). `!cancelled()` in the `if` defeats the cascade. Verifying on the next push:main run after merge.