### PR TITLE
fix(cli,shared,web): record the post author when a comment is marked as sent

### DIFF
--- a/cli/src/commands/drafts.ts
+++ b/cli/src/commands/drafts.ts
@@ -14,6 +14,11 @@ import {
   parseDedupPolicy,
   DEFAULT_DEDUP_POLICY,
 } from '@pitchbox/shared/contact-dedup';
+import {
+  commentTargetSpec,
+  indexCandidateAuthors,
+  resolveCommentTargetUser,
+} from '@pitchbox/shared/comment-target';
 import { notify } from '@pitchbox/shared/notifications';
 import { getProjectOrgId } from '@pitchbox/shared/orgs';
 import { loadQualityRubric } from '@pitchbox/shared/quality-judge';
@@ -68,10 +73,11 @@ function extractOfferSubject(config: unknown): string | null {
 }
 
 // Playbooks document their `drafts_create` payloads with an explicit `null`
-// for fields that do not apply to the kind being written: every commenter and
-// poster playbook on all three platforms shows `"targetUser": null` on a
-// `post`/`post_comment`, because the audience is the thread rather than one
-// user. Zod's `.optional()` accepts a missing key but NOT an explicit null,
+// for fields that do not apply to the kind being written: every poster
+// playbook shows `"targetUser": null` on a `post`, because the audience is
+// the thread rather than one user (the commenter playbooks did too until
+// #336, which made a comment contact with the post's author). Zod's
+// `.optional()` accepts a missing key but NOT an explicit null,
 // so a literal, playbook-compliant payload was rejected whole with "invalid
 // payload" and the agent lost the entire batch. Treat null as absent, and
 // keep the parsed type `T | undefined` so no consumer has to learn a third
@@ -194,6 +200,32 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
   // (issue #325); every other scenario either has no subject or builds its
   // compose URL from the body alone.
   const offerSubject = extractOfferSubject(campaign.config);
+
+  // A `post_comment` is contact with the post's author (issue #336), and the
+  // author is already on the run's own staged candidates, so fill it in here
+  // rather than trusting every playbook to copy the handle across. This runs
+  // ahead of the filter loop on purpose: a derived target then goes through
+  // the same blocklist and dedup checks as one the agent supplied, and
+  // marking the draft as sent later writes the contact_history row the Inbox
+  // dialog promises. Hacker News stages no candidates, so its playbook stays
+  // the only source there and a missing author stays null.
+  const commentSpec = commentTargetSpec(platform?.slug);
+  const needsCommentTarget = draftsInput.some((d) => d.kind === 'post_comment' && !d.targetUser);
+  if (commentSpec && needsCommentTarget) {
+    const candidates = await db
+      .select({ raw: schema.stagingScoutCandidates.raw })
+      .from(schema.stagingScoutCandidates)
+      .where(eq(schema.stagingScoutCandidates.runId, runId));
+    const authorsByPost = indexCandidateAuthors(
+      commentSpec,
+      candidates.map((c) => c.raw),
+    );
+    for (const d of draftsInput) {
+      if (d.kind !== 'post_comment' || d.targetUser) continue;
+      const derived = resolveCommentTargetUser(commentSpec, authorsByPost, d);
+      if (derived) d.targetUser = derived;
+    }
+  }
 
   // Load dedup policy from app_config.dedup_policy. Defaults to a 90-day
   // warn-only window when unset.

