### PR TITLE
fix(extension): mount the panel from the click, not from a card selector

### DIFF
--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -11,6 +11,7 @@ import {
   detectPageKind,
   findCommentComposer,
   findFeedPosts,
+  findPostComposerModal,
   readPostAuthor,
   readPostIdentifier,
   readPostText,
@@ -274,11 +275,38 @@ function logNoDraft(skipped: boolean): void {
  */
 const lastResultFor = new WeakMap<Element, CommentAssistState>();
 
-/** True when LinkedIn's composer already holds text the human typed. Their
- * half-written comment is intent we must not generate over, so the panel
- * waits to be asked in that one case (#439). */
+/**
+ * True when LinkedIn's composer already holds text the human typed (#439:
+ * their half-written comment is intent we must not generate over, so the
+ * panel waits to be asked in that one case).
+ *
+ * Not `textContent.trim()`, which is what shipped and what can read an empty
+ * box as a full one (#447). A rich-text editor's empty state is not an empty
+ * element: LinkedIn's is a `<p><br></p>`, its placeholder is a real node in
+ * the tree on some renders, and both carry text or zero-width characters
+ * that `textContent` faithfully returns. The panel that then mounts in
+ * `resting` looks, to the human, exactly like the feature not working.
+ *
+ * So: ignore anything the editor marks as not-content (`aria-hidden`, a
+ * placeholder attribute or class), drop zero-width and non-breaking
+ * whitespace, and require at least one real character.
+ */
 export function composerHasOwnText(composer: HTMLElement): boolean {
-  return (composer.textContent ?? '').trim().length > 0;
+  const clone = composer.cloneNode(true) as HTMLElement;
+  for (const node of clone.querySelectorAll(
+    '[aria-hidden="true"], [data-placeholder], [class*="placeholder" i], [class*="Placeholder"]',
+  )) {
+    node.remove();
+  }
+  const text = (clone.textContent ?? '')
+    // Zero-width space, zero-width non-joiner, zero-width joiner, BOM and
+    // non-breaking space: an empty editor is routinely made of these. Listed
+    // as alternatives rather than one character class, because ZWJ inside a
+    // class can join its neighbours into one grapheme
+    // (`no-misleading-character-class`).
+    .replace(/\u200b|\u200c|\u200d|\ufeff|\u00a0/g, '')
+    .trim();
+  return text.length > 0;
 }
 
 /**
@@ -559,10 +587,112 @@ export function scanFeedForAssist(root: ParentNode = document): void {
   }
 }
 
+/**
+ * Mounts the panel from a click anywhere in the document that landed inside
+ * a comment composer, whether or not any card selector resolved (#447).
+ *
+ * This is the path that has to work. `scanFeedForAssist` above can only wire
+ * a composer inside a card `findFeedPosts` recognises, so one unfamiliar
+ * feed variant - and LinkedIn ships several, per session, per account - took
+ * the whole feature off the page with nothing logged. Lorenzo reported
+ * exactly that twice, and the second report came with an activity export
+ * that showed the scripts running on a `feed-sdui` page and the panel never
+ * mounting.
+ *
+ * Delegation removes the card selector from the critical path: the composer
+ * itself is the thing the human clicked, so it is the thing we listen for.
+ * A card is still resolved when it can be, because it scopes the post
+ * readers to one card on a feed; when it cannot be, the readers fall back to
+ * the document and the panel still appears. Never dispatches a click, only
+ * listens for one (compliance rule 3). Exported for testing.
+ */
+export function delegateComposerClicks(): void {
+  document.addEventListener(
+    'click',
+    (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const composer = target.closest<HTMLElement>('[contenteditable="true"][role="textbox"]');
+      if (!composer) return;
+      // The post composer modal has its own script and its own panel; this
+      // one must not answer a click in it (#315).
+      if (findPostComposerModal(document)?.contains(composer)) return;
+      const anchor = resolveAnchor(composer);
+      if (panelFor(anchor)) return;
+      composerEverFound = true;
+      const card = resolveCardFor(composer);
+      logFromContent({
+        level: 'info',
+        source: 'linkedin-action',
+        message: 'activity.linkedin-action.assist-mounted',
+        messageParams: {
+          pageKind: detectPageKind(document),
+          card: card ? 'resolved' : 'unresolved',
+        },
+        meta: {
+          script: 'linkedin-comment-assist',
+          pageKind: detectPageKind(document),
+          cardResolved: Boolean(card),
+          composerHadOwnText: composerHasOwnText(composer),
+          url: location.href,
+        },
+      });
+      mountAssistPanel(composer, card ?? undefined);
+    },
+    { capture: true },
+  );
+}
+
+/** How much prose an ancestor must hold, beyond the composer itself, before
+ * it is credible as the post the comment is about. A card's own chrome
+ * (author line, reaction counts, buttons) is well under this; a post body is
+ * comfortably over it. */
+const CARD_MIN_TEXT = 120;
+
+/** How far up the tree the structural fallback is willing to look. Deep
+ * enough for LinkedIn's nesting (measured at seven levels between composer
+ * and card on the SDUI feed), shallow enough that it cannot reach the feed
+ * container. */
+const CARD_MAX_DEPTH = 14;
+
+/**
+ * The post card `composer` belongs to, without trusting a single selector.
+ *
+ * First `findFeedPosts`, which is the recognised shape and the one that
+ * scopes the readers best. Then the known post-container roles. Then, and
+ * this is the part that matters on an unfamiliar feed variant (#447), a
+ * structural walk: the largest ancestor that still contains exactly one
+ * comment composer, which is precisely the boundary between "this post" and
+ * "the feed". Two composers means the walk has left the card, so the last
+ * single-composer ancestor is as wide as it can honestly go - grounding a
+ * suggestion in somebody else's post would be worse than not grounding it.
+ */
+function resolveCardFor(composer: HTMLElement): Element | null {
+  for (const card of findFeedPosts(document)) {
+    if (card.contains(composer)) return card;
+  }
+  const known = composer.closest('[role="article"][data-urn], [role="listitem"]');
+  if (known) return known;
+
+  let candidate: Element | null = null;
+  let node: Element | null = composer.parentElement;
+  for (let depth = 0; node && depth < CARD_MAX_DEPTH; depth += 1, node = node.parentElement) {
+    if (node.querySelectorAll('[contenteditable="true"][role="textbox"]').length > 1) break;
+    if (node.tagName === 'MAIN' || node.tagName === 'BODY') break;
+    const own = (node.textContent ?? '').replace(composer.textContent ?? '', '').trim();
+    if (own.length >= CARD_MIN_TEXT) candidate = node;
+  }
+  return candidate;
+}
+
 const COMPOSER_WAIT_MS = 15_000;
 
 function init(): void {
   resetSelectorHealth();
+  // Delegation first, and it is the load-bearing one (#447): it works on a
+  // feed variant no card selector recognises. The per-card scan below still
+  // runs, because a resolved card is what scopes the post readers.
+  delegateComposerClicks();
   scanFeedForAssist();
   // This observer never disconnects (new cards can arrive for the tab's
   // whole lifetime), so its callback can still be queued for delivery after

--- a/extension/src/content/shared/linkedin-dom.ts
+++ b/extension/src/content/shared/linkedin-dom.ts
@@ -121,6 +121,7 @@ export type LinkedInSelectorId =
   | 'commentAuthor'
   | 'commentBody'
   | 'commentTimestamp'
+  | 'ownProfileTopcard'
   | 'ownProfileName'
   | 'ownProfileHeadline'
   | 'ownProfileAbout'
@@ -506,7 +507,15 @@ export function readPostText(
     record('postText', pageKind, text !== null);
     return text;
   }
-  return null;
+  // An unrecognised page kind is exactly what an unfamiliar LinkedIn variant
+  // looks like, and returning null here took the whole feature off the page
+  // (#447): the assist has a card to read, the human has clicked its comment
+  // box, and the only thing missing is our own classification. The generic
+  // fallback is scoped to that one card, so the worst case is reading the
+  // wrong block *inside* the post the human is answering.
+  const text = longestSubstantialText(post, post);
+  record('postText', pageKind, text !== null);
+  return text;
 }
 
 /**
@@ -940,17 +949,65 @@ function ownTextLines(scope: ParentNode): string[] {
  *   fixture - see the fixture-based test asserting exactly that, and the
  *   synthetic-markup one proving the row-reading logic itself against rows
  *   this account's profile does not have.
+ * - The name itself has its own chain, see `readOwnProfileName` below.
  */
+
+/**
+ * The profile owner's display name, from whichever of three sources this
+ * render actually has (#448).
+ *
+ * The topcard `<h2>` alone is what shipped, and Lorenzo's activity export
+ * on 2026-09-08 showed it missing five times in a row on his own profile
+ * while the same selector worked on the same URL in another browser: this
+ * page is server-driven UI and LinkedIn ships more than one shape of it.
+ * So: the topcard heading, then any `<h1>`/`<h2>` heading on the page, then
+ * the document title, which LinkedIn writes as "<name> | LinkedIn" and
+ * which no A/B variant has yet been seen without.
+ *
+ * The title is a legitimate source rather than a hack: the server-side
+ * guard is what decides whose profile this is (it compares the handle from
+ * the URL path against the persona it already holds), so this only ever
+ * names the page the human opened.
+ */
+function readOwnProfileName(topCard: Element | null, root: Document): string | null {
+  const heading = topCard ? queryDeep<Element>('h2', topCard) : null;
+  const fromTopCard = heading ? ownText(heading) || heading.textContent?.trim() || null : null;
+  if (fromTopCard) return fromTopCard;
+
+  for (const el of queryDeepAll<Element>('h1, h2', root)) {
+    const text = (ownText(el) || el.textContent?.trim() || '').trim();
+    // A heading long enough to be a headline or a section title is not a
+    // name; LinkedIn's own section headings ("Informazioni", "Attività")
+    // are short, so length alone is not the filter - a name has no
+    // sentence punctuation.
+    if (text.length > 0 && text.length <= 60 && !/[.:!?|]/.test(text)) return text;
+  }
+
+  const title = (root.title ?? '').split('|')[0]?.trim() ?? '';
+  return title.length > 0 && title.length <= 60 ? title : null;
+}
+
 export function readOwnProfile(root: Document = document): OwnProfileCapture | null {
   const topCard = queryDeep<Element>('[id$="Topcard"]', root);
-  const nameEl = topCard ? queryDeep<Element>('h2', topCard) : null;
-  const displayName = nameEl ? ownText(nameEl) || nameEl.textContent?.trim() || null : null;
+  // Tracked on its own (#448) so health reports the selector that broke
+  // rather than the field that survived it: the name has a chain of three
+  // sources now, so it can be green on a render where the topcard is gone.
+  record('ownProfileTopcard', 'profile', topCard !== null);
+  const displayName = readOwnProfileName(topCard, root);
   record('ownProfileName', 'profile', displayName !== null);
-  if (!topCard || !nameEl || !displayName) return null;
+  // The topcard is no longer required. It is where the headline comes from,
+  // and nothing else: a render without it still yields a usable persona
+  // (name, about, experience), and refusing to capture one at all is what
+  // left `operator_profiles` empty on Lorenzo's own profile page.
+  if (!displayName) return null;
 
   const handle = readOwnProfilePageHandle(root);
 
-  const headline = ownTextLines(topCard).find((line) => line !== displayName) ?? null;
+  // The headline is the topcard's own second text line, so it is the one
+  // field a render without a topcard genuinely cannot have (#448).
+  const headline = topCard
+    ? (ownTextLines(topCard).find((line) => line !== displayName) ?? null)
+    : null;
   record('ownProfileHeadline', 'profile', headline !== null);
 
   const aboutCard = queryDeep<Element>('[id$="About"]', root);

--- a/extension/src/lib/backend.ts
+++ b/extension/src/lib/backend.ts
@@ -5,10 +5,24 @@
  * further backends at runtime from the side panel; pairings are stored per
  * backend in chrome.storage.local (see storage.ts). See
  * docs/extension-connection-design.md for the full model.
+ *
+ * Read from a plain `__PITCHBOX_DEFAULT_BACKEND_URL__` define rather than
+ * `import.meta.env.VITE_DEFAULT_BACKEND_URL` (2026-09-08, #445). Vite owns
+ * `import.meta.env` for any `VITE_`-prefixed name and fills it from `.env`
+ * files, not from the process environment, so a `define` under that key was
+ * silently ignored: measured on this repo, a build with
+ * `VITE_DEFAULT_BACKEND_URL=https://preview.pitchbox.app` produced artifacts
+ * carrying `https://pitchbox.app` in every one of them, side panel and
+ * content scripts alike. The documented override did nothing, and a preview
+ * install only ever reached preview because its pairing named it explicitly.
  */
 
+declare const __PITCHBOX_DEFAULT_BACKEND_URL__: string | undefined;
+
 const RAW_DEFAULT =
-  (import.meta.env.VITE_DEFAULT_BACKEND_URL as string | undefined) || 'https://pitchbox.app';
+  (typeof __PITCHBOX_DEFAULT_BACKEND_URL__ === 'string'
+    ? __PITCHBOX_DEFAULT_BACKEND_URL__
+    : undefined) || 'https://pitchbox.app';
 
 /** The build-time default backend origin, normalized (no trailing slash). */
 export const DEFAULT_BACKEND_URL: string =

--- a/extension/tests/content/linkedin-comment-assist.test.ts
+++ b/extension/tests/content/linkedin-comment-assist.test.ts
@@ -256,7 +256,9 @@ describe('the panel mounts from the click, not from a card selector (#447)', () 
           </form>
         </div>
       </main>`;
-    const composer = document.querySelector<HTMLElement>('[contenteditable="true"][role="textbox"]');
+    const composer = document.querySelector<HTMLElement>(
+      '[contenteditable="true"][role="textbox"]',
+    );
     if (!composer) throw new Error('no composer in the fixture');
     return composer;
   }
@@ -283,9 +285,8 @@ describe('the panel mounts from the click, not from a card selector (#447)', () 
     composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await settle();
 
-    const mounted = logged.find(
-      (e) => e.message === 'activity.linkedin-action.assist-mounted',
-    ) as { meta?: Record<string, unknown> } | undefined;
+    const mounted = logged.find((e) => e.message === 'activity.linkedin-action.assist-mounted') as
+      { meta?: Record<string, unknown> } | undefined;
     expect(mounted).toBeTruthy();
     // The structural fallback resolved a card even though no selector did.
     expect(mounted!.meta).toMatchObject({ cardResolved: true, composerHadOwnText: false });

--- a/extension/tests/content/linkedin-comment-assist.test.ts
+++ b/extension/tests/content/linkedin-comment-assist.test.ts
@@ -42,8 +42,14 @@ vi.mock('../../src/lib/log-from-content.js', () => ({
   },
 }));
 
-const { wireCommentAssist, refusalMessage, scanFeedForAssist, readAssistPostFromCard } =
-  await import('../../src/content/linkedin-comment-assist.js');
+const {
+  wireCommentAssist,
+  refusalMessage,
+  scanFeedForAssist,
+  readAssistPostFromCard,
+  delegateComposerClicks,
+  composerHasOwnText,
+} = await import('../../src/content/linkedin-comment-assist.js');
 const { findFeedPosts } = await import('../../src/content/shared/linkedin-dom.js');
 
 // `projectId` (context/grounding) and `personalProjectId` (decision 5: where
@@ -228,6 +234,125 @@ describe('one signal, not two clicks (#439)', () => {
     await settle();
 
     expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(1);
+  });
+});
+
+describe('the panel mounts from the click, not from a card selector (#447)', () => {
+  // What Lorenzo's activity export showed: the scripts running on a
+  // `feed-sdui` page, `findFeedPosts` recognising nothing, and the panel
+  // never mounting - with no diagnostic, because the only one that existed
+  // fires on the classic post-detail page. Delegation is what makes the
+  // feature independent of that recognition.
+  function renderUnknownFeedVariant(): HTMLElement {
+    document.body.innerHTML = `
+      <main>
+        <div class="_someHashedClass">
+          <span>Davide Mastricci</span>
+          <div>We shipped the retry budget this week and the p99 halved. The interesting
+          part was not the cache, it was realising the budget was being spent on requests
+          nobody was waiting for.</div>
+          <form>
+            <div contenteditable="true" role="textbox" aria-label="Aggiungi un commento"></div>
+          </form>
+        </div>
+      </main>`;
+    const composer = document.querySelector<HTMLElement>('[contenteditable="true"][role="textbox"]');
+    if (!composer) throw new Error('no composer in the fixture');
+    return composer;
+  }
+
+  it('mounts and requests on a feed variant no card selector recognises', async () => {
+    const composer = renderUnknownFeedVariant();
+    expect(findFeedPosts(document)).toEqual([]);
+    suggest.mockImplementation(streamingSuggest('Because they measured it.', 'A real reply.'));
+
+    delegateComposerClicks();
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(shadows().length).toBe(1);
+    expect(suggest).toHaveBeenCalledTimes(1);
+    expect(shadow().querySelector('textarea')?.value).toBe('A real reply.');
+  });
+
+  it('logs what it mounted on, so silence is never the whole report', async () => {
+    const composer = renderUnknownFeedVariant();
+    suggest.mockImplementation(streamingSuggest('r', 'd'));
+
+    delegateComposerClicks();
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    const mounted = logged.find(
+      (e) => e.message === 'activity.linkedin-action.assist-mounted',
+    ) as { meta?: Record<string, unknown> } | undefined;
+    expect(mounted).toBeTruthy();
+    // The structural fallback resolved a card even though no selector did.
+    expect(mounted!.meta).toMatchObject({ cardResolved: true, composerHadOwnText: false });
+  });
+
+  it('ignores a click in the post composer modal, which has its own panel', async () => {
+    document.body.innerHTML = `
+      <div role="dialog">
+        <div contenteditable="true" role="textbox"></div>
+      </div>`;
+    const composer = document.querySelector<HTMLElement>('[contenteditable="true"]')!;
+
+    delegateComposerClicks();
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(shadows().length).toBe(0);
+    expect(suggest).not.toHaveBeenCalled();
+  });
+
+  it('mounts one panel however the click arrives, delegated or wired', async () => {
+    const composer = renderPost();
+    suggest.mockImplementation(streamingSuggest('r', 'd'));
+
+    delegateComposerClicks();
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(1);
+    expect(suggest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('an empty rich-text editor is empty (#447)', () => {
+  function editor(inner: string): HTMLElement {
+    document.body.innerHTML = `<div contenteditable="true" role="textbox">${inner}</div>`;
+    return document.querySelector<HTMLElement>('[contenteditable="true"]')!;
+  }
+
+  it('reads LinkedIn own empty states as empty', () => {
+    expect(composerHasOwnText(editor('<p><br></p>'))).toBe(false);
+    expect(composerHasOwnText(editor('\u200b'))).toBe(false);
+    expect(composerHasOwnText(editor('&nbsp;'))).toBe(false);
+    expect(
+      composerHasOwnText(editor('<span aria-hidden="true">Aggiungi un commento...</span>')),
+    ).toBe(false);
+    expect(composerHasOwnText(editor('<div data-placeholder="Add a comment"></div>'))).toBe(false);
+    expect(composerHasOwnText(editor('<span class="ql-placeholder">Add a comment</span>'))).toBe(
+      false,
+    );
+  });
+
+  it('still reads a half-written comment as the human own text', () => {
+    expect(composerHasOwnText(editor('<p>I was already writing this</p>'))).toBe(true);
+  });
+
+  it('does not leave the panel waiting on a placeholder-only composer', async () => {
+    const composer = renderPost();
+    composer.innerHTML = '<span aria-hidden="true">Aggiungi un commento...</span>';
+    suggest.mockImplementation(streamingSuggest('r', 'd'));
+
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(suggest).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/extension/tests/content/linkedin-dom.test.ts
+++ b/extension/tests/content/linkedin-dom.test.ts
@@ -603,9 +603,7 @@ describe('selector health: red on a broken profile selector, green on the intact
     const topcard = report.find(
       (e) => e.selector === 'ownProfileTopcard' && e.pageKind === 'profile',
     );
-    const name = report.find(
-      (e) => e.selector === 'ownProfileName' && e.pageKind === 'profile',
-    );
+    const name = report.find((e) => e.selector === 'ownProfileName' && e.pageKind === 'profile');
     expect(topcard?.lastResult).toBe('miss');
     expect(name?.lastResult).toBe('match');
   });

--- a/extension/tests/content/linkedin-dom.test.ts
+++ b/extension/tests/content/linkedin-dom.test.ts
@@ -581,7 +581,11 @@ describe('readOwnProfile: own-profile.html (SDUI profile frontend, real capture)
 });
 
 describe('selector health: red on a broken profile selector, green on the intact capture', () => {
-  it('goes red when the topcard id LinkedIn would normally render is missing', () => {
+  it('reports the topcard as the miss, and still captures what does not need it (#448)', () => {
+    // Lorenzo's own profile rendered a shape where this selector found
+    // nothing, five rescans in a row, and the capture returned null - so
+    // `operator_profiles` stayed empty over one missing container. The
+    // topcard is now tracked on its own and only the headline depends on it.
     const broken = OWN_PROFILE_HTML.replace(
       'com.linkedin.sdui.profile.card.refEXAMPLEMEMBERTopcard',
       'com.linkedin.sdui.profile.card.refEXAMPLEMEMBERTopcardBroken',
@@ -589,11 +593,30 @@ describe('selector health: red on a broken profile selector, green on the intact
     expect(broken).not.toBe(OWN_PROFILE_HTML);
     setUrl('/in/example-person/');
     render(broken);
-    expect(readOwnProfile(document)).toBeNull();
-    const name = getSelectorHealthReport().find(
+
+    const capture = readOwnProfile(document);
+    expect(capture).not.toBeNull();
+    expect(capture!.displayName).toBeTruthy();
+    expect(capture!.headline).toBeNull();
+
+    const report = getSelectorHealthReport();
+    const topcard = report.find(
+      (e) => e.selector === 'ownProfileTopcard' && e.pageKind === 'profile',
+    );
+    const name = report.find(
       (e) => e.selector === 'ownProfileName' && e.pageKind === 'profile',
     );
-    expect(name?.lastResult).toBe('miss');
+    expect(topcard?.lastResult).toBe('miss');
+    expect(name?.lastResult).toBe('match');
+  });
+
+  it('falls back to the document title when no heading names the member', () => {
+    setUrl('/in/example-person/');
+    document.title = 'Giulia Bianchi | LinkedIn';
+    render('<main><section><p>no headings anywhere in this render</p></section></main>');
+
+    const capture = readOwnProfile(document);
+    expect(capture?.displayName).toBe('Giulia Bianchi');
   });
 
   it('is green again for name against the unmodified capture', () => {

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -50,7 +50,15 @@ export default defineConfig({
     // The backend the extension defaults to on a fresh install. Overridable at
     // build time for a self-hosted or preview build; the user can also add
     // other backends at runtime from the side panel. See docs/extension-connection-design.md.
-    'import.meta.env.VITE_DEFAULT_BACKEND_URL': JSON.stringify(
+    //
+    // A plain identifier, not `import.meta.env.VITE_DEFAULT_BACKEND_URL`
+    // (#445): Vite owns `import.meta.env` for `VITE_`-prefixed names and
+    // fills it from `.env` files rather than the process environment, so a
+    // define under that key was silently dropped and every build carried the
+    // production fallback no matter what the environment said. `VITE_` also
+    // stays out of this name deliberately, so it cannot be reclaimed by that
+    // same mechanism later.
+    __PITCHBOX_DEFAULT_BACKEND_URL__: JSON.stringify(
       process.env.VITE_DEFAULT_BACKEND_URL || 'https://pitchbox.app',
     ),
   },

--- a/tests/extension-packaged-build.test.ts
+++ b/tests/extension-packaged-build.test.ts
@@ -35,8 +35,18 @@ function walk(dir: string): string[] {
 
 let files: string[] = [];
 
+const OVERRIDE_BACKEND = 'https://preview-invariant.pitchbox.app';
+
 beforeAll(() => {
-  execFileSync('pnpm', ['exec', 'vite', 'build'], { cwd: EXT_ROOT, stdio: 'pipe' });
+  // Built with the override set, so the same run proves both that the
+  // artifacts exist and that a self-hosted or preview build actually points
+  // where it was told to (#445: the documented variable was silently
+  // dropped, and every build carried the production default).
+  execFileSync('pnpm', ['exec', 'vite', 'build'], {
+    cwd: EXT_ROOT,
+    stdio: 'pipe',
+    env: { ...process.env, VITE_DEFAULT_BACKEND_URL: OVERRIDE_BACKEND },
+  });
   files = walk(DIST);
 }, 300_000);
 
@@ -135,5 +145,18 @@ describe('the packaged extension', () => {
     const js = readFileSync(path.join(DIST, 'src/content/auto-pair.js'), 'utf8');
     expect(js).not.toMatch(/\bimport\s*\(/);
     expect(js).toContain('/api/extension/auto-pair');
+  });
+
+  it('bakes the requested default backend into the build, not the production fallback', () => {
+    // #445: `VITE_DEFAULT_BACKEND_URL` was passed as a
+    // `import.meta.env.VITE_*` define, which Vite fills from `.env` files
+    // instead, so the override was dropped and every artifact carried
+    // `https://pitchbox.app`. A preview install still reached preview because
+    // its pairing named the backend explicitly, which is what hid this: the
+    // default only decides where a fresh, unpaired install talks.
+    const carriers = files.filter(
+      (f) => f.endsWith('.js') && readFileSync(f, 'utf8').includes(OVERRIDE_BACKEND),
+    );
+    expect(carriers.map((f) => path.relative(DIST, f)).length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes #447, closes #448. Under epic #385.

Lorenzo reported the overlay missing on the feed for the second time, and this time attached an activity export. That export is what made it diagnosable, and it is worth reading as evidence:

- `09:32:49` install, `09:33:00` paired;
- `09:33:10` and `09:33:14`, two `selector-miss` entries with `pageKind: feed-sdui` - so the scripts **were** injected and running on the feed, which means #438's fix landed;
- then nothing. No mount, no refusal, no suggestion, and no assist run or draft on preview in that window.

## Why silence was the only symptom

Mounting depended on our own recognition of the page. `scanFeedForAssist` wires a composer only inside a card `findFeedPosts` recognises, and `readPostText` returned `null` outright for a page kind we do not classify. LinkedIn ships several feed shapes per account and per session, so one unfamiliar variant took the whole feature off the page - and the only diagnostic that existed fires on the classic post-detail page, so nothing was logged.

Four changes, all in the same direction, removing our classification from the critical path:

1. **A document-level delegated click listener.** The composer the human clicked is the thing we listen for, so no card selector can keep the panel from appearing. Still never dispatches a click, only listens for one (compliance rule 3), and a click inside the post composer modal is left to that surface's own script.
2. **A structural card fallback**: the largest ancestor that still contains exactly one comment composer, which is the honest boundary between "this post" and "the feed". A wrong card would be worse than none, since it would ground the suggestion in somebody else's post.
3. **`readPostText` on an unknown page kind** now uses its card-scoped longest-block fallback instead of returning null.
4. **An `activity.linkedin-action.assist-mounted` entry** carrying page kind, whether a card resolved, and whether the composer already had text. The next report cannot be silence.

## The bug that could have produced the same symptom alone

`composerHasOwnText` was `textContent.trim()`. A rich-text editor's empty state is not an empty element: LinkedIn's is `<p><br></p>`, its placeholder is a real node on some renders, and both carry text or zero-width characters that `textContent` faithfully returns. So the panel could mount, decide the human was already writing, and sit there with a button - which looks exactly like the feature not working. It now ignores anything the editor marks as not-content (`aria-hidden`, placeholder attribute or class) and strips zero-width and non-breaking whitespace.

## The persona capture, from the same export (#448)

Five `ownProfileName` misses on his own profile page, ten seconds apart, while the same selector works on the same URL in the browser here. Worse than a missing field: `readOwnProfile` required `[id$="Topcard"]` **and** an `<h2>` inside it, so that render captured nothing at all.

The name now has three sources (topcard heading, then any short heading with no sentence punctuation, then `document.title`, which LinkedIn writes as `<name> | LinkedIn`), the topcard is tracked as its own selector-health id so the report names the container that broke rather than the field that survived it, and the capture no longer requires the topcard - it is where the headline comes from and nothing else.

## Verification

On the real feed in a signed-in Chrome against the deployed preview, and the sequence matters because it exercises #438 too:

- the extension was loaded **without** the LinkedIn permission, so nothing was registered and nothing mounted (which is also how I know the permission is what a fresh unpacked load drops);
- granting it from the side panel injected all six scripts **into the LinkedIn tab that was already open**, with no reload;
- clicking that tab's comment box mounted the panel and started generating with no second click;
- the new diagnostic logged `cardResolved: true, composerHadOwnText: false, pageKind: feed-sdui`;
- the model declined that post and said so in the product's own two lines.

The persona re-captured from the real profile page in the same run (`operator_profiles` updated at 09:56 UTC with name, headline and 1445 characters of about).

1764 tests, 0 lint errors, 770 files typechecked clean, compliance 15/15, packaged build 6/6. Both new behaviours proven to bite: reverting the unknown-page-kind fallback fails the delegated-mount test, and restoring the topcard requirement fails both new capture tests.
