### PR TITLE
chore(deploy): forward PITCHBOX_INTERNAL_TOKEN to the web and daemon containers

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -38,10 +38,9 @@ PITCHBOX_AUTH=off
 # failure backoff eventually pauses the campaign, recording the reason as
 # failed dispatches rather than an auth misconfiguration (#378). A secret of
 # its own, never reused from ENCRYPTION_KEY or anything else here, and it
-# must differ per environment (dev/preview/prod each need their own value) -
-# note this is NOT currently forwarded to the web/daemon containers by the
-# docker-compose.app*.yml overlays; wiring it into their `environment:`
-# blocks is a required follow-up before this reaches a Docker deployment.
+# must differ per environment (dev/preview/prod each need their own value).
+# `docker-compose.app.yml` forwards it into both the web and the daemon
+# service, since the daemon sends it and the web has to know it to accept it.
 PITCHBOX_INTERNAL_TOKEN=
 # Public URL the dashboard is served at (used for the auth guard above and as
 # adapter-node's ORIGIN for CSRF/form checks behind a reverse proxy).

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -26,6 +26,13 @@ services:
       PITCHBOX_ROOT: /app
       DATABASE_URL: ${DATABASE_URL:-postgresql://pitchbox:pitchbox@postgres:5432/pitchbox}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env}
+      # The daemon's own POST /api/run dispatch (#378). Only the daemon needs
+      # to send it, but the web has to know it to accept it, so both services
+      # read the same value. Empty by default, which leaves that route exactly
+      # as closed as every other /api/* route - and, with PITCHBOX_AUTH=on,
+      # leaves scheduled campaigns unable to dispatch, so it is required in
+      # any deployment that turns auth on.
+      PITCHBOX_INTERNAL_TOKEN: ${PITCHBOX_INTERNAL_TOKEN:-}
       # Cloud edition: dispatch runs to the cloud runner.
       PITCHBOX_EDITION: cloud
       PITCHBOX_RUNNER_URL: ${PITCHBOX_RUNNER_URL:?set PITCHBOX_RUNNER_URL in .env}
@@ -59,6 +66,8 @@ services:
       PITCHBOX_ROOT: /app
       DATABASE_URL: ${DATABASE_URL:-postgresql://pitchbox:pitchbox@postgres:5432/pitchbox}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env}
+      # Same value as the web service above, and for the same reason (#378).
+      PITCHBOX_INTERNAL_TOKEN: ${PITCHBOX_INTERNAL_TOKEN:-}
       # Reaches the web app over the compose network to trigger scheduled runs.
       PITCHBOX_WEB_URL: http://web:${WEB_PORT:-5180}
     depends_on:


### PR DESCRIPTION
The follow-up #453 flagged rather than silently skipped: it documented the variable and taught the daemon to send it, but neither compose service forwarded it into the container, so the fix for #378 could not reach a Docker deployment at all.

Both services read the same value, since the daemon is the one that sends it and the web is the one that has to know it to accept it. Empty by default, which leaves `/api/run` exactly as closed as every other `/api/*` route.

Proven rather than eyeballed:

```
PITCHBOX_INTERNAL_TOKEN=probe-token docker compose -f docker-compose.yml -f docker-compose.app.yml config | grep PITCHBOX_INTERNAL_TOKEN
19:      PITCHBOX_INTERNAL_TOKEN: probe-token
66:      PITCHBOX_INTERNAL_TOKEN: probe-token
```

Also corrects the note in `.env.docker.example` that said the wiring was still missing, which this makes false.

Refs #378. The remaining step is environment-side and mine: setting a real value in `/opt/apps/pitchbox-preview/.env` and `/opt/apps/pitchbox/.env` (both have `PITCHBOX_AUTH=on`), then re-running the dispatch curl from inside the compose network to see a 422 or 409 instead of the 401 the issue reproduced.