--- a/cli/tests/commands/drafts-comment-target.test.ts
+++ b/cli/tests/commands/drafts-comment-target.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { eq, sql } from 'drizzle-orm';
+import { createDrafts, Payload } from '../../src/commands/drafts.js';
+
+/**
+ * Issue #336: a `post_comment` draft carried no `targetUser`, so marking it as
+ * sent wrote no `contact_history` row even though the Inbox dialog said it
+ * would, and the same author could be replied to again with nothing to notice
+ * it. A comment is contact with the post's author, and `createDrafts` derives
+ * that author from the run's own staged candidates instead of trusting the
+ * playbook to copy the handle across.
+ *
+ * This runs against Postgres because the point is the ordering: the derived
+ * target has to reach the blocklist and dedup checks, not just the row.
+ */
+
+async function reset() {
+  const db = getDb();
+  // Deliberately leaves `platforms` and the seeded `default` organization
+  // alone: files share one database and run sequentially (see #373).
+  await db.execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, blocklist, contact_history, staging_scout_candidates RESTART IDENTITY CASCADE`,
+  );
+}
+
+async function seed(platformSlug: string, skillSlug: string) {
+  const db = getDb();
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, platformSlug));
+  const [org] = await db
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(sql`slug = 'default'`);
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `ct-${platformSlug}`, name: 'CT' })
+    .returning();
+  const [account] = await db
+    .insert(schema.accounts)
+    .values({
+      projectId: project.id,
+      platformId: platform.id,
+      handle: 'ourhandle',
+      role: 'personal',
+    })
+    .returning();
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({ projectId: project.id, platformId: platform.id, name: 'c', skillSlug, config: {} })
+    .returning();
+  const [run] = await db
+    .insert(schema.runs)
+    .values({ campaignId: campaign.id, trigger: 'manual', status: 'running' })
+    .returning();
+  return { orgId: org.id, platformId: platform.id, projectId: project.id, account, run };
+}
+
+async function stage(runId: number, raw: Record<string, unknown>) {
+  await getDb().insert(schema.stagingScoutCandidates).values({ runId, raw });
+}
+
+const PERMALINK = '/r/rpg/comments/abc/a_question/';
+
+function redditComment(accountId: number, permalink = PERMALINK) {
+  return {
+    accountId,
+    kind: 'post_comment' as const,
+    subreddit: 'rpg',
+    body: 'the answer is in the DMG appendix',
+    sourceRef: { permalink },
+    metadata: {},
+  };
+}
+
+/** Parsed through the real `drafts_create` schema, so what the test sends is
+ * what an agent could actually send (an omitted `targetUser` included). */
+function payload(drafts: unknown[]) {
+  return Payload.parse(drafts);
+}
+
+beforeEach(reset);
+
+describe('createDrafts derives the post author of a comment (#336)', () => {
+  it('records the staged candidate author as the target, so the sent comment can be logged', async () => {
+    const { account, run } = await seed('reddit', 'reddit-commenter');
+    await stage(run.id, {
+      user: { name: 'alice' },
+      post: { permalink: PERMALINK, title: 'a question' },
+    });
+
+    const res = await createDrafts(run.id, payload([redditComment(account.id)]));
+    expect(res.inserted).toBe(1);
+
+    const [draft] = await getDb().select().from(schema.drafts);
+    expect(draft.targetUser).toBe('alice');
+  });
+
+  it('leaves the agent-supplied target alone rather than overwriting it', async () => {
+    const { account, run } = await seed('reddit', 'reddit-commenter');
+    await stage(run.id, { user: { name: 'alice' }, post: { permalink: PERMALINK } });
+
+    await createDrafts(run.id, payload([{ ...redditComment(account.id), targetUser: 'bob' }]));
+
+    const [draft] = await getDb().select().from(schema.drafts);
+    expect(draft.targetUser).toBe('bob');
+  });
+
+  it('skips a comment on a post whose author is blocklisted', async () => {
+    const { account, run, platformId, projectId } = await seed('reddit', 'reddit-commenter');
+    await stage(run.id, { user: { name: 'alice' }, post: { permalink: PERMALINK } });
+    await getDb().insert(schema.blocklist).values({
+      platformId,
+      projectId,
+      kind: 'user',
+      value: 'alice',
+      reason: 'asked not to be contacted',
+    });
+
+    const res = await createDrafts(run.id, payload([redditComment(account.id)]));
+
+    expect(res.inserted).toBe(0);
+    expect(res.skipped).toEqual([{ targetUser: 'alice', reason: 'asked not to be contacted' }]);
+    expect(await getDb().select().from(schema.drafts)).toHaveLength(0);
+  });
+
+  it('warns on a comment addressed to someone already contacted inside the dedup window', async () => {
+    const { account, run, platformId, orgId } = await seed('reddit', 'reddit-commenter');
+    await stage(run.id, { user: { name: 'alice' }, post: { permalink: PERMALINK } });
+    await getDb()
+      .insert(schema.contactHistory)
+      .values({
+        platformId,
+        organizationId: orgId,
+        accountHandle: 'ourhandle',
+        targetUser: 'alice',
+        lastContactedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+      });
+
+    const res = await createDrafts(run.id, payload([redditComment(account.id)]));
+
+    expect(res.inserted).toBe(1);
+    const [draft] = await getDb().select().from(schema.drafts);
+    expect(draft.targetUser).toBe('alice');
+    expect(draft.dedupWarning).toContain('within 90d window');
+  });
+
+  it('leaves the target null when no staged candidate matches the draft', async () => {
+    const { account, run } = await seed('reddit', 'reddit-commenter');
+    await stage(run.id, {
+      user: { name: 'alice' },
+      post: { permalink: '/r/rpg/comments/zzz/another/' },
+    });
+
+    await createDrafts(run.id, payload([redditComment(account.id)]));
+
+    const [draft] = await getDb().select().from(schema.drafts);
+    expect(draft.targetUser).toBeNull();
+  });
+
+  it('derives a LinkedIn author from the post URN the draft carries', async () => {
+    const { account, run } = await seed('linkedin', 'linkedin-commenter');
+    await stage(run.id, {
+      author: { handle: 'jane-doe', name: 'Jane Doe' },
+      post: {
+        externalId: 'urn:li:activity:123',
+        url: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      },
+    });
+
+    await createDrafts(
+      run.id,
+      payload([
+        {
+          accountId: account.id,
+          kind: 'post_comment',
+          body: 'the second point matches what we saw',
+          sourceRef: { externalId: 'urn:li:activity:123' },
+          metadata: {},
+        },
+      ]),
+    );
+
+    const [draft] = await getDb().select().from(schema.drafts);
+    expect(draft.targetUser).toBe('jane-doe');
+  });
+});

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -63,6 +63,8 @@ Pitchbox tracks every successful outreach in `contact_history`. Before creating 
 
 Dedup is per organization (#263). Two organizations reaching the same handle do not warn each other, because doing so would tell one tenant that another had already been in touch. On a single-tenant install everything lives under the `default` organization, so this makes no difference.
 
+A public comment counts as contact with the post's author (#336). A `post_comment` draft therefore carries that author as its `target_user`, and marking it as sent writes a `contact_history` row exactly like a DM: the author enters the dedup window, the blocklist applies before the draft is even created, and a second reply to the same person is warned about or skipped per the policy below. The handle is not left to the playbook to copy across. `drafts:create` derives it from the run's own staged candidates, matching them to the draft by the post identifier the draft already carries (`shared/src/comment-target.ts`). Hacker News stages no candidates, so there the playbook remains the only source, and a comment whose author cannot be named keeps a null target and writes no contact row rather than an invented one.
+
 Behaviour is governed by `app_config.dedup_policy`:
 
 ```json

--- a/playbooks/hn-commenter.md
+++ b/playbooks/hn-commenter.md
@@ -83,7 +83,7 @@ Write like this instead:
      "accountId": 1,
      "kind": "post_comment",
      "fitScore": 4,
-     "targetUser": null,
+     "targetUser": "<the story's author, the candidate's `by` field>",
      "body": "<comment text>",
      "reasoning": "Why this story, what angle, what value you're adding.",
      "sourceRef": { "itemUrl": "https://news.ycombinator.com/item?id=12345", "title": "..." },
@@ -93,7 +93,7 @@ Write like this instead:
    }
    ```
 
-   `targetUser` is null for `post_comment` - the audience is the thread.
+   `targetUser` is the author of the story you are replying to (`by` on the item you scored). Commenting on someone's story counts as contacting them, so it feeds the blocklist, the dedup window and contact history. Hacker News has no scout staging candidates for the run, so nothing can recover this handle if you omit it: copy it across for every draft.
 
 8. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 

--- a/playbooks/linkedin-commenter.md
+++ b/playbooks/linkedin-commenter.md
@@ -99,7 +99,7 @@ Write like this instead:
      "accountId": 1,
      "kind": "post_comment",
      "fitScore": 4,
-     "targetUser": null,
+     "targetUser": "<the post author's profile slug, the candidate's author.handle>",
      "body": "<reply text>",
      "reasoning": "2-3 sentences on why this post, what angle, what value you're adding.",
      "sourceRef": {
@@ -112,7 +112,7 @@ Write like this instead:
    }
    ```
 
