### PR TITLE
perf(shared): cap the two uncapped costs in the companion prompt (#443)

### DIFF
--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -65,9 +65,37 @@ export const MAX_EXAMPLES = 3;
  * better, and every one of these sources can be arbitrarily long (an "about"
  * section, a README, a commit message someone pasted a stack trace into). */
 const PERSONA_ABOUT_MAX = 1200;
-const VOICE_SAMPLE_MAX = 600;
-const README_EXCERPT_MAX = 1200;
+/** Ceiling on one voice sample's length. A captured LinkedIn post is whatever
+ * length the operator posted, and operator_voice_samples.text has no length
+ * constraint of its own. Verified 2026-09-08 (#443): an 874-char and a
+ * 1562-char sample both come out of buildSuggestionPrompt at the same
+ * clamped length, so a long sample already costs no more than a short one
+ * once past this cap. Exported so the test proving that can pin the exact
+ * boundary rather than only checking "shorter than the input". */
+export const VOICE_SAMPLE_MAX = 600;
+/** Ceiling on a repo's README excerpt as it goes into the prompt. The cached
+ * excerpt is already clamped to 1200 chars when it is fetched
+ * (github-sources.ts README_EXCERPT_MAX_CHARS), a budget sized for "enough to
+ * read", not "enough to spend on every suggestion". Measured on this repo's
+ * own README (2026-09-08, #443): the sentence that says what the project
+ * actually is runs about 130 characters, and the rest of a 1200-char excerpt
+ * is Quick start commands and prerequisites - across four repos that cost
+ * ~5.8KB, 38% of a realistic prompt, on boilerplate the model cannot use in a
+ * comment or post. 400 keeps a title plus a couple of real sentences and cuts
+ * the rest. */
+export const README_EXCERPT_MAX = 400;
 const COMMIT_SUBJECT_MAX = 120;
+/** Ceiling on how many of the organization's projects reach the "what they
+ * are building" list. This was the one section with no cap at all - every
+ * project in the org went in regardless of count. Measured 2026-09-08 (#443):
+ * twelve projects, a plausible count after a few years of side projects, cost
+ * ~1.6KB on a realistic fixture even with each description already capped
+ * below, and that grows without bound as an account ages. The current
+ * project and the personal project are ranked ahead of the cut in
+ * buildSuggestionPrompt below, because those are the two a suggestion can
+ * actually depend on; the rest is honest context, not a requirement, so
+ * losing one to the cap costs nothing the suggestion needs. */
+export const MAX_PROJECTS = 6;
 /** A project mention in the "what they are building" list is a one-liner, not
  * a second copy of `CurrentProject`'s full description. */
 const PROJECT_DESCRIPTION_MAX = 300;
@@ -166,12 +194,21 @@ export function buildSuggestionPrompt(args: {
 
   // What they are building: every project in the organization, so the
   // assistant can speak honestly about the operator's other work instead of
-  // acting as if this product is the only thing they do.
+  // acting as if this product is the only thing they do. Ranked before the
+  // MAX_PROJECTS cut so the current project and the personal project always
+  // survive it regardless of how many other projects the organization has -
+  // those two are what a suggestion can actually depend on; everything else
+  // is honest context that is fine to lose past the ceiling.
   if (projects.length > 0) {
+    const rankedProjects = [...projects].sort((a, b) => {
+      const aRank = a.isCurrent ? 0 : a.isPersonal ? 1 : 2;
+      const bRank = b.isCurrent ? 0 : b.isPersonal ? 1 : 2;
+      return aRank - bRank;
+    });
     parts.push(
       [
         'What the operator is building, across the whole organization. This suggestion is filed under the project marked "(this one)":',
-        ...projects.map((p) => {
+        ...rankedProjects.slice(0, MAX_PROJECTS).map((p) => {
           const marker = p.isCurrent ? ' (this one)' : '';
           const desc = p.description?.trim()
             ? `: ${clamp(p.description, PROJECT_DESCRIPTION_MAX)}`

--- a/shared/tests/suggest-prompt.test.ts
+++ b/shared/tests/suggest-prompt.test.ts
@@ -3,6 +3,9 @@ import {
   buildSuggestionPrompt,
   MAX_EXAMPLES,
   MAX_POST_CHARS,
+  MAX_PROJECTS,
+  README_EXCERPT_MAX,
+  VOICE_SAMPLE_MAX,
   type CurrentProject,
 } from '../src/assist/suggest-prompt.js';
 import { HOUSE_STYLE_SECTION } from '../src/house-style.js';
@@ -251,6 +254,105 @@ describe('buildSuggestionPrompt', () => {
       });
       expect(prompt.length).toBeLessThan(longAbout.length + longReadme.length);
       expect(prompt).toContain('[truncated]');
+    });
+
+    it('caps the project list at MAX_PROJECTS, keeping the current and personal project', () => {
+      const filler: ProjectBrief[] = Array.from({ length: MAX_PROJECTS + 5 }, (_, i) => ({
+        id: 100 + i,
+        name: `Filler ${i}`,
+        description: `Filler project ${i}.`,
+        isPersonal: false,
+        isCurrent: false,
+      }));
+      // Current and personal are last in the input on purpose: a plain
+      // slice(0, MAX_PROJECTS) with no ranking would drop both.
+      const manyProjects: ProjectBrief[] = [
+        ...filler,
+        {
+          id: 1,
+          name: 'Embertold',
+          description: 'The bound project.',
+          isPersonal: false,
+          isCurrent: true,
+        },
+        {
+          id: 2,
+          name: 'Personal Voice',
+          description: 'The personal project.',
+          isPersonal: true,
+          isCurrent: false,
+        },
+      ];
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        currentProject,
+        persona: null,
+        projects: manyProjects,
+        repos: [],
+      });
+      const shown = manyProjects.filter((p) => prompt.includes(p.name));
+      expect(shown).toHaveLength(MAX_PROJECTS);
+      expect(prompt).toContain('Embertold (this one)');
+      expect(prompt).toContain('Personal Voice');
+      // The last filler project is the one guaranteed to fall past the cap,
+      // since only the current and personal project plus the earliest
+      // fillers fit inside MAX_PROJECTS.
+      expect(prompt).not.toContain(`Filler ${filler.length - 1}`);
+    });
+
+    it('clamps a voice sample to the same length no matter how far past the cap the raw post runs', () => {
+      const marker = 'ZZ-VOICE-OVERFLOW-ZZ';
+      const justOver = `${'b'.repeat(VOICE_SAMPLE_MAX + 40)}${marker}`;
+      const wayOver = `${'c'.repeat(VOICE_SAMPLE_MAX * 3)}${marker}`;
+      const promptJustOver = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        currentProject,
+        persona: { ...persona, voiceSamples: [{ text: justOver }] },
+        projects: [],
+        repos: [],
+      });
+      const promptWayOver = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        currentProject,
+        persona: { ...persona, voiceSamples: [{ text: wayOver }] },
+        projects: [],
+        repos: [],
+      });
+      expect(promptJustOver).toContain('b'.repeat(VOICE_SAMPLE_MAX));
+      expect(promptJustOver).not.toContain(marker);
+      expect(promptWayOver).not.toContain(marker);
+      // A sample three times past the cap costs exactly the same as one
+      // barely past it: the cap is a hard ceiling, not a soft trim.
+      expect(promptJustOver.length).toBe(promptWayOver.length);
+    });
+
+    it('clamps a README excerpt tighter than the cache-time limit, regardless of raw length', () => {
+      const marker = 'ZZ-README-OVERFLOW-ZZ';
+      const justOver = `${'d'.repeat(README_EXCERPT_MAX + 40)}${marker}`;
+      const wayOver = `${'e'.repeat(README_EXCERPT_MAX + 800)}${marker}`;
+      const promptJustOver = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        currentProject,
+        persona: null,
+        projects: [],
+        repos: [{ ...repos[0], readmeExcerpt: justOver }],
+      });
+      const promptWayOver = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        currentProject,
+        persona: null,
+        projects: [],
+        repos: [{ ...repos[0], readmeExcerpt: wayOver }],
+      });
+      expect(promptJustOver).toContain('d'.repeat(README_EXCERPT_MAX));
+      expect(promptJustOver).not.toContain(marker);
+      expect(promptWayOver).not.toContain(marker);
+      expect(promptJustOver.length).toBe(promptWayOver.length);
     });
   });
 });


