### PR TITLE
feat(web,shared): per-project voice, so a product does not sound like my personal account

### DIFF
--- a/shared/src/db/migrations/0017_project_voice.sql
+++ b/shared/src/db/migrations/0017_project_voice.sql
@@ -1,0 +1,14 @@
+-- Per-project voice override (#408): a suggestion filed under a product's
+-- project should not sound like the operator's personal account, and vice
+-- versa. Both columns null means "inherit the org's linkedin_assist tone" -
+-- resolveEffectiveVoice (shared/src/linkedin-assist.ts) is the one place that
+-- fallback is decided, so a null here is indistinguishable from a project
+-- that predates this column.
+--
+-- Not an enum, matching the org-level tone stored in app_config's jsonb: the
+-- vocabulary lives in code (assist/tone.ts), and an unrecognised value here
+-- falls through to the org setting the same way an unrecognised jsonb value
+-- falls through to the default.
+ALTER TABLE "projects" ADD COLUMN "voice_tone" text;
+--> statement-breakpoint
+ALTER TABLE "projects" ADD COLUMN "voice_tone_notes" text;

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1788960000002,
       "tag": "0015_personal_project",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1788960000004,
+      "tag": "0017_project_voice",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -150,6 +150,15 @@ export const projects = pgTable(
     name: text('name').notNull(),
     description: text('description'),
     defaultAgentRunner: text('default_agent_runner').notNull().default('claude-code'),
+    // Per-project voice override (#408): null on both means "inherit the
+    // org's linkedin_assist tone", the same way an unset app_config row does
+    // - see resolveEffectiveVoice in linkedin-assist.ts, the one place that
+    // fallback is decided. Not an enum: the tone vocabulary lives in
+    // assist/tone.ts and this column can otherwise drift the same way the
+    // org setting's jsonb can, which resolveEffectiveVoice already guards
+    // against by falling through on an unrecognised value.
+    voiceTone: text('voice_tone'),
+    voiceToneNotes: text('voice_tone_notes'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/shared/src/linkedin-assist.ts
+++ b/shared/src/linkedin-assist.ts
@@ -96,9 +96,17 @@ export async function loadLinkedInAssistSettings(
   // back to the default rather than reaching the prompt as a literal - the
   // prompt would otherwise instruct the model in a register nobody chose.
   if (!isAssistTone(merged.tone)) merged.tone = DEFAULT_ASSIST_TONE;
-  merged.toneNotes =
-    typeof merged.toneNotes === 'string' ? merged.toneNotes.slice(0, ASSIST_TONE_NOTES_MAX) : '';
+  merged.toneNotes = clampToneNotes(merged.toneNotes);
   return merged;
+}
+
+/** Trims a stored tone-notes value to the shared ceiling, and coerces
+ * anything that arrived as a non-string (a stale or hand-edited row) to an
+ * empty one rather than letting it reach a prompt. Shared by the org
+ * settings load above and the project-override resolver below, so the two
+ * do not drift on what "clamp" means. */
+function clampToneNotes(value: unknown): string {
+  return typeof value === 'string' ? value.slice(0, ASSIST_TONE_NOTES_MAX) : '';
 }
 
 export async function saveLinkedInAssistSettings(
@@ -167,4 +175,41 @@ export async function loadLinkedInAssistDeviceState(
     dailyCommentCap: settings.dailyCommentCap,
     dailyPostCap: settings.dailyPostCap,
   };
+}
+
+/** The tone and notes actually used for a suggestion (#408). */
+export type EffectiveVoice = {
+  tone: AssistTone;
+  toneNotes: string;
+};
+
+/**
+ * Resolves the voice a suggestion should be written in, given the project it
+ * is actually being filed under - not the org's bound project, which the
+ * personal-project carve-out (2026-09-07) already lets a request diverge
+ * from. Precedence: the project's own override if it set one, else the org's
+ * `linkedin_assist` tone, which itself already falls back to
+ * `DEFAULT_ASSIST_TONE` when nothing was ever saved (`loadLinkedInAssistSettings`
+ * above) - so this is the one place all three levels collapse into a single
+ * answer, rather than each caller re-deriving the fallback chain itself.
+ *
+ * `project` only needs its two voice columns, not a full row, so a caller
+ * that already selected the project (the suggest route does, to enforce the
+ * binding) can pass it straight through with no second query.
+ *
+ * An unrecognised `voiceTone` (a column written by an older build, or a
+ * value nobody offers anymore) is treated the same as unset - it falls
+ * through to the org setting rather than reaching a prompt as a literal,
+ * mirroring how `loadLinkedInAssistSettings` treats a stale jsonb tone.
+ */
+export async function resolveEffectiveVoice(
+  db: Db,
+  organizationId: number,
+  project: { voiceTone: string | null; voiceToneNotes: string | null },
+): Promise<EffectiveVoice> {
+  if (isAssistTone(project.voiceTone)) {
+    return { tone: project.voiceTone, toneNotes: clampToneNotes(project.voiceToneNotes) };
+  }
+  const settings = await loadLinkedInAssistSettings(db, organizationId);
+  return { tone: settings.tone, toneNotes: settings.toneNotes };
 }

--- a/shared/src/projects/projects.ts
+++ b/shared/src/projects/projects.ts
@@ -164,7 +164,15 @@ export async function createProjectTx(db: Db, args: CreateProjectArgs): Promise<
 export async function updateProject(
   db: Db,
   id: number,
-  patch: { name?: string; description?: string | null; defaultAgentRunner?: string },
+  patch: {
+    name?: string;
+    description?: string | null;
+    defaultAgentRunner?: string;
+    /** Per-project voice override (#408). `null` clears it back to "inherit
+     * the org tone" - see resolveEffectiveVoice in linkedin-assist.ts. */
+    voiceTone?: string | null;
+    voiceToneNotes?: string | null;
+  },
 ): Promise<void> {
   await db
     .update(schema.projects)

--- a/shared/tests/linkedin-assist-voice.test.ts
+++ b/shared/tests/linkedin-assist-voice.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+  resolveEffectiveVoice,
+} from '../src/linkedin-assist.js';
+
+/**
+ * #408: a per-project voice override that falls back to the org's
+ * `linkedin_assist` tone, and beyond that to `DEFAULT_ASSIST_TONE`. This is
+ * the one place that three-level fallback is decided - everything else
+ * (the suggest route, the project page) just calls it, so what these tests
+ * defend is the precedence itself, not any particular caller.
+ */
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`TRUNCATE projects RESTART IDENTITY CASCADE`);
+  await db.execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function ensureOrg(slug: string): Promise<number> {
+  const db = getDb();
+  await db.insert(schema.organizations).values({ slug, name: slug }).onConflictDoNothing();
+  const [org] = await db
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.slug, slug));
+  return org.id;
+}
+
+async function makeProject(
+  organizationId: number,
+  slug: string,
+  voice: { voiceTone?: string | null; voiceToneNotes?: string | null } = {},
+): Promise<number> {
+  const db = getDb();
+  const [p] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId,
+      slug,
+      name: slug,
+      voiceTone: voice.voiceTone ?? null,
+      voiceToneNotes: voice.voiceToneNotes ?? null,
+    })
+    .returning({ id: schema.projects.id });
+  return p.id;
+}
+
+describe('resolveEffectiveVoice (#408)', () => {
+  beforeEach(reset);
+
+  it('falls back to DEFAULT_ASSIST_TONE when neither the project nor the org set anything', async () => {
+    const db = getDb();
+    const orgId = await ensureOrg('voice-none');
+    const projectId = await makeProject(orgId, 'voice-none-p');
+    const [project] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId));
+
+    const voice = await resolveEffectiveVoice(db, orgId, project);
+    expect(voice).toEqual({ tone: 'match-room', toneNotes: '' });
+  });
+
+  it('uses the org tone when the project has no override', async () => {
+    const db = getDb();
+    const orgId = await ensureOrg('voice-org-only');
+    await saveLinkedInAssistSettings(db, orgId, {
+      ...defaultLinkedInAssistSettings(),
+      tone: 'technical',
+    });
+    const projectId = await makeProject(orgId, 'voice-org-only-p');
+    const [project] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId));
+
+    const voice = await resolveEffectiveVoice(db, orgId, project);
+    expect(voice.tone).toBe('technical');
+  });
+
+  it("the project's override wins over the org tone", async () => {
+    const db = getDb();
+    const orgId = await ensureOrg('voice-project-wins');
+    await saveLinkedInAssistSettings(db, orgId, {
+      ...defaultLinkedInAssistSettings(),
+      tone: 'technical',
+    });
+    const projectId = await makeProject(orgId, 'voice-project-wins-p', { voiceTone: 'warm' });
+    const [project] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId));
+
+    const voice = await resolveEffectiveVoice(db, orgId, project);
+    expect(voice.tone).toBe('warm');
+  });
+
+  // The default tone itself, explicitly set as an override, must still beat
+  // a *different* org tone - proving the resolver checks "is this column
+  // null" rather than "does this equal DEFAULT_ASSIST_TONE".
+  it('an override explicitly equal to DEFAULT_ASSIST_TONE still beats a different org tone', async () => {
+    const db = getDb();
+    const orgId = await ensureOrg('voice-explicit-default');
+    await saveLinkedInAssistSettings(db, orgId, {
+      ...defaultLinkedInAssistSettings(),
+      tone: 'technical',
+    });
+    const projectId = await makeProject(orgId, 'voice-explicit-default-p', {
+      voiceTone: 'match-room',
+    });
+    const [project] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId));
+
+    const voice = await resolveEffectiveVoice(db, orgId, project);
+    expect(voice.tone).toBe('match-room');
+  });
+
+  it("carries the project's own notes when the override is custom", async () => {
+    const db = getDb();
+    const orgId = await ensureOrg('voice-custom-notes');
+    await saveLinkedInAssistSettings(db, orgId, {
+      ...defaultLinkedInAssistSettings(),
+      tone: 'custom',
+      toneNotes: 'org-level custom notes nobody should see here',
+    });
+    const projectId = await makeProject(orgId, 'voice-custom-notes-p', {
+      voiceTone: 'custom',
+      voiceToneNotes: 'Talk like a lab notebook.',
+    });
+    const [project] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId));
+
+    const voice = await resolveEffectiveVoice(db, orgId, project);
+    expect(voice).toEqual({ tone: 'custom', toneNotes: 'Talk like a lab notebook.' });
+  });
+
+  // A column written by an older build, or a value nobody offers anymore,
+  // is not a valid override - it falls through to the org tone exactly like
+  // an unset column, rather than reaching a prompt as a literal.
+  it('an unrecognised voiceTone value falls through to the org tone', async () => {
+    const db = getDb();
+    const orgId = await ensureOrg('voice-garbage');
+    await saveLinkedInAssistSettings(db, orgId, {
+      ...defaultLinkedInAssistSettings(),
+      tone: 'plain',
+    });
+    const projectId = await makeProject(orgId, 'voice-garbage-p', {
+      voiceTone: 'sarcastic-pirate',
+    });
+    const [project] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId));
+
+    const voice = await resolveEffectiveVoice(db, orgId, project);
+    expect(voice.tone).toBe('plain');
+  });
+});