-   Note `targetUser` is null for `post_comment` - the audience is whoever reads the post, not one person, mirroring the Reddit/HN/Mastodon commenter convention.
+   `targetUser` is the author of the post you are replying to, and it is their profile slug (`author.handle`), never their display name: a name cannot be blocklisted or deduped. Commenting on someone's post counts as contacting them, so it feeds the blocklist, the dedup window and contact history, exactly as the in-page assist already does. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.externalId` points at; an observation captured without a slug has no target, and null is the right answer there.
 
 10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 

--- a/playbooks/mastodon-commenter.md
+++ b/playbooks/mastodon-commenter.md
@@ -98,7 +98,7 @@ Write like this instead:
      "accountId": 1,
      "kind": "post_comment",
      "fitScore": 4,
-     "targetUser": null,
+     "targetUser": "<the status author's fully qualified handle, the candidate's author.acct>",
      "body": "<reply text>",
      "reasoning": "2-3 sentences on why this status, what angle, what value you're adding.",
      "sourceRef": { "statusId": "109...", "statusUrl": "https://mastodon.social/@alice/109..." },
@@ -108,7 +108,7 @@ Write like this instead:
    }
    ```
 
-   Note `targetUser` is null for `post_comment` - the audience is whoever reads the thread, not one user, mirroring the Reddit/HN commenter convention.
+   `targetUser` is the author of the status you are replying to, as the fully qualified `author.acct` handle. Replying to someone counts as contacting them, so it feeds the blocklist, the dedup window and contact history. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.statusId` points at.
 
 10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 

