### PR TITLE
fix(web,shared): in the cloud edition a local runner can still be picked

### DIFF
--- a/shared/src/edition.ts
+++ b/shared/src/edition.ts
@@ -4,6 +4,8 @@
 // is expected to discover that path and wire it in; this helper is the
 // runtime gate used by the dispatch path and the dashboard.
 
+import { AGENT_RUNNER_META, type AgentRunnerSlug } from './agents/meta.js';
+
 export type Edition = 'self-hosted' | 'cloud';
 
 export function currentEdition(): Edition {
@@ -12,4 +14,40 @@ export function currentEdition(): Edition {
 
 export function isCloud(): boolean {
   return currentEdition() === 'cloud';
+}
+
+/**
+ * The runner slugs a caller may pick in this edition, asked by every picker
+ * (campaign/project forms, the Settings runners page) and every route that
+ * persists a runner slug, so the cloud/self-hosted line is drawn once
+ * instead of re-derived per call site. A cloud deployment only ever
+ * dispatches to the managed runner (`shared/src/agents/cloud.ts`): every
+ * local ACP backend is excluded here outright, not merely deprioritized,
+ * because whether a local CLI binary happens to be reachable on a cloud
+ * container's PATH says nothing about whether it should run there (#410) -
+ * a cloud web/daemon image can carry `claude`, `codex`, etc. for reasons
+ * unrelated to the deployment's architecture, and detection alone is not a
+ * trustworthy gate. Self-hosted keeps the full catalogue, matching the
+ * behavior before this function existed.
+ */
+export function allowedRunnerSlugs(): AgentRunnerSlug[] {
+  return isCloud() ? ['cloud'] : AGENT_RUNNER_META.map((m) => m.slug);
+}
+
+/**
+ * Whether `slug` is one this edition may dispatch to at all - used by every
+ * write path (the API routes) as the actual boundary check, since a picker
+ * that merely hides an option is not enforcement (a stale tab, an old row,
+ * or a direct call still reaches the route).
+ *
+ * Deliberately not "is `slug` in `allowedRunnerSlugs()`": self-hosted never
+ * validated a runner slug against the catalogue at the API layer - an
+ * unregistered string fails later, at `createAgentRunner` - and several
+ * tests rely on posting a deliberately-fake slug through untouched (see
+ * `campaign-cron-validation.test.ts`'s `NO_OP_RUNNER`). The only thing this
+ * guard adds is the cloud boundary: cloud dispatches to nothing but the
+ * managed runner, full stop.
+ */
+export function isRunnerAllowed(slug: string): boolean {
+  return !isCloud() || slug === 'cloud';
 }

--- a/shared/tests/edition.test.ts
+++ b/shared/tests/edition.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { AGENT_RUNNER_META } from '../src/agents/meta.js';
+import { allowedRunnerSlugs, isRunnerAllowed } from '../src/edition.js';
+
+// #410: the cloud edition must never allow a local ACP backend to be picked
+// or dispatched. `allowedRunnerSlugs`/`isRunnerAllowed` are the one place
+// every picker and every write route asks; a bug here reopens the leak
+// everywhere at once.
+describe('allowedRunnerSlugs / isRunnerAllowed (#410)', () => {
+  const saved = process.env.PITCHBOX_EDITION;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = saved;
+  });
+
+  it('the cloud edition allows only the cloud runner', () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    expect(allowedRunnerSlugs()).toEqual(['cloud']);
+    expect(isRunnerAllowed('cloud')).toBe(true);
+    for (const m of AGENT_RUNNER_META) {
+      if (m.slug === 'cloud') continue;
+      expect(isRunnerAllowed(m.slug)).toBe(false);
+    }
+  });
+
+  it('self-hosted allows every catalogued runner', () => {
+    delete process.env.PITCHBOX_EDITION;
+    const allowed = allowedRunnerSlugs();
+    for (const m of AGENT_RUNNER_META) {
+      expect(allowed).toContain(m.slug);
+      expect(isRunnerAllowed(m.slug)).toBe(true);
+    }
+  });
+
+  it('cloud rejects an unregistered slug too; self-hosted never validated the string at all', () => {
+    // Self-hosted's routes have always accepted any non-empty runner string
+    // and deferred to `createAgentRunner` throwing "Unknown agent runner" -
+    // this guard only draws the cloud boundary, it does not newly validate
+    // self-hosted against the catalogue (that would break the deliberately
+    // fake `NO_OP_RUNNER` fixture several campaign-creation tests rely on).
+    delete process.env.PITCHBOX_EDITION;
+    expect(isRunnerAllowed('not-a-real-runner')).toBe(true);
+    process.env.PITCHBOX_EDITION = 'cloud';
+    expect(isRunnerAllowed('not-a-real-runner')).toBe(false);
+  });
+});