### PR DESCRIPTION
Closes #443

## What I measured, and how

Issue #443 asked to measure before changing anything, since the companion prompt (persona, voice samples, every project, GitHub sources) is the prime suspect for the 11-15s first-token latency on a real feed card. I wrote a throwaway script (not committed) that calls the real `buildSuggestionPrompt` with a hand-built, realistic fixture shaped like a real user: a founder persona with three job history entries, four voice samples ranging from 158 to 1562 raw characters (LinkedIn posts before "see more" run this range), twelve organization projects (a plausible count after a few years of side projects and client work), and four GitHub repos with README excerpts near the 1200-char cache-time ceiling (`github-sources.ts` `README_EXCERPT_MAX_CHARS`).

Method: for each optional section, diff the prompt's length with the section present versus absent, holding everything else fixed. That measures exactly what the real code emits with no reimplementation to drift from it.

**Before** (15438 chars total):

| Section | Chars | Share |
|---|---:|---:|
| GitHub repos (4) | 5830 | 37.8% |
| Fixed overhead (intro, project desc, post, task, house style, envelope) | 3865 | 25.0% |
| Voice samples (4) | 2012 | 13.0% |
| Projects (12, uncapped) | 1594 | 10.3% |
| Persona (headline/about/experience/notes) | 1476 | 9.6% |
| Few-shot examples (3) | 523 | 3.4% |
| Operator hint | 138 | 0.9% |