--- a/playbooks/reddit-commenter.md
+++ b/playbooks/reddit-commenter.md
@@ -97,7 +97,7 @@ Write like this instead:
      "kind": "post_comment",
      "fitScore": 4,
      "subreddit": "Solo_Roleplaying",
-     "targetUser": null,
+     "targetUser": "<the post author's username, from the candidate's user.name>",
      "body": "<comment markdown>",
      "reasoning": "2-3 sentences on why this post, what angle, what value you're adding.",
      "sourceRef": { "permalink": "/r/Solo_Roleplaying/comments/abc/.../", "postTitle": "..." },
@@ -107,7 +107,7 @@ Write like this instead:
    }
    ```
 
-   Note `targetUser` is null for post_comment - the audience is the whole thread, not one user.
+   `targetUser` is the author of the post you are replying to. Commenting on someone's post counts as contacting them, so it feeds the blocklist, the dedup window and contact history. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.permalink` points at.
 
 9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -28,6 +28,7 @@
     "./campaigns/server": "./src/campaigns/server.ts",
     "./blocklist": "./src/blocklist.ts",
     "./contact-dedup": "./src/contact-dedup.ts",
+    "./comment-target": "./src/comment-target.ts",
     "./templates": "./src/templates.ts",
     "./house-style": "./src/house-style.ts",
     "./assist/suggest-prompt": "./src/assist/suggest-prompt.ts",

