### PR TITLE
feat(shared): a website source

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/pg@8.20.0)(pg@8.23.0)
+      html-to-text:
+        specifier: ^9.0.5
+        version: 9.0.5
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -221,6 +224,9 @@ importers:
         specifier: ^4.5.4
         version: 4.5.4
     devDependencies:
+      '@types/html-to-text':
+        specifier: ^9.0.4
+        version: 9.0.4
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -1533,6 +1539,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
 
@@ -1737,6 +1746,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/html-to-text@9.0.4':
+    resolution: {integrity: sha512-pUY3cKH/Nm2yYrEmDlPR1mR7yszjGx4DrwPjQ702C4/D5CwHuZTgZdIdwPkRbcuhs7BAh2L5rg3CL5cbRiGTCQ==}
 
   '@types/jsdom@30.0.0':
     resolution: {integrity: sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==}
@@ -2872,11 +2884,18 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
   html-void-elements@2.0.1:
     resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -3037,6 +3056,9 @@ packages:
   lazy-cache@1.0.4:
     resolution: {integrity: sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==}
     engines: {node: '>=0.10.0'}
+
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3483,6 +3505,9 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -3507,6 +3532,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -3799,6 +3827,9 @@ packages:
 
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
+
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
   select-files@1.0.1:
     resolution: {integrity: sha512-8h4DSpjfFa0hyMP3z3ye4SxyhdaE5RgaXeScRpH7xl4YblnZSHwexmLdLNdSKwTO8H9ccDKj7Votz0io+18+BQ==}
@@ -5321,6 +5352,11 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
+
   '@shikijs/core@2.5.0':
     dependencies:
       '@shikijs/engine-javascript': 2.5.0
@@ -5528,6 +5564,8 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/html-to-text@9.0.4': {}
 
   '@types/jsdom@30.0.0':
     dependencies:
@@ -6716,9 +6754,24 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
   html-void-elements@2.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   http-errors@2.0.1:
     dependencies:
@@ -6860,6 +6913,8 @@ snapshots:
   lazy-cache@0.2.7: {}
 
   lazy-cache@1.0.4: {}
+
+  leac@0.6.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -7424,6 +7479,11 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -7437,6 +7497,8 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
+
+  peberminta@0.9.0: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -7767,6 +7829,10 @@ snapshots:
       xmlchars: 2.2.0
 
   search-insights@2.17.3: {}
+
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
 
   select-files@1.0.1: {}
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -69,7 +69,8 @@
     "./scheduler/dispatch-lock": "./src/scheduler/dispatch-lock.ts",
     "./project-extraction": "./src/project-extraction/index.ts",
     "./linkedin-assist": "./src/linkedin-assist.ts",
-    "./assist-accept": "./src/assist-accept.ts"
+    "./assist-accept": "./src/assist-accept.ts",
+    "./website-source": "./src/website-source.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",
@@ -82,6 +83,7 @@
     "@ai-sdk/gateway": "^4.0.75",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
+    "html-to-text": "^9.0.5",
     "jose": "^6.2.3",
     "pg": "^8.23.0",
     "playwright": "^1.62.1",