--- a/web/src/lib/components/projects/ProjectOverviewTab.svelte
+++ b/web/src/lib/components/projects/ProjectOverviewTab.svelte
@@ -15,16 +15,11 @@
     type Recommendation,
   } from './CampaignRecommendationsList.svelte';
   import { DESCRIPTION_SCAFFOLD } from '@pitchbox/shared/project-extraction';
-  import { AGENT_RUNNER_META } from '@pitchbox/shared/agents/meta';
   import { TONE_BANNER_CLASS, TONE_TEXT_CLASS } from '$lib/config/status-badges';
   import StreamStatusBanner from '$lib/realtime/StreamStatusBanner.svelte';
   import { getSseManager } from '$lib/realtime/sse';
 
-  const RUNNER_OPTIONS = AGENT_RUNNER_META.map((m) => ({
-    value: m.slug,
-    label: m.implemented ? m.label : `${m.label} (not available yet)`,
-    disabled: !m.implemented,
-  }));
+  type RunnerMeta = { slug: string; label: string; implemented: boolean };
 
   type Project = {
     id: number;
@@ -53,6 +48,7 @@
     recommendations: Recommendation[];
     isAdmin: boolean;
     highlightRunId?: number | null;
+    runners: RunnerMeta[];
   };
   let {
     project,
@@ -62,7 +58,29 @@
     recommendations,
     isAdmin,
     highlightRunId = null,
+    runners,
   }: Props = $props();
+
+  // `runners` is already filtered to this deployment's edition (#410) - the
+  // list an admin can pick from. The project's own snapshot might predate
+  // that guard (or a since-changed edition), so it stays visible here as a
+  // disabled option rather than the select silently rendering blank for a
+  // real, persisted value.
+  const RUNNER_OPTIONS = $derived.by(() => {
+    const opts = runners.map((m) => ({
+      value: m.slug,
+      label: m.implemented ? m.label : `${m.label} (not available yet)`,
+      disabled: !m.implemented,
+    }));
+    if (!opts.some((o) => o.value === project.defaultAgentRunner)) {
+      opts.push({
+        value: project.defaultAgentRunner,
+        label: `${project.defaultAgentRunner} (not available in this edition)`,
+        disabled: true,
+      });
+    }
+    return opts;
+  });
 
   // svelte-ignore state_referenced_locally
   let name = $state(project.name);

--- a/web/src/lib/server/runner.ts
+++ b/web/src/lib/server/runner.ts
@@ -2,6 +2,7 @@ import { createAgentRunner } from '@pitchbox/shared/agents/registry';
 import type { AgentRunner } from '@pitchbox/shared/agents';
 import { loadRunnerConfig } from '@pitchbox/shared/agents/config';
 import { detectRunner, isDetectionConclusive } from '@pitchbox/shared/agents/detect';
