### PR TITLE
fix(extension,web): let the in-page assistant actually run on linkedin.com

### DIFF
--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -1,3 +1,7 @@
+// MUST stay the first import: it patches Trusted Types policy creation before
+// Svelte's runtime is evaluated, without which this script throws on
+// linkedin.com and the panel never mounts (#379). See the module's own note.
+import './shared/trusted-types-shim.js';
 import { api, type AcceptRefusalReason, type SuggestEvent, type SuggestUsage } from '../lib/api.js';
 import { logFromContent } from '../lib/log-from-content.js';
 import { mountPanel, panelFor } from './shared/panel-host.js';

--- a/extension/src/content/linkedin-post-assist.ts
+++ b/extension/src/content/linkedin-post-assist.ts
@@ -1,3 +1,7 @@
+// MUST stay the first import: see linkedin-comment-assist.ts and the shim's
+// own note. Without it Svelte's runtime throws on linkedin.com's
+// `trusted-types` allowlist and this script dies before mounting (#379).
+import './shared/trusted-types-shim.js';
 import { api, type AcceptRefusalReason, type SuggestEvent, type SuggestUsage } from '../lib/api.js';
 import { logFromContent } from '../lib/log-from-content.js';
 import { mountPanel, panelFor } from './shared/panel-host.js';

--- a/extension/src/content/shared/linkedin-dom.ts
+++ b/extension/src/content/shared/linkedin-dom.ts
@@ -356,6 +356,37 @@ function ownText(el: Element): string {
   return text.trim();
 }
 
