### PR TITLE
fix(extension): translate the one activity key the dictionaries were missing, and prove the rest stay covered

### DIFF
--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -144,6 +144,13 @@ export const en = {
     'LinkedIn assist produced no draft to insert (skipped: {skipped}).',
   'activity.linkedin-action.suggestion-inserted':
     'Inserted an accepted suggestion into the LinkedIn composer for draft {draftId}.',
+  // #449: mounted purely from the composer click (no card selector on the
+  // critical path), so this is the one signal that the delegated listener
+  // actually fired and where on LinkedIn it fired - `card` names whether a
+  // post card could be scoped around the composer, not whether the mount
+  // itself succeeded.
+  'activity.linkedin-action.assist-mounted':
+    'Comment assist opened on the {pageKind} page, with the post card {card}.',
   'activity.linkedin-action.post-submit-not-found':
     'Could not find the LinkedIn post submit button for draft {draftId} within 15s; posting will not be tracked automatically.',
   'activity.linkedin-action.post-confirm-unavailable':

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -145,6 +145,9 @@ export const it = {
     'LinkedIn assist non ha prodotto una bozza da inserire (skipped: {skipped}).',
   'activity.linkedin-action.suggestion-inserted':
     'Suggerimento accettato inserito nel box del commento LinkedIn per il draft {draftId}.',
+  // See the comment on `activity.linkedin-action.assist-mounted` in dict-en.ts.
+  'activity.linkedin-action.assist-mounted':
+    'Assistente commento aperto sulla pagina {pageKind}, con la card del post {card}.',
   'activity.linkedin-action.post-submit-not-found':
     'Impossibile trovare il pulsante di pubblicazione del post LinkedIn per il draft {draftId} entro 15s; la pubblicazione non verrà tracciata automaticamente.',
   'activity.linkedin-action.post-confirm-unavailable':

--- a/extension/tests/lib/activity-i18n-coverage.test.ts
+++ b/extension/tests/lib/activity-i18n-coverage.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { en } from '../../src/lib/i18n/dict-en.js';
+import { it as itDict } from '../../src/lib/i18n/dict-it.js';
+
+// #403: an `ActivityEvent.message` that has no dictionary entry renders as
+// its raw key (see `translate()`'s `?? key` fallback in `lib/i18n/index.ts`)
+// instead of a sentence, and the params silently vanish because nothing in
+// the raw key has a `{placeholder}` to catch them. This test enumerates
+// every `activity.<source>.<event>` key the extension can actually emit -
+// by scanning the sources, not by hand-listing them here - and fails if
+// either dictionary is missing one.
+//
+// Read via Vite's raw glob import rather than `node:fs`: the extension
+// tsconfig's `types` is deliberately narrow (chrome/vite/svelte only, see
+// its own comment) and excludes ambient Node globals, and pulling those in
+// just for this file would reopen the DOM/Node `setTimeout` type clash that
+// narrow list exists to avoid.
+const sourceFiles = import.meta.glob('../../src/**/*.{ts,svelte}', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>;
+
+// `ActivitySource` (`lib/activity.ts`) is the source of truth for which
+// `activity.<x>.*` keys are real event messages, as opposed to UI-chrome
+// keys that also live under the `activity.` namespace (`activity.level.*`,
+// `activity.filter.*`, `activity.actions.*`, ...): those never appear as
+// the first segment after `activity.` here, so scoping the scan to known
+// sources excludes them without a hand-picked denylist.
+function readActivitySources(): string[] {
+  const activityTsPath = Object.keys(sourceFiles).find((p) => p.endsWith('/lib/activity.ts'));
+  if (!activityTsPath) throw new Error('could not find lib/activity.ts among the scanned sources');
+  const text = sourceFiles[activityTsPath];
+  const match = text.match(/export type ActivitySource =([^;]+);/);
+  if (!match) throw new Error('could not find the ActivitySource union in lib/activity.ts');
+  return [...match[1].matchAll(/'([a-z-]+)'/g)].map((m) => m[1]);
+}
+
+// Every `activity.<source>.<event>` literal in the source tree, wherever it
+// appears (an `ActivityEvent.message` field, a helper that takes the key as
+// a plain string argument, and so on) - the dictionaries themselves are
+// excluded since they declare translations rather than emit events.
+function scanEmittedActivityKeys(): string[] {
+  const sources = readActivitySources();
+  const pattern = /activity\.([a-z0-9-]+)\.([a-z0-9-]+)/g;
+  const keys = new Set<string>();
+  for (const [path, text] of Object.entries(sourceFiles)) {
+    if (path.endsWith('/i18n/dict-en.ts') || path.endsWith('/i18n/dict-it.ts')) continue;
+    for (const m of text.matchAll(pattern)) {
+      if (sources.includes(m[1])) keys.add(m[0]);
+    }
+  }
+  return [...keys].sort();
+}
+
+describe('activity message key coverage', () => {
+  const emitted = scanEmittedActivityKeys();
+
+  it('scans a realistic number of activity.* event keys out of the sources', () => {
+    // Guards the scanner itself: a change to activity.ts's union shape or
+    // to the file layout it walks must not silently start matching nothing
+    // and pass vacuously.
+    expect(emitted.length).toBeGreaterThan(30);
+  });
+
+  it('every emitted activity.* key has an EN sentence', () => {
+    const dict = en as Record<string, string>;
+    const missing = emitted.filter((k) => !(k in dict));
+    expect(missing, `dict-en.ts is missing: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('every emitted activity.* key has an IT sentence', () => {
+    const dict = itDict as Record<string, string>;
+    const missing = emitted.filter((k) => !(k in dict));
+    expect(missing, `dict-it.ts is missing: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('no EN entry for an emitted key is still the bare key (a real sentence, not a fallback)', () => {
+    const dict = en as Record<string, string>;
+    const bare = emitted.filter((k) => dict[k] === k);
+    expect(bare, `dict-en.ts entries that just echo the key: ${bare.join(', ')}`).toEqual([]);
+  });
+});

--- a/extension/tests/lib/activity-row-render.test.ts
+++ b/extension/tests/lib/activity-row-render.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { translate } from '../../src/lib/i18n/index.js';
+
+// #403: proves the Activity list a human actually reads renders sentences,
+// not a raw message key next to a JSON params blob.
+//
+// This does not mount `ActivityRow.svelte` (its render is the one-line
+// `$t(event.message, event.messageParams)` asserted statically below) via a
+// real Svelte `mount()`: that component imports through the `$ext`/`$ui`
+// aliases extension/vite.config.ts defines, which only the extension's own
+// `vitest.config.ts` merges in - the root `vitest.config.ts` (what
+// `pnpm exec vitest run` from the repo root and the `preflight` pre-push
+// hook actually run) only knows `$lib` for `web/`, so a real mount of this
+// component fails there with an unresolved import. `translate()` is the
+// entire rendering logic ActivityRow hands `event.message`/`messageParams`
+// to, so exercising it directly with the same arguments the component
+// passes is equivalent proof without depending on aliases the root suite
+// does not have.
+//
+// Covers the three kinds of entry a human actually reads when something
+// went wrong, per #403: a LinkedIn action, a sync run, and a refusal/failure.
+const ACTIVITY_ROW_SOURCE = (
+  import.meta.glob('../../src/sidepanel/components/ActivityRow.svelte', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }) as Record<string, string>
+)['../../src/sidepanel/components/ActivityRow.svelte'];
+
+describe('ActivityRow renders a sentence, not a raw key', () => {
+  it('still hands the raw message and its params to $t, not a pre-rendered string', () => {
+    expect(ACTIVITY_ROW_SOURCE).toContain('$t(event.message, event.messageParams)');
+    // The historical bug shape #403 reports: the key printed next to a
+    // stringified params object.
+    expect(ACTIVITY_ROW_SOURCE).not.toMatch(/JSON\.stringify\(\s*event\.messageParams/);
+  });
+
+  it('EN: a LinkedIn action entry reads as a sentence', () => {
+    expect(
+      translate('en', 'activity.linkedin-action.assist-mounted', {
+        pageKind: 'feed-sdui',
+        card: 'unresolved',
+      }),
+    ).toBe('Comment assist opened on the feed-sdui page, with the post card unresolved.');
+  });
+
+  it('IT: the same LinkedIn action entry reads as a sentence', () => {
+    expect(
+      translate('it', 'activity.linkedin-action.assist-mounted', {
+        pageKind: 'feed-sdui',
+        card: 'unresolved',
+      }),
+    ).toBe('Assistente commento aperto sulla pagina feed-sdui, con la card del post unresolved.');
+  });
+
+  it('EN: a sync entry reads as a sentence', () => {
+    expect(translate('en', 'activity.dm-sync.ok', { inserted: 3, replied: 1 })).toBe(
+      'Reddit inbox sync - 3 new, 1 replied.',
+    );
+  });
+
+  it('IT: the same sync entry reads as a sentence', () => {
+    expect(translate('it', 'activity.dm-sync.ok', { inserted: 3, replied: 1 })).toBe(
+      'Sync inbox Reddit - 3 nuovi, 1 risposti.',
+    );
+  });
+
+  it('EN: a refusal reads as a sentence naming what failed, not what the code did', () => {
+    expect(
+      translate('en', 'activity.linkedin-action.suggestion-refused', {
+        reason: 'quota_exhausted',
+      }),
+    ).toBe('LinkedIn assist suggestion refused: quota_exhausted');
+  });
+
+  it('IT: the same refusal reads as a sentence', () => {
+    expect(
+      translate('it', 'activity.linkedin-action.suggestion-refused', {
+        reason: 'quota_exhausted',
+      }),
+    ).toBe('Suggerimento LinkedIn assist rifiutato: quota_exhausted');
+  });
+});

--- a/extension/tests/lib/activity.test.ts
+++ b/extension/tests/lib/activity.test.ts
@@ -78,6 +78,37 @@ describe('activity log', () => {
     expect(parsed.entries[0].message).toBe('x');
   });
 
+  it('exportActivityJSON keeps message, messageParams and meta raw, not rendered', async () => {
+    // #403: the panel renders `message` through the i18n dictionaries, but
+    // the export is the diagnostic channel a human reads directly - it must
+    // keep the structured fields the panel builds a sentence from, not a
+    // pre-rendered string that throws away messageParams/meta.
+    const { logEvent, exportActivityJSON } = await load();
+    await logEvent({
+      level: 'warn',
+      source: 'linkedin-action',
+      message: 'activity.linkedin-action.assist-mounted',
+      messageParams: { pageKind: 'feed-sdui', card: 'unresolved' },
+      meta: {
+        cardResolved: false,
+        composerHadOwnText: true,
+        pageKind: 'feed-sdui',
+        url: 'https://linkedin.com/feed',
+      },
+    });
+    const blob = await exportActivityJSON();
+    const parsed = JSON.parse(await blob.text());
+    const entry = parsed.entries[0];
+    expect(entry.message).toBe('activity.linkedin-action.assist-mounted');
+    expect(entry.messageParams).toEqual({ pageKind: 'feed-sdui', card: 'unresolved' });
+    expect(entry.meta).toEqual({
+      cardResolved: false,
+      composerHadOwnText: true,
+      pageKind: 'feed-sdui',
+      url: 'https://linkedin.com/feed',
+    });
+  });
+
   describe('eviction accounting', () => {
     it('reports no drops and no misleading claim of loss below the cap', async () => {
       const { logEvent, getActivity, getActivityStats, exportActivityJSON, ACTIVITY_LOG_CAP } =


### PR DESCRIPTION
## Cause

The activity log's rendering already does the right thing: `ActivityRow.svelte` calls `$t(event.message, event.messageParams)`, and `translate()` interpolates `{placeholder}` params into the dictionary sentence for the locale. Both `dict-en.ts` and `dict-it.ts` already had a real sentence for every `activity.*` key the extension emits, except one: `activity.linkedin-action.assist-mounted`, added in #449 for the click-delegated comment-assist mount (`delegateComposerClicks` in `linkedin-comment-assist.ts`). That commit never added a dictionary entry for it. `translate()` falls back to the raw key when neither dictionary has one (`primary[key] ?? fallback[key] ?? key`), and since the raw key has no `{pageKind}`/`{card}` placeholders, the params it was called with are silently dropped - exactly the "message key plus a JSON blob" symptom #403 describes, for this one key.

## Fix

- Added the EN/IT sentences for `activity.linkedin-action.assist-mounted` in both dictionaries.
- Added `extension/tests/lib/activity-i18n-coverage.test.ts`, which is the test the issue actually asked for: it scans every extension source file for `activity.<source>.<event>` literals (`<source>` read from the `ActivitySource` union in `lib/activity.ts`, not hand-listed) and fails if either dictionary is missing a real sentence for one, or if an entry is still the bare key. It reads sources via Vite's `?raw` glob import rather than `node:fs`, because the extension's `tsconfig.json` deliberately narrows `types` to `chrome`/`vite/client`/`svelte` (see its own build-config comments) and adding `node` there reopens a DOM/Node `setTimeout` type clash in `dm-compose.ts` - I checked this by trying it and reverting.
- Added `extension/tests/lib/activity-row-render.test.ts` covering what a human actually reads when something went wrong: a LinkedIn action entry, a sync entry, and a refusal, in both locales, plus a static check that `ActivityRow.svelte` still hands the raw message/params to `$t` rather than a pre-rendered string. This does **not** mount the real component with Svelte's `mount()`: `ActivityRow.svelte` imports through the `$ext`/`$ui` aliases that only `extension/vitest.config.ts` merges in from `extension/vite.config.ts`. The root `vitest.config.ts` - what `pnpm exec vitest run` from the repo root and the `preflight` pre-push hook actually run - only aliases `$lib` for `web/`, so a real mount fails there with an unresolved-import error. I found this by writing the mount test first: it passed under the extension-scoped config, then broke `preflight` on push. Since editing the root `vitest.config.ts` is shared infrastructure outside what this task named in scope, I called `translate()` directly instead, with the same key/params the component passes - that function is the entirety of the component's rendering logic, so it's equivalent proof without depending on aliases the root suite doesn't have. Worth a follow-up issue if a future PR wants real component mounts for sidepanel UI.
- Added a companion assertion to `extension/tests/lib/activity.test.ts` that `exportActivityJSON` still carries `message`, `messageParams` and `meta` raw, unrendered - the panel renders a sentence, but the export is the diagnostic channel a human reads directly (this morning's bug report used exactly that export), so it must stay structured.

## Scope I deliberately left out

The issue also asks to "give an error row the one action that resolves it: re-run the sync, re-grant the permission, open the backend." I did not implement that: it is a distinct UI feature (three different per-error actions, each needing its own wiring - a sync trigger, a `chrome.permissions.request` call, opening the paired backend URL) that the task I was given scoped out in favor of the translation-completeness work, which it called "the valuable part of this issue." Flagging this explicitly rather than silently dropping it: if it's still wanted, it needs its own issue/PR.

## Verified

- `pnpm -F @pitchbox/extension check` (svelte-check): `772 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`.
- `pnpm exec vitest run extension/tests/lib/activity-row-render.test.ts extension/tests/lib/activity-i18n-coverage.test.ts extension/tests/lib/activity.test.ts extension/tests/lib/i18n.test.ts` from the repo root (same config `preflight` uses): `4 passed, 28 passed`.
- `npx eslint` and `npx prettier --check` on every changed file: clean.
- `preflight` (the installed pre-push hook, full `pnpm test` against its own disposable Postgres): passed before this push went through.

### Bite proof

- Coverage + render tests: temporarily removed the new `activity.linkedin-action.assist-mounted` entry from `dict-en.ts`. Both `activity-i18n-coverage.test.ts`'s "every emitted activity.* key has an EN sentence" and `activity-row-render.test.ts`'s "EN: a LinkedIn action entry reads as a sentence" failed, the latter with `Received: "activity.linkedin-action.assist-mounted"` (the exact raw-key symptom). Restored, both pass again.
- Export test: temporarily changed `exportActivityJSON` to strip `messageParams`/`meta` from each entry. `activity.test.ts`'s new export-shape test failed with `expected undefined to deeply equal {...}`. Restored, passes again.

Closes #403
