### PR TITLE
fix(extension,web): make the packaged extension work in a real install

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -248,7 +248,12 @@ export async function syncLinkedInContentScript(): Promise<void> {
         {
           id: LINKEDIN_CONTENT_SCRIPT_ID,
           js: [linkedinCommentScriptPath],
-          matches: ['https://www.linkedin.com/feed/update/*'],
+          // `/posts/*` as well as `/feed/update/*` (#379): both serve the
+          // classic post-detail frontend that carries the composer and the
+          // activity URN, and `/posts/*` is the URL LinkedIn's own share and
+          // "copy link" hand out. Literal array on purpose - the compliance
+          // checker's rule 2 reads this initializer's text.
+          matches: ['https://www.linkedin.com/feed/update/*', 'https://www.linkedin.com/posts/*'],
           runAt: 'document_idle',
         },
       ]);

--- a/extension/src/background/linkedin-comment-assist-registration.ts
+++ b/extension/src/background/linkedin-comment-assist-registration.ts
@@ -17,11 +17,22 @@ const commentAssistScriptPath = panelScriptOutput(PANEL_CONTENT_SCRIPTS[0]);
 // per script, so a future LinkedIn content script has exactly one place to
 // add its own.
 //
-// Same match set as linkedin-comment.ts's own registration
-// (`/feed/update/*`): the comment composer, and the stable activity URN
-// this module needs to key a suggestion request on, only exist on the
-// classic post-detail page - see linkedin-comment-assist.ts's own doc
-// comment and linkedin-dom.ts's "Two frontends, one identifier".
+// Same match set as linkedin-comment.ts's own registration: the comment
+// composer, and the stable activity URN this module needs to key a suggestion
+// request on, only exist on a classic post-detail page - see
+// linkedin-comment-assist.ts's own doc comment and linkedin-dom.ts's "Two
+// frontends, one identifier".
+//
+// `/posts/*` belongs in that set as much as `/feed/update/*` (#379). It is the
+// canonical post URL: LinkedIn's own "Copia link al post" hands it out, a
+// shared link resolves to it, and content search results open it. Measured on
+// a real signed-in page: it serves the classic frontend, carries
+// `[role="article"][data-urn]` and holds the comment composer, so registering
+// only `/feed/update/*` left the assistant absent from the page a human is
+// most likely to be reading.
+// The literal array is deliberate: tests/compliance/linkedin-boundary.ts
+// rule 2 derives its scan set from the text of this initializer, so hoisting
+// it into a shared constant would silently drop this file out of the check.
 const LINKEDIN_COMMENT_ASSIST_SCRIPT_ID = 'pitchbox-linkedin-comment-assist';
 
 export async function registerLinkedInCommentAssistScript(): Promise<void> {
@@ -37,7 +48,7 @@ export async function registerLinkedInCommentAssistScript(): Promise<void> {
         {
           id: LINKEDIN_COMMENT_ASSIST_SCRIPT_ID,
           js: [commentAssistScriptPath],
-          matches: ['https://www.linkedin.com/feed/update/*'],
+          matches: ['https://www.linkedin.com/feed/update/*', 'https://www.linkedin.com/posts/*'],
           runAt: 'document_idle',
         },
       ]);