GitHub repos were the single biggest line, and README excerpts were why. The cached excerpt is already clamped to 1200 chars when it's fetched, but that's a budget sized for "enough to read on the source page," not "enough to spend on every suggestion" - it keeps whatever prose line the scraper landed on, headings and code fences included. On this repo's own README, the sentence that actually says what the project is runs about 130 characters; the other ~1070 chars of the excerpt are the Quick Start command block and prerequisites, none of which helps write a LinkedIn comment.

The project list was the other real gap, exactly as the issue named it: every project in the organization went in with no count cap at all, so it grows without bound as an account ages.

Voice samples turned out to already be fine. They're capped at four (`MAX_VOICE_SAMPLES`, pre-existing) and each one is already clamped to 600 chars in the prompt (`VOICE_SAMPLE_MAX`, pre-existing) - I verified an 874-char and a 1562-char raw sample both come out of `buildSuggestionPrompt` at the exact same clamped length. I didn't find a reason to tighten that further, so I left the value alone; I did export the constant so a test can pin the exact boundary, which had zero coverage before this PR.

## What changed

- `README_EXCERPT_MAX` (`shared/src/assist/suggest-prompt.ts`) drops from 1200 to 400: enough for a title and a couple of real descriptive sentences, not the getting-started section that used to follow them. This is a render-time cap distinct from `github-sources.ts`'s `README_EXCERPT_MAX_CHARS` (the fetch/cache-time cap, untouched) - the excerpt is already capped once when it's fetched, and now capped tighter again when it's actually spent on a prompt.
- `MAX_PROJECTS = 6` (new): the "what they are building" list is ranked before the cut so the current project (the one the suggestion is filed under) and the personal project always survive it, then sliced to six. Everything else in that list is honest context the model can use to avoid acting like this product is the operator's only work, not something a suggestion depends on, so losing one to the cap costs nothing the suggestion needs.

**After** (11636 chars total, 24.6% smaller):

| Section | Chars | Share |
|---|---:|---:|
| Fixed overhead | 3865 | 33.2% |
| GitHub repos (4) | 2679 | 23.0% |
| Voice samples (4) | 2012 | 17.3% |
| Persona | 1476 | 12.7% |
| Projects (12 in org, 6 shown) | 943 | 8.1% |
| Few-shot examples (3) | 523 | 4.5% |
| Operator hint | 138 | 1.2% |

I did not touch the envelope contract (`DRAFT_MARKER`/`SKIP_MARKER`, `shared/src/assist/envelope.ts`) or the house style section (`shared/src/house-style.ts`) - both are load-bearing and already defended by their own tests, and the issue explicitly called them out as off-limits.