--- a/shared/src/comment-target.ts
+++ b/shared/src/comment-target.ts
@@ -1,0 +1,147 @@
+/**
+ * Who a public comment is addressed to (issue #336).
+ *
+ * A `post_comment` draft used to carry `targetUser: null`, so marking it as
+ * sent wrote no `contact_history` row: the Inbox dialog promised one, the
+ * dedup window never saw the author, and a run could reply to the same person
+ * twice with nothing to notice it. The answer is that commenting on someone's
+ * post *is* contact with that person, which is already how the rest of the
+ * system reasons: `reddit:scout` drops candidates whose author is in
+ * `contact_history`, the LinkedIn drain (`cli/src/commands/linkedin.ts`) skips
+ * an observation whose author is inside the dedup window, and the LinkedIn
+ * assist accept path (`shared/src/assist-accept.ts`) already sets the post
+ * author as `targetUser` on a `post_comment`.
+ *
+ * Copying the author's handle from the candidate into the draft is mechanical
+ * work with one correct answer, which is exactly the kind of step a model
+ * drops intermittently, so the code does it instead of the prompt: the run's
+ * own staged candidates are the source, matched to the draft by the post
+ * identifier the draft already carries. The playbooks still name the author,
+ * and this makes the value correct by construction when they don't.
+ *
+ * Hacker News is the one platform with nothing to match against: it has no
+ * scout and stages no candidates (`cli/src/commands/hn.ts` only searches, and
+ * the playbook drafts straight from the tool result), so there its playbook
+ * remains the only source and a missing author stays null.
+ */
+
+/** Where a platform keeps the author and the post identity, in the two shapes
+ * that have to meet: `staging_scout_candidates.raw` on one side, a draft's
+ * `sourceRef`/`metadata` on the other. Dotted paths into `raw`; plain keys on
+ * the draft side, looked up in `sourceRef` first and then `metadata`. */
+export interface CommentTargetSpec {
+  /** Path to the author's stable handle. A display name is not a handle: it
+   * cannot be blocklisted, deduped or matched against an incoming reply, so a
+   * platform whose candidate carries only a name has no author here. */
+  authorPath: string;
+  /** Paths to values that identify the post the candidate is about. */
+  candidateIdPaths: string[];
+  /** Keys under which a draft names that same post. */
+  draftIdKeys: string[];
+}
+
+export const COMMENT_TARGET_SPECS: Record<string, CommentTargetSpec> = {
+  reddit: {
+    authorPath: 'user.name',
+    candidateIdPaths: ['post.permalink'],
+    draftIdKeys: ['permalink'],
+  },
+  mastodon: {
+    authorPath: 'author.acct',
+    candidateIdPaths: ['status.id', 'status.url'],
+    draftIdKeys: ['statusId', 'statusUrl'],
+  },
+  linkedin: {
+    // `author.handle` is the profile slug; `author.name` sits next to it and is
+    // deliberately not used (see CommentTargetSpec.authorPath). An observation
+    // captured without a slug therefore yields no target, which is the same
+    // rule the LinkedIn drain applies before it blocklist-checks a candidate.
+    authorPath: 'author.handle',
+    candidateIdPaths: ['post.externalId', 'post.url'],
+    draftIdKeys: ['externalId', 'url'],
+  },
+};
+
+export function commentTargetSpec(
+  platformSlug: string | null | undefined,
+): CommentTargetSpec | null {
+  if (!platformSlug) return null;
+  return COMMENT_TARGET_SPECS[platformSlug] ?? null;
+}
+
+function at(source: unknown, path: string): unknown {
+  let cursor: unknown = source;
+  for (const key of path.split('.')) {
+    if (cursor == null || typeof cursor !== 'object') return undefined;
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+  return cursor;
+}
+
+/**
+ * One comparable form for a post identifier, so a candidate's Reddit permalink
+ * (`/r/x/comments/abc/slug/`) still matches a draft that wrote it as a full
+ * URL, and a Mastodon status id matches itself. Scheme and host go, the query
+ * and fragment go, case and the trailing slash are normalised. Numbers are
+ * accepted because a numeric id (HN, Mastodon) reaches JSON as one.
+ */
+export function normalizePostId(value: unknown): string | null {
+  let raw: string;
+  if (typeof value === 'string') raw = value;
+  else if (typeof value === 'number' && Number.isFinite(value)) raw = String(value);
+  else return null;
+
+  let s = raw.trim();
+  if (s === '' || s.length > 512) return null;
+  s = s.replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]+/i, '');
+  s = s.split('#')[0].split('?')[0];
+  s = s.replace(/\/+$/, '');
+  s = s.toLowerCase();
+  return s === '' ? null : s;
+}
+
+/**
+ * Post identifier -> author handle, over one run's staged candidates. An
+ * identifier two candidates disagree about maps to `null`: an ambiguous match
+ * is worse than none, since the wrong handle would enter `contact_history`
+ * under the dedup key of a person who was never contacted.
+ */
+export function indexCandidateAuthors(
+  spec: CommentTargetSpec,
+  raws: unknown[],
+): Map<string, string | null> {
+  const index = new Map<string, string | null>();
+  for (const raw of raws) {
+    const author = at(raw, spec.authorPath);
+    if (typeof author !== 'string' || author.trim() === '') continue;
+    const handle = author.trim();
+    for (const path of spec.candidateIdPaths) {
+      const id = normalizePostId(at(raw, path));
+      if (id == null) continue;
+      if (!index.has(id)) index.set(id, handle);
+      else if (index.get(id) !== handle) index.set(id, null);
+    }
+  }
+  return index;
+}
+
+/**
+ * The author of the post a draft comments on, or null when the run's
+ * candidates cannot name one. Never guesses: only an identifier the draft
+ * itself carries is looked up.
+ */
+export function resolveCommentTargetUser(
+  spec: CommentTargetSpec,
+  index: Map<string, string | null>,
+  draft: { sourceRef?: Record<string, unknown>; metadata?: Record<string, unknown> },
+): string | null {
+  for (const key of spec.draftIdKeys) {
+    for (const source of [draft.sourceRef, draft.metadata]) {
+      const id = normalizePostId(source?.[key]);
+      if (id == null) continue;
+      const handle = index.get(id);
+      if (handle) return handle;
+    }
+  }
+  return null;
+}

