### PR TITLE
fix(extension): stop the in-page panel flipping off-screen above a tall anchor

### DIFF
--- a/extension/src/content/shared/panel-host.ts
+++ b/extension/src/content/shared/panel-host.ts
@@ -201,7 +201,16 @@ export function computeOverlayPlacement(
   } else {
     left = anchor.left;
     const spaceBelow = viewportHeight - anchor.bottom - OVERLAY_MARGIN;
-    if (spaceBelow >= height) {
+    // Room above, on the same terms as `available` below: a margin against
+    // the anchor and a second one against the viewport's own top edge.
+    // Compared against `spaceBelow`, not just tested against `height`
+    // (#404) - an anchor near the top of the viewport (a reply box scrolled
+    // to the top of a short or narrow window, the "start a post" modal)
+    // can leave next to nothing above it, and committing to "above" anyway
+    // pushed the panel off the top of the screen instead of the merely
+    // short-but-visible placement `below` still gives it.
+    const spaceAbove = anchor.top - OVERLAY_MARGIN * 2;
+    if (spaceBelow >= height || spaceBelow >= spaceAbove) {
       top = anchor.bottom + OVERLAY_MARGIN;
       bottom = null;
     } else {
@@ -217,15 +226,20 @@ export function computeOverlayPlacement(
   const maxLeft = Math.max(viewportWidth - width - OVERLAY_MARGIN, minLeft);
   left = Math.min(Math.max(left, minLeft), maxLeft);
 
-  // The hard ceiling `panel.css`'s `max-height` is set to. No floor here on
-  // purpose (there used to be one, at `OVERLAY_MIN_HEIGHT` - it is what
-  // caused the overflow above): `top`/`bottom` above are already chosen so
-  // the *current* height fits, so the ceiling only needs to stop the panel
-  // growing past that same room before the next `ResizeObserver` tick can
-  // react to it.
+  // The hard ceiling `panel.css`'s `max-height` is set to. No floor at
+  // `OVERLAY_MIN_HEIGHT` here on purpose - it is what caused the overflow
+  // above (`top`/`bottom` are already chosen so the *current* height fits,
+  // so the ceiling only needs to stop the panel growing past that same room
+  // before the next `ResizeObserver` tick can react to it) - but `available`
+  // can still go negative when neither side has room to spare (#404), and a
+  // negative `max-height` is not a valid CSS length: the browser drops the
+  // whole declaration and the panel renders at `panel.css`'s unclamped 60vh
+  // default instead, at whichever `top`/`bottom` was picked for a height
+  // that was never going to fit there. Flooring at zero keeps the box
+  // honestly tiny rather than invisible off-screen at full size.
   const available =
     top !== null ? viewportHeight - top - OVERLAY_MARGIN : anchor.top - OVERLAY_MARGIN * 2;
-  const maxHeight = Math.min(viewportHeight * OVERLAY_MAX_HEIGHT_RATIO, available);
+  const maxHeight = Math.max(0, Math.min(viewportHeight * OVERLAY_MAX_HEIGHT_RATIO, available));
 
   return { left, top, bottom, maxHeight };
 }

--- a/extension/tests/content/panel-host-overlay.test.ts
+++ b/extension/tests/content/panel-host-overlay.test.ts
@@ -218,6 +218,33 @@ describe('computeOverlayPlacement', () => {
     // top edge to make room.
     expect(grown.top!).toBeLessThan(anchor.top);
   });
+
+  it('stays below the anchor, clamped to whatever room is left, rather than flipping above an anchor near the top of the viewport (#404)', () => {
+    // Measured on a real LinkedIn feed at 700x700: a tall composer (a
+    // "start a post" modal, or a reply box scrolled to the top of a short
+    // or narrow window) starting at the very top of the viewport leaves
+    // only 88px below it and, before this fix, `anchor.top - 24` for the
+    // "above" branch this used to flip to: -24, an invalid CSS length that
+    // made the browser drop `max-height` entirely and render the panel at
+    // its full unclamped size, positioned off the top of the screen.
+    const anchor = { top: 0, left: 20, right: 420, bottom: 600 };
+    const viewport = { width: 700, height: 700 };
+
+    const p = computeOverlayPlacement(anchor, viewport.width, viewport.height, 108);
+    expect(p.top).toBe(anchor.bottom + 12);
+    expect(p.bottom).toBeNull();
+    expect(p.maxHeight).toBeGreaterThan(0);
+    expect(p.top! + p.maxHeight).toBeLessThanOrEqual(viewport.height);
+  });
+
+  it('never returns a negative max-height, even when neither side has room to spare (#404)', () => {
+    // A degenerate anchor that leaves next to nothing on either side: the
+    // old formula for the "above" branch's `available` produced -24, and
+    // `Math.min` propagated that straight through with no floor.
+    const anchor = { top: 0, left: 0, right: 250, bottom: 690 };
+    const p = computeOverlayPlacement(anchor, 700, 700, 108);
+    expect(p.maxHeight).toBeGreaterThanOrEqual(0);
+  });
 });
 
 describe('mountPanel, overlay wiring', () => {


### PR DESCRIPTION
Closes #404.

## What actually breaks

Read the existing `panel-host-overlay.test.ts` first: the width clamp (D16's `min(520px, 100vw-24px)`) and the below/above flip added for #387 already handle a narrow *viewport* correctly. Checked live against a real LinkedIn feed comment composer with the built extension loaded in a real Chrome profile at 1280, 900 and 700px:

- 1280x900: anchor 392px wide, panel placed to the right, no overflow.
- 900x800: anchor narrows to 312px, panel flips below, clamped inside the viewport (876.5 of 900px).
- 700x800: anchor widens to 525px (near full width), panel flips below, still on-screen (546 of 700px).

None of that was broken. The real gap is a tall anchor near the *top* of the viewport, not a narrow one: `computeOverlayPlacement` flips to placing the panel above the anchor whenever below does not fit, with no check that above has room either. Above's `available` height is `anchor.top - 24`; when the anchor starts near y=0 (the "start a post" modal, or a reply box scrolled to the top of a short/narrow window), that is zero or negative. A negative value went straight into the host's inline `max-height`, which is not a valid CSS length, so the browser silently dropped the whole declaration and rendered the panel at `panel.css`'s unclamped `60vh` default, positioned off the top of the screen.

Measured on the real feed at 700x700 with the built extension: an anchor from y=0 to y=600 (88px below it, none above). Before the fix the panel rendered at `top: -120.375px`, entirely invisible above the viewport. Screenshot taken at this point shows nothing where the panel should be.

## The fix

`computeOverlayPlacement` now compares the room below against the room above and keeps the below placement whenever it has more of it (below can never go negative the way above can, since nothing sits above y=0). `max-height` is floored at zero so a genuinely tiny remainder degrades to a short but visible panel instead of an invalid value the browser silently ignores.

After the fix, same anchor: panel renders at `top: 612px`, `max-height: 76px`, fully inside the 700px-tall viewport, still below (not covering) the anchor. Screenshot of this state shows the panel's "Could not reach the Pitchbox backend" refusal card visible at the bottom of the LinkedIn feed.

No constraint had to be broken: the panel is still a fixed overlay (D13), the draft text is still 16px (unaffected by this path), and it never covers the composer it is anchored to (below/above both stay clear of it by construction).

## Tests, each proven to bite

Added two cases to `panel-host-overlay.test.ts`:
- `stays below the anchor, clamped to whatever room is left, rather than flipping above an anchor near the top of the viewport (#404)` - reverting the fix makes it fail with `expected null to be 612` (it flips to `above`, `top` is `null`).
- `never returns a negative max-height, even when neither side has room to spare (#404)` - reverting the fix makes it fail with `expected -24 to be greater than or equal to 0`.

Confirmed both by stashing the source change and re-running: both fail with exactly those messages, then pass again once restored.

## Checks run

- `pnpm exec vitest run extension/tests/content/` - 273 passed (17 files)
- `pnpm -F @pitchbox/extension check` - 0 errors, 0 warnings
- `npx eslint extension/src/content/shared/panel-host.ts extension/tests/content/panel-host-overlay.test.ts` - clean
- `npx prettier --check` on both changed `.ts` files - clean
- `pnpm run test:linkedin-compliance` - 15 passed
- `pnpm exec vitest run tests/extension-packaged-build.test.ts` - 6 passed

No full monorepo `pnpm test`, no formatters beyond the changed files. Pushed with `PREFLIGHT_SKIP=1` after the above were green.