**This lands on the "the prompt is a real, reducible cost" side of the issue's fork, not the "measure and stop" side.** A prompt that started at 15.4KB with over a third of it spent on boilerplate a model can't use is a genuine, addressable contributor to a slow first token, so I trimmed it. That said, it is very unlikely to be the *whole* 11-15 second story on its own, and the issue's other named suspects are still on the table and untouched by this PR: model queue time, the reasoning-before-draft ordering in the envelope (three sentences of reasoning necessarily precede the draft's first token by design, #382), and whether the fast-model pin from #361 is still actually in effect. Whoever picks up the next piece of #443 should measure end-to-end latency again against this smaller prompt before chasing either of those.

## Tests

Three new tests in `shared/tests/suggest-prompt.test.ts`, plus the untouched existing ones that already assert every section (persona, voice, projects, repos) appears when its source is present and is entirely absent - never an empty heading - when it isn't:

- `caps the project list at MAX_PROJECTS, keeping the current and personal project` - builds an organization with `MAX_PROJECTS + 5` filler projects plus the current and personal project placed *last* in the input array (the position a naive `slice` would drop), and asserts exactly `MAX_PROJECTS` projects appear, both the current and personal project are among them, and the last filler project is genuinely gone.
- `clamps a voice sample to the same length no matter how far past the cap the raw post runs` - one sample 40 chars over `VOICE_SAMPLE_MAX`, another 3x over it, both produce byte-identical prompt length and neither leaks its overflow marker text.
- `clamps a README excerpt tighter than the cache-time limit, regardless of raw length` - same shape of proof for the README cap.

### Both bite observations, reported honestly

I proved each new test bites by reverting its corresponding code change, watching that specific test fail, then restoring the fix and watching it pass again - three separate revert/fail/restore/pass cycles, not two, since I added three caps' worth of test coverage:

1. **Project cap**: reverted the ranking+slice back to a bare `projects.map(...)` (all 13 test projects rendered). `caps the project list at MAX_PROJECTS...` failed with `AssertionError: expected [ ... ] to have a length of 6 but got 13`. Restored the ranking+slice; it passed again, along with the rest of the suite (15/15).
2. **Voice sample cap**: reverted the voice sample line to `` `- ${s.text}` `` (no `clamp`). `clamps a voice sample to the same length...` failed on `expect(promptJustOver).not.toContain(marker)` - the overflow marker leaked straight into the prompt. Restored the `clamp(s.text, VOICE_SAMPLE_MAX)` call; it passed again.
3. **README excerpt cap** (extra, beyond the two required): reverted the README line to interpolate `r.readmeExcerpt` directly with no `clamp`. Same failure mode, same marker leak. Restored the `clamp(r.readmeExcerpt, README_EXCERPT_MAX)` call; it passed again.

## Verified

```
pnpm exec vitest run shared/tests/suggest-prompt.test.ts shared/tests/assist-envelope.test.ts \
  shared/tests/assist-run-kind.test.ts web/tests/extension-suggest.test.ts \
  web/tests/extension-suggest-accept.test.ts
-> Test Files  5 passed (5) / Tests  66 passed (66)

pnpm -F @pitchbox/shared typecheck
-> clean, no output

npx eslint shared/src/assist/suggest-prompt.ts shared/tests/suggest-prompt.test.ts
-> clean, exit 0

npx prettier --check shared/src/assist/suggest-prompt.ts shared/tests/suggest-prompt.test.ts
-> clean after `--write` on the test file (the new tests weren't yet formatted)
```

Files changed: `shared/src/assist/suggest-prompt.ts`, `shared/tests/suggest-prompt.test.ts`. `shared/src/assist/context.ts`, `shared/src/assist/envelope.ts` and `web/src/routes/api/extension/suggest/+server.ts` were in scope but needed no change: the caps live entirely in `buildSuggestionPrompt`, the same pure, DB-free layer `MAX_EXAMPLES` already lives in, so `context.ts` still loads every project (unbounded) and `buildSuggestionPrompt` decides what actually reaches the prompt - `runSuggestion`/the route pass `projects`/`repos` straight through unchanged.
