### PR TITLE
fix(extension): make VITE_DEFAULT_BACKEND_URL actually reach the build

### DIFF
--- a/extension/src/lib/backend.ts
+++ b/extension/src/lib/backend.ts
@@ -5,10 +5,24 @@
  * further backends at runtime from the side panel; pairings are stored per
  * backend in chrome.storage.local (see storage.ts). See
  * docs/extension-connection-design.md for the full model.
+ *
+ * Read from a plain `__PITCHBOX_DEFAULT_BACKEND_URL__` define rather than
+ * `import.meta.env.VITE_DEFAULT_BACKEND_URL` (2026-09-08, #445). Vite owns
+ * `import.meta.env` for any `VITE_`-prefixed name and fills it from `.env`
+ * files, not from the process environment, so a `define` under that key was
+ * silently ignored: measured on this repo, a build with
+ * `VITE_DEFAULT_BACKEND_URL=https://preview.pitchbox.app` produced artifacts
+ * carrying `https://pitchbox.app` in every one of them, side panel and
+ * content scripts alike. The documented override did nothing, and a preview
+ * install only ever reached preview because its pairing named it explicitly.
  */
 
+declare const __PITCHBOX_DEFAULT_BACKEND_URL__: string | undefined;
+
 const RAW_DEFAULT =
-  (import.meta.env.VITE_DEFAULT_BACKEND_URL as string | undefined) || 'https://pitchbox.app';
+  (typeof __PITCHBOX_DEFAULT_BACKEND_URL__ === 'string'
+    ? __PITCHBOX_DEFAULT_BACKEND_URL__
+    : undefined) || 'https://pitchbox.app';
 
 /** The build-time default backend origin, normalized (no trailing slash). */
 export const DEFAULT_BACKEND_URL: string =

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -50,7 +50,15 @@ export default defineConfig({
     // The backend the extension defaults to on a fresh install. Overridable at
     // build time for a self-hosted or preview build; the user can also add
     // other backends at runtime from the side panel. See docs/extension-connection-design.md.
-    'import.meta.env.VITE_DEFAULT_BACKEND_URL': JSON.stringify(
+    //
+    // A plain identifier, not `import.meta.env.VITE_DEFAULT_BACKEND_URL`
+    // (#445): Vite owns `import.meta.env` for `VITE_`-prefixed names and
+    // fills it from `.env` files rather than the process environment, so a
+    // define under that key was silently dropped and every build carried the
+    // production fallback no matter what the environment said. `VITE_` also
+    // stays out of this name deliberately, so it cannot be reclaimed by that
+    // same mechanism later.
+    __PITCHBOX_DEFAULT_BACKEND_URL__: JSON.stringify(
       process.env.VITE_DEFAULT_BACKEND_URL || 'https://pitchbox.app',
     ),
   },

--- a/tests/extension-packaged-build.test.ts
+++ b/tests/extension-packaged-build.test.ts
@@ -35,8 +35,18 @@ function walk(dir: string): string[] {
 
 let files: string[] = [];
 
+const OVERRIDE_BACKEND = 'https://preview-invariant.pitchbox.app';
+
 beforeAll(() => {
-  execFileSync('pnpm', ['exec', 'vite', 'build'], { cwd: EXT_ROOT, stdio: 'pipe' });
+  // Built with the override set, so the same run proves both that the
+  // artifacts exist and that a self-hosted or preview build actually points
+  // where it was told to (#445: the documented variable was silently
+  // dropped, and every build carried the production default).
+  execFileSync('pnpm', ['exec', 'vite', 'build'], {
+    cwd: EXT_ROOT,
+    stdio: 'pipe',
+    env: { ...process.env, VITE_DEFAULT_BACKEND_URL: OVERRIDE_BACKEND },
+  });
   files = walk(DIST);
 }, 300_000);
 
@@ -135,5 +145,18 @@ describe('the packaged extension', () => {
     const js = readFileSync(path.join(DIST, 'src/content/auto-pair.js'), 'utf8');
     expect(js).not.toMatch(/\bimport\s*\(/);
     expect(js).toContain('/api/extension/auto-pair');
+  });
+
+  it('bakes the requested default backend into the build, not the production fallback', () => {
+    // #445: `VITE_DEFAULT_BACKEND_URL` was passed as a
+    // `import.meta.env.VITE_*` define, which Vite fills from `.env` files
+    // instead, so the override was dropped and every artifact carried
+    // `https://pitchbox.app`. A preview install still reached preview because
+    // its pairing named the backend explicitly, which is what hid this: the
+    // default only decides where a fresh, unpaired install talks.
+    const carriers = files.filter(
+      (f) => f.endsWith('.js') && readFileSync(f, 'utf8').includes(OVERRIDE_BACKEND),
+    );
+    expect(carriers.map((f) => path.relative(DIST, f)).length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes #445, under epic #385.

Found while staging a preview build for the Mac: `VITE_DEFAULT_BACKEND_URL=https://preview.pitchbox.app pnpm run build:extension` produced artifacts carrying `https://pitchbox.app` in every one of them, side panel and content scripts alike.

Cause: the value was passed as `define: { 'import.meta.env.VITE_DEFAULT_BACKEND_URL': ... }`. Vite owns `import.meta.env` for any `VITE_`-prefixed name and fills it from `.env` files rather than from the process environment, so that define was silently dropped and `backend.ts`'s `|| 'https://pitchbox.app'` fallback won every time.

Why nobody noticed: a preview install still reaches preview, because the device pairs against a named backend and the pairing wins over the default. The default only decides where a fresh, unpaired install talks, plus it made the runbook sentence I wrote for Lorenzo ("built pointed at preview") false.

Fix: a plain `__PITCHBOX_DEFAULT_BACKEND_URL__` define, which Vite does not reclaim, with `VITE_` deliberately kept out of the name so the same mechanism cannot take it back later. The build input stays `VITE_DEFAULT_BACKEND_URL`, so nothing about how a build is invoked changes.

The packaged-build suite now builds with the variable set and asserts the value lands in the artifacts. Proven to bite by restoring the old define key and watching only that assertion fail (1 failed, 5 passed), then restoring it (6 passed).