--- a/extension/src/background/linkedin-reply-ingest-registration.ts
+++ b/extension/src/background/linkedin-reply-ingest-registration.ts
@@ -28,6 +28,8 @@ export async function registerLinkedInReplyIngestScript(): Promise<void> {
           js: [replyIngestScriptPath],
           matches: [
             'https://www.linkedin.com/feed/update/*',
+            // The same post-detail page under its canonical URL (#379).
+            'https://www.linkedin.com/posts/*',
             'https://www.linkedin.com/notifications*',
             'https://www.linkedin.com/messaging*',
           ],

--- a/extension/src/sidepanel/components/ConnectionCard.svelte
+++ b/extension/src/sidepanel/components/ConnectionCard.svelte
@@ -20,6 +20,20 @@
   import { DEFAULT_BACKEND_URL, normalizeBackendUrl } from '$ext/backend';
   import { originStillNeeded } from '$ext/permissions';
   import { autoPairOutcomeMessageKey, type AutoPairOutcome } from '$ext/auto-pair-outcome';
+  // The *built* auto-pair script, as a standalone IIFE, because this path
+  // injects it on demand into a tab that has usually run it once already.
+  //
+  // Two bugs sat here. Injecting the source path `src/content/auto-pair.ts`
+  // only ever worked under `vite dev`, where that file is served as written;
+  // in a real build it does not exist, executeScript rejected, and pairing
+  // reported "No Pitchbox dashboard found in that tab" while looking straight
+  // at the dashboard. Pointing at crxjs's `?script` output fixed the
+  // rejection and replaced it with a silent no-op: that output is an ESM
+  // loader that dynamic-imports the real chunk, and the dashboard's own
+  // declared content script has already imported that chunk in this
+  // document, so the module is cached and its top-level run never happens a
+  // second time. `?iife` is self-contained, so every injection executes.
+  import autoPairScriptPath from '../../content/auto-pair.ts?iife';
 
   let pairings = $state<Pairing[]>([]);
   let busy = $state(false);
@@ -148,7 +162,7 @@
       const timer = setTimeout(() => finish({ kind: 'no-dashboard' }), 4000);
       chrome.runtime.onMessage.addListener(listener);
       chrome.scripting
-        .executeScript({ target: { tabId: target.tabId }, files: ['src/content/auto-pair.ts'] })
+        .executeScript({ target: { tabId: target.tabId }, files: [autoPairScriptPath] })
         .catch(() => finish({ kind: 'no-dashboard' }));
     });
   }

