### PR TITLE
feat(cli,shared): expose the Pitchbox MCP tools to the SDK as a tool set

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -7,14 +7,19 @@
   "bin": {
     "pitchbox": "./dist/index.js"
   },
+  "exports": {
+    "./mcp/tool-set": "./src/mcp/tool-set.ts"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/mcp": "^2.0.45",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@pitchbox/shared": "workspace:*",
+    "ai": "^7.0.93",
     "commander": "^15.0.0",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",

--- a/cli/src/mcp/tool-set.ts
+++ b/cli/src/mcp/tool-set.ts
@@ -1,0 +1,69 @@
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMCPClient, type MCPTransport } from '@ai-sdk/mcp';
+import { createPitchboxMcpServer, type PitchboxMcpContext } from './server.js';
+
+/**
+ * Session binding for the Pitchbox MCP tools: which run, campaign, or project
+ * this tool set is scoped to. Identical shape to `PitchboxMcpContext`
+ * (./server.ts) - the SDK runner passes it straight through rather than
+ * choosing ids itself.
+ */
+export type PitchboxToolSetArgs = PitchboxMcpContext;
+
+export interface PitchboxToolSet {
+  /** The AI SDK tool set, as returned by the MCP client's `tools()`. */
+  tools: Record<string, unknown>;
+  /** Releases both ends of the in-memory MCP connection. */
+  close(): Promise<void>;
+}
+
+/**
+ * Bridges the Pitchbox MCP server to the Vercel AI SDK's tool interface for
+ * the in-process SDK runner (#415/#416): `createPitchboxMcpServer` is
+ * connected to one half of an in-memory MCP transport, the AI SDK's MCP
+ * client to the other, and the resulting tool set is handed to
+ * `streamText`/`generateText` unmodified. The tool list this produces is
+ * therefore the same list the ACP path sees (docs/cloud-runner.md, "#415")
+ * because it comes from the same registration code, not a second,
+ * hand-maintained surface - and the org scoping and ownership checks that
+ * live inside those tool handlers (`checkOwnership` in ./server.ts) stay the
+ * single enforcement point rather than something this bridge has to
+ * reimplement.
+ *
+ * The session binding travels in `args`, exactly as `createPitchboxMcpServer`
+ * expects: an explicit context always wins over env-derived defaults there,
+ * which is the path this in-process caller needs - there is no child process
+ * to forward PITCHBOX_RUN_ID/PITCHBOX_CAMPAIGN_ID/PITCHBOX_PROJECT_ID to, the
+ * way the ACP backend's `buildPitchboxMcpServer` does for a subprocess.
+ *
+ * Lives in `cli` rather than `shared` deliberately: this is the workspace
+ * that already owns the MCP surface and the MCP SDK dependency, and `shared`
+ * stays the leaf every other workspace imports rather than the other way
+ * around (see AGENTS.md). `shared/src/agents/sdk/tools.ts` re-exports this
+ * same name and signature via a lazy `import()`, mirroring how
+ * `shared/src/agents/cloud.ts` reaches the private cloud adapter.
+ */
+export async function createPitchboxToolSet(
+  args: PitchboxToolSetArgs = {},
+): Promise<PitchboxToolSet> {
+  const server = createPitchboxMcpServer(args);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = await createMCPClient({ transport: clientTransport as unknown as MCPTransport });
+  const tools = await client.tools();
+
+  return {
+    tools,
+    async close() {
+      // Closing either end of an in-memory pair cascades to the other
+      // (InMemoryTransport#close calls its counterpart's close in turn), so
+      // this releases both the client and the server side of the
+      // connection - a run that finishes or is cancelled does not leave a
+      // live server behind. Calling both explicitly (rather than relying on
+      // the cascade alone) keeps the guarantee independent of which side
+      // happens to close first.
+      await client.close();
+      await server.close();
+    },
+  };
+}