@@ -90,6 +92,7 @@
     "zod": "^4.5.4"
   },
   "devDependencies": {
+    "@types/html-to-text": "^9.0.4",
     "@types/pg": "^8.20.0",
     "drizzle-kit": "^0.31.10",
     "tsx": "^4.23.13"

--- a/shared/src/website-source.ts
+++ b/shared/src/website-source.ts
@@ -1,0 +1,492 @@
+// A website whose text is kept and refreshed on demand (#433). This is the
+// second `project_sources` kind after `github` (shared/src/github-sources.ts),
+// and it follows that module's shape rather than inventing a second one: a
+// fetch failure is recorded on the source's own `fetch_error` and never
+// thrown, so a project with three sources and one dead link still reads -
+// only that one row goes stale.
+//
+// The only fetching primitives that existed in this repo before this file
+// were the Reddit Playwright scraper and the HN Algolia client
+// (shared/src/platforms/), neither of which fits an arbitrary marketing/docs
+// URL: Reddit's stack drags a real Chromium for a page that needs none, and
+// HN's client only ever talks to a fixed JSON API. This crawl instead does a
+// plain `fetch` plus `html-to-text`.
+//
+// Dependency choice: `html-to-text` vs `@mozilla/readability` (+ `jsdom`) vs
+// hand-rolled `cheerio` extraction, compared on 2026-09-08.
+// - `@mozilla/readability` needs a live DOM (jsdom under Node), and jsdom is
+//   a full HTML/CSS/layout engine - installing one to read text off a page
+//   we already have as a string is the "drags in a browser" case this issue
+//   calls out to avoid, for a algorithm tuned to isolate one article from
+//   chrome, which is narrower than "whatever text is on the page" (a docs
+//   sidebar is exactly the kind of content Readability is designed to
+//   discard).
+// - `cheerio` gives a jQuery-like DOM but not text extraction: this module
+//   would still have to hand-write block/inline handling, whitespace
+//   collapsing and list/heading formatting, which is the actual work
+//   `html-to-text` already does.
+// - `html-to-text` (10.0.1) is a parser (`htmlparser2`) plus a handful of
+//   pure-JS selector/formatting packages (`selderee`, `parseley`,
+//   `deepmerge-ts`) - five packages total, none of them a DOM or a browser,
+//   actively maintained (published within the month at the time of this
+//   change), and it already skips `<script>`/`<style>` and renders
+//   headings/paragraphs/lists as readable text out of the box. That is the
+//   one installed here.
+import { schema, type Db } from './db/client.js';
+import { eq } from 'drizzle-orm';
+import { convert } from 'html-to-text';
+import { createProjectSource, type ProjectSourceRow } from './project-sources.js';
+
+/** Identifies this crawler to a `robots.txt`. A distinct name (rather than
+ * reusing a browser UA) is what lets a site operator distinguish "Pitchbox
+ * fetched this on a project's behalf" from ordinary traffic and write a
+ * `User-agent: PitchboxBot` group if they want to treat it differently from
+ * `*`. */
+export const WEBSITE_USER_AGENT = 'PitchboxBot/1.0 (+https://pitchbox.app)';
+
+/** Per-request budget. A page that never responds (a hung TCP connection, a
+ * host behind a black-holed firewall) would otherwise stall a run
+ * indefinitely - this runs inside a request handler on a shared deployment,
+ * so every fetch this module makes carries one. */
+export const WEBSITE_FETCH_TIMEOUT_MS = 8_000;
+
+/** Per-page byte cap, enforced while streaming the response body rather than
+ * after buffering it whole - a page that serves gigabytes never gets fully
+ * read into memory in the first place. */
+export const WEBSITE_MAX_BYTES_PER_PAGE = 2 * 1024 * 1024;
+
+/** One page by default, or up to this many when `crawlLinks` is set (the
+ * root page plus same-host links found on it). "A small cap" per the issue -
+ * enough to pick up a docs site's landing page and a couple of its children
+ * without turning one source into an open-ended crawl. */
+export const WEBSITE_MAX_PAGES = 5;
+
+/** Clamp on the combined extracted text actually stored on the source row -
+ * this feeds a prompt (like `README_EXCERPT_MAX_CHARS` in
+ * `github-sources.ts`), not an archive of the site. */
+export const WEBSITE_MAX_TEXT_CHARS = 20_000;
+
+/** What this module needs from `fetch`: a string URL, an abort signal, and a
+ * `Response` whose body can be streamed. Narrower than `typeof fetch` for the
+ * same reason `GithubFetch` is in `github-sources.ts` - a test double only
+ * has to satisfy this shape. */
+export type WebsiteFetch = (url: string, init?: { signal?: AbortSignal }) => Promise<Response>;
+
+export interface RobotsRules {
+  isAllowed(pathname: string): boolean;
+}
+
+const ALLOW_ALL: RobotsRules = { isAllowed: () => true };
+
+/**
+ * A minimal `robots.txt` parser: groups by `User-agent`, `Disallow`/`Allow`
+ * rules within a group, longest-matching-path-prefix wins (the standard
+ * tie-break - RFC 9309 §2.2.2). No wildcard/`$`-anchor support, since the
+ * issue's bar is "a disallow is honoured" against a real fixture, not a
+ * conformance suite - a real docs/marketing site's `robots.txt` is
+ * overwhelmingly plain path prefixes.
+ */
+export function parseRobotsTxt(text: string, userAgent: string): RobotsRules {
+  type Rule = { path: string; allow: boolean };
+  type Group = { agents: string[]; rules: Rule[] };
+  const groups: Group[] = [];
+  let current: Group | null = null;
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.split('#')[0]!.trim();
+    if (!line) continue;
+    const sep = line.indexOf(':');
+    if (sep === -1) continue;
+    const field = line.slice(0, sep).trim().toLowerCase();
+    const value = line.slice(sep + 1).trim();
+
+    if (field === 'user-agent') {
+      // Consecutive User-agent lines (before any rule) belong to the same
+      // group and share whatever Allow/Disallow rules follow.
+      if (!current || current.rules.length > 0) {
+        current = { agents: [], rules: [] };
+        groups.push(current);
+      }
+      current.agents.push(value.toLowerCase());
+    } else if (field === 'disallow' && current) {
+      if (value !== '') current.rules.push({ path: value, allow: false });
+    } else if (field === 'allow' && current) {
+      if (value !== '') current.rules.push({ path: value, allow: true });
+    }
+  }
+
+  const lowerAgent = userAgent.toLowerCase();
+  const group =
+    groups.find((g) => g.agents.some((a) => lowerAgent.includes(a) || a.includes(lowerAgent))) ??
+    groups.find((g) => g.agents.includes('*'));
+  const rules = group?.rules ?? [];
+  if (rules.length === 0) return ALLOW_ALL;
+
+  return {
+    isAllowed(pathname: string): boolean {
+      let best: Rule | null = null;
+      for (const rule of rules) {
+        if (pathname.startsWith(rule.path) && (!best || rule.path.length > best.path.length)) {
+          best = rule;
+        }
+      }
+      return best ? best.allow : true;
+    },
+  };
+}
+
+/** Fetches and parses `${origin}/robots.txt`. Any failure (network error,
+ * timeout, non-2xx, no file at all) is treated as "allow everything" - a
+ * missing or broken robots.txt is not a reason to refuse a page a browser
+ * would happily load. */
+export async function fetchRobotsTxt(
+  origin: string,
+  fetchImpl: WebsiteFetch,
+  timeoutMs: number,
+  userAgent: string,
+): Promise<RobotsRules> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(`${origin}/robots.txt`, { signal: controller.signal });
+    if (!res.ok) return ALLOW_ALL;
+    const text = await res.text();
+    return parseRobotsTxt(text, userAgent);
+  } catch {
+    return ALLOW_ALL;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+type CappedFetchResult =
+  { ok: true; body: string; bytes: number; truncated: boolean } | { ok: false; reason: string };
+
+/**
+ * Fetches one URL with a timeout and a byte cap enforced while streaming -
+ * the cap is checked chunk-by-chunk against the response body's reader, so a
+ * page that serves an unbounded/huge stream is cut off and read as its first
+ * `maxBytes`, never buffered whole first.
+ */
+async function fetchCapped(
+  url: string,
+  fetchImpl: WebsiteFetch,
+  opts: { maxBytes: number; timeoutMs: number },
+): Promise<CappedFetchResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+  try {
+    let res: Response;
+    try {
+      res = await fetchImpl(url, { signal: controller.signal });
+    } catch (err) {
+      if (controller.signal.aborted)
+        return { ok: false, reason: `timed out after ${opts.timeoutMs}ms` };
+      return { ok: false, reason: `network error: ${(err as Error).message}` };
+    }
+    if (!res.ok) return { ok: false, reason: `HTTP ${res.status}` };
+
+    const contentType = res.headers.get('content-type') ?? '';
+    if (contentType && !/text\/html|text\/plain|application\/xhtml/.test(contentType)) {
+      return { ok: false, reason: `unsupported content-type: ${contentType}` };
+    }
+
+    if (!res.body) {
+      const text = await res.text();
+      const bytes = Buffer.byteLength(text, 'utf8');
+      const truncated = bytes > opts.maxBytes;
+      return {
+        ok: true,
+        body: truncated
+          ? Buffer.from(text, 'utf8').subarray(0, opts.maxBytes).toString('utf8')
+          : text,
+        bytes: truncated ? opts.maxBytes : bytes,
+        truncated,
+      };
+    }
+
+    const reader = res.body.getReader();
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let truncated = false;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const remaining = opts.maxBytes - total;
+      if (remaining <= 0) {
+        truncated = true;
+        await reader.cancel().catch(() => {});
+        break;
+      }
+      const chunk = value.byteLength > remaining ? value.subarray(0, remaining) : value;
+      if (chunk.byteLength < value.byteLength) truncated = true;
+      chunks.push(Buffer.from(chunk));
+      total += chunk.byteLength;
+      if (total >= opts.maxBytes) {
+        await reader.cancel().catch(() => {});
+        break;
+      }
+    }
+    return { ok: true, body: Buffer.concat(chunks).toString('utf8'), bytes: total, truncated };
+  } catch (err) {
+    if (controller.signal.aborted)
+      return { ok: false, reason: `timed out after ${opts.timeoutMs}ms` };
+    return { ok: false, reason: `network error: ${(err as Error).message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Renders HTML to readable plain text: headings, paragraphs and lists kept
+ * as text, script/style/images dropped, link targets dropped (the anchor
+ * text alone reads better in a prompt than `text [https://...]` repeated for
+ * every nav item). */
+export function extractPageText(html: string): string {
+  return convert(html, {
+    wordwrap: false,
+    selectors: [
+      { selector: 'a', options: { ignoreHref: true } },
+      { selector: 'img', format: 'skip' },
+    ],
+  }).trim();
+}
+
+/** Same-host `<a href>` targets on a page, resolved against `baseUrl`,
+ * deduplicated, `baseUrl` itself excluded. A hand-written regex rather than a
+ * DOM parse - the same reasoning as the dependency note above: this only
+ * needs `href` values, not a tree. */
+export function extractSameHostLinks(html: string, baseUrl: string): string[] {
+  const base = new URL(baseUrl);
+  const seen = new Set<string>([base.toString()]);
+  const links: string[] = [];
+  const hrefRe = /<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+  let match: RegExpExecArray | null;
+  while ((match = hrefRe.exec(html))) {
+    const raw = match[1] ?? match[2] ?? '';
+    if (!raw || raw.startsWith('#') || raw.startsWith('mailto:') || raw.startsWith('tel:'))
+      continue;
+    let resolved: URL;
+    try {
+      resolved = new URL(raw, base);
+    } catch {
+      continue;
+    }
+    resolved.hash = '';
+    if (resolved.hostname !== base.hostname) continue;
+    if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') continue;
+    const normalized = resolved.toString();
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    links.push(normalized);
+  }
+  return links;
+}
+
+export interface WebsiteCrawlOptions {
+  /** Injectable fetch, defaults to the global one. Tests substitute a real
+   * fixture server rather than a mock, since the byte cap and the robots
+   * honouring both depend on real streaming/response behaviour. */
+  fetchImpl?: WebsiteFetch;
+  timeoutMs?: number;
+  maxBytesPerPage?: number;
+  /** Total page cap including the root page. Clamped to
+   * `WEBSITE_MAX_PAGES` regardless of what a caller passes. */
+  maxPages?: number;
+  /** Follow same-host links found on the root page, up to `maxPages`. Off by
+   * default: "one page by default, optionally the pages it links" (#433). */
+  crawlLinks?: boolean;
+  userAgent?: string;
+}
+
+export interface WebsiteCrawlPage {
+  url: string;
+  text: string;
+  bytes: number;
+  truncated: boolean;
+}
+
+export type WebsiteCrawlResult =
+  { ok: true; pages: WebsiteCrawlPage[] } | { ok: false; reason: string };
+
+/**
+ * Fetches one page (and optionally the same-host pages it links to, up to a
+ * small cap), honouring `robots.txt`, a per-page byte cap and a timeout on
+ * every request. Never throws: every failure mode - an invalid URL, a
+ * disallow, a network error, a bad status - comes back as `{ ok: false }`
+ * for the caller to record as that source's own `fetch_error`.
+ */
+export async function crawlWebsite(
+  rootUrl: string,
+  opts: WebsiteCrawlOptions = {},
+): Promise<WebsiteCrawlResult> {
+  const fetchImpl = opts.fetchImpl ?? ((url, init) => fetch(url, init));
+  const timeoutMs = opts.timeoutMs ?? WEBSITE_FETCH_TIMEOUT_MS;
+  const maxBytesPerPage = opts.maxBytesPerPage ?? WEBSITE_MAX_BYTES_PER_PAGE;
+  const maxPages = Math.max(1, Math.min(opts.maxPages ?? WEBSITE_MAX_PAGES, WEBSITE_MAX_PAGES));
+  const userAgent = opts.userAgent ?? WEBSITE_USER_AGENT;
+
+  let root: URL;
+  try {
+    root = new URL(rootUrl);
+  } catch {
+    return { ok: false, reason: 'invalid URL' };
+  }
+  if (root.protocol !== 'http:' && root.protocol !== 'https:') {
+    return { ok: false, reason: 'only http(s) URLs are supported' };
+  }
+
+  const robots = await fetchRobotsTxt(root.origin, fetchImpl, timeoutMs, userAgent);
+  if (!robots.isAllowed(root.pathname || '/')) {
+    return { ok: false, reason: 'robots.txt disallows fetching this page' };
+  }
+
+  const rootFetch = await fetchCapped(root.toString(), fetchImpl, {
+    maxBytes: maxBytesPerPage,
+    timeoutMs,
+  });
+  if (!rootFetch.ok) return { ok: false, reason: rootFetch.reason };
+
+  const pages: WebsiteCrawlPage[] = [
+    {
+      url: root.toString(),
+      text: extractPageText(rootFetch.body),
+      bytes: rootFetch.bytes,
+      truncated: rootFetch.truncated,
+    },
+  ];
+
+  if (opts.crawlLinks && maxPages > 1) {
+    const candidates = extractSameHostLinks(rootFetch.body, root.toString()).filter((link) =>
+      robots.isAllowed(new URL(link).pathname || '/'),
+    );
+    for (const link of candidates) {
+      if (pages.length >= maxPages) break;
+      const pageFetch = await fetchCapped(link, fetchImpl, {
+        maxBytes: maxBytesPerPage,
+        timeoutMs,
+      });
+      if (!pageFetch.ok) continue; // best-effort: one broken linked page does not fail the whole source
+      pages.push({
+        url: link,
+        text: extractPageText(pageFetch.body),
+        bytes: pageFetch.bytes,
+        truncated: pageFetch.truncated,
+      });
+    }
+  }
+
+  return { ok: true, pages };
+}
+
+/** The `output` jsonb shape for a `website` `project_sources` row. */
+export interface WebsiteSourceOutput {
+  url: string;
+  pages: Array<{ url: string; text: string }>;
+  /** All pages' text joined, clamped to `WEBSITE_MAX_TEXT_CHARS` - what a
+   * prompt actually reads, so a caller does not have to re-join and re-clamp
+   * `pages` itself every time. */
+  text: string;
+  fetchedPageCount: number;
+}
+
+/**
+ * Refreshes one `website` source's cached text unconditionally - "refreshed
+ * on demand" (#433) means the caller decides when, not a TTL like
+ * `github-sources.ts`'s anonymous-API budget forces. Never throws: a crawl
+ * failure becomes this row's own `fetch_error`, leaving whatever `output` it
+ * last carried untouched (mirrors `recordFetchError` in
+ * `github-sources.ts`), so a project with several sources still reads when
+ * one of them is down.
+ */
+export async function refreshWebsiteSource(
+  db: Db,
+  id: number,
+  opts: WebsiteCrawlOptions = {},
+): Promise<void> {
+  const [row] = await db
+    .select()
+    .from(schema.projectSources)
+    .where(eq(schema.projectSources.id, id));
+  if (!row || row.kind !== 'website') return;
+
+  const config = row.config as { url?: unknown };
+  const url = typeof config.url === 'string' ? config.url : '';
+  if (!url) {
+    await db
+      .update(schema.projectSources)
+      .set({
+        fetchError: 'source has no url configured',
+        fetchedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.projectSources.id, id));
+    return;
+  }
+
+  const result = await crawlWebsite(url, opts);
+  if (!result.ok) {
+    await db
+      .update(schema.projectSources)
+      .set({ fetchError: result.reason, fetchedAt: new Date(), updatedAt: new Date() })
+      .where(eq(schema.projectSources.id, id));
+    return;
+  }
+
+  const joinedText = result.pages.map((p) => p.text).join('\n\n---\n\n');
+  const output: WebsiteSourceOutput = {
+    url,
+    pages: result.pages.map((p) => ({ url: p.url, text: p.text })),
+    text:
+      joinedText.length > WEBSITE_MAX_TEXT_CHARS
+        ? joinedText.slice(0, WEBSITE_MAX_TEXT_CHARS)
+        : joinedText,
+    fetchedPageCount: result.pages.length,
+  };
+
+  await db
+    .update(schema.projectSources)
+    .set({ output, fetchError: null, fetchedAt: new Date(), updatedAt: new Date() })
+    .where(eq(schema.projectSources.id, id));
+}
+
+export type AddWebsiteSourceResult =
+  | { ok: true; source: ProjectSourceRow }
+  | { ok: false; code: 'invalid_url'; reason: string }
+  | { ok: false; code: 'not_found' };
+
+/**
+ * Adds a website source to a project and does its first fetch inline, so the
+ * caller gets back a source that already has text (or already has its
+ * error) rather than an empty row that only fills in on a later refresh -
+ * mirrors `addGithubSource`.
+ */
+export async function addWebsiteSource(
+  db: Db,
+  organizationId: number,
+  projectId: number,
+  url: string,
+  opts: WebsiteCrawlOptions = {},
+): Promise<AddWebsiteSourceResult> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, code: 'invalid_url', reason: 'not a valid URL' };
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, code: 'invalid_url', reason: 'only http(s) URLs are supported' };
+  }
+
+  const created = await createProjectSource(db, organizationId, projectId, 'website', {
+    url: parsed.toString(),
+  });
+  if (!created) return { ok: false, code: 'not_found' };
+
+  await refreshWebsiteSource(db, created.id, opts);
+
+  const [fresh] = await db
+    .select()
+    .from(schema.projectSources)
+    .where(eq(schema.projectSources.id, created.id));
+  return { ok: true, source: fresh ?? created };
+}

