### PR TITLE
fix(deploy): the blue-green web tier never saw PITCHBOX_INTERNAL_TOKEN

### DIFF
--- a/docker-compose.bluegreen.yml
+++ b/docker-compose.bluegreen.yml
@@ -23,6 +23,14 @@ x-web-common: &web-common
     PITCHBOX_ROOT: /app
     DATABASE_URL: ${DATABASE_URL:-postgresql://pitchbox:pitchbox@postgres:5432/pitchbox}
     ENCRYPTION_KEY: ${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env}
+    # The daemon's own POST /api/run dispatch (#378). Declared here as well as
+    # in docker-compose.app.yml's `web`, and that duplication is the point:
+    # this overlay replaces the base service's whole `environment` block
+    # through `x-web-common`, so a variable added only to the base never
+    # reaches a blue-green deployment. Measured on preview 2026-09-08 - the
+    # daemon had the token and the active web did not, which is a 401 with
+    # both sides configured.
+    PITCHBOX_INTERNAL_TOKEN: ${PITCHBOX_INTERNAL_TOKEN:-}
     PITCHBOX_EDITION: cloud
     PITCHBOX_RUNNER_URL: ${PITCHBOX_RUNNER_URL:?set PITCHBOX_RUNNER_URL in .env}
     # Per-org auth (CLD-P1, preferred): mints a JWT per dispatch when set.


### PR DESCRIPTION
Found by verifying #454 on the deployment instead of trusting it. After that PR deployed to preview:

```
pitchbox-preview-daemon-1: 3de1761c
pitchbox-preview-web-green: (nothing)
```

The daemon had the token, the active web did not, which is still a 401 with both sides apparently configured.

`docker-compose.bluegreen.yml` replaces the base web service's entire `environment` block through its `x-web-common` anchor, so a variable added to `docker-compose.app.yml`'s `web` reaches every deployment shape except the blue-green one, which is the only shape preview and prod actually run (`scripts/deploy.sh` composes `docker-compose.yml`, `app.yml`, `app.runner.yml`, `bluegreen.yml`).

Declared in both files now, with a comment on the duplicate saying exactly why it is deliberate, so the next variable does not repeat this.

Proven over the same four overlays the deploy script uses:

```
PITCHBOX_INTERNAL_TOKEN=probe docker compose -f docker-compose.yml -f docker-compose.app.yml \
  -f docker-compose.app.runner.yml -f docker-compose.bluegreen.yml config | grep -c 'PITCHBOX_INTERNAL_TOKEN: probe'
4
```

Four: `web` (disabled in this shape but still configured), `web-blue`, `web-green`, `daemon`.

Refs #378. Once this deploys I will re-run the dispatch call from inside the preview compose network and report the status it returns; the issue's reproduction was a 401 and the fix is only proven when that call is no longer one.