--- a/shared/tests/comment-target.test.ts
+++ b/shared/tests/comment-target.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import {
+  commentTargetSpec,
+  indexCandidateAuthors,
+  normalizePostId,
+  resolveCommentTargetUser,
+  COMMENT_TARGET_SPECS,
+} from '../src/comment-target.js';
+
+/**
+ * Issue #336: a `post_comment` is contact with the post's author, and the
+ * author is derived from the run's own staged candidates rather than copied
+ * across by the playbook. These are the rules that derivation must not break:
+ * it matches only on an identifier the draft itself carries, it refuses an
+ * ambiguous match, and it never promotes a display name to a handle.
+ */
+
+const reddit = COMMENT_TARGET_SPECS.reddit;
+const mastodon = COMMENT_TARGET_SPECS.mastodon;
+const linkedin = COMMENT_TARGET_SPECS.linkedin;
+
+describe('normalizePostId', () => {
+  it('matches a permalink against the same permalink written as a full URL', () => {
+    expect(normalizePostId('https://www.reddit.com/r/rpg/comments/abc/slug/')).toBe(
+      normalizePostId('/r/rpg/comments/abc/slug'),
+    );
+  });
+
+  it('ignores a query string and a fragment, which carry no identity', () => {
+    expect(normalizePostId('/r/rpg/comments/abc/slug/?utm_source=x#comment')).toBe(
+      normalizePostId('/r/rpg/comments/abc/slug'),
+    );
+  });
+
+  it('accepts a numeric id, since JSON delivers one as a number', () => {
+    expect(normalizePostId(109254)).toBe('109254');
+  });
+
+  it('refuses what cannot identify a post', () => {
+    expect(normalizePostId('')).toBeNull();
+    expect(normalizePostId('   ')).toBeNull();
+    expect(normalizePostId(null)).toBeNull();
+    expect(normalizePostId({ permalink: '/r/x/1' })).toBeNull();
+    expect(normalizePostId('x'.repeat(513))).toBeNull();
+  });
+});
+
+describe('commentTargetSpec', () => {
+  it('has a spec for every platform that stages candidates', () => {
+    expect(commentTargetSpec('reddit')).not.toBeNull();
+    expect(commentTargetSpec('mastodon')).not.toBeNull();
+    expect(commentTargetSpec('linkedin')).not.toBeNull();
+  });
+
+  it('has none for Hacker News, which stages nothing to derive from', () => {
+    expect(commentTargetSpec('hackernews')).toBeNull();
+    expect(commentTargetSpec(null)).toBeNull();
+    expect(commentTargetSpec(undefined)).toBeNull();
+  });
+});
+
+describe('resolveCommentTargetUser', () => {
+  it('finds the Reddit post author from the draft permalink', () => {
+    const index = indexCandidateAuthors(reddit, [
+      { user: { name: 'alice' }, post: { permalink: '/r/rpg/comments/abc/slug/' } },
+      { user: { name: 'bob' }, post: { permalink: '/r/rpg/comments/def/other/' } },
+    ]);
+    expect(
+      resolveCommentTargetUser(reddit, index, {
+        sourceRef: { permalink: 'https://www.reddit.com/r/rpg/comments/def/other/' },
+      }),
+    ).toBe('bob');
+  });
+
+  it('finds the Mastodon author from either the status id or its URL', () => {
+    const index = indexCandidateAuthors(mastodon, [
+      {
+        author: { acct: 'alice@mastodon.social' },
+        status: { id: '109254', url: 'https://mastodon.social/@alice/109254' },
+      },
+    ]);
+    expect(resolveCommentTargetUser(mastodon, index, { sourceRef: { statusId: '109254' } })).toBe(
+      'alice@mastodon.social',
+    );
+    expect(
+      resolveCommentTargetUser(mastodon, index, {
+        sourceRef: { statusUrl: 'https://mastodon.social/@alice/109254' },
+      }),
+    ).toBe('alice@mastodon.social');
+  });
+
+  it('finds the LinkedIn author from the post URN', () => {
+    const index = indexCandidateAuthors(linkedin, [
+      {
+        author: { handle: 'jane-doe', name: 'Jane Doe' },
+        post: {
+          externalId: 'urn:li:activity:123',
+          url: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+        },
+      },
+    ]);
+    expect(
+      resolveCommentTargetUser(linkedin, index, {
+        sourceRef: { externalId: 'urn:li:activity:123' },
+      }),
+    ).toBe('jane-doe');
+  });
+
+  it('refuses a display name when the handle is missing, since a name cannot be deduped', () => {
+    const index = indexCandidateAuthors(linkedin, [
+      {
+        author: { handle: null, name: 'Jane Doe' },
+        post: { externalId: 'urn:li:activity:123' },
+      },
+    ]);
+    expect(
+      resolveCommentTargetUser(linkedin, index, {
+        sourceRef: { externalId: 'urn:li:activity:123' },
+      }),
+    ).toBeNull();
+  });
+
+  it('refuses an identifier two candidates disagree about', () => {
+    const index = indexCandidateAuthors(reddit, [
+      { user: { name: 'alice' }, post: { permalink: '/r/rpg/comments/abc/slug/' } },
+      { user: { name: 'bob' }, post: { permalink: '/r/rpg/comments/abc/slug/' } },
+    ]);
+    expect(
+      resolveCommentTargetUser(reddit, index, {
+        sourceRef: { permalink: '/r/rpg/comments/abc/slug/' },
+      }),
+    ).toBeNull();
+  });
+
+  it('never guesses: an unmatched or absent identifier yields no target', () => {
+    const index = indexCandidateAuthors(reddit, [
+      { user: { name: 'alice' }, post: { permalink: '/r/rpg/comments/abc/slug/' } },
+    ]);
+    expect(
+      resolveCommentTargetUser(reddit, index, {
+        sourceRef: { permalink: '/r/rpg/comments/zzz/nope/' },
+      }),
+    ).toBeNull();
+    expect(resolveCommentTargetUser(reddit, index, { sourceRef: {}, metadata: {} })).toBeNull();
+    expect(resolveCommentTargetUser(reddit, index, {})).toBeNull();
+  });
+
+  it('reads the identifier from metadata when the draft put it there', () => {
+    const index = indexCandidateAuthors(mastodon, [
+      { author: { acct: 'alice@m.example' }, status: { id: '42' } },
+    ]);
+    expect(resolveCommentTargetUser(mastodon, index, { metadata: { statusId: '42' } })).toBe(
+      'alice@m.example',
+    );
+  });
+});