--- a/extension/src/sidepanel/index.html
+++ b/extension/src/sidepanel/index.html
@@ -4,27 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pitchbox</title>
-    <script>
-      // Synchronously apply theme + density before mount to avoid flash.
-      // chrome.storage.local.get is async, so we keep the html hidden for the
-      // first paint and reveal it after we read the stored settings.
-      document.documentElement.style.visibility = 'hidden';
-      (async () => {
-        try {
-          const out = await chrome.storage.local.get('extensionSettings');
-          const s = out.extensionSettings || {};
-          const theme = s.theme || 'system';
-          const density = s.density || 'comfortable';
-          const isDark =
-            theme === 'dark' ||
-            (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-          if (isDark) document.documentElement.classList.add('dark');
-          if (density === 'compact') document.documentElement.classList.add('density-compact');
-        } finally {
-          document.documentElement.style.visibility = '';
-        }
-      })();
-    </script>
+    <!-- Must stay an external module: MV3's extension CSP is `script-src
+         'self'`, so an inline script here is refused outright (see
+         theme-boot.ts). Module scripts run in document order, so this one
+         still lands before main.ts. -->
+    <script type="module" src="./theme-boot.ts"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/extension/src/sidepanel/theme-boot.ts
+++ b/extension/src/sidepanel/theme-boot.ts
@@ -1,0 +1,36 @@
+/**
+ * Applies the stored theme + density before the app mounts, so the panel does
+ * not flash the wrong palette on open.
+ *
+ * This lived as an inline `<script>` in index.html until it was loaded from a
+ * real install rather than `vite dev`. MV3's default extension CSP is
+ * `script-src 'self'`, which has no `unsafe-inline` and cannot be relaxed for
+ * an extension page, so Chrome refused to execute it: "Executing inline script
+ * violates the following Content Security Policy directive 'script-src
+ * 'self''". The panel still rendered, which is why it survived review, but the
+ * theme was never applied and every open logged an error that surfaces as a
+ * red "Errors" badge on chrome://extensions.
+ *
+ * Kept as its own module rather than folded into main.ts because it has to run
+ * before the app's own imports are evaluated: module scripts execute in
+ * document order, so this one wins.
+ */
+document.documentElement.style.visibility = 'hidden';
+
+void (async () => {
+  try {
+    const out = (await chrome.storage.local.get('extensionSettings')) as {
+      extensionSettings?: { theme?: string; density?: string };
+    };
+    const s = out.extensionSettings ?? {};
+    const theme = s.theme ?? 'system';
+    const density = s.density ?? 'comfortable';
+    const isDark =
+      theme === 'dark' ||
+      (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    if (isDark) document.documentElement.classList.add('dark');
+    if (density === 'compact') document.documentElement.classList.add('density-compact');
+  } finally {
+    document.documentElement.style.visibility = '';
+  }
+})();

--- a/extension/tests/background/linkedin-registration-matches.test.ts
+++ b/extension/tests/background/linkedin-registration-matches.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * #379: the comment send-detection, the in-page comment assistant and the
+ * reply ingestion were all registered for `/feed/update/*` only, so the
+ * assistant was absent from `/posts/<slug>-<id>/` - the canonical post URL,
+ * which is what LinkedIn's own "copy link" produces, what a shared link
+ * resolves to, and where content search sends a reader. Measured on a real
+ * signed-in page: it serves the classic frontend, carries
+ * `[role="article"][data-urn]` and holds the comment composer, so there was
+ * nothing to gain by excluding it and a whole surface to lose.
+ *
+ * These assert the registered match set, not the file's text, so a future
+ * refactor of how the matches are built cannot quietly drop a page.
+ */
+
+const registered: chrome.scripting.RegisteredContentScript[] = [];
+
+const chromeMock = {
+  storage: {
+    local: { get: vi.fn(async () => ({})), set: vi.fn(async () => undefined) },
+    onChanged: { addListener: vi.fn() },
+  },
+  alarms: { clear: vi.fn(async () => true), create: vi.fn(), onAlarm: { addListener: vi.fn() } },
+  permissions: {
+    contains: vi.fn(async () => true),
+    request: vi.fn(async () => true),
+    remove: vi.fn(async () => true),
+    onAdded: { addListener: vi.fn() },
+    onRemoved: { addListener: vi.fn() },
+  },
+  scripting: {
+    getRegisteredContentScripts: vi.fn(async () => []),
+    registerContentScripts: vi.fn(async (scripts: chrome.scripting.RegisteredContentScript[]) => {
+      registered.push(...scripts);
+    }),
+    unregisterContentScripts: vi.fn(async () => undefined),
+  },
+  runtime: {
+    onInstalled: { addListener: vi.fn() },
+    onStartup: { addListener: vi.fn() },
+    onMessage: { addListener: vi.fn() },
+    getManifest: () => ({ version: '0.0.0' }) as chrome.runtime.Manifest,
+  },
+};
+
+// The mock covers only what these registrations touch, so it cannot satisfy
+// the full `typeof chrome` surface. Both casts are named rather than inline:
+// the global has no `chrome` in a plain vitest environment, and the mock is
+// deliberately partial.
+const globalWithChrome = globalThis as unknown as { chrome: typeof chrome };
+const chromeApi = chromeMock as unknown as typeof chrome;
+globalWithChrome.chrome = chromeApi;
+
+beforeEach(() => {
+  registered.length = 0;
+  vi.clearAllMocks();
+});
+
+const POST_DETAIL_URLS = [
+  'https://www.linkedin.com/feed/update/urn:li:activity:7502751599493160960/',
+  'https://www.linkedin.com/posts/aiagents-share-7502751597039562752-zgxL/',
+];
+
+/** True when `matches` (Chrome match patterns) covers `url`. */
+function covers(matches: string[] | undefined, url: string): boolean {
+  return (matches ?? []).some((pattern) => {
+    const rx = new RegExp(
+      '^' +
+        pattern
+          .split('*')
+          .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+          .join('.*') +
+        '$',
+    );
+    return rx.test(url);
+  });
+}
+
+describe('LinkedIn content scripts reach both shapes of a post-detail URL (#379)', () => {
+  it('registers the comment send-detection script for /feed/update and /posts', async () => {
+    const { syncLinkedInContentScript } = await import('../../src/background.js');
+    await syncLinkedInContentScript();
+    const entry = registered.find((s) => s.id === 'pitchbox-linkedin-comment');
+    expect(entry).toBeTruthy();
+    for (const url of POST_DETAIL_URLS) expect(covers(entry!.matches, url)).toBe(true);
+  });
+
+  it('registers the in-page comment assistant for /feed/update and /posts', async () => {
+    const { registerLinkedInCommentAssistScript } =
+      await import('../../src/background/linkedin-comment-assist-registration.js');
+    await registerLinkedInCommentAssistScript();
+    const entry = registered.find((s) => s.id === 'pitchbox-linkedin-comment-assist');
+    expect(entry).toBeTruthy();
+    for (const url of POST_DETAIL_URLS) expect(covers(entry!.matches, url)).toBe(true);
+  });
+
+  it('registers reply ingestion for /feed/update, /posts, notifications and messaging', async () => {
+    const { registerLinkedInReplyIngestScript } =
+      await import('../../src/background/linkedin-reply-ingest-registration.js');
+    await registerLinkedInReplyIngestScript();
+    const entry = registered.find((s) => s.id === 'pitchbox-linkedin-reply-ingest');
+    expect(entry).toBeTruthy();
+    for (const url of [
+      ...POST_DETAIL_URLS,
+      'https://www.linkedin.com/notifications/?filter=all',
+      'https://www.linkedin.com/messaging/thread/123/',
+    ]) {
+      expect(covers(entry!.matches, url)).toBe(true);
+    }
+  });
+
+  it('keeps the observation collector on the pages it already covered', async () => {
+    const { syncLinkedInObserveContentScript } = await import('../../src/background.js');
+    await syncLinkedInObserveContentScript();
+    const entry = registered.find((s) => s.id === 'pitchbox-linkedin-observe');
+    expect(entry).toBeTruthy();
+    for (const url of [
+      'https://www.linkedin.com/feed/',
+      'https://www.linkedin.com/posts/aiagents-share-7502751597039562752-zgxL/',
+      'https://www.linkedin.com/in/informatizzato/recent-activity/all/',
+    ]) {
+      expect(covers(entry!.matches, url)).toBe(true);
+    }
+  });
+
+  it('never widens past linkedin.com, so the optional grant stays meaningful', async () => {
+    const { syncLinkedInContentScript, syncLinkedInObserveContentScript } =
+      await import('../../src/background.js');
+    await syncLinkedInContentScript();
+    await syncLinkedInObserveContentScript();
+    for (const entry of registered) {
+      for (const pattern of entry.matches ?? []) {
+        expect(pattern.startsWith('https://www.linkedin.com/')).toBe(true);
+      }
+    }
+  });
+});

--- a/tests/extension-packaged-build.test.ts
+++ b/tests/extension-packaged-build.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Invariants that only exist in the packaged build, which is exactly where
+ * #379's first three defects lived: every one of them was invisible under
+ * `vite dev` and shipped anyway.
+ *
+ *  - An inline `<script>` in an extension page is refused by MV3's
+ *    `script-src 'self'` CSP, so it never runs and every open logs an error.
+ *  - A runtime script path pointing at a `.ts` source file resolves while Vite
+ *    serves the source and never in `dist`, so `chrome.scripting` rejects and
+ *    the feature reports a misleading failure (pairing said "No Pitchbox
+ *    dashboard found in that tab").
+ *
+ * This builds the extension for real rather than reading the source, because
+ * the artifact is the thing that was wrong. It is the slowest test in the
+ * suite by design.
+ */
+
+const EXT_ROOT = path.resolve(import.meta.dirname, '../extension');
+const DIST = path.join(EXT_ROOT, 'dist');
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const p = path.join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else out.push(p);
+  }
+  return out;
+}
+
+let files: string[] = [];
+
+beforeAll(() => {
+  execFileSync('pnpm', ['exec', 'vite', 'build'], { cwd: EXT_ROOT, stdio: 'pipe' });
+  files = walk(DIST);
+}, 300_000);
+
+describe('the packaged extension', () => {
+  it('emits the pages and content scripts the manifest and registrations name', () => {
+    expect(existsSync(path.join(DIST, 'manifest.json'))).toBe(true);
+    expect(existsSync(path.join(DIST, 'src/sidepanel/index.html'))).toBe(true);
+    for (const script of [
+      'auto-pair.js',
+      'linkedin-comment.js',
+      'linkedin-observe.js',
+      'linkedin-reply-ingest.js',
+      'linkedin-comment-assist.js',
+      'linkedin-post-assist.js',
+    ]) {
+      expect(existsSync(path.join(DIST, 'src/content', script)), script).toBe(true);
+    }
+  });
+
+  it('has no inline script in any page, which MV3 refuses to execute', () => {
+    for (const file of files.filter((f) => f.endsWith('.html'))) {
+      const html = readFileSync(file, 'utf8');
+      const inline = [...html.matchAll(/<script(?![^>]*\bsrc=)[^>]*>/g)].map((m) => m[0]);
+      expect(inline, path.relative(DIST, file)).toEqual([]);
+    }
+  });
+
+  it('hands chrome.scripting only paths that exist in the build', () => {
+    // The literals inside a `files:`/`js:` array are the script paths Chrome
+    // is asked to inject or register. A source `.ts` path lands here when the
+    // code was only ever exercised under `vite dev`, and Chrome answers with a
+    // rejection the caller usually reports as something else entirely. Bare
+    // identifiers are skipped: those are the `?script`/`?iife` imports, whose
+    // value is checked by the emitted-files assertion above.
+    const offenders: string[] = [];
+    for (const file of files.filter((f) => f.endsWith('.js'))) {
+      const js = readFileSync(file, 'utf8');
+      for (const call of js.matchAll(/\b(?:files|js)\s*:\s*\[([^\]]{0,400})\]/g)) {
+        for (const literal of call[1].matchAll(/["'`]([^"'`]+)["'`]/g)) {
+          if (existsSync(path.join(DIST, literal[1]))) continue;
+          offenders.push(`${path.relative(DIST, file)}: ${literal[1]}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the injectable auto-pair script self-contained, so a second injection still runs', () => {
+    // crxjs's `?script` output is an ESM loader that dynamic-imports the real
+    // chunk. Modules are cached per document and the dashboard's declared
+    // content script has already imported that chunk, so injecting the loader
+    // again resolves without executing anything - a silent no-op that read as
+    // "no dashboard in that tab". An IIFE has no import to be cached.
+    const js = readFileSync(path.join(DIST, 'src/content/auto-pair.js'), 'utf8');
+    expect(js).not.toMatch(/\bimport\s*\(/);
+    expect(js).toContain('/api/extension/auto-pair');
+  });
+});

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { getDb, schema } from '$lib/server/db.js';
 import { eq } from 'drizzle-orm';
 import { loadSession } from '@pitchbox/shared/auth';
 import { loadActiveOrganization } from '@pitchbox/shared/orgs';
+import { extensionCorsHeaders } from '$lib/server/extension-cors.js';
 
 /**
  * One-shot cleanup on server boot.
@@ -58,19 +59,6 @@ if (process.env.PITCHBOX_EMBED_DAEMON === '1') {
   };
   process.once('SIGINT', () => void stop('SIGINT'));
   process.once('SIGTERM', () => void stop('SIGTERM'));
-}
-
-const EXTENSION_ALLOWED_ORIGINS = new Set(['https://www.reddit.com', 'https://old.reddit.com']);
-
-function extensionCorsHeaders(origin: string | null): Record<string, string> {
-  const allowed = origin && EXTENSION_ALLOWED_ORIGINS.has(origin) ? origin : 'null';
-  return {
-    'access-control-allow-origin': allowed,
-    'access-control-allow-methods': 'GET, POST, OPTIONS',
-    'access-control-allow-headers': 'authorization, content-type',
-    'access-control-max-age': '86400',
-    vary: 'Origin',
-  };
 }
 
 const AUTH_ON = process.env.PITCHBOX_AUTH === 'on';

--- a/web/src/lib/server/extension-cors.ts
+++ b/web/src/lib/server/extension-cors.ts
@@ -1,0 +1,38 @@
+/**
+ * CORS for `/api/extension/*`.
+ *
+ * These routes are called by the extension's content scripts, which run in
+ * the page's origin, so the browser preflights them and the allowlist below
+ * is what decides whether the extension can talk to this server at all.
+ *
+ * It lived inline in hooks.server.ts and held the two Reddit origins only,
+ * which is how the entire LinkedIn in-page surface shipped dead (#379): from
+ * a real linkedin.com page every call failed with "Response to preflight
+ * request doesn't pass access control check". Nothing caught it because the
+ * server answers a request with no `Origin` (curl, the dashboard's own
+ * fetches) exactly as before, and under `vite dev` the page origin is
+ * localhost. It is its own module now so a test can assert the allowlist
+ * without importing hooks.server.ts, whose module body reaps orphaned runs
+ * against the database.
+ *
+ * A page origin the extension does not inject into has no business here, so
+ * the answer for anything else is the literal `null` origin rather than a
+ * wildcard: `access-control-allow-origin: *` would let any site on the
+ * internet spend a stolen device token from a victim's browser.
+ */
+export const EXTENSION_ALLOWED_ORIGINS: ReadonlySet<string> = new Set([
+  'https://www.reddit.com',
+  'https://old.reddit.com',
+  'https://www.linkedin.com',
+]);
+
+export function extensionCorsHeaders(origin: string | null): Record<string, string> {
+  const allowed = origin && EXTENSION_ALLOWED_ORIGINS.has(origin) ? origin : 'null';
+  return {
+    'access-control-allow-origin': allowed,
+    'access-control-allow-methods': 'GET, POST, OPTIONS',
+    'access-control-allow-headers': 'authorization, content-type',
+    'access-control-max-age': '86400',
+    vary: 'Origin',
+  };
+}

--- a/web/tests/extension-cors.test.ts
+++ b/web/tests/extension-cors.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EXTENSION_ALLOWED_ORIGINS,
+  extensionCorsHeaders,
+} from '../src/lib/server/extension-cors.js';
+
+/**
+ * #379: the allowlist held the two Reddit origins only, so every in-page
+ * LinkedIn call died in the browser's preflight and the whole assistant did
+ * nothing, on a server that looked healthy from curl. Each origin here is a
+ * page the extension injects a content script into; anything else must get
+ * the literal `null` back rather than a wildcard.
+ */
+describe('extension CORS allowlist', () => {
+  it('allows every page origin the extension injects into', () => {
+    for (const origin of [
+      'https://www.linkedin.com',
+      'https://www.reddit.com',
+      'https://old.reddit.com',
+    ]) {
+      expect(extensionCorsHeaders(origin)['access-control-allow-origin']).toBe(origin);
+    }
+  });
+
+  it('refuses an origin the extension does not run on', () => {
+    for (const origin of [
+      'https://evil.example',
+      'https://linkedin.com',
+      'http://www.linkedin.com',
+      'https://www.linkedin.com.evil.example',
+    ]) {
+      expect(extensionCorsHeaders(origin)['access-control-allow-origin']).toBe('null');
+    }
+  });
+
+  it('never answers with a wildcard, since a device token rides these calls', () => {
+    for (const origin of [...EXTENSION_ALLOWED_ORIGINS, 'https://evil.example', null]) {
+      expect(extensionCorsHeaders(origin)['access-control-allow-origin']).not.toBe('*');
+    }
+  });
+
+  it('varies on Origin, so a cached preflight cannot leak across origins', () => {
+    expect(extensionCorsHeaders('https://www.linkedin.com').vary).toBe('Origin');
+  });
+
+  it('allows the methods and headers the content scripts actually send', () => {
+    const h = extensionCorsHeaders('https://www.linkedin.com');
+    expect(h['access-control-allow-methods']).toContain('POST');
+    expect(h['access-control-allow-headers']).toContain('authorization');
+  });
+});


### PR DESCRIPTION
Closes #379.

I installed the built extension in a real Chrome (a logged-in profile on the devbox, loaded over CDP since `--load-extension` is ignored on this Chrome) and drove it against preview. Four defects, none of which can happen under `vite dev`, which is the only way this surface had ever been exercised.

1. **Pairing could never work in a packaged build.** The side panel injected `files: ['src/content/auto-pair.ts']`. That path exists only while Vite serves the source, so `executeScript` rejected and the catch reported `no-dashboard`: "No Pitchbox dashboard found in that tab", while looking straight at the dashboard. This is exactly what Lorenzo hit on his Mac.
2. **crxjs's `?script` output fixes the rejection and replaces it with a silent no-op.** That output is an ESM loader that dynamic-imports the real chunk, the dashboard's own declared content script has already imported that chunk in the document, and a cached module does not re-run its body. Reproduced both states, before and after. `?iife` is self-contained, so every injection executes.
3. **The side panel's inline theme script is refused by MV3's `script-src 'self'`.** The theme was never applied and every open logged the CSP error that surfaces as the red Errors badge on chrome://extensions, which is the "errore" in the report.
4. **LinkedIn was never in the extension CORS allowlist, so the whole in-page surface did nothing.** From a real linkedin.com page: `Access to fetch at 'https://preview.pitchbox.app/api/extension/linkedin-assist' from origin 'https://www.linkedin.com' has been blocked by CORS policy`. Invisible to curl and the dashboard (no Origin) and to `vite dev` (localhost Origin).
5. **The assistant was not registered for the canonical post URL.** `/posts/<slug>-<id>/` is what LinkedIn's own "Copia link al post" hands out and where content search sends you. Measured on a real page: classic frontend, `[role="article"][data-urn]` present, comment composer present. Comment send-detection, the in-page assistant and reply ingestion now match it alongside `/feed/update/*`.

## Verification

- Pairing driven through the real UI in that Chrome after the fix: Disconnect, "Pair with this tab", "Confirm & pair", and the card comes back Connected with the org name and `handshake 0s`. Before the fix the same clicks gave the "No Pitchbox dashboard found" error.
- The LinkedIn host permission granted through Settings -> "Grant access" (the native Chrome prompt clicked over X), then `chrome.scripting.getRegisteredContentScripts()` lists all five scripts.
- `web/tests/extension-cors.test.ts`: the allowlist, including that it never answers `*` and varies on Origin.
- `extension/tests/background/linkedin-registration-matches.test.ts`: the registered match sets cover both post-detail URL shapes and never widen past linkedin.com.
- `tests/extension-packaged-build.test.ts`: builds the extension and asserts on the artifact. Proven to bite: putting the inline script back and restoring the `.ts` injection path fails exactly those two assertions.
- `pnpm run test:linkedin-compliance` 15/15, `pnpm -F @pitchbox/extension check` and `pnpm -F web check` clean.

The end-to-end LinkedIn run against preview needs the CORS fix deployed, so I am merging this and then finishing that verification on the deployed preview.