--- a/cli/tests/mcp/tool-set.test.ts
+++ b/cli/tests/mcp/tool-set.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, beforeEach, afterAll } from 'vitest';
+import { getDb, getPool, schema } from '@pitchbox/shared/db';
+import { eq, sql } from 'drizzle-orm';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createPitchboxMcpServer } from '../../src/mcp/server.js';
+import { createPitchboxToolSet } from '../../src/mcp/tool-set.js';
+
+// This suite proves the bridge in src/mcp/tool-set.ts, not the Pitchbox MCP
+// server's own tool behaviour (that is server.test.ts's job, in this same
+// directory). Each test exercises a real Postgres row through the real AI
+// SDK tool set - the point of #417 is that the tool list and the
+// org/ownership enforcement are inherited from src/mcp/server.ts by
+// construction, so a test that mocked the MCP layer would prove nothing.
+//
+// shared/src/agents/sdk/tools.ts re-exports createPitchboxToolSet from here
+// via a lazy import() (mirroring shared/src/agents/cloud.ts's private
+// cloud-adapter loader) so `shared` stays a leaf workspace with no
+// dependency on `cli`. That loader has no behaviour of its own to test - it
+// only resolves this module and delegates - so the real coverage lives here,
+// against the concrete implementation.
+
+interface ToolCallResult {
+  isError?: boolean;
+  content: { type: string; text?: string }[];
+}
+
+type ToolExecuteOptions = {
+  toolCallId: string;
+  messages: unknown[];
+};
+
+type ToolExecute = (
+  input: Record<string, unknown>,
+  options: ToolExecuteOptions,
+) => Promise<ToolCallResult>;
+
+function executable(tools: Record<string, unknown>, name: string): ToolExecute {
+  const tool = tools[name] as { execute?: unknown } | undefined;
+  if (!tool || typeof tool.execute !== 'function') {
+    throw new Error(`tool set has no executable tool named "${name}"`);
+  }
+  return tool.execute.bind(tool) as ToolExecute;
+}
+
+async function call(
+  tools: Record<string, unknown>,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolCallResult> {
+  return executable(tools, name)(args, { toolCallId: `test-${name}`, messages: [] });
+}
+
+function parse(res: ToolCallResult): unknown {
+  return JSON.parse(res.content[0]?.text ?? 'null');
+}
+
+async function reset() {
+  const db = getDb();
+  await db.execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, blocklist, contact_history, staging_scout_candidates RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function redditPlatformId(): Promise<number> {
+  const db = getDb();
+  const [p] = await db.select().from(schema.platforms).where(eq(schema.platforms.slug, 'reddit'));
+  return p.id;
+}
+
+const SCOUT_PROFILE = {
+  targetSubreddits: ['rpg'],
+  topicKeywords: ['ai dm'],
+  avoidKeywords: [],
+  fitScoreThreshold: 3,
+  voice: {
+    tone: 'casual',
+    hardBans: [],
+    dos: [],
+    openerStyle: 'lowercase-casual',
+    disclosure: 'i build this',
+  },
+  offer: { productUrl: 'https://example.com', subject: 'invite', text: 'short pitch' },
+  systemInstructions: 'casual tone',
+};
+
+/** Seeds a whole new organization (project + account + scout campaign), so two
+ * calls with different slugs give two orgs whose ids never collide. */
+async function seedOrgScoutCampaign(slug: string) {
+  const db = getDb();
+  const platformId = await redditPlatformId();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `${slug}-proj`, name: `${slug} project` })
+    .returning();
+  const [account] = await db
+    .insert(schema.accounts)
+    .values({ projectId: project.id, platformId, handle: `${slug}-acc`, role: 'personal' })
+    .returning();
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({
+      projectId: project.id,
+      platformId,
+      name: 'Scout',
+      skillSlug: 'reddit-scout',
+      config: SCOUT_PROFILE,
+    })
+    .returning();
+  return {
+    orgId: org.id,
+    projectId: project.id,
+    accountId: account.id,
+    campaignId: campaign.id,
+  };
+}
+
+describe('createPitchboxToolSet', () => {
+  beforeEach(async () => {
+    await reset();
+  });
+
+  it('exposes the same tool list the ACP path sees', async () => {
+    // The ACP path connects a fresh createPitchboxMcpServer() to its own
+    // in-memory pair and lists its tools directly - the reference this test
+    // compares against, rather than a hardcoded array of names that could
+    // drift from the real registration code.
+    const referenceServer = createPitchboxMcpServer();
+    const [refClientT, refServerT] = InMemoryTransport.createLinkedPair();
+    await referenceServer.connect(refServerT);
+    const referenceClient = new Client({ name: 'reference', version: '0.0.0' });
+    await referenceClient.connect(refClientT);
+    const { tools: referenceTools } = await referenceClient.listTools();
+    const referenceNames = referenceTools.map((t) => t.name).sort();
+    await referenceClient.close();
+
+    const toolSet = await createPitchboxToolSet();
+    try {
+      const bridgedNames = Object.keys(toolSet.tools).sort();
+      expect(bridgedNames).toEqual(referenceNames);
+      expect(bridgedNames.length).toBeGreaterThan(0);
+    } finally {
+      await toolSet.close();
+    }
+  });
+
+  it('drafts_create writes a real draft with the session-bound project and run ids', async () => {
+    const { campaignId, accountId, projectId } = await seedOrgScoutCampaign('sdk-write');
+    const toolSet = await createPitchboxToolSet({ campaignId });
+    try {
+      const { runId } = parse(await call(toolSet.tools, 'run_start', {})) as { runId: number };
+      expect(runId).toBeGreaterThan(0);
+
+      const res = await call(toolSet.tools, 'drafts_create', {
+        runId,
+        drafts: [
+          { accountId, kind: 'dm', targetUser: 'good-guy', body: 'hey, nice post', fitScore: 4 },
+        ],
+      });
+      expect(res.isError).toBeFalsy();
+      const data = parse(res) as { inserted: number };
+      expect(data.inserted).toBe(1);
+
+      const db = getDb();
+      const rows = await db.select().from(schema.drafts).where(eq(schema.drafts.runId, runId));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.runId).toBe(runId);
+      expect(rows[0]?.projectId).toBe(projectId);
+      expect(rows[0]?.targetUser).toBe('good-guy');
+    } finally {
+      await toolSet.close();
+    }
+  });
+
+  it("cannot write into another organization's run", async () => {
+    const a = await seedOrgScoutCampaign('sdk-org-a');
+    const b = await seedOrgScoutCampaign('sdk-org-b');
+
+    const toolSetA = await createPitchboxToolSet({ campaignId: a.campaignId });
+    const toolSetB = await createPitchboxToolSet({ campaignId: b.campaignId });
+    try {
+      const { runId: runIdB } = parse(await call(toolSetB.tools, 'run_start', {})) as {
+        runId: number;
+      };
+
+      // Session A tries to write a draft into session B's run by overriding
+      // the runId argument - the ownership check must catch this even though
+      // the argument itself is well-formed.
+      const res = await call(toolSetA.tools, 'drafts_create', {
+        runId: runIdB,
+        drafts: [{ accountId: a.accountId, kind: 'dm', targetUser: 'x', body: 'y', fitScore: 3 }],
+      });
+
+      // A usable error returned to the caller, not a thrown exception - the
+      // whole point (docs/cloud-runner.md, "#417 has to keep").
+      expect(res.isError).toBe(true);
+      expect(res.content[0]?.text ?? '').toContain(
+        "does not belong to this session's organization",
+      );
+
+      const db = getDb();
+      const rows = await db.select().from(schema.drafts).where(eq(schema.drafts.runId, runIdB));
+      expect(rows).toHaveLength(0);
+    } finally {
+      await toolSetA.close();
+      await toolSetB.close();
+    }
+  });
+
+  it('a tool whose command throws returns a usable error instead of an exception', async () => {
+    // Reproduces the exact case the #415 spike hit: a campaign config that
+    // fails the scenario's structured-format validation makes startRun()
+    // throw a raw Error; the MCP handler's own try/catch turns that into an
+    // isError result. What this test proves at the #417 boundary is that the
+    // AI SDK's execute() surfaces that as a returned result, not a rejected
+    // promise that would kill stopWhen's loop.
+    const db = getDb();
+    const platformId = await redditPlatformId();
+    const [org] = await db
+      .insert(schema.organizations)
+      .values({ slug: 'sdk-bad-config', name: 'sdk-bad-config' })
+      .returning();
+    const [project] = await db
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'sdk-bad-config-proj', name: 'bad config project' })
+      .returning();
+    const [campaign] = await db
+      .insert(schema.campaigns)
+      .values({
+        projectId: project.id,
+        platformId,
+        name: 'Bad Config Scout',
+        skillSlug: 'reddit-scout',
+        // Not the structured SCOUT_PROFILE shape - fails scenarioSchema.safeParse.
+        config: { legacy: true },
+      })
+      .returning();
+
+    const toolSet = await createPitchboxToolSet({ campaignId: campaign.id });
+    try {
+      const res = await call(toolSet.tools, 'run_start', {});
+      expect(res.isError).toBe(true);
+      expect(res.content[0]?.text ?? '').toContain('structured format');
+    } finally {
+      await toolSet.close();
+    }
+  });
+
+  it('close() releases both ends: a call after close fails rather than hanging', async () => {
+    const { campaignId } = await seedOrgScoutCampaign('sdk-close');
+    const toolSet = await createPitchboxToolSet({ campaignId });
+    await toolSet.close();
+
+    // A genuine wall-clock race, deliberately: the property under test is
+    // "does not hang forever", and there is no event to await instead - a
+    // closed InMemoryTransport either rejects promptly (pass) or the call
+    // never settles (the failure this guards against). vitest's own test
+    // timeout would eventually catch a hang too, but with a generic timeout
+    // failure rather than naming what happened.
+    const outcome = await Promise.race([
+      call(toolSet.tools, 'run_start', {}).then(
+        () => 'resolved' as const,
+        (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+      ),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('call after close() hung instead of failing')), 3000),
+      ),
+    ]);
+    expect(outcome).toBeInstanceOf(Error);
+  });
+});
+
+afterAll(async () => {
+  await getPool().end();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,12 +67,18 @@ importers:
 
   cli:
     dependencies:
+      '@ai-sdk/mcp':
+        specifier: ^2.0.45
+        version: 2.0.45(zod@4.5.4)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.5.4)
       '@pitchbox/shared':
         specifier: workspace:*
         version: link:../shared
+      ai:
+        specifier: ^7.0.93
+        version: 7.0.93(zod@4.5.4)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -343,6 +349,12 @@ packages:
 
   '@ai-sdk/gateway@4.0.75':
     resolution: {integrity: sha512-HOnhw3oXtBnboBF7kAKipjToCN6+5w6EuukiUKiULcxBitS+vbHRRv9IUBcq+Z1wkXcJjfywKrt5r++I6OYyXg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mcp@2.0.45':
+    resolution: {integrity: sha512-ROukI/LfoPHf5F4gi1GKQebK5658fR1EG3kt0P0vzrfSy1FAGQ5FyKr9j2lbkXAV9X3kfpf9LJdif7w67XDtgw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2152,6 +2164,12 @@ packages:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ai@7.0.93:
+    resolution: {integrity: sha512-CJss6zb9mlltk/mCr8qom20NBnqEQxVawkqwtT62tCwsxilZpXfHNRMRwcS3XRpzdP1kEluVuDBUayYWEEd95g==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -4477,6 +4495,14 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.5.4
 
+  '@ai-sdk/mcp@2.0.45(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@4.5.4)
+      cross-spawn: 7.0.6
+      pkce-challenge: 5.0.1
+      zod: 4.5.4
+
   '@ai-sdk/provider-utils@5.0.36(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.10
@@ -5954,6 +5980,13 @@ snapshots:
   acorn@8.17.0: {}
 
   acorn@8.18.0: {}
+
+  ai@7.0.93(zod@4.5.4):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.75(zod@4.5.4)
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@4.5.4)
+      zod: 4.5.4
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:

--- a/shared/package.json
+++ b/shared/package.json
@@ -70,7 +70,8 @@
     "./project-extraction": "./src/project-extraction/index.ts",
     "./linkedin-assist": "./src/linkedin-assist.ts",
     "./assist-accept": "./src/assist-accept.ts",
-    "./website-source": "./src/website-source.ts"
+    "./website-source": "./src/website-source.ts",
+    "./agents/sdk/tools": "./src/agents/sdk/tools.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",

--- a/shared/src/agents/sdk/tools.ts
+++ b/shared/src/agents/sdk/tools.ts
@@ -1,0 +1,76 @@
+// The Pitchbox MCP tool set lives in `cli/src/mcp/tool-set.ts`: `cli` already
+// owns the MCP surface and its SDK dependency, and `shared` stays the leaf
+// workspace every other one imports rather than the other way around (see
+// AGENTS.md, "DB access is centralised in shared"). This module re-exports
+// the same name and signature #416's runner imports via a lazy `import()`,
+// mirroring how `shared/src/agents/cloud.ts` reaches the private cloud
+// adapter without declaring a dependency on it.
+
+/**
+ * Session binding for the Pitchbox MCP tools: which run, campaign, or project
+ * this tool set is scoped to.
+ */
+export interface PitchboxToolSetArgs {
+  runId?: number;
+  campaignId?: number;
+  projectId?: number;
+}
+
+export interface PitchboxToolSet {
+  /** The AI SDK tool set, as returned by the MCP client's `tools()`. */
+  tools: Record<string, unknown>;
+  /** Releases both ends of the in-memory MCP connection. */
+  close(): Promise<void>;
+}
+
+interface ToolSetModule {
+  createPitchboxToolSet(args?: PitchboxToolSetArgs): Promise<PitchboxToolSet>;
+}
+
+async function importToolSetModule(): Promise<ToolSetModule> {
+  // A bundled build (the web SSR build, once it declares the dependency)
+  // resolves the package specifier via cli's own exports map; tsx/vitest -
+  // where nothing gets bundled and no workspace dependency is declared -
+  // falls back to the source path under the umbrella. Both throw when cli's
+  // tool-set module is genuinely missing; the caller below wraps that into
+  // an actionable error.
+  try {
+    // @ts-expect-error cli owns the MCP surface; shared does not declare a
+    // dependency on it (see the module comment above) - resolved at runtime
+    // via cli's exports map when present, tsx/vitest fallback below.
+    return (await import('@pitchbox/cli/mcp/tool-set')) as ToolSetModule;
+  } catch (primaryErr) {
+    try {
+      const spec = ['..', '..', '..', '..', 'cli', 'src', 'mcp', 'tool-set.js'].join('/');
+      // Intentionally dynamic (tsx/vitest-only fallback); tell Vite not to try to analyze it.
+      return (await import(/* @vite-ignore */ spec)) as ToolSetModule;
+    } catch {
+      // The path fallback only applies to the unbundled tsx/vitest case; in
+      // a bundled build it never resolves. Surface the primary error - it's
+      // the real cause.
+      throw primaryErr;
+    }
+  }
+}
+
+/**
+ * Bridges the Pitchbox MCP server to the Vercel AI SDK's tool interface for
+ * the in-process SDK runner (#415/#416). See `cli/src/mcp/tool-set.ts` for
+ * the real implementation and its doc comment - this function only resolves
+ * that module and delegates.
+ */
+export async function createPitchboxToolSet(
+  args: PitchboxToolSetArgs = {},
+): Promise<PitchboxToolSet> {
+  let mod: ToolSetModule;
+  try {
+    mod = await importToolSetModule();
+  } catch (err) {
+    throw new Error(
+      'Pitchbox MCP tool set not available - expected cli/src/mcp/tool-set.ts in this checkout. ' +
+        String(err instanceof Error ? err.message : err),
+      { cause: err },
+    );
+  }
+  return mod.createPitchboxToolSet(args);
+}


### PR DESCRIPTION
Bridges the Pitchbox MCP surface to the Vercel AI SDK's tool interface for the in-process SDK runner (#415/#416). `createPitchboxMcpServer(ctx)` connects to one half of an `InMemoryTransport.createLinkedPair()`, `@ai-sdk/mcp`'s `createMCPClient` connects to the other, and `await client.tools()` is handed back unmodified - the tool list is the same list by construction, not by maintenance.

## Where the code lives (updated from the first version of this PR)
The real implementation is `cli/src/mcp/tool-set.ts`, not `shared`: `cli` already owns the MCP surface and the MCP SDK dependency, and `shared` stays the leaf workspace every other one imports (AGENTS.md: "DB access is centralised in shared"). Making `shared` depend on `@pitchbox/cli` - my first attempt - inverted that layering into a real (if pnpm-tolerated) circular workspace dependency.

`shared/src/agents/sdk/tools.ts` keeps the exact public name and signature #416 imports, implemented as a lazy loader that mirrors `shared/src/agents/cloud.ts`'s existing pattern for the private cloud adapter: try the `@pitchbox/cli/mcp/tool-set` package specifier, fall back to the relative source path for the unbundled tsx/vitest case, throw an actionable error naming the missing module if neither resolves. `shared` gains no new dependency for this.

## What this keeps
- The org scoping and per-tool ownership checks (`sessionOrgId`, `checkOwnership`) stay inside `cli/src/mcp/server.ts` as the single enforcement point.
- The session binding (`runId`/`campaignId`/`projectId`) travels through `createPitchboxMcpServer`'s explicit-context path, which already wins over env-derived defaults.
- A tool call that fails (an internal `errorResult()`, or an uncaught throw the MCP server's own dispatcher catches) returns a usable `isError` result to the caller instead of throwing and killing the `stopWhen` loop.

## Package layout
- `cli/src/mcp/tool-set.ts` exports `createPitchboxToolSet`; `cli/package.json` exports it as `./mcp/tool-set` and gains `ai` + `@ai-sdk/mcp` as dependencies (it already had `@modelcontextprotocol/sdk`).
- `shared/package.json`'s `./agents/sdk/tools` export is unchanged in shape - `createPitchboxToolSet(args): Promise<{ tools, close() }>` - now backed by the lazy loader.

## Tests (`cli/tests/mcp/tool-set.test.ts`, alongside `server.test.ts` which already covers the MCP server itself; 5 tests, all against a real Postgres DB)
- The bridged tool list matches a fresh `createPitchboxMcpServer()`'s own `listTools()` call - measured **26 tools**, matching the #415 spike's number exactly, compared as a real list rather than a hardcoded array.
- `drafts_create` writes a real row through the tool set against a seeded campaign/run; asserts `runId`/`projectId` on the row.
- A session bound to one organization cannot write into a second organization's run even via an explicit `runId` argument override - asserts a returned `isError` (not a thrown exception) and that no row landed.
- A command that throws internally (the exact unstructured-campaign-config case from the #415 spike) also surfaces as a returned error, not a rejected promise.
- A call after `close()` fails rather than hanging (raced against a 3s timer since there's no other signal for "hung forever").

Every assertion was proven to bite (broke each of the five behaviors in turn, confirmed the exact expected failure, restored, re-ran green) - both before and after the relocation to `cli`.

## Non-goals (per issue)
Does not touch the runner (#416) or the event/usage normalizer (#418). Does not change any Pitchbox MCP tool's behavior, schema, or ownership check.

## Sibling coordination
#416 (`shared/src/agents/sdk/runner.ts`) imports `createPitchboxToolSet` from `shared`'s public export by this signature - unaffected by where the implementation actually lives. #418 owns the event normalizer, independent of this file.

Closes #417
