### PR TITLE
feat(web,shared): configure which model does which job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,10 @@ WEB_PORT=5180
 # Boot the daemon loops inside the web server instead of running a separate
 # `pitchbox daemon` process. Recommended for single-host self-hosters.
 # PITCHBOX_EMBED_DAEMON=1
+
+# AI Gateway key, used by the model configuration page in the instance admin
+# area to list the models that can be picked (#411) and, once the SDK runner
+# lands (#416), to reach the models themselves. Optional: with no key the page
+# still saves a model id typed by hand, and every job falls back to its coded
+# default.
+# AI_GATEWAY_API_KEY=

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: ^1.1.0
         version: 1.1.0(zod@4.5.4)
+      '@ai-sdk/gateway':
+        specifier: ^4.0.75
+        version: 4.0.75(zod@4.5.4)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -331,6 +334,22 @@ packages:
     resolution: {integrity: sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  '@ai-sdk/gateway@4.0.75':
+    resolution: {integrity: sha512-HOnhw3oXtBnboBF7kAKipjToCN6+5w6EuukiUKiULcxBitS+vbHRRv9IUBcq+Z1wkXcJjfywKrt5r++I6OYyXg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.36':
+    resolution: {integrity: sha512-MFXBn6XDyf37PNQAge/HTatPJE8Vmg/g/w4WPtjSV53jq8FKAzoaN5+43hsdQa9bqgN+/13jxug9ChvsG+godQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.10':
+    resolution: {integrity: sha512-fX2ENAc7iDpZ+Wp4+Rk06Usn/Ys7dI9uAkGv0jlF6XVrW13NkRWx5Ou+U6lIM2E1fTLkCs16GGrUAaVvroag7A==}
+    engines: {node: '>=22'}
 
   '@algolia/abtesting@1.21.1':
     resolution: {integrity: sha512-Wia5/mNTfiU0PIUN25UMfAGGdASkkwuCS9nBAdmhqrNPY/ff7U/6MgBVdwFDPsa3sA1msutPtO50gvOzx6MOXA==}
@@ -514,11 +533,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -1965,6 +1984,10 @@ packages:
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2091,6 +2114,9 @@ packages:
 
   '@webcomponents/custom-elements@1.6.0':
     resolution: {integrity: sha512-CqTpxOlUCPWRNUPZDxT5v2NnHXA4oox612iUGnmTUGQFhZ1Gkj8kirtl/2wcF6MqX7+PqqicZzOCBKKfIn0dww==}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -2979,6 +3005,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -4094,6 +4123,10 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
+    engines: {node: '>=20.18.1'}
+
   undici@8.10.2:
     resolution: {integrity: sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==}
     engines: {node: '>=22.19.0'}
@@ -4405,6 +4438,26 @@ snapshots:
   '@agentclientprotocol/sdk@1.1.0(zod@4.5.4)':
     dependencies:
       zod: 4.5.4
+
+  '@ai-sdk/gateway@4.0.75(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@4.5.4)
+      '@vercel/oidc': 3.2.0
+      zod: 4.5.4
+
+  '@ai-sdk/provider-utils@5.0.36(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.10
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.1
+      zod: 4.5.4
+
+  '@ai-sdk/provider@4.0.10':
+    dependencies:
+      json-schema: 0.4.0
 
   '@algolia/abtesting@1.21.1':
     dependencies:
@@ -5696,6 +5749,8 @@ snapshots:
 
   '@ungap/structured-clone@1.3.2': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@26.1.0)(lightningcss@1.33.0))(vue@3.5.39(@typescript/typescript6@6.0.2))':
     dependencies:
       vite: 5.4.21(@types/node@26.1.0)(lightningcss@1.33.0)
@@ -5842,6 +5897,8 @@ snapshots:
       - typescript
 
   '@webcomponents/custom-elements@1.6.0': {}
+
+  '@workflow/serde@4.1.0': {}
 
   accepts@2.0.0:
     dependencies:
@@ -6775,6 +6832,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -8073,6 +8132,8 @@ snapshots:
   undici-types@8.10.2: {}
 
   undici-types@8.3.0: {}
+
+  undici@7.29.1: {}
 
   undici@8.10.2: {}
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -51,6 +51,8 @@
     "./auth": "./src/auth.ts",
     "./orgs": "./src/orgs.ts",
     "./edition": "./src/edition.ts",
+    "./ai/model-functions": "./src/ai/model-functions.ts",
+    "./ai/gateway-catalogue": "./src/ai/gateway-catalogue.ts",
     "./retention": "./src/retention.ts",
     "./observed-targets": "./src/observed-targets.ts",
     "./runlog": "./src/runlog/index.ts",
@@ -74,6 +76,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.1.0",
+    "@ai-sdk/gateway": "^4.0.75",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "jose": "^6.2.3",

--- a/shared/src/ai/gateway-catalogue.ts
+++ b/shared/src/ai/gateway-catalogue.ts
@@ -1,0 +1,102 @@
+import { createGateway } from '@ai-sdk/gateway';
+
+// The Gateway's own model list, so the admin form offers what can actually be
+// picked instead of a free-text box where a typo becomes a failed run for every
+// tenant (#411). Measured 2026-09-08: 345 models, each with an id and per-token
+// pricing.
+//
+// Everything here degrades rather than throws. A deployment with no Gateway key
+// (every self-host install today) has no catalogue and must still be able to
+// read and save the configuration, so a failure returns an empty list plus the
+// reason, and the form falls back to accepting an id typed by hand.
+
+export interface GatewayModel {
+  id: string;
+  name: string;
+  /** USD per input token, as the Gateway reports it. Null when it does not. */
+  inputPerToken: number | null;
+  outputPerToken: number | null;
+}
+
+export interface GatewayCatalogue {
+  models: GatewayModel[];
+  /** Null when the list is real; a sentence to show the operator when it is not. */
+  unavailable: string | null;
+  fetchedAt: Date;
+}
+
+const CACHE_TTL_MS = 10 * 60 * 1000;
+let cache: { value: GatewayCatalogue; expiresAt: number } | null = null;
+
+export function clearGatewayCatalogueCache(): void {
+  cache = null;
+}
+
+function num(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  // The Gateway reports pricing as decimal strings ("0.00000012"), which is
+  // deliberate on their side: these are small enough that a float printed back
+  // would read as noise.
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function pricingOf(model: unknown): { input: unknown; output: unknown } {
+  if (!model || typeof model !== 'object' || !('pricing' in model))
+    return { input: null, output: null };
+  const pricing = model.pricing;
+  if (!pricing || typeof pricing !== 'object') return { input: null, output: null };
+  return {
+    input: 'input' in pricing ? pricing.input : null,
+    output: 'output' in pricing ? pricing.output : null,
+  };
+}
+
+export async function loadGatewayCatalogue(
+  opts: { apiKey?: string | null; force?: boolean } = {},
+): Promise<GatewayCatalogue> {
+  const now = Date.now();
+  if (!opts.force && cache && cache.expiresAt > now) return cache.value;
+
+  const apiKey = opts.apiKey ?? process.env.AI_GATEWAY_API_KEY ?? null;
+  if (!apiKey) {
+    return {
+      models: [],
+      unavailable:
+        'No AI Gateway key is configured on this deployment, so the model list cannot be fetched. Type a model id to set one anyway.',
+      fetchedAt: new Date(),
+    };
+  }
+
+  try {
+    const gateway = createGateway({ apiKey });
+    const response = await gateway.getAvailableModels();
+    const models: GatewayModel[] = response.models
+      .map((m) => {
+        const pricing = pricingOf(m);
+        return {
+          id: m.id,
+          name: m.name ?? m.id,
+          inputPerToken: num(pricing.input),
+          outputPerToken: num(pricing.output),
+        };
+      })
+      .sort((a, b) => a.id.localeCompare(b.id));
+    const value: GatewayCatalogue = { models, unavailable: null, fetchedAt: new Date() };
+    cache = { value, expiresAt: now + CACHE_TTL_MS };
+    return value;
+  } catch (err) {
+    // Not cached: a transient Gateway failure should not blank the form for the
+    // next ten minutes.
+    return {
+      models: [],
+      unavailable: `The AI Gateway model list could not be read: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      fetchedAt: new Date(),
+    };
+  }
+}

--- a/shared/src/ai/model-functions.ts
+++ b/shared/src/ai/model-functions.ts
@@ -1,0 +1,209 @@
+import { eq } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+import { appConfig } from '../db/schema.js';
+
+// Which model does which job (#411). Before this, the only knob was
+// `runner_configs`, keyed by runner slug and shared by every plane, which is
+// why the assist path had to hardcode its own fast default and why an operator
+// pinning a model for one purpose pinned it for all of them.
+//
+// The functions are the jobs the product actually runs, not the playbooks:
+// several playbooks draft a message and want the same model, and a job with no
+// model call of its own does not get a knob. Judging quality is the deliberate
+// omission: the rubric is evaluated inside the drafting run rather than by a
+// call of its own (`shared/src/quality-judge.ts` loads a rubric and never
+// reaches a model), so a `quality_judge` entry would be a setting nobody reads.
+// It earns one when it earns a model call.
+
+export const MODEL_FUNCTIONS = [
+  'campaign_draft',
+  'assist_suggest',
+  'project_extract',
+  'project_insights',
+  'skill_generate',
+] as const;
+
+export type ModelFunction = (typeof MODEL_FUNCTIONS)[number];
+
+export interface ModelFunctionMeta {
+  fn: ModelFunction;
+  label: string;
+  /** What the model is doing, in the operator's terms, for the admin form. */
+  description: string;
+  /**
+   * The model this function runs on when nobody configured it. One cheap fast
+   * model everywhere on purpose: the expensive default is the one that costs
+   * money on every tenant's every run before anyone has measured whether the
+   * job needs it. `google/gemini-3.1-flash-lite` is the id sazio runs its own
+   * conversation loop on.
+   */
+  defaultModelId: string;
+}
+
+const FAST_DEFAULT = 'google/gemini-3.1-flash-lite';
+
+export const MODEL_FUNCTION_META: readonly ModelFunctionMeta[] = [
+  {
+    fn: 'campaign_draft',
+    label: 'Drafting outreach',
+    description:
+      'A campaign run reading candidates and writing the drafts a human reviews in the Inbox. Also the model behind a reply draft and a regenerated draft, which are the same job with a narrower input.',
+    defaultModelId: FAST_DEFAULT,
+  },
+  {
+    fn: 'assist_suggest',
+    label: 'Answering in the panel',
+    description:
+      'The in-page companion suggesting a comment or a post while somebody waits for it. The only path here with a human watching an empty panel, so first-token latency is the constraint that matters.',
+    defaultModelId: FAST_DEFAULT,
+  },
+  {
+    fn: 'project_extract',
+    label: 'Describing a project',
+    description:
+      'Reading a repository, a folder or a website and writing what the project is. Runs rarely and its output is read by every later prompt.',
+    defaultModelId: FAST_DEFAULT,
+  },
+  {
+    fn: 'project_insights',
+    label: 'Summarising insights',
+    description: 'Turning what a project knows into the notes the drafting prompts carry.',
+    defaultModelId: FAST_DEFAULT,
+  },
+  {
+    fn: 'skill_generate',
+    label: 'Generating a campaign profile',
+    description:
+      'Writing a campaign profile from a project and a scenario, which then has to validate against that scenario schema.',
+    defaultModelId: FAST_DEFAULT,
+  },
+];
+
+export function isModelFunction(value: unknown): value is ModelFunction {
+  return typeof value === 'string' && (MODEL_FUNCTIONS as readonly string[]).includes(value);
+}
+
+/**
+ * Which function a playbook slug belongs to. Several playbooks are the same job:
+ * every commenter, poster and scout drafts outreach, and so do the reply drafter
+ * and the draft regenerator. A slug nobody mapped falls back to `campaign_draft`
+ * rather than throwing, because this resolves inside a dispatch that is already
+ * running and a new playbook is not a reason to fail the run.
+ */
+export function modelFunctionForPlaybook(slug: string): ModelFunction {
+  if (slug === 'project-extractor') return 'project_extract';
+  if (slug === 'project-insighter') return 'project_insights';
+  if (slug === 'campaign-skill-generator') return 'skill_generate';
+  return 'campaign_draft';
+}
+
+const KEY = 'model_functions';
+
+type StoredBlob = Record<string, { modelId?: unknown } | undefined>;
+
+export type ModelFunctionConfig = Record<ModelFunction, string | null>;
+
+function emptyConfig(): ModelFunctionConfig {
+  const out = {} as ModelFunctionConfig;
+  for (const fn of MODEL_FUNCTIONS) out[fn] = null;
+  return out;
+}
+
+// A short cache because this is read on every dispatch and every suggestion,
+// and the row behind it changes when an admin saves a form. The TTL is the
+// backstop for a multi-instance deployment where another process saved it; the
+// same-process save invalidates explicitly, so an admin never has to wait to
+// see their own change take effect (the acceptance criterion is "no restart",
+// not "eventually").
+const CACHE_TTL_MS = 30_000;
+let cache: { value: ModelFunctionConfig; expiresAt: number } | null = null;
+
+export function clearModelFunctionCache(): void {
+  cache = null;
+}
+
+export async function loadModelFunctionConfig(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: PgDatabase<any, any, any>,
+): Promise<ModelFunctionConfig> {
+  const now = Date.now();
+  if (cache && cache.expiresAt > now) return cache.value;
+
+  const [row] = await db.select().from(appConfig).where(eq(appConfig.key, KEY));
+  const stored = (row?.value ?? {}) as StoredBlob;
+  const value = emptyConfig();
+  for (const fn of MODEL_FUNCTIONS) {
+    const raw = stored[fn]?.modelId;
+    // jsonb holds no enum, so a hand-edited row or an older build can put
+    // anything here. An unusable value reads as unset, which lands on the coded
+    // default rather than sending a garbage model id to the Gateway.
+    if (typeof raw === 'string' && raw.trim()) value[fn] = raw.trim();
+  }
+  cache = { value, expiresAt: now + CACHE_TTL_MS };
+  return value;
+}
+
+export async function saveModelFunctionModel(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: PgDatabase<any, any, any>,
+  fn: ModelFunction,
+  modelId: string | null,
+): Promise<void> {
+  const [row] = await db.select().from(appConfig).where(eq(appConfig.key, KEY));
+  const stored = { ...((row?.value ?? {}) as StoredBlob) };
+  const trimmed = modelId?.trim();
+  if (trimmed) stored[fn] = { modelId: trimmed };
+  else delete stored[fn];
+  await db
+    .insert(appConfig)
+    .values({ key: KEY, value: stored })
+    .onConflictDoUpdate({ target: appConfig.key, set: { value: stored } });
+  clearModelFunctionCache();
+}
+
+export function defaultModelForFunction(fn: ModelFunction): string {
+  return MODEL_FUNCTION_META.find((m) => m.fn === fn)?.defaultModelId ?? FAST_DEFAULT;
+}
+
+/**
+ * The model a function runs on: what an admin configured, else the coded
+ * default. Never throws and never returns empty, because this is called inside
+ * a dispatch that is already running: a run that dies because nobody
+ * configured a function is worse than a run on a default.
+ */
+export async function resolveFunctionModel(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: PgDatabase<any, any, any>,
+  fn: ModelFunction,
+): Promise<string> {
+  const config = await loadModelFunctionConfig(db);
+  return config[fn] ?? defaultModelForFunction(fn);
+}
+
+/**
+ * Whether a runner slug takes a Gateway model id at all. Only the managed
+ * runner does: an ACP backend is a coding-agent CLI whose `model` option is
+ * that CLI's own vocabulary (`sonnet`, `opus`), so handing it
+ * `google/gemini-3.1-flash-lite` would fail the run on a deployment that never
+ * asked for any of this. This is why the resolution below returns undefined
+ * rather than a default for those: undefined means "leave today's behaviour
+ * alone", which is the operator's `runner_configs` pin if they set one and the
+ * CLI's own default if they did not.
+ */
+export function runnerTakesGatewayModel(slug: string): boolean {
+  return slug === 'cloud';
+}
+
+/**
+ * The model a dispatch should ask for, given the runner it is dispatching to
+ * and the playbook it is running. Undefined when the runner does not speak
+ * Gateway ids, so a caller can leave its config untouched.
+ */
+export async function resolveModelForRun(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: PgDatabase<any, any, any>,
+  args: { runnerSlug: string; playbookSlug: string },
+): Promise<string | undefined> {
+  if (!runnerTakesGatewayModel(args.runnerSlug)) return undefined;
+  return resolveFunctionModel(db, modelFunctionForPlaybook(args.playbookSlug));
+}

--- a/shared/tests/model-functions.test.ts
+++ b/shared/tests/model-functions.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getDb } from '../src/db/client.js';
+import {
+  MODEL_FUNCTIONS,
+  clearModelFunctionCache,
+  defaultModelForFunction,
+  loadModelFunctionConfig,
+  modelFunctionForPlaybook,
+  resolveFunctionModel,
+  resolveModelForRun,
+  runnerTakesGatewayModel,
+  saveModelFunctionModel,
+} from '../src/ai/model-functions.js';
+import { appConfig } from '../src/db/schema.js';
+
+// #411: which model does which job. The properties worth defending are the
+// ones a caller depends on at dispatch time, when nobody is watching: an
+// unconfigured function still runs, a saved change is visible without a
+// restart, and a garbage value in the jsonb does not reach the Gateway.
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`DELETE FROM app_config WHERE key = 'model_functions'`);
+  clearModelFunctionCache();
+}
+
+describe('model function configuration', () => {
+  beforeEach(reset);
+
+  it('resolves an unset function to its coded default rather than throwing', async () => {
+    const db = getDb();
+    for (const fn of MODEL_FUNCTIONS) {
+      expect(await resolveFunctionModel(db, fn)).toBe(defaultModelForFunction(fn));
+    }
+  });
+
+  it('makes a saved model visible immediately, with no restart and no stale cache', async () => {
+    const db = getDb();
+    // Warm the cache with the default first, which is what a live deployment
+    // has done long before an admin opens the form.
+    expect(await resolveFunctionModel(db, 'assist_suggest')).toBe(
+      defaultModelForFunction('assist_suggest'),
+    );
+    await saveModelFunctionModel(db, 'assist_suggest', 'anthropic/claude-haiku-4.5');
+    expect(await resolveFunctionModel(db, 'assist_suggest')).toBe('anthropic/claude-haiku-4.5');
+  });
+
+  it('clearing a function goes back to the default instead of to nothing', async () => {
+    const db = getDb();
+    await saveModelFunctionModel(db, 'campaign_draft', 'openai/gpt-5-mini');
+    expect(await resolveFunctionModel(db, 'campaign_draft')).toBe('openai/gpt-5-mini');
+    await saveModelFunctionModel(db, 'campaign_draft', null);
+    expect(await resolveFunctionModel(db, 'campaign_draft')).toBe(
+      defaultModelForFunction('campaign_draft'),
+    );
+  });
+
+  it('saving one function leaves the others alone', async () => {
+    const db = getDb();
+    await saveModelFunctionModel(db, 'campaign_draft', 'openai/gpt-5-mini');
+    await saveModelFunctionModel(db, 'project_extract', 'anthropic/claude-sonnet-4.6');
+    const config = await loadModelFunctionConfig(db);
+    expect(config.campaign_draft).toBe('openai/gpt-5-mini');
+    expect(config.project_extract).toBe('anthropic/claude-sonnet-4.6');
+    expect(config.assist_suggest).toBeNull();
+  });
+
+  it('reads an unusable stored value as unset', async () => {
+    const db = getDb();
+    // jsonb holds no enum, so an older build or a hand-edited row can put
+    // anything here. Sending "  " or a number to the Gateway is a failed run
+    // for every tenant of that function.
+    await db.insert(appConfig).values({
+      key: 'model_functions',
+      value: { assist_suggest: { modelId: '   ' }, campaign_draft: { modelId: 42 } },
+    });
+    clearModelFunctionCache();
+    const config = await loadModelFunctionConfig(db);
+    expect(config.assist_suggest).toBeNull();
+    expect(config.campaign_draft).toBeNull();
+    expect(await resolveFunctionModel(db, 'campaign_draft')).toBe(
+      defaultModelForFunction('campaign_draft'),
+    );
+  });
+
+  it('leaves an ACP backend alone and only hands a Gateway id to the managed runner', async () => {
+    const db = getDb();
+    await saveModelFunctionModel(db, 'campaign_draft', 'openai/gpt-5-mini');
+    // `sonnet` and `google/gemini-3.1-flash-lite` are not the same vocabulary:
+    // handing a claude-code spawn a Gateway id fails the run on a local
+    // install that never asked for any of this.
+    expect(runnerTakesGatewayModel('claude-code')).toBe(false);
+    expect(
+      await resolveModelForRun(db, { runnerSlug: 'claude-code', playbookSlug: 'hn-commenter' }),
+    ).toBeUndefined();
+    expect(
+      await resolveModelForRun(db, { runnerSlug: 'cloud', playbookSlug: 'hn-commenter' }),
+    ).toBe('openai/gpt-5-mini');
+  });
+
+  it('maps a playbook to the job it is, and an unknown slug to drafting', async () => {
+    expect(modelFunctionForPlaybook('linkedin-commenter')).toBe('campaign_draft');
+    expect(modelFunctionForPlaybook('reply-drafter')).toBe('campaign_draft');
+    expect(modelFunctionForPlaybook('project-extractor')).toBe('project_extract');
+    expect(modelFunctionForPlaybook('project-insighter')).toBe('project_insights');
+    expect(modelFunctionForPlaybook('campaign-skill-generator')).toBe('skill_generate');
+    // A playbook nobody mapped resolves inside a dispatch that is already
+    // running, so it takes the drafting model rather than failing the run.
+    expect(modelFunctionForPlaybook('some-future-playbook')).toBe('campaign_draft');
+  });
+});

--- a/web/src/lib/server/runner.ts
+++ b/web/src/lib/server/runner.ts
@@ -1,6 +1,7 @@
 import { createAgentRunner } from '@pitchbox/shared/agents/registry';
 import type { AgentRunner } from '@pitchbox/shared/agents';
 import { loadRunnerConfig } from '@pitchbox/shared/agents/config';
+import { resolveModelForRun } from '@pitchbox/shared/ai/model-functions';
 import { detectRunner, isDetectionConclusive } from '@pitchbox/shared/agents/detect';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import type { AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
@@ -162,7 +163,19 @@ async function dispatchRun(
       );
     }
     const config = await loadRunnerConfig(db, slug);
-    runner = createAgentRunner(run.agentRunner, config);
+    // Which model does this job is an instance-level setting (#411). An
+    // explicit `runner_configs` pin still wins, since an operator who set one
+    // meant it; otherwise the function's configured model applies, and for an
+    // ACP backend nothing changes at all (`resolveModelForRun` returns
+    // undefined, because `sonnet` and `google/gemini-3.1-flash-lite` are not
+    // the same vocabulary).
+    const functionModel = await resolveModelForRun(db, {
+      runnerSlug: slug,
+      playbookSlug: opts.playbookSlug,
+    });
+    const withModel =
+      functionModel && !config.model?.trim() ? { ...config, model: functionModel } : config;
+    runner = createAgentRunner(run.agentRunner, withModel);
   } catch (err) {
     const errMsg = String(err instanceof Error ? err.message : err);
     const failureReason = await classifyFailedRun(run.id, 1, errMsg);

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -6,6 +6,7 @@ import { createAgentRunner } from '@pitchbox/shared/agents/registry';
 import type { AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
 import { loadRunnerConfig, type RunnerConfig } from '@pitchbox/shared/agents/config';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
+import { resolveFunctionModel, runnerTakesGatewayModel } from '@pitchbox/shared/ai/model-functions';
 import {
   buildSuggestionPrompt,
   type CurrentProject,
@@ -86,10 +87,20 @@ export const ASSIST_DEFAULT_MODEL = 'sonnet';
  * An explicit runner config wins: an operator who pinned a model for this
  * runner meant it, including for suggestions. Everything else, including an
  * empty string from a cleared form field, falls back to the fast default.
+ *
+ * `functionModel` is the per-function configuration (#411), and it only exists
+ * for a runner that speaks Gateway model ids. An ACP backend keeps
+ * `ASSIST_DEFAULT_MODEL` instead: `sonnet` is that CLI's own vocabulary, and
+ * `google/gemini-3.1-flash-lite` would fail the call on a local install that
+ * never asked for any of this.
  */
-export function resolveAssistRunnerConfig(config: RunnerConfig): RunnerConfig {
+export function resolveAssistRunnerConfig(
+  config: RunnerConfig,
+  functionModel?: string,
+): RunnerConfig {
   const pinned = config.model?.trim();
-  return pinned ? config : { ...config, model: ASSIST_DEFAULT_MODEL };
+  if (pinned) return config;
+  return { ...config, model: functionModel?.trim() || ASSIST_DEFAULT_MODEL };
 }
 
 export function runSuggestion(args: {
@@ -168,7 +179,17 @@ export function runSuggestion(args: {
     }
     const config = await loadRunnerConfig(db, args.runnerSlug as AgentRunnerSlug);
     if (cancelled) throw new Cancelled();
-    const runner = createAgentRunner(args.runnerSlug, resolveAssistRunnerConfig(config));
+    // Which model answers in the panel is an instance-level setting a system
+    // admin owns (#411), read here rather than baked in. Undefined for an ACP
+    // backend, which keeps the fast alias it has always used.
+    const functionModel = runnerTakesGatewayModel(args.runnerSlug)
+      ? await resolveFunctionModel(db, 'assist_suggest')
+      : undefined;
+    if (cancelled) throw new Cancelled();
+    const runner = createAgentRunner(
+      args.runnerSlug,
+      resolveAssistRunnerConfig(config, functionModel),
+    );
 
     // The agent still gets a working directory, and it must not be the repo:
     // this session has no tools attached, but a cwd it could read is a cwd it

--- a/web/src/routes/api/settings/model-functions/+server.ts
+++ b/web/src/routes/api/settings/model-functions/+server.ts
@@ -1,0 +1,39 @@
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '$lib/server/db.js';
+import { requireInstanceAdmin } from '$lib/server/auth.js';
+import {
+  MODEL_FUNCTIONS,
+  loadModelFunctionConfig,
+  saveModelFunctionModel,
+  type ModelFunction,
+} from '@pitchbox/shared/ai/model-functions';
+
+// Which model does which job (#411). Instance-wide configuration, so
+// `requireInstanceAdmin` rather than `requireRole`, matching the other
+// instance-wide writes on this rail (default-runner, runner-config, quota).
+
+const Body = z.object({
+  fn: z.enum(MODEL_FUNCTIONS),
+  /**
+   * An empty string clears the setting, which resolves back to the coded
+   * default rather than to nothing. That is the reason the stored value is
+   * nullable: an operator who clears the field is picking the default, not
+   * breaking every run of that job.
+   */
+  modelId: z.string().max(200),
+});
+
+export async function GET(event: RequestEvent) {
+  await requireInstanceAdmin(event);
+  return json(await loadModelFunctionConfig(getDb()));
+}
+
+export async function POST(event: RequestEvent) {
+  await requireInstanceAdmin(event);
+  const parsed = Body.safeParse(await event.request.json().catch(() => null));
+  if (!parsed.success) throw error(400, parsed.error.issues[0]?.message ?? 'invalid body');
+  const { fn, modelId } = parsed.data;
+  await saveModelFunctionModel(getDb(), fn as ModelFunction, modelId.trim() ? modelId : null);
+  return json(await loadModelFunctionConfig(getDb()));
+}

--- a/web/src/routes/settings/admin/models/+page.server.ts
+++ b/web/src/routes/settings/admin/models/+page.server.ts
@@ -1,0 +1,34 @@
+import type { PageServerLoad } from './$types';
+import { getDb } from '$lib/server/db.js';
+import { requireInstanceAdmin } from '$lib/server/auth.js';
+import { MODEL_FUNCTION_META, loadModelFunctionConfig } from '@pitchbox/shared/ai/model-functions';
+import { loadGatewayCatalogue } from '@pitchbox/shared/ai/gateway-catalogue';
+
+// Which model does which job, for the operator of the deployment rather than
+// for a member of one organization (#411, inside the area #412 built). The
+// area's `+layout.server.ts` already gates the whole subtree, and this loader
+// gates itself again: the write path next door does the same, and the API is
+// the boundary that holds when somebody types a URL rather than following a
+// link that was hidden from them.
+
+export const load: PageServerLoad = async (event) => {
+  await requireInstanceAdmin(event);
+  const db = getDb();
+  const [configured, catalogue] = await Promise.all([
+    loadModelFunctionConfig(db),
+    loadGatewayCatalogue(),
+  ]);
+  return {
+    functions: MODEL_FUNCTION_META.map((meta) => ({
+      fn: meta.fn,
+      label: meta.label,
+      description: meta.description,
+      defaultModelId: meta.defaultModelId,
+      configuredModelId: configured[meta.fn],
+    })),
+    catalogue: {
+      models: catalogue.models,
+      unavailable: catalogue.unavailable,
+    },
+  };
+};

--- a/web/src/routes/settings/admin/models/+page.svelte
+++ b/web/src/routes/settings/admin/models/+page.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import * as Card from '$lib/components/ui/card';
+  import * as Alert from '$lib/components/ui/alert';
+  import { Info, TriangleAlert } from '@lucide/svelte';
+  import { Button } from '$lib/components/ui/button';
+  import { Input } from '$lib/components/ui/input';
+  import { SelectField } from '$lib/components/ui/select-field';
+  import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageContainer from '$lib/components/PageContainer.svelte';
+  import Seo from '$lib/components/Seo.svelte';
+  import { toast } from 'svelte-sonner';
+  import { untrack } from 'svelte';
+
+  type GatewayModel = {
+    id: string;
+    name: string;
+    inputPerToken: number | null;
+    outputPerToken: number | null;
+  };
+  type FunctionRow = {
+    fn: string;
+    label: string;
+    description: string;
+    defaultModelId: string;
+    configuredModelId: string | null;
+  };
+  type PageData = {
+    functions: FunctionRow[];
+    catalogue: { models: GatewayModel[]; unavailable: string | null };
+  };
+
+  let { data }: { data: PageData } = $props();
+
+  // The catalogue is the offer, not the constraint: a deployment with no
+  // Gateway key still has to be able to set an id, so the free-text field is
+  // always there and the select is an easier way to fill it.
+  const options = $derived(
+    data.catalogue.models.map((m) => ({
+      value: m.id,
+      label: m.inputPerToken != null ? `${m.id} (${perMillion(m.inputPerToken)} in)` : m.id,
+    })),
+  );
+
+  function perMillion(perToken: number): string {
+    const usd = perToken * 1_000_000;
+    return usd < 1 ? `$${usd.toFixed(2)}/Mtok` : `$${usd.toFixed(0)}/Mtok`;
+  }
+
+  // Read once on purpose: this is the form's own editable copy of what the
+  // loader returned, not a mirror of it.
+  let values = $state<Record<string, string>>(
+    Object.fromEntries(
+      untrack(() => data.functions).map((f) => [f.fn, f.configuredModelId ?? '']),
+    ),
+  );
+  let saving = $state<string | null>(null);
+
+  async function save(fn: string) {
+    saving = fn;
+    try {
+      const res = await fetch('/api/settings/model-functions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ fn, modelId: values[fn] ?? '' }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const row = data.functions.find((f) => f.fn === fn);
+      toast.success(
+        values[fn]?.trim()
+          ? `${row?.label ?? fn} now runs on ${values[fn]}`
+          : `${row?.label ?? fn} is back on the default, ${row?.defaultModelId}`,
+      );
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not save the model');
+    } finally {
+      saving = null;
+    }
+  }
+</script>
+
+<Seo
+  title="Settings - Model configuration"
+  description="Which model runs which job on this deployment."
+/>
+
+<PageContainer size="default">
+  <PageHeader
+    title="Model configuration"
+    description="Which model does which job. A job nobody configured runs on the coded default, so an unset field is a working deployment rather than a broken one."
+  />
+
+  {#if data.catalogue.unavailable}
+    <Alert.Root class="mb-4">
+      <TriangleAlert class="size-4" />
+      <Alert.Description>{data.catalogue.unavailable}</Alert.Description>
+    </Alert.Root>
+  {:else}
+    <Alert.Root class="mb-4">
+      <Info class="size-4" />
+      <Alert.Description>
+        {data.catalogue.models.length} models from the AI Gateway. A change applies to the next run,
+        with no restart.
+      </Alert.Description>
+    </Alert.Root>
+  {/if}
+
+  <div class="flex flex-col gap-4">
+    {#each data.functions as row (row.fn)}
+      <Card.Root data-function={row.fn}>
+        <Card.Header>
+          <Card.Title>{row.label}</Card.Title>
+          <Card.Description>{row.description}</Card.Description>
+        </Card.Header>
+        <Card.Content class="flex flex-col gap-3">
+          {#if options.length > 0}
+            <SelectField
+              value={values[row.fn] ?? ''}
+              {options}
+              placeholder="Pick a model from the Gateway"
+              onValueChange={(v: string) => (values[row.fn] = v)}
+            />
+          {/if}
+          <Input
+            bind:value={values[row.fn]}
+            placeholder={row.defaultModelId}
+            aria-label={`Model id for ${row.label}`}
+          />
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-xs text-muted-foreground">
+              {#if values[row.fn]?.trim()}
+                Default is {row.defaultModelId}. Clear the field to go back to it.
+              {:else}
+                Running on the default, {row.defaultModelId}.
+              {/if}
+            </span>
+            <Button size="sm" disabled={saving === row.fn} onclick={() => save(row.fn)}>
+              {saving === row.fn ? 'Saving' : 'Save'}
+            </Button>
+          </div>
+        </Card.Content>
+      </Card.Root>
+    {/each}
+  </div>
+</PageContainer>

--- a/web/tests/instance-admin-gating.test.ts
+++ b/web/tests/instance-admin-gating.test.ts
@@ -8,6 +8,11 @@ import { PUT as runnerConfigPut } from '../src/routes/api/settings/runner-config
 import { PUT as defaultRunnerPut } from '../src/routes/api/settings/default-runner/+server.js';
 import { POST as webhookRetryPost } from '../src/routes/api/webhooks/deliveries/[id]/retry/+server.js';
 import { PUT as webhooksPut } from '../src/routes/api/settings/webhooks/+server.js';
+import {
+  GET as modelFunctionsGet,
+  POST as modelFunctionsPost,
+} from '../src/routes/api/settings/model-functions/+server.js';
+import { clearModelFunctionCache } from '@pitchbox/shared/ai/model-functions';
 import { type CookieJar, runThroughHandle } from './helpers/handle-harness.js';
 
 const PASSWORD = 'correct-horse-battery';
@@ -203,6 +208,56 @@ describe('instance-admin gating on global config routes', () => {
         return webhookRetryPost(event);
       });
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe('/api/settings/model-functions (via real handle)', () => {
+    // Which model does which job is instance-wide (#411): an org admin who
+    // created their own organization must not be able to swap the model every
+    // other tenant's runs go through, or read what it is.
+    it('an org admin who is not instance-admin is forbidden on the read (403)', async () => {
+      const jar = await sessionFor('iag-models-admin', 'admin', false);
+      const req = new Request('http://localhost/api/settings/model-functions');
+      await expect(runThroughHandle(req, jar, modelFunctionsGet as any)).rejects.toMatchObject({
+        status: 403,
+      });
+    });
+
+    it('an org admin who is not instance-admin is forbidden on the write (403)', async () => {
+      const jar = await sessionFor('iag-models-admin-w', 'admin', false);
+      const req = new Request('http://localhost/api/settings/model-functions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ fn: 'assist_suggest', modelId: 'openai/gpt-5-mini' }),
+      });
+      await expect(runThroughHandle(req, jar, modelFunctionsPost as any)).rejects.toMatchObject({
+        status: 403,
+      });
+    });
+
+    it('an instance-admin writes it and reads the new value back (200)', async () => {
+      clearModelFunctionCache();
+      const jar = await sessionFor('iag-models-iadmin', 'admin', true);
+      const req = new Request('http://localhost/api/settings/model-functions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ fn: 'assist_suggest', modelId: 'openai/gpt-5-mini' }),
+      });
+      const res = await runThroughHandle(req, jar, modelFunctionsPost as any);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ assist_suggest: 'openai/gpt-5-mini' });
+    });
+
+    it('rejects a function nobody defined instead of storing it', async () => {
+      const jar = await sessionFor('iag-models-iadmin2', 'admin', true);
+      const req = new Request('http://localhost/api/settings/model-functions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ fn: 'not_a_function', modelId: 'openai/gpt-5-mini' }),
+      });
+      await expect(runThroughHandle(req, jar, modelFunctionsPost as any)).rejects.toMatchObject({
+        status: 400,
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #411. Under epic #395, inside the area #412 just landed.

The five functions are the jobs the product runs rather than the playbooks it runs them with, since several playbooks are the same job: every commenter, poster and scout drafts outreach, and so do the reply drafter and the draft regenerator. Judging quality is deliberately absent: the rubric is evaluated inside the drafting run (`shared/src/quality-judge.ts` loads a rubric and never reaches a model), so a `quality_judge` entry would be a setting nobody reads. It earns one when it earns a model call.

**The subtlety worth reviewing: the resolution is runner-aware.** An ACP backend's `model` option is that CLI's own vocabulary (`sonnet`, `opus`), so handing `claude-code` a Gateway id like `google/gemini-3.1-flash-lite` would fail runs on every local install that never asked for any of this. `resolveModelForRun` returns undefined for those and the dispatch leaves its config untouched, and the assist path keeps its `sonnet` alias for the same reason. An explicit `runner_configs` pin still wins everywhere, because an operator who set one meant it.

**A missing key resolves to the coded default rather than throwing.** This is read inside a dispatch that is already running, and a run that dies because nobody configured a function is worse than a run on a default. Clearing the field is choosing the default, which is why the stored value is nullable rather than an empty string.

**The catalogue is the offer, not the constraint.** `loadGatewayCatalogue` returned 345 models with pricing when I ran it, and it degrades rather than throws: with no `AI_GATEWAY_API_KEY` (every self-host install today) the page says so and the free-text field still saves an id. A transient Gateway failure is not cached, so the form is not blank for the next ten minutes.

Verified against a real dev server on 5191, not by reading the code:

- Both catalogue states rendered at 1440x1200 in both themes. Keyless: the warning line plus five cards, each with the default in its placeholder and "Running on the default, google/gemini-3.1-flash-lite" under it (`/tmp/pb-w411/`). With a key: "345 models from the AI Gateway. A change applies to the next run, with no restart.", a select above each input, and the second card showing `anthropic/claude-haiku-4.5 ($1/Mtok in)` (`/tmp/pb-w411b/`).
- A real `POST /api/settings/model-functions` followed by a `GET` returned `{"assist_suggest":"anthropic/claude-haiku-4.5"}`, so the write path and the read-back are exercised end to end rather than only in a test.

Tests, and what I broke to prove each one bites:

- `shared/tests/model-functions.test.ts`, 7 tests. Removing `clearModelFunctionCache()` from the save broke "makes a saved model visible immediately". Trusting whatever is in the jsonb broke "reads an unusable stored value as unset" (a hand-edited `"   "` or a number would otherwise reach the Gateway). Making `runnerTakesGatewayModel` always true broke the ACP test. Four of seven failed under those three mutations together.
- `web/tests/instance-admin-gating.test.ts` grew four cases for the new route, in the file that already owns this question rather than in a new one. Removing `requireInstanceAdmin` from the read and the write flipped exactly the two 403 tests.
- `web/tests/extension-suggest.test.ts` still passes 26/26 with `resolveAssistRunnerConfig`'s new second argument.

`pnpm -F web check` 0 errors, `pnpm -F @pitchbox/shared typecheck` clean, eslint and prettier clean on every changed file.

`@ai-sdk/gateway` is a new `shared` dependency. It is the same package #416 needs for the runner itself, and the catalogue read is the smaller half of it.