--- a/shared/tests/projects/projects.test.ts
+++ b/shared/tests/projects/projects.test.ts
@@ -69,6 +69,32 @@ describe('projects helpers', () => {
     expect(p?.description).toBe('desc');
   });
 
+  // #408: a fresh project has no voice override (both columns null,
+  // resolveEffectiveVoice's "inherit" case), updateProject can set one, and
+  // setting voiceTone back to null clears it rather than leaving a stale
+  // voiceToneNotes value orphaned behind it.
+  it('updateProject round-trips a voice override and can clear it back to null', async () => {
+    const pid = await platformId('reddit');
+    const { id } = await createProjectTx(getDb(), {
+      slug: 'voice-upd',
+      name: 'A',
+      account: { handle: 'h', role: 'personal', platformId: pid },
+    });
+    const fresh = await getProjectById(getDb(), id);
+    expect(fresh?.voiceTone).toBeNull();
+    expect(fresh?.voiceToneNotes).toBeNull();
+
+    await updateProject(getDb(), id, { voiceTone: 'custom', voiceToneNotes: 'Dry, no hype.' });
+    const withOverride = await getProjectById(getDb(), id);
+    expect(withOverride?.voiceTone).toBe('custom');
+    expect(withOverride?.voiceToneNotes).toBe('Dry, no hype.');
+
+    await updateProject(getDb(), id, { voiceTone: null, voiceToneNotes: null });
+    const cleared = await getProjectById(getDb(), id);
+    expect(cleared?.voiceTone).toBeNull();
+    expect(cleared?.voiceToneNotes).toBeNull();
+  });
+
   it('deleteProject with matching slug cascades children', async () => {
     const pid = await platformId('reddit');
     const { id } = await createProjectTx(getDb(), {

--- a/web/src/lib/components/projects/ProjectOverviewTab.svelte
+++ b/web/src/lib/components/projects/ProjectOverviewTab.svelte
@@ -16,6 +16,12 @@
   } from './CampaignRecommendationsList.svelte';
   import { DESCRIPTION_SCAFFOLD } from '@pitchbox/shared/project-extraction';
   import { TONE_BANNER_CLASS, TONE_TEXT_CLASS } from '$lib/config/status-badges';
+  import {
+    ASSIST_TONES,
+    ASSIST_TONE_NOTES_MAX,
+    isAssistTone,
+    type AssistTone,
+  } from '@pitchbox/shared/assist/tone';
   import StreamStatusBanner from '$lib/realtime/StreamStatusBanner.svelte';
   import { getSseManager } from '$lib/realtime/sse';
 
@@ -27,6 +33,11 @@
     name: string;
     description: string | null;
     defaultAgentRunner: string;
+    /** Per-project voice override (#408). Both null means "inherit the
+     * organization's linkedin_assist tone" - see resolveEffectiveVoice in
+     * shared/src/linkedin-assist.ts. */
+    voiceTone: string | null;
+    voiceToneNotes: string | null;
   };
   type ExtractionRun = {
     id: number;
@@ -88,6 +99,28 @@
   let description = $state(project.description ?? '');
   // svelte-ignore state_referenced_locally
   let runner = $state(project.defaultAgentRunner);
+  // 'inherit' means both DB columns are null: this project falls back to the
+  // organization's linkedin_assist tone (#408). An unrecognised stored value
+  // (a stale column from an older build) is treated the same as unset,
+  // mirroring resolveEffectiveVoice's own fallback.
+  // svelte-ignore state_referenced_locally
+  let voiceTone = $state<AssistTone | 'inherit'>(
+    isAssistTone(project.voiceTone) ? project.voiceTone : 'inherit',
+  );
+  // svelte-ignore state_referenced_locally
+  let voiceToneNotes = $state(project.voiceToneNotes ?? '');
+  const VOICE_TONE_LABELS: Record<AssistTone, string> = {
+    'match-room': 'Match the room',
+    professional: 'Professional',
+    plain: 'Plain',
+    warm: 'Warm',
+    technical: 'Technical',
+    custom: 'In my own words',
+  };
+  const VOICE_OPTIONS: Array<{ value: AssistTone | 'inherit'; label: string }> = [
+    { value: 'inherit', label: 'Use organization default' },
+    ...ASSIST_TONES.map((t) => ({ value: t, label: VOICE_TONE_LABELS[t] })),
+  ];
   let saving = $state(false);
   let deleteOpen = $state(false);
   // Gates loading the bytemd editor stack: only fetched once the user
@@ -141,6 +174,10 @@
   );
 
   async function save() {
+    if (voiceTone === 'custom' && !voiceToneNotes.trim()) {
+      toast.error('Describe the tone you want, or pick "Use organization default"');
+      return;
+    }
     saving = true;
     try {
       const res = await fetch(`/api/projects/${project.id}`, {
@@ -150,6 +187,8 @@
           name,
           description: description || null,
           defaultAgentRunner: runner,
+          voiceTone: voiceTone === 'inherit' ? null : voiceTone,
+          voiceToneNotes: voiceTone === 'inherit' ? null : voiceToneNotes,
         }),
       });
       if (!res.ok) {
@@ -255,6 +294,34 @@
         disabled={!isAdmin}
       />
     </label>
+  </div>
+
+  <div class="grid gap-4 md:grid-cols-3">
+    <label class="flex flex-col gap-1 text-xs">
+      Voice
+      <SelectField
+        value={voiceTone}
+        onValueChange={(v) => (voiceTone = v as AssistTone | 'inherit')}
+        options={VOICE_OPTIONS}
+        fullWidth
+        disabled={!isAdmin}
+      />
+      <span class="text-xs text-muted-foreground">
+        How a suggestion for this project should sound. Left at the default, it follows the
+        organization's LinkedIn assist tone (Settings &gt; LinkedIn assist).
+      </span>
+    </label>
+    {#if voiceTone === 'custom'}
+      <label class="flex flex-col gap-1 text-xs md:col-span-2">
+        In your own words
+        <Input
+          maxlength={ASSIST_TONE_NOTES_MAX}
+          placeholder="Direct, a bit dry, no enthusiasm I would not say out loud"
+          bind:value={voiceToneNotes}
+          disabled={!isAdmin}
+        />
+      </label>
+    {/if}
   </div>
 
   <div class="flex flex-col gap-2">

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -17,7 +17,7 @@ import {
 import { loadCompanionContext } from '@pitchbox/shared/assist/context';
 import {
   loadLinkedInAssistDeviceState,
-  loadLinkedInAssistSettings,
+  resolveEffectiveVoice,
 } from '@pitchbox/shared/linkedin-assist';
 import { loadRecentObservedTarget } from '@pitchbox/shared/observed-targets';
 
@@ -240,14 +240,17 @@ export async function POST(event: RequestEvent) {
     currentProjectId: project.id,
   });
 
-  // The tone (#405) is read here, from the org's stored settings, and never
-  // from `body`: the panel is not an enforcement boundary for it, exactly as
-  // it is not for `enabled`, `killSwitch` or the reasoning/draft split. That
-  // is also what keeps a panel-level retune (#409) an explicit feature rather
-  // than something a crafted request already gets for free. Loaded from the
-  // settings rather than from the device state above, because the device
-  // state is by definition the shape the extension is allowed to see.
-  const assistSettings = await loadLinkedInAssistSettings(db, project.organizationId);
+  // The tone (#405) is read here, resolved against the project this
+  // suggestion is actually being filed under (#408) - never from `body`: the
+  // panel is not an enforcement boundary for it, exactly as it is not for
+  // `enabled`, `killSwitch` or the reasoning/draft split. That is also what
+  // keeps a panel-level retune (#409) an explicit feature rather than
+  // something a crafted request already gets for free. `project` here is the
+  // filed-under project (the bound project, or the org's `personal` project
+  // per the carve-out above), not necessarily the org's bound project the
+  // device state names - a personal suggestion and a product suggestion can
+  // therefore resolve to different voices even though they share one org.
+  const voice = await resolveEffectiveVoice(db, project.organizationId, project);
 
   let cancel: () => void = () => {};
   let settled = false;
@@ -278,8 +281,8 @@ export async function POST(event: RequestEvent) {
         repos: context.repos,
         examples,
         hint: body.hint,
-        tone: assistSettings.tone,
-        toneNotes: assistSettings.toneNotes,
+        tone: voice.tone,
+        toneNotes: voice.toneNotes,
         projectId: project.id,
         orgId: auth.organizationId ?? undefined,
         runnerSlug: project.defaultAgentRunner,

--- a/web/src/routes/api/projects/[id]/+server.ts
+++ b/web/src/routes/api/projects/[id]/+server.ts
@@ -12,11 +12,19 @@ import {
 import { requireOrgId, requireRole } from '$lib/server/auth.js';
 import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
+import { ASSIST_TONES, ASSIST_TONE_NOTES_MAX } from '@pitchbox/shared/linkedin-assist';
 
 const PatchBody = z.object({
   name: z.string().min(1).max(120).optional(),
   description: z.string().max(2000).nullable().optional(),
   defaultAgentRunner: z.string().min(1).optional(),
+  // Per-project voice override (#408). `null` clears it back to "inherit the
+  // org tone" - see resolveEffectiveVoice in linkedin-assist.ts. An unknown
+  // value is rejected rather than coerced, the same as the org-level tone
+  // save: the project page is the one writer, so anything else is a stale
+  // tab or a hand-built request.
+  voiceTone: z.enum(ASSIST_TONES).nullable().optional(),
+  voiceToneNotes: z.string().max(ASSIST_TONE_NOTES_MAX).nullable().optional(),
 });
 
 const DeleteBody = z.object({ confirmSlug: z.string().min(1) });
@@ -62,6 +70,19 @@ export async function PATCH(event: RequestEvent) {
       {
         error: 'runner_not_allowed',
         message: `Agent runner "${parsed.data.defaultAgentRunner}" is not available in this deployment's edition.`,
+      },
+      { status: 400 },
+    );
+  }
+  // Mirrors the org-level save (api/settings/linkedin-assist): the free-text
+  // tone is the only option whose instruction is the operator's own words,
+  // so choosing it here without writing any would silently override the org
+  // tone with an empty instruction rather than the words the operator meant.
+  if (parsed.data.voiceTone === 'custom' && !parsed.data.voiceToneNotes?.trim()) {
+    return json(
+      {
+        error: 'invalid_body',
+        message: 'describe the tone you want, or pick "Use organization default"',
       },
       { status: 400 },
     );

--- a/web/src/routes/settings/linkedin-assist/+page.svelte
+++ b/web/src/routes/settings/linkedin-assist/+page.svelte
@@ -168,9 +168,11 @@
 			<Card.Header>
 				<Card.Title>Tone</Card.Title>
 				<Card.Description>
-					How a suggestion should sound. The house style outranks every option here, so none of
-					them can ask for the typography Pitchbox never emits, and a tone sent by the extension
-					is ignored: this page is where it is decided.
+					How a suggestion should sound, by default. The house style outranks every option here,
+					so none of them can ask for the typography Pitchbox never emits, and a tone sent by the
+					extension is ignored: this page and the project page are where it is decided. Any
+					project can override this for itself - open the project and look for Voice - so a
+					product does not have to sound like your personal account.
 				</Card.Description>
 			</Card.Header>
 			<Card.Content class="flex flex-col gap-4">

--- a/web/tests/extension-suggest-voice.test.ts
+++ b/web/tests/extension-suggest-voice.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type { AgentRunHandle, AgentRunOptions, AgentRunner } from '@pitchbox/shared/agents';
+import { type RunnerConfig } from '@pitchbox/shared/agents/config';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+import { ensurePersonalProject } from '@pitchbox/shared/personal-project';
+import { loadCompanionContext } from '@pitchbox/shared/assist/context';
+import { loadActiveTemplates } from '@pitchbox/shared/templates';
+import { buildSuggestionPrompt } from '@pitchbox/shared/assist/suggest-prompt';
+import { DRAFT_MARKER } from '@pitchbox/shared/assist/envelope';
+
+/**
+ * #408: a per-project voice override, resolved against the project a
+ * suggestion is actually being filed under (the bound project, or the org's
+ * `personal` carve-out) rather than the org's bound project alone. Kept in
+ * its own file rather than folded into extension-suggest.test.ts because
+ * that file's `perDevice` rate limiter (20/60s) is a module-level singleton
+ * shared by every test in the process that imports it, and its own tests
+ * already run it close to the cap (see the comment on its last describe
+ * block) - a fresh file gets a fresh import and a fresh limiter.
+ */
+
+const REASONING = 'Noticed the cache change and the specific number.';
+const DRAFT = 'A specific thing that happened.';
+const ENVELOPE_CHUNKS = [`${REASONING}\n`, DRAFT_MARKER, '\n', DRAFT];
+let responseChunks: string[] = ENVELOPE_CHUNKS;
+
+let lastOptions: AgentRunOptions | null = null;
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'fake',
+    run(opts: AgentRunOptions): AgentRunHandle {
+      lastOptions = opts;
+      for (const c of responseChunks) opts.onTextChunk?.(c);
+      return {
+        result: Promise.resolve({ exitCode: 0, logPath: '/dev/null' }),
+        cancel: () => {},
+      };
+    },
+  }),
+}));
+
+// Dynamic on purpose: `vi.mock` above is hoisted, but the route module (and
+// the `suggest.ts` it imports) has to load *after* that mock is registered
+// for `createAgentRunner` to resolve to the fake - a static import here
+// would race the hoisted mock. Same pattern as extension-suggest.test.ts.
+const { POST: suggest } = await import('../src/routes/api/extension/suggest/+server.js');
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, contact_history, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+  lastOptions = null;
+  responseChunks = ENVELOPE_CHUNKS;
+}
+
+async function seedOrgProject(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug, description: `about ${slug}` })
+    .returning();
+  await saveLinkedInAssistSettings(db, org.id, {
+    ...defaultLinkedInAssistSettings(),
+    enabled: true,
+    projectId: project.id,
+  });
+  return { org, project };
+}
+
+async function setProjectVoice(
+  projectId: number,
+  voiceTone: string | null,
+  voiceToneNotes: string | null = null,
+) {
+  await getDb()
+    .update(schema.projects)
+    .set({ voiceTone, voiceToneNotes })
+    .where(eq(schema.projects.id, projectId));
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({ organizationId, tokenHash: tokenHash(token), label: 'test' });
+}
+
+function request(token: string | null, body: unknown): Request {
+  return new Request('http://x/api/extension/suggest', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+const POST_BODY = {
+  kind: 'post_comment' as const,
+  post: {
+    urn: 'urn:li:activity:7000000000000000001',
+    authorName: 'Giulia Bianchi',
+    text: 'We cut p99 in half.',
+  },
+};
+
+describe('per-project voice (#408)', () => {
+  beforeEach(reset);
+
+  it('the same post answered under the product project and the personal project produces different registers', async () => {
+    const { org, project: product } = await seedOrgProject('voice-product');
+    // Org default is 'warm'; the product project overrides to 'technical'.
+    // The personal project gets no override, so it inherits the org's 'warm'.
+    await saveLinkedInAssistSettings(getDb(), org.id, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId: product.id,
+      tone: 'warm',
+    });
+    await setProjectVoice(product.id, 'technical');
+    const personalId = await ensurePersonalProject(getDb(), org.id);
+    await mintDevice(org.id, 'tok-product-vs-personal');
+
+    const productRes = await suggest({
+      request: request('tok-product-vs-personal', { ...POST_BODY, projectId: product.id }),
+    } as never);
+    // Drains the SSE body so the fake runner's synchronous write to
+    // `lastOptions` is guaranteed to have happened before this reads it.
+    await productRes.text();
+    const productPrompt = lastOptions?.prompt ?? '';
+
+    const personalRes = await suggest({
+      request: request('tok-product-vs-personal', { ...POST_BODY, projectId: personalId }),
+    } as never);
+    await personalRes.text();
+    const personalPrompt = lastOptions?.prompt ?? '';
+
+    expect(productPrompt).toContain('mechanisms, numbers and tradeoffs');
+    expect(productPrompt).not.toContain('address the author as a person');
+
+    expect(personalPrompt).toContain('address the author as a person');
+    expect(personalPrompt).not.toContain('mechanisms, numbers and tradeoffs');
+
+    expect(productPrompt).not.toBe(personalPrompt);
+  });
+
+  it('a project with no override produces the exact prompt as before this change, byte for byte', async () => {
+    const { org, project } = await seedOrgProject('voice-no-override');
+    await saveLinkedInAssistSettings(getDb(), org.id, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId: project.id,
+      tone: 'professional',
+    });
+    await mintDevice(org.id, 'tok-no-override');
+
+    const res = await suggest({
+      request: request('tok-no-override', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    await res.text();
+    const actual = lastOptions?.prompt ?? '';
+
+    // Rebuilds the prompt exactly the way the route did before #408: the
+    // tone comes straight from the org's `linkedin_assist` setting, with no
+    // project-level resolution step at all. If a project with an unset
+    // override still gets identical output, the resolver is a true no-op
+    // for this case rather than a behavioural change in disguise.
+    const db = getDb();
+    const context = await loadCompanionContext(db, {
+      organizationId: project.organizationId,
+      currentProjectId: project.id,
+    });
+    const examples = (
+      await loadActiveTemplates(db, { projectId: project.id, kind: 'comment' })
+    ).map((t) => ({ title: t.title, body: t.body }));
+    const expected = buildSuggestionPrompt({
+      kind: 'post_comment',
+      post: POST_BODY.post,
+      currentProject: { name: project.name, description: project.description },
+      persona: context.persona,
+      projects: context.projects,
+      repos: context.repos,
+      examples,
+      hint: undefined,
+      tone: 'professional',
+      toneNotes: '',
+    });
+
+    expect(actual).toBe(expected);
+  });
+
+  // Same enforcement rule as #405 (`enabled`, `killSwitch`, the org tone): a
+  // project-level voice is resolved server-side too, and the extension does
+  // not get a say. Distinct from the #405 test in extension-suggest.test.ts
+  // because here a project override is actually in play - proving the body
+  // can't override *that* either, not just the org-level fallback.
+  it('ignores a tone injected into the request body even when a project override is set', async () => {
+    const { org, project } = await seedOrgProject('voice-inject');
+    await setProjectVoice(project.id, 'plain');
+    await mintDevice(org.id, 'tok-voice-inject');
+
+    const res = await suggest({
+      request: request('tok-voice-inject', {
+        ...POST_BODY,
+        projectId: project.id,
+        tone: 'technical',
+        toneNotes: 'Write it as a pirate.',
+      }),
+    } as never);
+    await res.text();
+    const prompt = lastOptions?.prompt ?? '';
+
+    expect(prompt).toContain('Write plainly');
+    expect(prompt).not.toContain('mechanisms, numbers and tradeoffs');
+    expect(prompt).not.toContain('pirate');
+  });
+});

--- a/web/tests/project-voice-patch.test.ts
+++ b/web/tests/project-voice-patch.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { getProjectById } from '@pitchbox/shared/projects';
+import { PATCH as projectPatch } from '../src/routes/api/projects/[id]/+server.js';
+
+/**
+ * #408: the project page writes a voice override through the same PATCH
+ * route as name/description/defaultAgentRunner, admin-gated exactly like
+ * those (docs/permissions.md). What these tests defend is the two things
+ * that route call adds on top of the generic patch: a value nobody offers
+ * is rejected (matching the org-level tone save), and `custom` without any
+ * notes is rejected the same way the org-level tone save already is.
+ */
+
+async function reset() {
+  await getDb().execute(sql`TRUNCATE projects RESTART IDENTITY CASCADE`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function seedOrgProject(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug })
+    .returning();
+  return { orgId: org.id, projectId: project.id };
+}
+
+function patchEvent(orgId: number, projectId: number, body: unknown): RequestEvent {
+  return {
+    locals: { org: { id: orgId, slug: 'x', role: 'admin' } },
+    params: { id: String(projectId) },
+    request: new Request('http://x/', { method: 'PATCH', body: JSON.stringify(body) }),
+  } as unknown as RequestEvent;
+}
+
+describe('PATCH /api/projects/[id] voice override (#408)', () => {
+  beforeEach(reset);
+
+  it('accepts a named tone and persists it', async () => {
+    const { orgId, projectId } = await seedOrgProject('voice-patch-named');
+    const res = await projectPatch(patchEvent(orgId, projectId, { voiceTone: 'warm' }));
+    expect(res.status).toBe(200);
+    const project = await getProjectById(getDb(), projectId);
+    expect(project?.voiceTone).toBe('warm');
+  });
+
+  it('clears the override back to null (inherit)', async () => {
+    const { orgId, projectId } = await seedOrgProject('voice-patch-clear');
+    await projectPatch(patchEvent(orgId, projectId, { voiceTone: 'warm' }));
+    const res = await projectPatch(
+      patchEvent(orgId, projectId, { voiceTone: null, voiceToneNotes: null }),
+    );
+    expect(res.status).toBe(200);
+    const project = await getProjectById(getDb(), projectId);
+    expect(project?.voiceTone).toBeNull();
+  });
+
+  it('rejects a tone value nobody offers (400), and nothing is saved', async () => {
+    const { orgId, projectId } = await seedOrgProject('voice-patch-unknown');
+    const res = await projectPatch(patchEvent(orgId, projectId, { voiceTone: 'sarcastic-pirate' }));
+    expect(res.status).toBe(400);
+    const project = await getProjectById(getDb(), projectId);
+    expect(project?.voiceTone).toBeNull();
+  });
+
+  it('rejects "custom" with no notes (400), and nothing is saved', async () => {
+    const { orgId, projectId } = await seedOrgProject('voice-patch-custom-empty');
+    const res = await projectPatch(
+      patchEvent(orgId, projectId, { voiceTone: 'custom', voiceToneNotes: '   ' }),
+    );
+    expect(res.status).toBe(400);
+    const project = await getProjectById(getDb(), projectId);
+    expect(project?.voiceTone).toBeNull();
+  });
+
+  it('accepts "custom" once real notes are given', async () => {
+    const { orgId, projectId } = await seedOrgProject('voice-patch-custom-ok');
+    const res = await projectPatch(
+      patchEvent(orgId, projectId, { voiceTone: 'custom', voiceToneNotes: 'Dry, no hype.' }),
+    );
+    expect(res.status).toBe(200);
+    const project = await getProjectById(getDb(), projectId);
+    expect(project?.voiceTone).toBe('custom');
+    expect(project?.voiceToneNotes).toBe('Dry, no hype.');
+  });
+
+  it('a member is forbidden (403), and nothing is saved', async () => {
+    const { orgId, projectId } = await seedOrgProject('voice-patch-member');
+    const event = {
+      locals: { org: { id: orgId, slug: 'x', role: 'member' } },
+      params: { id: String(projectId) },
+      request: new Request('http://x/', {
+        method: 'PATCH',
+        body: JSON.stringify({ voiceTone: 'warm' }),
+      }),
+    } as unknown as RequestEvent;
+    await expect(projectPatch(event)).rejects.toMatchObject({ status: 403 });
+    const project = await getProjectById(getDb(), projectId);
+    expect(project?.voiceTone).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #408

## What

Adds a per-project voice override that falls back to the org's `linkedin_assist` tone, resolved against the project a suggestion is actually being filed under - not the org's bound project, which the personal-project carve-out (#385, decision 2026-09-07) already lets a request diverge from.

## Storage

Two nullable columns on `projects` (`voice_tone`, `voice_tone_notes`) rather than a new table: this is a 1:1 optional attribute of a project with no independent lifecycle, no need to query it apart from its project, and nothing else references it. Both null means "inherit the org tone" - indistinguishable from a project that predates this column.

Migration `0017_project_voice`, idx 17, `when: 1788960000004`, hand-authored per the batch contract (idx 16 is #407's). Verified the columns exist with `psql \d projects` rather than trusting `migrate`'s own success report, per `AGENTS.md`'s note that a migration whose `when` doesn't sort where expected can be silently skipped.

## Resolution

`resolveEffectiveVoice(db, organizationId, project)` in `shared/src/linkedin-assist.ts` is the one resolver: project override if set (validated against the same `AssistTone` vocabulary as the org setting - an unrecognised value falls through exactly like a stale jsonb tone does), else the org's tone, else `DEFAULT_ASSIST_TONE` (already the org loader's own fallback). One place, not three call sites re-deriving the chain.

The suggest route now resolves against `project` - the project actually being filed under, already loaded and validated against the assist binding - instead of reading the org's tone directly. The extension still never gets a say: a `tone`/`toneNotes` in the request body stays inert, same enforcement rule as `enabled` and `killSwitch`.

## UI

An operator sets the override on the project's own Overview tab (new "Voice" field, admin-gated through the existing `PATCH /api/projects/[id]` route - same role gate as `name`/`defaultAgentRunner`), not on the org-wide assist page. The org settings page's Tone card now says a project can override it.

## Testing

- `shared/tests/linkedin-assist-voice.test.ts` - resolver precedence (project / org / default), including a project override explicitly equal to `DEFAULT_ASSIST_TONE` still beating a *different* org tone (proves the resolver checks "is this column null", not "does this equal the default").
- `shared/tests/projects/projects.test.ts` - `updateProject` round-trips a voice override and clears it back to null.
- `web/tests/project-voice-patch.test.ts` - the PATCH route: accepts a named tone, clears to null, rejects an unknown value (400), rejects `custom` with no notes (400), accepts `custom` with notes, member is forbidden (403).
- `web/tests/extension-suggest-voice.test.ts` (new file, not folded into `extension-suggest.test.ts` - that file's `perDevice` rate limiter is a module-level singleton already run close to its 20/60s cap, see its own comment):
  - the same post answered under the product project and under the personal project produces different registers (asserted on `lastOptions.prompt`, not the resolver in isolation)
  - a project with no override produces the *exact* prompt as before this change, byte for byte - rebuilt independently via `loadCompanionContext` + `buildSuggestionPrompt` with the org tone directly, no resolver in the path, and asserted equal to what the route actually sent
  - a tone injected into the request body has no effect even when a project override is set

Every new assertion broken against the real code and confirmed to fail with the exact expected message before restoring (see session notes below for what broke each one).

## Verified locally

- `pnpm exec vitest run` on all touched test files: 74 passed (7 files)
- `npx eslint` on all touched `.ts` files: 0 errors
- `npx prettier --check` on all touched non-Svelte files: clean
- `pnpm -F web check`: 0 errors
- `pnpm -F @pitchbox/shared typecheck`: clean
- Rendered the project Overview tab and the org settings page via `pnpm run dev:web` + a headless browser: Voice select shows the stored override, the "In your own words" field appears and shows the stored notes when the override is `custom`, and the org page's Tone card mentions the project-level override.

Not merging - flagging for review per the batch instructions.