+/**
+ * Class tokens LinkedIn puts on text that exists for a screen reader and is
+ * clipped out of the rendered page ("35 minuti fa - Visibile a tutti su
+ * LinkedIn e altrove", "Attiva per visualizzare un'immagine piu grande").
+ *
+ * `aria-hidden="true"` is the opposite case and already skipped; this is the
+ * one that actually cost us. On a real signed-in post page the first element
+ * with 30+ characters of its own text was the clipped timestamp line, so
+ * `readPostText` returned it and the suggestion request carried LinkedIn's
+ * visibility metadata instead of the post (#379). The model then said so and
+ * refused, which is the right behaviour and no substitute for sending it the
+ * post.
+ *
+ * Matched on class tokens rather than geometry on purpose: every element has
+ * a zero-size box in jsdom, so a `getBoundingClientRect` filter would empty
+ * the fixture-driven tests instead of narrowing them.
+ */
+const SCREEN_READER_ONLY_CLASSES = new Set([
+  'visually-hidden',
+  'a11y-text',
+  'sr-only',
+  'screen-reader-text',
+]);
+
+function isScreenReaderOnly(el: Element): boolean {
+  for (const token of Array.from(el.classList)) {
+    if (SCREEN_READER_ONLY_CLASSES.has(token)) return true;
+  }
+  return false;
+}
+
 function isWithinExcludedRegion(el: Element, boundary: Element): boolean {
   let node: Element | null = el;
   while (node) {
@@ -382,6 +413,7 @@ function isWithinExcludedRegion(el: Element, boundary: Element): boolean {
 function firstSubstantialText(scope: ParentNode, boundary: Element): string | null {
   for (const el of queryDeepAll<Element>('span, p, div', scope)) {
     if (el.getAttribute('aria-hidden') === 'true') continue;
+    if (isScreenReaderOnly(el)) continue;
     if (isWithinExcludedRegion(el, boundary)) continue;
     const text = ownText(el);
     if (text.length >= MIN_SUBSTANTIAL_TEXT_LENGTH) return text;
@@ -395,9 +427,10 @@ function firstSubstantialText(scope: ParentNode, boundary: Element): string | nu
  * - SDUI feed: every `[data-sdui-anchor-id^="commentary-"]` element inside
  *   `post`, joined - LinkedIn's own instrumentation for the post's text
  *   blocks.
- * - Classic: no `data-*` attribute marks the post body either (see module
- *   header), so this falls back to `firstSubstantialText`, deliberately
- *   scoped away from comments and the composer.
+ * - Classic: LinkedIn's own body container (`.update-components-text`) when
+ *   it is there, which is what the rendered post text lives in; otherwise a
+ *   fallback to `firstSubstantialText`, deliberately scoped away from
+ *   comments, the composer and screen-reader-only lines.
  */
 export function readPostText(
   post: Element,
@@ -413,7 +446,12 @@ export function readPostText(
     return text;
   }
   if (pageKind === 'post-detail-classic') {
-    const text = firstSubstantialText(post, post);
+    // Prefer the container LinkedIn itself wraps the body in. The generic
+    // fallback reads whichever element happens to come first, which on a real
+    // page was the clipped "35 minuti fa - Visibile a tutti" line (#379).
+    const container = queryDeep<Element>('.update-components-text', post);
+    const containerText = container?.textContent?.trim() || null;
+    const text = containerText ?? firstSubstantialText(post, post);
     record('postText', pageKind, text !== null);
     return text;
   }

--- a/extension/src/content/shared/trusted-types-shim.ts
+++ b/extension/src/content/shared/trusted-types-shim.ts
@@ -1,0 +1,83 @@
+/**
+ * Lets a Svelte-rendered content script boot on a page that ships a
+ * `trusted-types` CSP allowlist, which LinkedIn does.
+ *
+ * Svelte's client runtime creates a Trusted Types policy while its module is
+ * evaluating (`trustedTypes.createPolicy('svelte-trusted-html')`). A content
+ * script runs in an isolated world and is exempt from the page's CSP for DOM
+ * sinks, but Chrome still applies the page's **policy-name allowlist** to
+ * `createPolicy` there, so on linkedin.com that call throws
+ *
+ *   TypeError: Failed to execute 'createPolicy' on
+ *   'TrustedTypePolicyFactory': Policy "svelte-trusted-html" disallowed.
+ *
+ * The throw lands mid module graph, so it takes the whole script down before
+ * anything mounts: measured on a real signed-in post page, where the in-page
+ * assistant simply never appeared and the only trace was one uncaught
+ * exception (#379).
+ *
+ * So `createPolicy` is wrapped, in this world only, to fall back to an
+ * identity policy when the real factory refuses the name. The strings it
+ * returns are then assigned by Svelte to the same sinks it would have used
+ * anyway, which the isolated world already permits. The page is unaffected:
+ * its own realm keeps its own untouched factory, and nothing here creates a
+ * policy the page can reach.
+ *
+ * Imported first by every panel-bearing content script, because the patch has
+ * to be installed before Svelte's runtime module is evaluated. The DOM lib in
+ * use has no Trusted Types definitions, hence the local structural types.
+ */
+
+type PolicyOptions = {
+  createHTML?: (input: string) => string;
+  createScript?: (input: string) => string;
+  createScriptURL?: (input: string) => string;
+};
+
+type PolicyLike = {
+  name: string;
+  createHTML: (input: string) => string;
+  createScript: (input: string) => string;
+  createScriptURL: (input: string) => string;
+};
+
+export type PolicyFactoryLike = {
+  createPolicy: (name: string, options?: PolicyOptions) => PolicyLike;
+};
+
+/** Named rather than inline: `globalThis` has no `trustedTypes` in this TS lib,
+ * and a browser that predates Trusted Types has none at runtime either. */
+const globalWithTrustedTypes = globalThis as unknown as { trustedTypes?: PolicyFactoryLike };
+
+/** Same call surface, no sanitisation: exactly what Svelte's own policy does
+ * with the template strings it built itself. */
+function identityPolicy(name: string, options?: PolicyOptions): PolicyLike {
+  return {
+    name,
+    createHTML: (input) => options?.createHTML?.(input) ?? input,
+    createScript: (input) => options?.createScript?.(input) ?? input,
+    createScriptURL: (input) => options?.createScriptURL?.(input) ?? input,
+  };
+}
+
+/**
+ * Wraps `factory.createPolicy` so a refused policy name yields an identity
+ * policy instead of throwing. A policy the factory accepts is returned
+ * untouched. Exported so it can be tested directly; the call below is what
+ * matters at runtime, since it must happen on import.
+ */
+export function installTrustedTypesFallback(
+  factory: PolicyFactoryLike | undefined = globalWithTrustedTypes.trustedTypes,
+): void {
+  if (!factory || typeof factory.createPolicy !== 'function') return;
+  const original = factory.createPolicy.bind(factory);
+  factory.createPolicy = (name, options) => {
+    try {
+      return original(name, options);
+    } catch {
+      return identityPolicy(name, options);
+    }
+  };
+}
+
+installTrustedTypesFallback();

--- a/extension/tests/content/linkedin-dom.test.ts
+++ b/extension/tests/content/linkedin-dom.test.ts
@@ -147,6 +147,34 @@ describe('post-detail.html (classic Ember frontend, real capture)', () => {
     render(POST_DETAIL_HTML);
     expect(readOwnProfileHandle(document)).toBeNull();
   });
+
+  // #379, measured on a real signed-in `/posts/...` page: the first element
+  // with 30+ characters of its own text was a clipped, screen-reader-only
+  // line ("35 minuti fa - Visibile a tutti su LinkedIn e altrove"), so the
+  // suggestion request carried LinkedIn's visibility metadata instead of the
+  // post. Both shapes below are what that page actually contains.
+  it('readPostText skips a screen-reader-only line that precedes the body', () => {
+    render(`
+      <div role="article" data-urn="urn:li:activity:7000000000000000002" data-view-name="post">
+        <span class="visually-hidden">35 minuti fa • Visibile a tutti su LinkedIn e altrove</span>
+        <span>We are letting AI agents handle more of the outreach work behind the product.</span>
+      </div>`);
+    const [post] = findFeedPosts(document);
+    expect(readPostText(post, document)).toMatch(/AI agents handle more/);
+  });
+
+  it("readPostText prefers LinkedIn's own body container when it is present", () => {
+    render(`
+      <div role="article" data-urn="urn:li:activity:7000000000000000003" data-view-name="post">
+        <span class="a11y-text">2 ore fa • Visibile a tutti</span>
+        <div class="update-components-text">The workflow runs on a queue and a human approves every message.</div>
+        <div data-id="comment:1"><span>A commenter saying something long enough to qualify.</span></div>
+      </div>`);
+    const [post] = findFeedPosts(document);
+    const text = readPostText(post, document);
+    expect(text).toMatch(/runs on a queue/);
+    expect(text).not.toMatch(/commenter/);
+  });
 });
 
 describe('selector health: matches expected structure on both real captures', () => {

--- a/extension/tests/content/trusted-types-shim.test.ts
+++ b/extension/tests/content/trusted-types-shim.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import {
+  installTrustedTypesFallback,
+  type PolicyFactoryLike,
+} from '../../src/content/shared/trusted-types-shim.js';
+
+/**
+ * #379: linkedin.com ships a `trusted-types` CSP allowlist. A content script
+ * is exempt from the page's CSP for DOM sinks, but Chrome still applies the
+ * policy-name allowlist to `createPolicy` in the isolated world, so Svelte's
+ * own `createPolicy('svelte-trusted-html')` throws while the module graph is
+ * evaluating and the whole panel script dies before mounting - measured on a
+ * real signed-in post page, where the only trace was one uncaught exception.
+ *
+ * The fallback has to leave an accepted policy alone (never hand back a fake
+ * when the real one works) and only stand in when the name is refused.
+ */
+
+function refusingFactory(): PolicyFactoryLike {
+  return {
+    createPolicy: (name) => {
+      throw new TypeError(`Policy "${name}" disallowed.`);
+    },
+  };
+}
+
+describe('installTrustedTypesFallback', () => {
+  it('falls back to an identity policy when the page refuses the policy name', () => {
+    const factory = refusingFactory();
+    installTrustedTypesFallback(factory);
+
+    const policy = factory.createPolicy('svelte-trusted-html', { createHTML: (s) => s });
+    expect(policy.name).toBe('svelte-trusted-html');
+    expect(policy.createHTML('<b>x</b>')).toBe('<b>x</b>');
+  });
+
+  it('returns the real policy untouched when the page allows it', () => {
+    const real = {
+      name: 'real-policy',
+      createHTML: (s: string) => s,
+      createScript: (s: string) => s,
+      createScriptURL: (s: string) => s,
+    };
+    const factory: PolicyFactoryLike = { createPolicy: () => real };
+    installTrustedTypesFallback(factory);
+
+    expect(factory.createPolicy('svelte-trusted-html')).toBe(real);
+  });
+
+  it("honours the caller's own createHTML in the fallback rather than dropping it", () => {
+    const factory = refusingFactory();
+    installTrustedTypesFallback(factory);
+
+    const policy = factory.createPolicy('svelte-trusted-html', {
+      createHTML: (s) => `wrapped:${s}`,
+    });
+    expect(policy.createHTML('x')).toBe('wrapped:x');
+  });
+
+  it('does nothing when the environment has no Trusted Types at all', () => {
+    expect(() => installTrustedTypesFallback(undefined)).not.toThrow();
+  });
+});

--- a/web/src/routes/api/extension/handshake/+server.ts
+++ b/web/src/routes/api/extension/handshake/+server.ts
@@ -1,7 +1,14 @@
 import { json } from '@sveltejs/kit';
 import { requireExtensionAuth } from '$lib/server/extension-auth.js';
+import pkg from '../../../../../package.json';
 
-const VERSION = process.env.npm_package_version ?? '0.0.0';
+// Bundled at build time from web/package.json, the same source the dashboard
+// sidebar reads (see $lib/shared/version.ts). It used to be
+// `process.env.npm_package_version`, which is only set when the process was
+// started by a package-manager script: the deployed container runs `node
+// --import tsx` directly, so every real install saw the fallback and the
+// extension's "Test connection" reported "Connected - server v0.0.0" (#379).
+const VERSION = pkg.version;
 
 export async function POST({ request }: { request: Request }) {
   await requireExtensionAuth(request);

--- a/web/tests/extension-handshake-version.test.ts
+++ b/web/tests/extension-handshake-version.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { POST as handshake } from '../src/routes/api/extension/handshake/+server.js';
+import pkg from '../package.json';
+
+/**
+ * #379: the version came from `process.env.npm_package_version`, which is set
+ * only when a package-manager script started the process. The deployed
+ * container runs `node --import tsx` directly, so every real install saw the
+ * `0.0.0` fallback and the extension's "Test connection" said "Connected -
+ * server v0.0.0". A version that is only right in development is worse than
+ * none: it is the field an operator uses to tell two deployments apart.
+ */
+
+async function reset() {
+  await getDb().execute(sql`TRUNCATE extension_devices RESTART IDENTITY CASCADE`);
+}
+
+async function mintDevice(token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({
+      organizationId: null,
+      tokenHash: createHash('sha256').update(token).digest('hex'),
+      label: 'handshake test',
+    });
+}
+
+function request(token: string): Request {
+  return new Request('http://x/api/extension/handshake', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}` },
+  });
+}
+
+describe('POST /api/extension/handshake', () => {
+  beforeEach(reset);
+
+  it('reports the real deployed version, not a dev-only fallback', async () => {
+    const token = 'handshake-token-1';
+    await mintDevice(token);
+
+    const res = await handshake({ request: request(token) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; version: string };
+    expect(body.ok).toBe(true);
+    expect(body.version).toBe(pkg.version);
+    expect(body.version).not.toBe('0.0.0');
+  });
+
+  it('still refuses a device that was never paired', async () => {
+    await expect(handshake({ request: request('not-a-real-token') })).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Second round on #379, from driving the fixed build through a real signed-in LinkedIn session end to end. Each of these was found by the next step working and revealing the one after it.

1. **The panel never mounted, and the only trace was one uncaught exception.** LinkedIn ships a `trusted-types` CSP allowlist. A content script is exempt from the page's CSP for DOM sinks, but Chrome still applies the policy-name allowlist to `createPolicy` inside the isolated world, and Svelte's runtime creates `svelte-trusted-html` while its module is evaluating: `TypeError: Failed to execute 'createPolicy' on 'TrustedTypePolicyFactory': Policy "svelte-trusted-html" disallowed.` That throw killed the script before anything rendered. Both panel scripts now install a fallback as their first import, which leaves an accepted policy untouched and only stands in when the name is refused.

2. **With the panel up, the first suggestion was grounded in the wrong text, and the model said so.** `readPostText`'s classic-page fallback returns the first element carrying 30+ characters of its own text, which on a real page is a clipped screen-reader-only line: "35 minuti fa - Visibile a tutti su LinkedIn e altrove". `aria-hidden="true"` was already skipped; this is the opposite pattern and was not. The reader now prefers LinkedIn's own body container (`.update-components-text`) and skips screen-reader-only class tokens in the fallback. Verified from both ends afterwards: the observation buffer holds the real post body, and the next suggestion was about the post.

3. **The handshake reported `version 0.0.0` in every real install.** It read `process.env.npm_package_version`, which exists only when a package-manager script started the process; the deployed container runs `node --import tsx` directly. So "Test connection" in the side panel said "Connected - server v0.0.0" against a healthy 0.10.16 deployment. It now reads web/package.json, the same source the dashboard sidebar uses.

## Verification, on the real thing

Driven in a logged-in Chrome profile on the devbox against the deployed preview:

- The in-page panel mounts on a real post page (`/posts/<slug>-<id>/`) once the composer is clicked, naming the post's author, with no exceptions in the page.
- "Suggest a comment" streams: "Reading the post…", then the text, grounded in the actual post body.
- "Insert" writes the draft to preview and fills LinkedIn's own composer, leaving the send to the human: draft 8, `post_comment`, `target_user = alfonso-graziano`, so the author handle reaches contact history exactly as #336 intends.
- The observation collector wrote the post with its real body text and author handle; the row captured before the reader fix still holds the metadata line, which is the before/after in one table.
- Nothing was published on LinkedIn. Insertion is as far as this goes by design.

Tests: the fallback's three behaviours plus the no-Trusted-Types case, both post-text shapes measured on the real page, and the handshake version. The screen-reader check matches class tokens rather than geometry because jsdom gives every element a zero-size box, which would empty the fixture-driven tests instead of narrowing them.