+import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import type { AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
 import { notify } from '@pitchbox/shared/notifications';
 import { classifyFailure } from '@pitchbox/shared/runlog/classify-failure';
@@ -131,6 +132,21 @@ async function dispatchRun(
   let runner: AgentRunner;
   try {
     const slug = run.agentRunner as AgentRunnerSlug;
+    // Cloud edition never dispatches to a local ACP backend, full stop - not
+    // "unless detected", because a cloud web/daemon container can have a CLI
+    // binary reachable on PATH for reasons unrelated to whether it should run
+    // there (#410: an image with `claude` on PATH made the detection probe
+    // below report it available, and this pre-flight was the only thing
+    // standing between that and a real local agent spawn on shared cloud
+    // infra). Checked before detection so a rejection never depends on what
+    // happens to be installed.
+    if (!isRunnerAllowed(slug)) {
+      throw new Error(
+        `Agent runner "${slug}" is not available in this deployment's edition: only the ` +
+          `managed Pitchbox Cloud runner can dispatch here. Change the runner in project or ` +
+          `campaign settings to continue.`,
+      );
+    }
     // Pre-flight the snapshot. A run whose runner cannot start here fails the
     // same way whatever the reason, but the message has to say so: before #219
     // a cloud-edition install dispatching 'claude-code' spawned the ACP adapter

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -5,6 +5,7 @@ import { getDb } from './db.js';
 import { createAgentRunner } from '@pitchbox/shared/agents/registry';
 import type { AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
 import { loadRunnerConfig, type RunnerConfig } from '@pitchbox/shared/agents/config';
+import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import {
   buildSuggestionPrompt,
   type CurrentProject,
@@ -152,6 +153,19 @@ export function runSuggestion(args: {
   const result: Promise<SuggestionResult> = (async () => {
     const db = getDb();
     if (cancelled) throw new Cancelled();
+    // Same edition boundary as a campaign run's dispatch pre-flight
+    // (runner.ts): a suggestion reads `project.defaultAgentRunner` straight
+    // off the project row, so a project whose snapshot predates the guard on
+    // the write routes (or was written before this deployment ever ran the
+    // cloud edition) would otherwise reach a local agent spawn here with no
+    // check at all (#410).
+    if (!isRunnerAllowed(args.runnerSlug)) {
+      throw new Error(
+        `Agent runner "${args.runnerSlug}" is not available in this deployment's edition: ` +
+          `only the managed Pitchbox Cloud runner can dispatch here. Change the project's ` +
+          `default runner in Settings to continue.`,
+      );
+    }
     const config = await loadRunnerConfig(db, args.runnerSlug as AgentRunnerSlug);
     if (cancelled) throw new Cancelled();
     const runner = createAgentRunner(args.runnerSlug, resolveAssistRunnerConfig(config));

--- a/web/src/routes/api/campaigns/+server.ts
+++ b/web/src/routes/api/campaigns/+server.ts
@@ -7,6 +7,7 @@ import { runCampaignSkillGeneration } from '$lib/server/runner.js';
 import { previewCron } from '@pitchbox/daemon/cron';
 import { requireOrgId } from '$lib/server/auth.js';
 import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
+import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import { SCENARIO_SLUGS } from '@pitchbox/shared/campaigns';
 
 const Body = z.object({
@@ -42,6 +43,21 @@ export async function POST(event: RequestEvent) {
     .from(schema.projects)
     .where(eq(schema.projects.id, body.projectId));
   if (!project) return json({ error: 'project_not_found' }, { status: 400 });
+
+  // The campaign's actual runner, explicit or inherited from the project - a
+  // new campaign resolving to a disallowed slug is a new write either way,
+  // even when the value only arrived by inheriting the project's own
+  // snapshot (which itself may predate this guard or this edition).
+  const effectiveRunner = body.agentRunner ?? project.defaultAgentRunner;
+  if (!isRunnerAllowed(effectiveRunner)) {
+    return json(
+      {
+        error: 'runner_not_allowed',
+        message: `Agent runner "${effectiveRunner}" is not available in this deployment's edition.`,
+      },
+      { status: 400 },
+    );
+  }
 
   const [platform] = await db
     .select()

--- a/web/src/routes/api/campaigns/[id]/+server.ts
+++ b/web/src/routes/api/campaigns/[id]/+server.ts
@@ -12,6 +12,7 @@ import {
 } from '@pitchbox/shared/campaigns/server';
 import { requireOrgId, requireRole } from '$lib/server/auth.js';
 import { campaignBelongsToOrg } from '@pitchbox/shared/orgs';
+import { isRunnerAllowed } from '@pitchbox/shared/edition';
 
 const Patch = z.object({
   name: z.string().min(1).max(120).optional(),
@@ -71,7 +72,18 @@ export async function PATCH(event: RequestEvent) {
     }
     patch.cronExpression = trimmed;
   }
-  if (parsed.data.agentRunner !== undefined) patch.agentRunner = parsed.data.agentRunner;
+  if (parsed.data.agentRunner !== undefined) {
+    if (!isRunnerAllowed(parsed.data.agentRunner)) {
+      return json(
+        {
+          error: 'runner_not_allowed',
+          message: `Agent runner "${parsed.data.agentRunner}" is not available in this deployment's edition.`,
+        },
+        { status: 400 },
+      );
+    }
+    patch.agentRunner = parsed.data.agentRunner;
+  }
   if (parsed.data.autoPost !== undefined) patch.autoPost = parsed.data.autoPost;
 
   if (parsed.data.config !== undefined) {

--- a/web/src/routes/api/projects/+server.ts
+++ b/web/src/routes/api/projects/+server.ts
@@ -5,6 +5,7 @@ import { getDb, schema } from '$lib/server/db.js';
 import { resolveOrgId, requireOrgId, requireRole } from '$lib/server/auth.js';
 import { listProjects, createProjectTx, ProjectSlugConflictError } from '@pitchbox/shared/projects';
 import { resolveDefaultRunnerSlug } from '@pitchbox/shared/agents/config';
+import { isRunnerAllowed } from '@pitchbox/shared/edition';
 
 const slugRegex = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 
@@ -51,6 +52,20 @@ export async function POST(event) {
   const slug = body.slug ?? slugify(body.name);
   if (!slugRegex.test(slug)) {
     return json({ error: 'invalid_slug', slug }, { status: 400 });
+  }
+
+  // An explicit runner in the request bypasses `resolveDefaultRunnerSlug`
+  // (the resolver every other caller goes through, which is edition-aware
+  // already) - the create form never sends this itself, but a direct API
+  // call still can, and that call is a new write like any other (#410).
+  if (body.defaultAgentRunner !== undefined && !isRunnerAllowed(body.defaultAgentRunner)) {
+    return json(
+      {
+        error: 'runner_not_allowed',
+        message: `Agent runner "${body.defaultAgentRunner}" is not available in this deployment's edition.`,
+      },
+      { status: 400 },
+    );
   }
 
   let accountArg: { handle: string; role: 'personal' | 'brand'; platformId: number } | undefined;

--- a/web/src/routes/api/projects/[id]/+server.ts
+++ b/web/src/routes/api/projects/[id]/+server.ts
@@ -11,6 +11,7 @@ import {
 } from '@pitchbox/shared/projects';
 import { requireOrgId, requireRole } from '$lib/server/auth.js';
 import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
+import { isRunnerAllowed } from '@pitchbox/shared/edition';
 
 const PatchBody = z.object({
   name: z.string().min(1).max(120).optional(),
@@ -53,6 +54,18 @@ export async function PATCH(event: RequestEvent) {
   const db = getDb();
   const project = await getProjectById(db, id);
   if (!project) return json({ error: 'not_found' }, { status: 404 });
+  if (
+    parsed.data.defaultAgentRunner !== undefined &&
+    !isRunnerAllowed(parsed.data.defaultAgentRunner)
+  ) {
+    return json(
+      {
+        error: 'runner_not_allowed',
+        message: `Agent runner "${parsed.data.defaultAgentRunner}" is not available in this deployment's edition.`,
+      },
+      { status: 400 },
+    );
+  }
   await updateProject(db, id, parsed.data);
   return json({ ok: true });
 }

--- a/web/src/routes/api/settings/default-runner/+server.ts
+++ b/web/src/routes/api/settings/default-runner/+server.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getDb } from '$lib/server/db.js';
 import { AGENT_RUNNER_META, type AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
 import { loadDefaultRunnerSlug, saveDefaultRunnerSlug } from '@pitchbox/shared/agents/config';
+import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import { requireInstanceAdmin, requireRole } from '$lib/server/auth.js';
 
 const Body = z.object({ slug: z.string() });
@@ -24,6 +25,9 @@ export async function PUT(event: RequestEvent) {
   if (!parsed.success) throw error(400, 'invalid_body');
   if (!AGENT_RUNNER_META.some((m) => m.slug === parsed.data.slug && m.implemented)) {
     throw error(400, 'runner_not_implemented');
+  }
+  if (!isRunnerAllowed(parsed.data.slug)) {
+    throw error(400, 'runner_not_allowed');
   }
   await saveDefaultRunnerSlug(getDb(), parsed.data.slug as AgentRunnerSlug);
   return json({ ok: true, slug: parsed.data.slug });

--- a/web/src/routes/campaigns/new/+page.server.ts
+++ b/web/src/routes/campaigns/new/+page.server.ts
@@ -5,6 +5,7 @@ import { AGENT_RUNNER_META } from '@pitchbox/shared/agents/meta';
 import { detectAllRunners } from '@pitchbox/shared/agents/detect';
 import { listProjects } from '@pitchbox/shared/projects';
 import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
+import { allowedRunnerSlugs } from '@pitchbox/shared/edition';
 import { resolveOrgId } from '$lib/server/auth.js';
 
 export const load: PageServerLoad = async (event) => {
@@ -55,8 +56,12 @@ export const load: PageServerLoad = async (event) => {
         .orderBy(desc(schema.campaignRecommendations.createdAt))
     : [];
 
+  // Cloud edition offers only the runner it can actually dispatch (#410) -
+  // filtering the meta list here, not just disabling entries, so the picker
+  // never even shows a local backend as a (greyed-out) choice.
+  const allowed = allowedRunnerSlugs();
   const detections = await detectAllRunners();
-  const runners = AGENT_RUNNER_META.map((m) => ({
+  const runners = AGENT_RUNNER_META.filter((m) => allowed.includes(m.slug)).map((m) => ({
     slug: m.slug,
     label: m.label,
     implemented: m.implemented,

--- a/web/src/routes/campaigns/new/+page.svelte
+++ b/web/src/routes/campaigns/new/+page.svelte
@@ -12,7 +12,6 @@
 		platformSupportsAutoPost,
 		type ScenarioSlug,
 	} from '@pitchbox/shared/campaigns';
-	import { AGENT_RUNNER_META } from '@pitchbox/shared/agents/meta';
 	import CampaignRecommendationsList, {
 		type Recommendation,
 	} from '$lib/components/projects/CampaignRecommendationsList.svelte';
@@ -46,11 +45,20 @@
 	);
 	let name = $state(untrack(() => data.preselected?.name ?? ''));
 	// Pre-select the first available runner. Because the runner list is cloud-first
-	// (AGENT_RUNNER_META), this picks the cloud runner whenever it is configured, so
-	// the user just sees the cloud runner in use. Falls back to claude-code when no
-	// runner is detected as available yet.
+	// (AGENT_RUNNER_META) and `data.runners` is already filtered to this
+	// deployment's edition (#410), this picks the cloud runner whenever it is
+	// configured. Falls back to claude-code when it is one of the allowed
+	// runners and none is detected as available yet, or to whatever heads the
+	// (edition-filtered) list otherwise - cloud edition never falls through to
+	// a slug it cannot dispatch.
 	let runner = $state<string>(
-		untrack(() => data.runners.find((r) => r.available)?.slug ?? 'claude-code'),
+		untrack(
+			() =>
+				data.runners.find((r) => r.available)?.slug ??
+				data.runners.find((r) => r.slug === 'claude-code')?.slug ??
+				data.runners[0]?.slug ??
+				'claude-code',
+		),
 	);
 	let objective = $state(untrack(() => data.preselected?.objective ?? ''));
 	let cron = $state('');
@@ -88,14 +96,14 @@
 			label: s.label,
 		})),
 	);
-	const runnerOptions = AGENT_RUNNER_META.map((m) => {
-		const det = data.runners.find((r) => r.slug === m.slug);
-		const available = det?.available ?? false;
-		let label = m.label;
-		if (!m.implemented) label = `${m.label} (not available yet)`;
-		else if (!available) label = `${m.label} (not installed)`;
-		return { value: m.slug, label, disabled: !available };
-	});
+	const runnerOptions = $derived(
+		data.runners.map((r) => {
+			let label = r.label;
+			if (!r.implemented) label = `${r.label} (not available yet)`;
+			else if (!r.available) label = `${r.label} (not installed)`;
+			return { value: r.slug, label, disabled: !r.available };
+		}),
+	);
 	const selectedScenarioDescription = $derived(
 		SCENARIO_META.find((s) => s.slug === scenarioSlug)?.description ?? '',
 	);

--- a/web/src/routes/projects/[id]/+page.server.ts
+++ b/web/src/routes/projects/[id]/+page.server.ts
@@ -5,6 +5,8 @@ import { getDb, schema } from '$lib/server/db.js';
 import { getProjectById } from '@pitchbox/shared/projects';
 import { requireOrgId } from '$lib/server/auth.js';
 import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
+import { AGENT_RUNNER_META } from '@pitchbox/shared/agents/meta';
+import { allowedRunnerSlugs } from '@pitchbox/shared/edition';
 import {
   queryProjectRunsPage,
   parseProjectRunsCursor,
@@ -84,6 +86,12 @@ export const load: PageServerLoad = async (event) => {
             : (latestInsight.generatedAt as unknown as string),
       }
     : null;
+  // The runner picker offers only what this deployment's edition can
+  // dispatch (#410); the project's own snapshot is never filtered - an
+  // existing project keeps loading and showing its current runner even when
+  // that runner predates the guard or a since-changed edition.
+  const allowed = allowedRunnerSlugs();
+  const runners = AGENT_RUNNER_META.filter((m) => allowed.includes(m.slug));
   return {
     project,
     accounts,
@@ -94,5 +102,6 @@ export const load: PageServerLoad = async (event) => {
     recommendations,
     templates,
     latestInsight: latestInsightSerialized,
+    runners,
   };
 };

--- a/web/src/routes/projects/[id]/+page.svelte
+++ b/web/src/routes/projects/[id]/+page.svelte
@@ -90,6 +90,7 @@
     recommendations={data.recommendations}
     {isAdmin}
     {highlightRunId}
+    runners={data.runners}
   />
 {:else if tab === 'accounts'}
   <ProjectAccountsTab

--- a/web/src/routes/settings/runners/+page.server.ts
+++ b/web/src/routes/settings/runners/+page.server.ts
@@ -6,6 +6,7 @@ import {
   loadDefaultRunnerSlug,
   type RunnerConfig,
 } from '@pitchbox/shared/agents/config';
+import { allowedRunnerSlugs } from '@pitchbox/shared/edition';
 import { getDb } from '../../../lib/server/db.js';
 
 export interface RunnerInfo {
@@ -41,7 +42,11 @@ export const load: PageServerLoad = async (event) => {
   if (isAdmin) {
     const detections = await detectAllRunners();
     const runnerConfigs = await loadRunnerConfigs(db);
-    runners = AGENT_RUNNER_META.map((m) => ({
+    // Cloud edition offers only the runner it can dispatch (#410) - a local
+    // backend never appears here to be set as instance default, matching
+    // what the campaign/project forms offer.
+    const allowed = allowedRunnerSlugs();
+    runners = AGENT_RUNNER_META.filter((m) => allowed.includes(m.slug)).map((m) => ({
       slug: m.slug,
       label: m.label,
       implemented: m.implemented,

--- a/web/tests/extension-suggest.test.ts
+++ b/web/tests/extension-suggest.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { createHash } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
@@ -605,6 +605,52 @@ describe('POST /api/extension/suggest', () => {
       expect(lastOptions?.prompt).not.toContain('whatever the panel scraped');
       expect(lastOptions?.prompt).toContain('Recent Author');
     });
+  });
+});
+
+// #410: `runSuggestion` reads `project.defaultAgentRunner` straight off the
+// project row and used to hand it to `createAgentRunner` with no check at
+// all - unlike a campaign run's dispatch, this path had no edition guard
+// whatsoever. A project whose default was hand-changed (or predates the
+// cloud edition) would otherwise reach a local agent spawn on every
+// suggestion. Calls `runSuggestion` directly rather than through the SSE
+// route: the route's per-device rate limiter is in-memory and keyed by
+// deviceId, and every test's freshly-truncated device reuses id 1, so
+// routing this through another HTTP call would eat into the fixed-window
+// budget the tone tests below also rely on for no reason - the guard being
+// tested lives in `runSuggestion` itself, before any network/auth concern.
+describe('runSuggestion refuses a local runner in the cloud edition (#410)', () => {
+  // Resets the mocked registry's recorded call state (`lastOptions` etc.) -
+  // this test never touches the DB, but the mock module state is shared
+  // across every test in this file.
+  beforeEach(reset);
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  it('rejects before the runner is ever created', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    // seedOrgProject/project creation never set defaultAgentRunner, so the
+    // column default ('claude-code') stands in for a project created before
+    // this deployment ever ran the cloud edition - passed here directly as
+    // the resolved runnerSlug, matching what the route hands `runSuggestion`.
+    const handle = runSuggestion({
+      kind: 'post_comment',
+      post: { urn: 'urn:li:activity:1', authorName: 'A', text: 'hi' },
+      currentProject: { name: 'p', description: null },
+      persona: null,
+      projects: [],
+      repos: [],
+      projectId: 1,
+      runnerSlug: 'claude-code',
+    });
+
+    await expect(handle.result).rejects.toThrow(/claude-code/);
+    await expect(handle.result).rejects.toThrow(/edition/i);
+    // The mocked registry records every call it receives - none reached it.
+    expect(lastOptions).toBeNull();
   });
 });
 

--- a/web/tests/runner-defaults.test.ts
+++ b/web/tests/runner-defaults.test.ts
@@ -5,6 +5,13 @@
 // could never spawn: the dispatch honored the snapshot, spawned the ACP adapter
 // via npx and failed with "ACP initialize timed out" ~10s later. The admin's
 // Settings choice (app_config.default_runner) was write-only - nothing read it.
+//
+// #410 closes the follow-on gap: before this file's second half, none of the
+// four write routes (or the campaign-creation inherit path, or project
+// creation's own explicit-slug back door) rejected a local slug in the cloud
+// edition - only dispatch did, and only when the local CLI happened to be
+// undetected. A cloud container that happens to have `claude`/`codex` on
+// PATH for unrelated reasons made detection lie and dispatch let it through.
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { z } from 'zod';
@@ -13,6 +20,12 @@ import { getDb, schema } from '@pitchbox/shared/db';
 import { clearDetectionCache } from '@pitchbox/shared/agents/detect';
 import { POST as projectsPost } from '../src/routes/api/projects/+server.js';
 import { POST as campaignsPost } from '../src/routes/api/campaigns/+server.js';
+import { PATCH as campaignsPatch } from '../src/routes/api/campaigns/[id]/+server.js';
+import {
+  GET as projectsGet,
+  PATCH as projectsPatch,
+} from '../src/routes/api/projects/[id]/+server.js';
+import { PUT as defaultRunnerPut } from '../src/routes/api/settings/default-runner/+server.js';
 import { runProjectExtraction } from '../src/lib/server/runner.js';
 
 async function reset() {
@@ -63,6 +76,53 @@ async function runnerOf(projectId: number): Promise<string> {
     .from(schema.projects)
     .where(eq(schema.projects.id, projectId));
   return row.runner;
+}
+
+function patchEvent<T>(orgId: number, id: number, body: unknown): T {
+  return {
+    locals: { org: { id: orgId, slug: 'default', role: 'owner' } },
+    params: { id: String(id) },
+    request: new Request(`http://x/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    }),
+  } as unknown as T;
+}
+
+function getEvent<T>(orgId: number, id: number): T {
+  return {
+    locals: { org: { id: orgId, slug: 'default', role: 'owner' } },
+    params: { id: String(id) },
+  } as unknown as T;
+}
+
+function putEvent<T>(body: unknown): T {
+  return {
+    locals: {},
+    request: new Request('http://x/', {
+      method: 'PUT',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    }),
+  } as unknown as T;
+}
+
+async function createCampaign(
+  projectId: number,
+  body: Record<string, unknown> = {},
+): Promise<{ status: number; body: { error?: string; id?: number } }> {
+  const res = await campaignsPost(
+    postEvent(await defaultOrgId(), {
+      projectId,
+      platformSlug: 'reddit',
+      scenarioSlug: 'reddit-scout',
+      name: 'c',
+      objective: 'find people',
+      ...body,
+    }),
+  );
+  return { status: res.status, body: await res.json() };
 }
 
 describe('runner snapshot defaults (#219)', () => {
@@ -141,6 +201,136 @@ describe('dispatch refuses a runner this deployment cannot launch (#219)', () =>
     expect(run.error).toMatch(/cloud/);
     expect(run.error).toMatch(/not available/i);
     // The bug was a 10s ACP initialize timeout; the guard is a pre-flight check.
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+});
+
+describe('cloud edition rejects a local runner slug at the API boundary (#410)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(reset);
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+    clearDetectionCache();
+  });
+
+  it('POST /api/campaigns refuses an explicit local runner', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const projectId = await createProject('Cloud project');
+    const { status, body } = await createCampaign(projectId, { agentRunner: 'claude-code' });
+    expect(status).toBe(400);
+    expect(body.error).toBe('runner_not_allowed');
+  });
+
+  it('POST /api/campaigns refuses a new campaign that would inherit a disallowed project default', async () => {
+    // The project predates the cloud edition (or the guard): it was allowed
+    // to snapshot claude-code while self-hosted. A new campaign that never
+    // names a runner itself still resolves to it by inheritance, and that
+    // resolution is a new write like any other.
+    delete process.env.PITCHBOX_EDITION;
+    const projectId = await createProject('Legacy local default', {
+      defaultAgentRunner: 'claude-code',
+    });
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const { status, body } = await createCampaign(projectId);
+    expect(status).toBe(400);
+    expect(body.error).toBe('runner_not_allowed');
+  });
+
+  it('PATCH /api/campaigns/[id] refuses an explicit local runner', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const projectId = await createProject('Patch campaign project');
+    const { body: created } = await createCampaign(projectId);
+    const campaignId = created.id as number;
+    process.env.PITCHBOX_EDITION = 'cloud';
+
+    const res = await campaignsPatch(
+      patchEvent(await defaultOrgId(), campaignId, { agentRunner: 'codex' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('runner_not_allowed');
+
+    const [campaign] = await getDb()
+      .select({ runner: schema.campaigns.agentRunner })
+      .from(schema.campaigns)
+      .where(eq(schema.campaigns.id, campaignId));
+    expect(campaign.runner).toBe('claude-code');
+  });
+
+  it('PATCH /api/projects/[id] refuses an explicit local runner', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const projectId = await createProject('Patch project');
+    process.env.PITCHBOX_EDITION = 'cloud';
+
+    const res = await projectsPatch(
+      patchEvent(await defaultOrgId(), projectId, { defaultAgentRunner: 'gemini' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('runner_not_allowed');
+    expect(await runnerOf(projectId)).toBe('claude-code');
+  });
+
+  it('PUT /api/settings/default-runner refuses a local runner', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    // The route throws SvelteKit's `error()` helper rather than returning a
+    // Response - calling the handler directly (no request-handling
+    // machinery to catch it) surfaces that as a rejection.
+    await expect(defaultRunnerPut(putEvent({ slug: 'claude-code' }))).rejects.toMatchObject({
+      status: 400,
+      body: { message: 'runner_not_allowed' },
+    });
+  });
+
+  it('POST /api/projects refuses an explicit local runner (the resolver back door)', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const res = await projectsPost(
+      postEvent(await defaultOrgId(), { name: 'Direct call', defaultAgentRunner: 'opencode' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('runner_not_allowed');
+  });
+});
+
+describe('an existing local snapshot survives the cloud edition guard (#410)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(reset);
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+    clearDetectionCache();
+  });
+
+  it('a read of the project still loads and shows the pre-existing local runner', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const projectId = await createProject('Pre-existing', { defaultAgentRunner: 'claude-code' });
+    process.env.PITCHBOX_EDITION = 'cloud';
+
+    const res = await projectsGet(getEvent(await defaultOrgId(), projectId));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.project.defaultAgentRunner).toBe('claude-code');
+  });
+
+  it('dispatch refuses the pre-existing local runner with a readable reason instead of spawning it', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const projectId = await createProject('Pre-existing dispatch', {
+      defaultAgentRunner: 'claude-code',
+    });
+    process.env.PITCHBOX_EDITION = 'cloud';
+    clearDetectionCache();
+
+    const started = Date.now();
+    const { runId } = await runProjectExtraction(projectId, { kind: 'folder', value: '/tmp' });
+    const [run] = await getDb()
+      .select({ status: schema.runs.status, error: schema.runs.error })
+      .from(schema.runs)
+      .where(eq(schema.runs.id, runId));
+
+    expect(run.status).toBe('failed');
+    expect(run.error).toMatch(/claude-code/);
+    expect(run.error).toMatch(/edition/i);
+    // Refusing on the edition check happens before the detection probe or any
+    // spawn attempt, so this stays fast the same way the #219 guard does.
     expect(Date.now() - started).toBeLessThan(5_000);
   });
 });


### PR DESCRIPTION
Closes #410.

## The leak, enumerated

Pickers with no edition filter (fixed):
- `web/src/routes/campaigns/new/+page.server.ts:59` (list built from every `AGENT_RUNNER_META` entry)
- `web/src/lib/components/projects/ProjectOverviewTab.svelte:23` (same, hardcoded import)
- `web/src/routes/settings/runners/+page.server.ts:44`

Routes that accepted a slug with no edition check (fixed):
- `POST /api/campaigns` (`agentRunner`, also the inherited-from-project case)
- `PATCH /api/campaigns/[id]` (`agentRunner`)
- `PATCH /api/projects/[id]` (`defaultAgentRunner`)
- `PUT /api/settings/default-runner` (`slug`, only checked `implemented`)
- a fifth one the issue didn't name: `POST /api/projects` also accepts an explicit `defaultAgentRunner` in the body, bypassing `resolveDefaultRunnerSlug` entirely - the create form never sends it, but a direct call can.

Dispatch paths:
- The campaign/project run pre-flight (`web/src/lib/server/runner.ts`) was the only real enforcement, and it was environment-dependent: it refuses a slug only when `detectRunner` reports it unavailable. I set `PITCHBOX_EDITION=cloud` in this sandbox (which happens to have `claude` on PATH) and confirmed `detectRunner('claude-code')` returns `available: true` there - a cloud deployment whose image carries a CLI binary for any unrelated reason would let dispatch spawn it for real, not fail loud.
- The assist plane (`web/src/lib/server/suggest.ts`, called from `POST /api/extension/suggest`) had **no guard of any kind** - it reads `project.defaultAgentRunner` and hands it straight to `createAgentRunner`. Confirmed by reproducing #410's own note that a hand-changed project default "breaks panel suggestions too."

## The fix

One function pair in `shared/src/edition.ts`, next to `currentEdition`/`isCloud`:
- `allowedRunnerSlugs()` - the list every picker filters to (`['cloud']` in cloud edition, the full catalogue self-hosted).
- `isRunnerAllowed(slug)` - the boundary check every write/dispatch path asks. Deliberately **not** derived from catalogue membership in self-hosted: self-hosted never validated a runner string against the catalogue at the API layer (an unregistered slug always failed later, at `createAgentRunner`), and `campaign-cron-validation.test.ts`/`campaign-scenario-autopost.test.ts` rely on posting a deliberately-fake `NO_OP_RUNNER` slug through untouched. The only thing this guard adds is the cloud boundary.

## Existing-row decision

Refuse, don't coerce. A project or campaign that already snapshotted a local runner keeps loading and reading exactly as before - the picker shows its current value (disabled, labelled "not available in this edition") instead of silently blanking it. Only a **new** write (POST/PATCH) or a **new** dispatch attempt against it is refused, with a readable message. I chose refuse over silent coercion because rewriting an admin's stored config to a different runner (different auth model, different config schema, different behavior) without being asked is a bigger surprise than a clear 400 or a clear failed-run message telling them what to change.

The refusal is visible in run events: it goes through the same `error`/`failureReason` path a run already uses (`dispatchRun`'s catch → `run.error` + `run:finished`), so it shows up the same way #219's pre-flight message does, not a blank failure.

## Tests

- `shared/tests/edition.test.ts` (new): `allowedRunnerSlugs`/`isRunnerAllowed` in both editions, plus the self-hosted/unregistered-slug case that motivated the "not catalogue membership" design.
- `web/tests/runner-defaults.test.ts`: extended with two new suites -
  - "cloud edition rejects a local runner slug at the API boundary" - one test per guarded route (5 total, including the `POST /api/projects` back door), at the API boundary rather than the picker.
  - "an existing local snapshot survives the cloud edition guard" - a project created self-hosted with `claude-code`, then read (`GET`) under cloud edition (still loads, unchanged value), then dispatched under cloud edition (fails fast with a readable message, not a spawn).
- `web/tests/extension-suggest.test.ts`: one new test proving the assist plane's guard fires before the (mocked) runner registry is ever called.

Proven to bite: temporarily disabled the `POST /api/campaigns` guard and the dispatch pre-flight guard and re-ran the corresponding tests - the API test went from 400 to 201, and the dispatch test's run status went from `failed` to `running` (i.e. without the guard, the run in this sandbox actually starts spawning the real `claude` CLI, live confirmation of the leak). Restored both, reran, green.

## Checks run

- `DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5434/pitchbox_test_w410 pnpm exec vitest run shared/tests/edition.test.ts web/tests/runner-defaults.test.ts web/tests/extension-suggest.test.ts` - green (41 tests), plus a wider regression sweep (settings/instance-admin gating, campaign cron/autopost/delete, route guards, project detail loaders) - all green, no other test relied on the old unguarded behavior except the two I fixed forward (`isRunnerAllowed` design) rather than breaking.
- `pnpm -F @pitchbox/shared typecheck` - clean.
- `pnpm -F web check` - clean (0 errors, 0 warnings; fixed a `state_referenced_locally` warning my own change introduced by making `runnerOptions` a proper `$derived`).
- `npx eslint <changed files>` - clean.
- `npx prettier --check <changed .ts files>` - clean.
- Pushed with `PREFLIGHT_SKIP=1` after the above; did not run the full monorepo suite.

Non-goals per the issue: no extension changes, no `shared/src/assist/suggest-prompt.ts` or `shared/src/assist/envelope.ts` edits (those are Main's, untouched).