--- a/shared/tests/website-source.test.ts
+++ b/shared/tests/website-source.test.ts
@@ -1,0 +1,473 @@
+// Exercises shared/src/website-source.ts: a `website` project_sources kind
+// whose text is fetched and refreshed on demand (#433). Covers the robots.txt
+// parser and the crawl's caps against real served fixtures (a local HTTP
+// server, not a mocked fetch) - a disallow, a huge page, a redirect and an
+// unreachable host are all real network behaviour, not something a parser
+// unit test alone would catch - plus the `project_sources` wiring
+// (`addWebsiteSource` / `refreshWebsiteSource`) and its failure isolation.
+import { randomUUID } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, getPool, schema } from '../src/db/client.js';
+import { listProjectSources } from '../src/project-sources.js';
+import {
+  addWebsiteSource,
+  crawlWebsite,
+  extractPageText,
+  extractSameHostLinks,
+  parseRobotsTxt,
+  refreshWebsiteSource,
+  WEBSITE_MAX_PAGES,
+} from '../src/website-source.js';
+
+// ---- Fixture server -------------------------------------------------------
+
+type RouteHandler = (req: IncomingMessage, res: ServerResponse) => void;
+
+/** Starts a throwaway HTTP server for one test, routed by exact pathname. */
+async function startFixtureServer(
+  routes: Record<string, RouteHandler>,
+): Promise<{ origin: string; close: () => Promise<void> }> {
+  const server: Server = createServer((req, res) => {
+    const pathname = new URL(req.url ?? '/', 'http://localhost').pathname;
+    const handler = routes[pathname];
+    if (!handler) {
+      res.writeHead(404).end('not found');
+      return;
+    }
+    handler(req, res);
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    origin: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+const openServers: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  while (openServers.length > 0) await openServers.pop()!();
+});
+
+function html(body: string): string {
+  return `<!doctype html><html><body>${body}</body></html>`;
+}
+
+// ---- parseRobotsTxt --------------------------------------------------------
+
+describe('parseRobotsTxt', () => {
+  it('disallows a path listed under the matching group', () => {
+    const rules = parseRobotsTxt('User-agent: *\nDisallow: /private\n', 'PitchboxBot/1.0');
+    expect(rules.isAllowed('/private/page')).toBe(false);
+    expect(rules.isAllowed('/public')).toBe(true);
+  });
+
+  it('lets the longest matching rule win between an Allow and a Disallow', () => {
+    const rules = parseRobotsTxt('User-agent: *\nDisallow: /docs\nAllow: /docs/public\n', '*');
+    expect(rules.isAllowed('/docs/secret')).toBe(false);
+    expect(rules.isAllowed('/docs/public/page')).toBe(true);
+  });
+
+  it('allows everything when the file has no matching group', () => {
+    const rules = parseRobotsTxt('User-agent: SomeOtherBot\nDisallow: /\n', 'PitchboxBot/1.0');
+    expect(rules.isAllowed('/anything')).toBe(true);
+  });
+
+  it('allows everything for an empty file', () => {
+    expect(parseRobotsTxt('', 'PitchboxBot/1.0').isAllowed('/x')).toBe(true);
+  });
+});
+
+// ---- extractSameHostLinks ---------------------------------------------------
+
+describe('extractSameHostLinks', () => {
+  it('keeps only same-host http(s) links, resolved and deduplicated', () => {
+    const page = html(`
+      <a href="/docs">Docs</a>
+      <a href="/docs">Docs again</a>
+      <a href="https://other-host.example/x">Off-host</a>
+      <a href="#section">Anchor only</a>
+      <a href="mailto:hi@example.com">Mail</a>
+      <a href="https://example.com/">Root again</a>
+    `);
+    const links = extractSameHostLinks(page, 'https://example.com/');
+    expect(links).toEqual(['https://example.com/docs']);
+  });
+});
+
+// ---- extractPageText --------------------------------------------------------
+
+describe('extractPageText', () => {
+  it('keeps heading and paragraph text, drops script/style/img', () => {
+    const text = extractPageText(
+      '<html><head><style>.x{color:red}</style></head><body>' +
+        '<script>doSomethingEvil();</script>' +
+        '<h1>Welcome</h1><p>Readable sentence.</p><img src="x.png" alt="pic"/>' +
+        '</body></html>',
+    );
+    expect(text).toContain('WELCOME');
+    expect(text).toContain('Readable sentence.');
+    expect(text).not.toContain('doSomethingEvil');
+    expect(text).not.toContain('color:red');
+  });
+});
+
+// ---- crawlWebsite against real fixture servers -----------------------------
+
+describe('crawlWebsite', () => {
+  it('fetches the root page and extracts readable text', async () => {
+    const { origin, close } = await startFixtureServer({
+      '/': (_req, res) =>
+        res
+          .writeHead(200, { 'content-type': 'text/html' })
+          .end(html('<h1>Hello</h1><p>World.</p>')),
+    });
+    openServers.push(close);
+
+    const result = await crawlWebsite(origin + '/');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0]!.text).toContain('HELLO');
+    expect(result.pages[0]!.text).toContain('World.');
+  });
+
+  it('honours a robots.txt disallow against a served fixture, refusing the page', async () => {
+    const { origin, close } = await startFixtureServer({
+      '/robots.txt': (_req, res) =>
+        res.writeHead(200, { 'content-type': 'text/plain' }).end('User-agent: *\nDisallow: /\n'),
+      '/': (_req, res) =>
+        res
+          .writeHead(200, { 'content-type': 'text/html' })
+          .end(html('<p>Should never be read.</p>')),
+    });
+    openServers.push(close);
+
+    const result = await crawlWebsite(origin + '/');
+    expect(result).toEqual({ ok: false, reason: 'robots.txt disallows fetching this page' });
+  });
+
+  it('still fetches an allowed page when robots.txt disallows a different path', async () => {
+    const { origin, close } = await startFixtureServer({
+      '/robots.txt': (_req, res) =>
+        res
+          .writeHead(200, { 'content-type': 'text/plain' })
+          .end('User-agent: *\nDisallow: /private\n'),
+      '/': (_req, res) =>
+        res.writeHead(200, { 'content-type': 'text/html' }).end(html('<p>Public page.</p>')),
+    });
+    openServers.push(close);
+
+    const result = await crawlWebsite(origin + '/');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.pages[0]!.text).toContain('Public page.');
+  });
+
+  it('crawls same-host linked pages up to the cap when crawlLinks is set', async () => {
+    const pageCount = WEBSITE_MAX_PAGES + 5;
+    const servePage: RouteHandler = (req, res) => {
+      const i = Number(new URL(req.url ?? '/', 'http://localhost').pathname.replace('/page', ''));
+      res.writeHead(200, { 'content-type': 'text/html' }).end(html(`<p>Page ${i} body.</p>`));
+    };
+    const routes: Record<string, RouteHandler> = {
+      '/': (_req, res) =>
+        res
+          .writeHead(200, { 'content-type': 'text/html' })
+          .end(
+            html(
+              Array.from({ length: pageCount }, (_, i) => `<a href="/page${i}">p${i}</a>`).join(''),
+            ),
+          ),
+    };
+    for (let i = 0; i < pageCount; i++) routes[`/page${i}`] = servePage;
+    const { origin, close } = await startFixtureServer(routes);
+    openServers.push(close);
+
+    const result = await crawlWebsite(origin + '/', { crawlLinks: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Root plus linked pages, never more than the small cap.
+    expect(result.pages.length).toBe(WEBSITE_MAX_PAGES);
+  });
+
+  it('does not follow a cross-host link even with crawlLinks set', async () => {
+    const { origin, close } = await startFixtureServer({
+      '/': (_req, res) =>
+        res
+          .writeHead(200, { 'content-type': 'text/html' })
+          .end(html('<a href="https://not-this-host.example/x">off</a>')),
+    });
+    openServers.push(close);
+
+    const result = await crawlWebsite(origin + '/', { crawlLinks: true });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.pages).toHaveLength(1);
+  });
+
+  it('caps a deliberately huge page at the byte limit instead of buffering it whole', async () => {
+    const { origin, close } = await startFixtureServer({
+      '/': (_req, res) => {
+        res.writeHead(200, { 'content-type': 'text/html' });
+        // 20MB of filler, far past any reasonable page cap - written in
+        // chunks so the server itself never buffers it all either.
+        const chunk = '<p>' + 'x'.repeat(64 * 1024) + '</p>';
+        let written = 0;
+        const target = 20 * 1024 * 1024;
+        const pump = () => {
+          while (written < target) {
+            if (!res.write(chunk)) {
+              res.once('drain', pump);
+              return;
+            }
+            written += chunk.length;
+          }
+          res.end();
+        };
+        pump();
+      },
+    });
+    openServers.push(close);
+
+    const maxBytesPerPage = 50_000;
+    const result = await crawlWebsite(origin + '/', { maxBytesPerPage, timeoutMs: 15_000 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.pages[0]!.bytes).toBeLessThanOrEqual(maxBytesPerPage);
+    expect(result.pages[0]!.truncated).toBe(true);
+  }, 20_000);
+
+  it('follows a redirect to a same-host page and extracts its text', async () => {
+    const { origin, close } = await startFixtureServer({
+      '/': (_req, res) => res.writeHead(302, { location: '/final' }).end(),
+      '/final': (_req, res) =>
+        res.writeHead(200, { 'content-type': 'text/html' }).end(html('<p>Landed here.</p>')),
+    });
+    openServers.push(close);
+
+    const result = await crawlWebsite(origin + '/');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.pages[0]!.text).toContain('Landed here.');
+  });
+
+  it('fails with a network-error reason for an unreachable host, never throwing', async () => {
+    // Nothing listens on this port (a server started then immediately
+    // closed) - a real connection-refused, not a mocked failure.
+    const { origin, close } = await startFixtureServer({});
+    await close();
+
+    const result = await crawlWebsite(origin + '/');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/network error/);
+  });
+
+  it('times out a page that never finishes responding, within the given budget', async () => {
+    const { origin, close } = await startFixtureServer({
+      '/': (_req, res) => {
+        res.writeHead(200, { 'content-type': 'text/html' });
+        res.write('<p>start...');
+        // Never calls res.end() - the connection just hangs.
+      },
+    });
+    openServers.push(close);
+
+    const result = await crawlWebsite(origin + '/', { timeoutMs: 200 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/timed out/);
+  }, 5_000);
+
+  it('rejects an invalid URL without making a request', async () => {
+    const result = await crawlWebsite('not a url');
+    expect(result).toEqual({ ok: false, reason: 'invalid URL' });
+  });
+});
+
+// ---- addWebsiteSource / refreshWebsiteSource (DB-backed) -------------------
+
+const createdOrgIds: number[] = [];
+afterEach(async () => {
+  const db = getDb();
+  while (createdOrgIds.length > 0) {
+    const id = createdOrgIds.pop()!;
+    await db.delete(schema.organizations).where(eq(schema.organizations.id, id));
+  }
+});
+afterAll(async () => {
+  await getPool().end();
+});
+
+async function setupOrgAndProject() {
+  const db = getDb();
+  const slug = `website-source-test-${randomUUID()}`;
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  createdOrgIds.push(org.id);
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: 'p', name: 'P' })
+    .returning();
+  return { orgId: org.id, projectId: project.id };
+}
+
+/** Narrows a source row's `output` jsonb down to its `text` field, for
+ * assertions - a type guard rather than an inline cast, since `output` is
+ * `unknown` at the schema level. */
+function outputText(output: unknown): string {
+  if (
+    !output ||
+    typeof output !== 'object' ||
+    !('text' in output) ||
+    typeof output.text !== 'string'
+  ) {
+    throw new Error('expected a website source output carrying text');
+  }
+  return output.text;
+}
+
+describe('addWebsiteSource', () => {
+  it('creates a website source and fetches it inline', async () => {
+    const { origin, close } = await startFixtureServer({
+      '/': (_req, res) =>
+        res
+          .writeHead(200, { 'content-type': 'text/html' })
+          .end(html('<h1>Acme</h1><p>We make widgets.</p>')),
+    });
+    openServers.push(close);
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+
+    const result = await addWebsiteSource(db, orgId, projectId, origin + '/');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.source.kind).toBe('website');
+    expect(result.source.fetchError).toBeNull();
+    expect(result.source.fetchedAt).not.toBeNull();
+    expect(outputText(result.source.output)).toContain('We make widgets.');
+  });
+
+  it('rejects a non-http(s) URL without creating a row', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+
+    const result = await addWebsiteSource(db, orgId, projectId, 'ftp://example.com/file');
+    expect(result).toEqual({
+      ok: false,
+      code: 'invalid_url',
+      reason: 'only http(s) URLs are supported',
+    });
+    expect(await listProjectSources(db, orgId, projectId)).toEqual([]);
+  });
+
+  it('does not create a source for a project in a different organization', async () => {
+    const { projectId } = await setupOrgAndProject();
+    const { orgId: otherOrgId } = await setupOrgAndProject();
+    const db = getDb();
+
+    const result = await addWebsiteSource(db, otherOrgId, projectId, 'https://example.com');
+    expect(result).toEqual({ ok: false, code: 'not_found' });
+  });
+
+  it('an unreachable host fails only its own source, leaving the project (and its other sources) readable', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+
+    // A working source already on the project, to prove it survives.
+    const { origin: goodOrigin, close } = await startFixtureServer({
+      '/': (_req, res) =>
+        res.writeHead(200, { 'content-type': 'text/html' }).end(html('<p>I still work.</p>')),
+    });
+    openServers.push(close);
+    const good = await addWebsiteSource(db, orgId, projectId, goodOrigin + '/');
+    expect(good.ok).toBe(true);
+
+    const { origin: deadOrigin, close: closeDead } = await startFixtureServer({});
+    await closeDead(); // nothing listens here
+
+    const failed = await addWebsiteSource(db, orgId, projectId, deadOrigin + '/');
+    expect(failed.ok).toBe(true); // the row is created; only its own fetch fails
+    if (failed.ok) {
+      expect(failed.source.fetchError).toMatch(/network error/);
+      expect(failed.source.output).toBeNull();
+    }
+
+    // The project's source list is still readable, including both rows.
+    const sources = await listProjectSources(db, orgId, projectId);
+    expect(sources).toHaveLength(2);
+    const stillGood = sources.find((s) => s.id === (good.ok ? good.source.id : -1));
+    expect(stillGood?.fetchError).toBeNull();
+    expect(outputText(stillGood?.output)).toContain('I still work.');
+  });
+});
+
+describe('refreshWebsiteSource', () => {
+  it('re-fetches in place, clearing a previous fetch_error on success', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+
+    const { origin, close } = await startFixtureServer({});
+    await close(); // starts unreachable
+    const created = await addWebsiteSource(db, orgId, projectId, origin + '/');
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    expect(created.source.fetchError).not.toBeNull();
+
+    // Bring the same origin back up and refresh the same row.
+    const { close: closeAgain } = await startFixtureServerOnPort(new URL(origin).port, {
+      '/': (_req, res) =>
+        res.writeHead(200, { 'content-type': 'text/html' }).end(html('<p>Back online.</p>')),
+    });
+    openServers.push(closeAgain);
+
+    await refreshWebsiteSource(db, created.source.id);
+    const [refreshed] = await listProjectSources(db, orgId, projectId);
+    expect(refreshed.fetchError).toBeNull();
+    expect(outputText(refreshed.output)).toContain('Back online.');
+  });
+
+  it('is a no-op for a row that is not a website source', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+    const [row] = await db
+      .insert(schema.projectSources)
+      .values({ projectId, kind: 'folder', config: { value: '/tmp/a' } })
+      .returning();
+
+    await expect(refreshWebsiteSource(db, row!.id)).resolves.toBeUndefined();
+    const [after] = await listProjectSources(db, orgId, projectId);
+    expect(after.fetchError).toBeNull();
+    expect(after.fetchedAt).toBeNull();
+  });
+});
+
+/** Re-binds a fixture server to a specific already-freed port, for the
+ * "unreachable, then comes back" refresh test above. */
+async function startFixtureServerOnPort(
+  port: string,
+  routes: Record<string, RouteHandler>,
+): Promise<{ origin: string; close: () => Promise<void> }> {
+  const server: Server = createServer((req, res) => {
+    const pathname = new URL(req.url ?? '/', 'http://localhost').pathname;
+    const handler = routes[pathname];
+    if (!handler) {
+      res.writeHead(404).end('not found');
+      return;
+    }
+    handler(req, res);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(Number(port), '127.0.0.1', resolve);
+  });
+  return {
+    origin: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}


### PR DESCRIPTION
Closes #433

## What

Adds `website` as a `project_sources` kind (#398/#431): a URL whose text is fetched and refreshed on demand. `shared/src/website-source.ts` (new):

- `crawlWebsite(url, opts)`: fetches one page by default, optionally the same-host pages it links to (`crawlLinks: true`) up to `WEBSITE_MAX_PAGES` (5, including the root), honours `robots.txt`, enforces a per-page byte cap (`WEBSITE_MAX_BYTES_PER_PAGE`, 2MB, checked while streaming) and a timeout (`WEBSITE_FETCH_TIMEOUT_MS`, 8s) on every request. Never throws - every failure comes back as `{ ok: false, reason }`.
- `parseRobotsTxt` / `fetchRobotsTxt`: a minimal `robots.txt` parser (groups, `Allow`/`Disallow`, longest-prefix wins). Missing or broken `robots.txt` = allow everything.
- `extractPageText` (via `html-to-text`) and `extractSameHostLinks` (hand-rolled `href` regex, since this only needs targets, not a tree).
- `addWebsiteSource` / `refreshWebsiteSource`: wire a crawl into a `project_sources` row, following `github-sources.ts`'s shape exactly - a failure lands on that row's own `fetch_error`, never thrown, so one dead source does not take its project (or its siblings) down.

## Dependency choice

Compared three ways to go from HTML to readable text:

- **`@mozilla/readability` + `jsdom`**: needs a live DOM under Node, i.e. installing a full HTML/CSS/layout engine to read text that already exists as a string - the "drags in a browser" case the issue calls out to avoid. It's also tuned to isolate one article from chrome, narrower than "whatever text is on the page" (a docs sidebar is exactly what Readability is built to discard).
- **`cheerio`**: gives a DOM-ish tree but no text extraction; this module would still have to hand-write block/inline handling, whitespace collapsing, and heading/list formatting.
- **`html-to-text`**: a parser (`htmlparser2`) plus a handful of pure-JS selector/formatting packages (`selderee`, `parseley`, `dom-serializer`) - no DOM, no browser, and it already skips `<script>`/`<style>` and renders headings/paragraphs/lists as text out of the box.

Picked `html-to-text`. One wrinkle: v10.0.1 (current) shipped without bundled types and DefinitelyTyped hasn't caught up past 9.0.4, so I pinned `html-to-text@9.0.5` (the same API, one major behind) with `@types/html-to-text@9.0.4` rather than hand-writing an ambient `.d.ts` for a library this small.

## Real URLs (ran `crawlWebsite` directly against both)

`https://pitchbox.app` (this redirects to `/login` for an unauthenticated visit, which the crawler follows and reads):
```
Sign in to Pitchbox
Username Password Sign in
```

`https://nodejs.org/en/docs` (redirects too - a second real exercise of following a redirect and extracting the destination):
```
Skip to content
Node.js
----------------------------------------
 * About this documentation
 * Usage and example
 * Assertion testing
 * Asynchronous context tracking
 * Async hooks
 * Buffer
 * C++ addons
 ...
```
Both come back as short, readable text - no script/style noise, no markup.

## Tests (`shared/tests/website-source.test.ts`, 22 tests, all against a real local `node:http` fixture server or a real DB, never a mocked `fetch`)

- `robots.txt` disallow **honoured against a served fixture** (not just a parser unit test): a fixture serving `Disallow: /` makes `crawlWebsite` refuse the page before ever reading it; a fixture disallowing a different path still serves the root.
- Byte cap holds against a fixture that streams 20MB in 64KB chunks: capped at the configured `maxBytesPerPage`, `truncated: true`, and the request completes well inside its timeout budget (no whole-body buffering).
- A fixture that 302-redirects: followed, and the destination's text is what's read.
- An unreachable host (a server started then closed, so nothing listens): `crawlWebsite` returns `{ ok: false, reason: 'network error: ...' }`; wired through `addWebsiteSource`, that source's own row gets `fetch_error` set while a working sibling source on the same project stays fully readable (`output`/`fetchError: null` intact).
- A hung connection that never responds within the timeout comes back `{ ok: false, reason: 'timed out after ...' }`.
- Cross-host links are dropped even with `crawlLinks: true`; same-host links are followed up to the page cap.
- `refreshWebsiteSource` re-fetches a row in place and clears a previous `fetch_error` on success; it's a no-op for a `project_sources` row of a different kind.

Every new assertion was proven to bite by breaking the code under it and watching the exact assertion fail, then restoring:
- robots.txt bypass -> `expect(result).toEqual({ ok: false, reason: 'robots.txt disallows fetching this page' })` fails, returns the fetched page instead.
- byte-cap removal -> the huge-page test fails (`result.ok` false: without the cap it blows the request timeout trying to read all 20MB).
- timeout removal -> the timeout test itself times out (the hung connection never gets aborted).
- host-filter removal -> `extractSameHostLinks` unit test fails, includes the off-host URL.
- turning the refresh failure path into a throw -> the "stays readable" test fails with an uncaught `Error: network error: ...` instead of a clean `fetch_error`.
- removing the protocol check in `addWebsiteSource` -> the invalid-URL test fails (an `ftp://` row gets created, only caught downstream by `crawlWebsite`'s own check, leaving an orphaned failed row instead of never creating one).

## Non-goals (per issue)

No project-page UI (#432) and no change to description re-derivation (#434) - this is the fetch/cache primitive only.

## Verification run

```
pnpm -F @pitchbox/shared typecheck
npx eslint shared/src/website-source.ts shared/tests/website-source.test.ts
npx prettier --check shared/src/website-source.ts shared/tests/website-source.test.ts shared/package.json
pnpm exec vitest run shared/tests/website-source.test.ts   # 22 passed
```

Not merging - reporting for review per the batch's instructions.