--- a/web/src/lib/components/DraftDetail.svelte
+++ b/web/src/lib/components/DraftDetail.svelte
@@ -664,8 +664,9 @@
 		<Dialog.Header>
 			<Dialog.Title>Mark as sent</Dialog.Title>
 			<Dialog.Description>
-				Paste or edit what you actually sent. Saved on the draft for future reference and logged
-				to contact history.
+				Paste or edit what you actually sent. Saved on the draft for future reference{draft?.targetUser
+					? ' and logged to contact history.'
+					: '. This draft has no recipient, so nothing is written to contact history.'}
 			</Dialog.Description>
 		</Dialog.Header>
 		{#if overQuota && quotaKind && usage && limits}

--- a/web/tests/inbox-comment-contact-history.test.ts
+++ b/web/tests/inbox-comment-contact-history.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { PATCH } from '../src/routes/inbox/[id]/+server.js';
+
+/**
+ * Issue #336: marking a `post_comment` as sent left `contact_history` empty,
+ * so nothing recorded that the author had been engaged, the dedup window never
+ * saw them, and the dialog's "logged to contact history" was false. Comment
+ * drafts now carry the post's author as `targetUser` (derived in
+ * `createDrafts`), and this is the assertion that the promise holds: one row,
+ * naming that author, on the platform the draft belongs to.
+ */
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, blocklist, contact_history, draft_events RESTART IDENTITY CASCADE`,
+  );
+}
+
+async function seedCommentDraft(targetUser: string | null) {
+  const db = getDb();
+  const [org] = await db
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(sql`slug = 'default'`);
+  const [proj] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: 'comment-contact', name: 'comment-contact' })
+    .returning();
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'reddit'));
+  const [account] = await db
+    .insert(schema.accounts)
+    .values({ projectId: proj.id, platformId: platform.id, handle: 'ourhandle' })
+    .returning();
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({
+      projectId: proj.id,
+      platformId: platform.id,
+      name: 'c',
+      skillSlug: 'reddit-commenter',
+    })
+    .returning();
+  const [run] = await db
+    .insert(schema.runs)
+    .values({ campaignId: campaign.id, trigger: 'manual', status: 'success' })
+    .returning();
+  const [draft] = await db
+    .insert(schema.drafts)
+    .values({
+      runId: run.id,
+      projectId: proj.id,
+      platformId: platform.id,
+      accountId: account.id,
+      kind: 'post_comment',
+      body: 'the answer is in the DMG appendix',
+      targetUser,
+      sourceRef: { permalink: '/r/rpg/comments/abc/a_question/' },
+      state: 'approved',
+    })
+    .returning();
+  return { org, platform, draft };
+}
+
+function patchEvent(id: number, body: unknown): RequestEvent {
+  return {
+    locals: {},
+    params: { id: String(id) },
+    request: new Request(`http://localhost/inbox/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as RequestEvent;
+}
+
+describe('marking a comment as sent logs contact history (#336)', () => {
+  beforeEach(reset);
+
+  it('writes exactly one row naming the post author', async () => {
+    const { org, platform, draft } = await seedCommentDraft('alice');
+
+    const res = await PATCH(patchEvent(draft.id, { state: 'sent', version: draft.version }));
+    expect(res.status).toBe(200);
+
+    const contacts = await getDb()
+      .select()
+      .from(schema.contactHistory)
+      .where(eq(schema.contactHistory.draftId, draft.id));
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].targetUser).toBe('alice');
+    expect(contacts[0].accountHandle).toBe('ourhandle');
+    expect(contacts[0].platformId).toBe(platform.id);
+    expect(contacts[0].organizationId).toBe(org.id);
+  });
+
+  it('writes nothing when the comment has no author to name, so the row is never invented', async () => {
+    const { draft } = await seedCommentDraft(null);
+
+    const res = await PATCH(patchEvent(draft.id, { state: 'sent', version: draft.version }));
+    expect(res.status).toBe(200);
+
+    expect(await getDb().select().from(schema.contactHistory)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #336.

Marking a `post_comment` as sent wrote no `contact_history` row, though the dialog said it did. The insert in `web/src/routes/inbox/[id]/+server.ts` is gated on the draft's `target_user`, and all four commenter playbooks set it to `null` (not an empty string, as the issue said). Nothing recorded that the author had been engaged, so the dedup window never saw them, a run could reply to the same person again with nothing to notice it, `dedup_warning` could never fire for a comment, and analytics counted a send with no contact behind it.

I took the option that a public comment is contact with the post's author, which is already how the rest of the system reasons: `reddit:scout` drops candidates whose author is in `contact_history`, the LinkedIn drain skips an observation whose author is inside the dedup window, and the LinkedIn assist accept path (`shared/src/assist-accept.ts`) already sets the author as `target_user` on a `post_comment`. So the campaign commenters now agree with the assist path. No migration: `contact_history.target_user` is already `NOT NULL` and simply gets a value.

The consequence worth naming: commenting on someone's post now puts them inside the dedup window for DMs too, and a second comment on another post by the same author is warned about (or skipped, under `mode: skip`). That is the point of the dedup window, and it stays configurable in `app_config.dedup_policy`.

Copying the handle across is mechanical work with one correct answer, so the code does it instead of the prompt: `createDrafts` derives the author from the run's own staged candidates, matched to the draft by the post identifier the draft already carries (`shared/src/comment-target.ts`). It runs ahead of the filter loop, so a derived target goes through the same blocklist and dedup checks as one the agent supplied. An ambiguous identifier, or a LinkedIn observation captured without a profile slug, yields no target rather than a guess: a display name is not a handle. Hacker News stages no candidates (it has no scout), so there the playbook remains the only source and its note says so.

The dialog copy now says which of the two actually happened rather than promising a row unconditionally.

## Verification

- `shared/tests/comment-target.test.ts`: 13 tests over the resolver, including permalink-vs-full-URL matching, the ambiguous identifier, and the refusal to promote a display name.
- `cli/tests/commands/drafts-comment-target.test.ts`: against Postgres, the derived target reaches the row, the blocklist skips a comment on a blocklisted author, the dedup window warns, an unmatched draft stays null, and an agent-supplied target is never overwritten. Proven to bite: disabling the derivation block fails 4 of the 6.
- `web/tests/inbox-comment-contact-history.test.ts`: marking a comment as sent writes exactly one row naming the author, and nothing when there is no author. Proven to bite: restoring the old `kind === 'dm'` gate fails the first.
- Full suite green: 223 files, 1576 tests. `pnpm -F web check` 0 errors, `pnpm run docs:build` complete.
