### PR TITLE
feat(shared): map the SDK stream to run_events, usage and cost

### DIFF
--- a/docs/runners.md
+++ b/docs/runners.md
@@ -52,13 +52,17 @@ Whenever a run transitions to `failed`, Pitchbox classifies the failure into one
 | Reason                | Heuristic                                                                                               |
 | --------------------- | ------------------------------------------------------------------------------------------------------- |
 | `runner_missing`      | Exit non-zero with `command not found` / `ENOENT`                                                       |
+| `cancelled`           | SDK run aborted by the client (`normalizeStopReason('cancelled', ...)`)                                 |
+| `step_limit_reached`  | SDK run hit `stopWhen(stepCountIs(n))` before the agent finished                                        |
+| `agent_timeout`       | ACP backend did not respond within `opts.timeoutMs`, or an SDK run's own AbortSignal timeout fired      |
 | `auth_expired`        | Any event mentioning `auth`, `401`, `403`, `token expired`                                              |
 | `quota_exhausted`     | Any event mentioning `quota` or `rate limit`                                                            |
+| `network`             | `ECONNREFUSED`, `ECONNRESET`, `ENOTFOUND`, `ETIMEDOUT`, `getaddrinfo`, `fetch failed`, `socket hang up` |
+| `provider_error`      | An SDK `error` stream part closed the run without an auth/quota/network match                           |
+| `content_filtered`    | SDK run stopped on a `refusal`/content-filter finish reason                                             |
 | `playbook_error`      | Exit non-zero with a Node-style or Python stack trace                                                   |
 | `playbook_incomplete` | Exit zero, but the playbook never called the finish tool that commits its result (see below)            |
-| `network`             | `ECONNREFUSED`, `ECONNRESET`, `ENOTFOUND`, `ETIMEDOUT`, `getaddrinfo`, `fetch failed`, `socket hang up` |
 | `agent_crashed`       | ACP backend subprocess exited unexpectedly without a `stop_reason`                                      |
-| `agent_timeout`       | ACP backend did not respond within `opts.timeoutMs`                                                     |
 | `unknown`             | Default, nothing else matched                                                                           |
 
 The classifier order matters: `runner_missing` wins over `playbook_error` because an `ENOENT` will otherwise look like a generic stack trace. Order beyond that is stable and covered by `shared/tests/runlog/classify-failure.test.ts`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,12 @@ importers:
       '@ai-sdk/gateway':
         specifier: ^4.0.75
         version: 4.0.75(zod@4.5.4)
+      '@ai-sdk/mcp':
+        specifier: ^2.0.45
+        version: 2.0.45(zod@4.5.4)
+      ai:
+        specifier: ^7.0.93
+        version: 7.0.93(zod@4.5.4)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2

--- a/shared/package.json
+++ b/shared/package.json
@@ -71,7 +71,8 @@
     "./linkedin-assist": "./src/linkedin-assist.ts",
     "./assist-accept": "./src/assist-accept.ts",
     "./website-source": "./src/website-source.ts",
-    "./agents/sdk/tools": "./src/agents/sdk/tools.ts"
+    "./agents/sdk/tools": "./src/agents/sdk/tools.ts",
+    "./agents/sdk/event-normalizer": "./src/agents/sdk/event-normalizer.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",
@@ -82,6 +83,8 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.1.0",
     "@ai-sdk/gateway": "^4.0.75",
+    "@ai-sdk/mcp": "^2.0.45",
+    "ai": "^7.0.93",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "html-to-text": "^9.0.5",

--- a/shared/src/agents/sdk/event-normalizer.ts
+++ b/shared/src/agents/sdk/event-normalizer.ts
@@ -1,0 +1,438 @@
+// shared/src/agents/sdk/event-normalizer.ts
+//
+// Normalizes the Vercel AI SDK's `streamText` stream (see #415,
+// docs/cloud-runner.md's decision section) into the same ParsedEvent shape
+// the ACP normalizer produces (shared/src/agents/acp/event-normalizer.ts is
+// the working reference this mirrors), so the run view, the SSE feed and the
+// dedup in dispatchRun (web/src/lib/server/runner.ts) don't know the SDK
+// runner exists.
+//
+// Split into two halves, same as the ACP side:
+//   - `normalizeSdkPart` turns one `ai` TextStreamPart into zero or more
+//     ParsedEvents, driven by the runner's own seq counter exactly like
+//     `normalizeAcpUpdate`.
+//   - `normalizeStopReason` turns an already-classified outcome (the runner
+//     is the only place that knows which AbortSignal fired or whether the
+//     step ceiling was hit - see docs/cloud-runner.md's "aborted streamText
+//     does not throw" finding) into the closing `result` event, exactly like
+//     ACP's function of the same name.
+// Usage/cost is "more than a mapping" per #418: a Gateway run can be any
+// model, and cached input has to be priced separately from fresh input
+// (~/projects/personal/canonry/packages/ai/src/usage.ts is the reference for
+// that split). `buildSdkUsage`/`computeSdkCostUsd`/`pricingFromCatalogueEntry`
+// do that math; they take already-resolved pricing rather than calling the
+// Gateway themselves, so the runner (the only piece that holds the Gateway
+// client) fetches `gateway.getAvailableModels()` and this module stays a
+// pure function of its inputs.
+import type { ParsedEvent } from '../../runlog/types.js';
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return typeof v === 'object' && v !== null ? (v as Record<string, unknown>) : null;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Usage + cost
+// ---------------------------------------------------------------------------
+
+/** Already-classified usage totals, ready to attach to a closing `result` event. */
+export interface SdkUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+  totalCostUsd?: number;
+}
+
+/**
+ * Structurally the shape of `ai`'s `LanguageModelUsage` (streamText's
+ * `result.totalUsage`, and each `finish-step` part's `usage`): `inputTokens`
+ * is the TOTAL prompt tokens, of which `inputTokenDetails.cacheReadTokens`
+ * and `.cacheWriteTokens` are subsets, not additions - the AI SDK's own type
+ * says so and two measured Gateway calls confirm it (see canonry's
+ * packages/ai/src/usage.ts, the reference for this split). Declared locally
+ * instead of imported from `ai` so this module has no runtime dependency on
+ * the SDK: the runner passes `result.totalUsage` (or its own step-accumulated
+ * total) and the structural match is enough.
+ */
+export interface SdkLanguageModelUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  inputTokenDetails?: {
+    noCacheTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
+}
+
+/**
+ * Add two step-level usage totals together. The runner needs this because a
+ * mid-loop provider error closes the stream with an `error` part and no
+ * top-level `finish` part (confirmed by reading `ai`'s streamText source: the
+ * catch branch around the step-continuation call enqueues `error` then closes
+ * the stream, skipping the `finish` part entirely) - so on that path there is
+ * no single "total usage" object to read, only whatever `finish-step` parts
+ * already went by. The runner accumulates those with this as it iterates the
+ * stream, and hands the running total to `buildSdkUsage` whichever way the
+ * run ends, so a call that failed after spending input tokens still records
+ * what it spent instead of reporting zero.
+ */
+export function addSdkUsage(
+  a: SdkLanguageModelUsage | undefined,
+  b: SdkLanguageModelUsage | undefined,
+): SdkLanguageModelUsage {
+  const add = (x: number | undefined, y: number | undefined): number | undefined =>
+    x == null && y == null ? undefined : (x ?? 0) + (y ?? 0);
+  return {
+    inputTokens: add(a?.inputTokens, b?.inputTokens),
+    outputTokens: add(a?.outputTokens, b?.outputTokens),
+    inputTokenDetails: {
+      noCacheTokens: add(a?.inputTokenDetails?.noCacheTokens, b?.inputTokenDetails?.noCacheTokens),
+      cacheReadTokens: add(
+        a?.inputTokenDetails?.cacheReadTokens,
+        b?.inputTokenDetails?.cacheReadTokens,
+      ),
+      cacheWriteTokens: add(
+        a?.inputTokenDetails?.cacheWriteTokens,
+        b?.inputTokenDetails?.cacheWriteTokens,
+      ),
+    },
+  };
+}
+
+/** Per-token USD rates, already resolved for one model. Cache rates are
+ * never absent here: `pricingFromCatalogueEntry` fills them in from the plain
+ * input rate when the catalogue doesn't carry a discount, the same fallback
+ * direction canonry's `computeCost` uses and for the same reason - a provider
+ * that doesn't discount cache reads bills them at the input rate, not free. */
+export interface SdkModelPricing {
+  inputPerToken: number;
+  outputPerToken: number;
+  cachedInputPerToken: number;
+  cacheCreationPerToken: number;
+}
+
+/** The pricing shape `@ai-sdk/gateway`'s `GatewayLanguageModelEntry.pricing`
+ * carries: per-token USD as strings, cache fields only present for
+ * providers/models that support prompt caching. */
+export interface GatewayCataloguePricing {
+  input: string;
+  output: string;
+  cachedInputTokens?: string;
+  cacheCreationInputTokens?: string;
+}
+
+/**
+ * Parse one Gateway model catalogue entry (`gateway.getAvailableModels()`'s
+ * `models[i]`) into `SdkModelPricing`. Returns `undefined` when the catalogue
+ * has no pricing for the model (some entries carry `pricing: null`), so the
+ * caller falls back to the run's self-reported cost or leaves it null -
+ * never a hardcoded default, for the same reason `resolvePricingForRunner`
+ * in runlog/usage.ts refuses to guess for an unknown model.
+ */
+export function pricingFromCatalogueEntry(
+  entry: { pricing?: GatewayCataloguePricing | null } | null | undefined,
+): SdkModelPricing | undefined {
+  const p = entry?.pricing;
+  if (!p) return undefined;
+  const inputPerToken = Number(p.input);
+  const outputPerToken = Number(p.output);
+  if (!Number.isFinite(inputPerToken) || !Number.isFinite(outputPerToken)) return undefined;
+  const cachedInputPerToken =
+    p.cachedInputTokens != null ? Number(p.cachedInputTokens) : inputPerToken;
+  const cacheCreationPerToken =
+    p.cacheCreationInputTokens != null ? Number(p.cacheCreationInputTokens) : inputPerToken;
+  return {
+    inputPerToken,
+    outputPerToken,
+    cachedInputPerToken: Number.isFinite(cachedInputPerToken) ? cachedInputPerToken : inputPerToken,
+    cacheCreationPerToken: Number.isFinite(cacheCreationPerToken)
+      ? cacheCreationPerToken
+      : inputPerToken,
+  };
+}
+
+/**
+ * Price a token split. `inputTokens` is the TOTAL (matches `ai`'s own usage
+ * semantics); `cacheReadTokens`/`cacheCreationTokens` are subsets of it, so
+ * "fresh" input is whatever is left over once both are subtracted, clamped so
+ * a provider reporting more cached tokens than its own total can't produce a
+ * negative bill (same clamp as canonry's `splitInput`).
+ */
+export function computeSdkCostUsd(
+  tokens: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+  },
+  pricing: SdkModelPricing | undefined,
+): number | null {
+  if (!pricing) return null;
+  const cacheRead = Math.min(Math.max(tokens.cacheReadTokens, 0), tokens.inputTokens);
+  const cacheWrite = Math.min(
+    Math.max(tokens.cacheCreationTokens, 0),
+    tokens.inputTokens - cacheRead,
+  );
+  const fresh = tokens.inputTokens - cacheRead - cacheWrite;
+  const cost =
+    fresh * pricing.inputPerToken +
+    cacheRead * pricing.cachedInputPerToken +
+    cacheWrite * pricing.cacheCreationPerToken +
+    tokens.outputTokens * pricing.outputPerToken;
+  return Number(cost.toFixed(4));
+}
+
+/** Same shape as `shared/src/runlog/usage.ts`'s `RunUsage`, and as
+ * `AgentRunResult.usage` (shared/src/agents/base.ts) - drops straight in. */
+export interface RunUsageResult {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  /** Null when not self-reported and pricing for the run's model is unknown. */
+  costUsd: number | null;
+  /** True when `opts.reportedCostUsd` came from the Gateway; false when computed locally. */
+  costReported: boolean;
+}
+
+/**
+ * Turn accumulated SDK usage into the run's final token + cost figures.
+ * Keeps the existing self-reported-cost path honest: when the caller has a
+ * Gateway-reported cost (from `getGenerationInfo` or provider metadata),
+ * `opts.reportedCostUsd` wins outright, same as ACP's `total_cost_usd`.
+ * Otherwise this prices from the model's own catalogue entry rather than
+ * Claude's hardcoded table (the Gateway can front any model), and returns
+ * `null` only when neither a reported cost nor a catalogue entry exists.
+ */
+export function buildSdkUsage(
+  usage: SdkLanguageModelUsage,
+  opts: { reportedCostUsd?: number; pricing?: SdkModelPricing } = {},
+): RunUsageResult {
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+  const cacheReadTokens = usage.inputTokenDetails?.cacheReadTokens ?? 0;
+  const cacheCreationTokens = usage.inputTokenDetails?.cacheWriteTokens ?? 0;
+  const tokens = { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens };
+  const reported = typeof opts.reportedCostUsd === 'number';
+  const costUsd = reported
+    ? Number(opts.reportedCostUsd!.toFixed(4))
+    : computeSdkCostUsd(tokens, opts.pricing);
+  return { ...tokens, costUsd, costReported: reported };
+}
+
+// ---------------------------------------------------------------------------
+// Stream part -> ParsedEvent
+// ---------------------------------------------------------------------------
+
+/** MCP `CallToolResult.content` is an array of `{type:'text', text}` blocks
+ * (plus image/resource variants we don't render inline) - the exact shape
+ * ACP's `joinContent` already handles for the same reason: it's the same MCP
+ * protocol on both sides of the tool boundary. */
+function extractMcpText(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part) => {
+      const p = asRecord(part);
+      if (!p) return '';
+      if (p.type === 'text' && typeof p.text === 'string') return p.text;
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+function extractToolResultOutput(output: unknown): { text: string; isError: boolean } {
+  const o = asRecord(output);
+  if (!o) {
+    if (typeof output === 'string') return { text: output, isError: false };
+    if (output == null) return { text: '', isError: false };
+    try {
+      return { text: JSON.stringify(output), isError: false };
+    } catch {
+      return { text: String(output), isError: false };
+    }
+  }
+  // MCP tools carry their own `isError` inside the CallToolResult (the
+  // decision doc's finding: "a tool that fails returns its error to the
+  // model instead of killing the loop" - this is that path, not a stream
+  // failure). Prefer the rendered `content` text; fall back to the whole
+  // envelope as JSON so nothing is silently dropped.
+  const isError = o.isError === true;
+  if (Array.isArray(o.content)) {
+    const joined = extractMcpText(o.content);
+    if (joined) return { text: joined, isError };
+  }
+  try {
+    return { text: JSON.stringify(o), isError };
+  } catch {
+    return { text: '', isError };
+  }
+}
+
+/**
+ * Normalize one `ai` `TextStreamPart` (from `streamText`'s `fullStream`) into
+ * zero or more `ParsedEvent`s. `seq` is supplied by the caller and advances
+ * exactly like `normalizeAcpUpdate`'s: the runner owns one counter across the
+ * whole run and increments it by however many events this call produced.
+ *
+ * `part` is untyped on purpose (mirrors `normalizeAcpUpdate(update: unknown, ...)`):
+ * this module carries no runtime dependency on the `ai` package, only a
+ * structural expectation of `{ type: string, ... }`.
+ *
+ * Framing-only parts (`start`, `start-step`, `finish-step`, `text-start`,
+ * `text-end`, `reasoning-start`, `reasoning-end`, `tool-input-*`, `source`,
+ * `file`, `reasoning-file`, `custom`, `raw`, `tool-output-denied`,
+ * `tool-approval-*`) return `[]` - nothing for the run log to render, same
+ * "cosmetic, skip it" precedent as ACP's `tool_call_update` branch.
+ *
+ * The three terminal part types (`finish`, `abort`, `error`) are NOT handled
+ * here: an aborted or errored `fullStream` never throws (docs/cloud-runner.md
+ * #415), and only the runner knows *why* it ended - which AbortSignal fired,
+ * whether the step ceiling was hit - so the runner detects those three types
+ * in its own loop and calls `normalizeStopReason` with an already-classified
+ * reason, exactly like ACP's `session/prompt` response never goes through
+ * `normalizeAcpUpdate` either. `error` still gets a narrow defensive mapping
+ * below so a build that routes every part through this function uniformly
+ * still gives the classifier a "provider error" marker instead of nothing.
+ */
+export function normalizeSdkPart(part: unknown, raw: string, seq: number): ParsedEvent[] {
+  const p = asRecord(part);
+  const type = typeof p?.type === 'string' ? p.type : undefined;
+  if (!p || !type) return [];
+
+  switch (type) {
+    case 'text-delta': {
+      const text = typeof p.text === 'string' ? p.text : '';
+      if (!text) return [];
+      return [{ seq, kind: 'assistant', payload: { type: 'assistant', text }, raw }];
+    }
+    case 'reasoning-delta': {
+      const text = typeof p.text === 'string' ? p.text : '';
+      if (!text) return [];
+      return [{ seq, kind: 'thinking', payload: { type: 'thinking', text }, raw }];
+    }
+    case 'tool-call': {
+      const id = typeof p.toolCallId === 'string' ? p.toolCallId : undefined;
+      const name = typeof p.toolName === 'string' ? p.toolName : 'tool';
+      const input = asRecord(p.input) ?? {};
+      return [{ seq, kind: 'tool-call', payload: { type: 'tool-call', id, name, input }, raw }];
+    }
+    case 'tool-result': {
+      const toolUseId = typeof p.toolCallId === 'string' ? p.toolCallId : undefined;
+      const { text, isError } = extractToolResultOutput(p.output);
+      return [
+        {
+          seq,
+          kind: 'tool-result',
+          payload: { type: 'tool-result', raw: p.output, text, isError, toolUseId },
+          raw,
+        },
+      ];
+    }
+    case 'tool-error': {
+      // Tool execution itself threw (transport failure calling the MCP
+      // server, say), distinct from a tool that ran and returned
+      // isError:true - both end up as an errored tool-result, which is the
+      // shape the run log already knows how to render.
+      const toolUseId = typeof p.toolCallId === 'string' ? p.toolCallId : undefined;
+      const text = errorMessage(p.error);
+      return [
+        {
+          seq,
+          kind: 'tool-result',
+          payload: { type: 'tool-result', raw: p.error, text, isError: true, toolUseId },
+          raw,
+        },
+      ];
+    }
+    case 'error': {
+      const marker = `provider error: ${errorMessage(p.error)}`;
+      return [
+        {
+          seq,
+          kind: 'unknown',
+          payload: { type: 'unknown', eventType: 'error', raw: marker },
+          raw: raw ? `${marker}\n${raw}` : marker,
+        },
+      ];
+    }
+    default:
+      return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stop reason -> closing `result` event
+// ---------------------------------------------------------------------------
+
+/**
+ * Already-classified run outcome, decided by the runner from facts only it
+ * has: which AbortSignal fired (`cancelled` vs `timeout`), whether an `error`
+ * part closed the stream, whether the terminal `finish` part's finishReason
+ * came back `tool-calls` with no further step (the step ceiling cut the loop
+ * off before the model could act on it - #415's `stopWhen(stepCountIs(n))`),
+ * or content-filter/refusal. Mirrors ACP's `AcpStopReasonKind`.
+ */
+export type SdkStopReasonKind =
+  'end_turn' | 'cancelled' | 'timeout' | 'error' | 'max_turn_requests' | 'refusal';
+
+// Marker text embedded in the closing event's `raw`/`text` so classifyFailure
+// (shared/src/runlog/classify-failure.ts) has something distinctive to match
+// beyond "unknown" for every non-success reason.
+const STOP_REASON_TEXT: Partial<Record<SdkStopReasonKind, string>> = {
+  cancelled: 'run cancelled: aborted by the client',
+  timeout: 'run timed out: exceeded its time limit and was aborted',
+  error: 'run failed: a provider error ended the run',
+  max_turn_requests: 'run stopped: step limit reached before the agent finished',
+  refusal: 'run stopped: the model refused to continue',
+};
+
+/**
+ * Synthesize the closing `result` ParsedEvent for an SDK run, exactly like
+ * ACP's `normalizeStopReason`: `success` is true only for a natural
+ * `end_turn`, so an aborted stream (which never throws, per #415) or a
+ * step-ceiling exhaustion never reads as success just because nothing threw.
+ *
+ * The marker text is embedded into the event's own `raw`/`payload.text`
+ * regardless of what `raw` the caller passes in (ACP's real call site passes
+ * `''`), so classifyFailure has a reason-specific substring to match even
+ * when nothing else about the run is distinctive - a step-limit run has no
+ * "error" anywhere in its transcript otherwise.
+ */
+export function normalizeStopReason(
+  reason: SdkStopReasonKind | string,
+  usage: SdkUsage | undefined,
+  raw: string,
+  seq: number,
+): ParsedEvent[] {
+  const success = reason === 'end_turn';
+  const marker = STOP_REASON_TEXT[reason as SdkStopReasonKind];
+  const combinedRaw = marker ? (raw ? `${marker}\n${raw}` : marker) : raw;
+  return [
+    {
+      seq,
+      kind: 'result',
+      payload: {
+        type: 'result',
+        success,
+        text: marker,
+        inputTokens: usage?.inputTokens,
+        outputTokens: usage?.outputTokens,
+        cacheReadTokens: usage?.cacheReadTokens,
+        cacheCreationTokens: usage?.cacheCreationTokens,
+        totalCostUsd: usage?.totalCostUsd,
+      },
+      raw: combinedRaw,
+    },
+  ];
+}

--- a/shared/src/runlog/classify-failure.ts
+++ b/shared/src/runlog/classify-failure.ts
@@ -17,6 +17,10 @@ export type RunFailureReason =
   | 'network'
   | 'agent_crashed'
   | 'agent_timeout'
+  | 'cancelled'
+  | 'provider_error'
+  | 'step_limit_reached'
+  | 'content_filtered'
   | 'unknown';
 
 export const RUN_FAILURE_REASONS: readonly RunFailureReason[] = [
@@ -28,6 +32,10 @@ export const RUN_FAILURE_REASONS: readonly RunFailureReason[] = [
   'network',
   'agent_crashed',
   'agent_timeout',
+  'cancelled',
+  'provider_error',
+  'step_limit_reached',
+  'content_filtered',
   'unknown',
 ] as const;
 
@@ -87,14 +95,35 @@ const STACK_TRACE_PATTERNS = [
   'traceback (most recent call last)',
 ];
 
+// Markers the SDK event normalizer (shared/src/agents/sdk/event-normalizer.ts)
+// embeds into the closing `result` event's raw/text for outcomes an ACP
+// backend never produces: a `streamText` call aborted by the client or by
+// its own timeoutMs never throws (#415, docs/cloud-runner.md), and a
+// stopWhen(stepCountIs(n)) ceiling is not a crash either - both need a
+// specific marker rather than falling through to `unknown`.
+const CANCELLED_PATTERNS = ['run cancelled: aborted by the client'];
+
+const SDK_TIMEOUT_PATTERNS = ['exceeded its time limit'];
+
+const STEP_LIMIT_PATTERNS = ['step limit reached before the agent finished'];
+
+const PROVIDER_ERROR_PATTERNS = ['provider error'];
+
+const CONTENT_FILTERED_PATTERNS = ['the model refused to continue'];
+
 /**
  * Pure classifier mapping (events, exit code) to a structured failure reason.
  *
  * Heuristic order matters: runner-missing is checked first because an ENOENT
- * looks like a generic playbook error otherwise. Quota / auth / network are
- * scanned next in priority order, and playbook_error catches anything that
- * still has a recognisable stack trace. Everything else falls back to
- * `unknown` so the UI never has to deal with a null reason on a failed run.
+ * looks like a generic playbook error otherwise. The SDK-specific markers
+ * (cancelled / timeout / step limit) are checked next since they are
+ * synthesized substrings unique to `normalizeStopReason`'s own output and
+ * never collide with anything else. Auth / quota / network are scanned
+ * before the generic `provider_error` catch-all so a provider error whose
+ * own message is actually about auth or quota still gets the more specific
+ * reason. playbook_error catches anything that still has a recognisable
+ * stack trace. Everything else falls back to `unknown` so the UI never has
+ * to deal with a null reason on a failed run.
  */
 export function classifyFailure(events: ParsedEvent[], exitCode: number | null): RunFailureReason {
   const failed = exitCode == null || exitCode !== 0;
@@ -103,9 +132,14 @@ export function classifyFailure(events: ParsedEvent[], exitCode: number | null):
   const haystack = events.map(eventHaystack).join('\n');
 
   if (RUNNER_MISSING_PATTERNS.some((p) => haystack.includes(p))) return 'runner_missing';
+  if (CANCELLED_PATTERNS.some((p) => haystack.includes(p))) return 'cancelled';
+  if (STEP_LIMIT_PATTERNS.some((p) => haystack.includes(p))) return 'step_limit_reached';
+  if (SDK_TIMEOUT_PATTERNS.some((p) => haystack.includes(p))) return 'agent_timeout';
   if (AUTH_PATTERNS.some((p) => haystack.includes(p))) return 'auth_expired';
   if (QUOTA_PATTERNS.some((p) => haystack.includes(p))) return 'quota_exhausted';
   if (NETWORK_PATTERNS.some((p) => haystack.includes(p))) return 'network';
+  if (PROVIDER_ERROR_PATTERNS.some((p) => haystack.includes(p))) return 'provider_error';
+  if (CONTENT_FILTERED_PATTERNS.some((p) => haystack.includes(p))) return 'content_filtered';
   if (STACK_TRACE_PATTERNS.some((p) => haystack.includes(p))) return 'playbook_error';
 
   return 'unknown';

--- a/shared/tests/agents/sdk/event-normalizer.test.ts
+++ b/shared/tests/agents/sdk/event-normalizer.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect } from 'vitest';
+import { classifyFailure } from '../../../src/runlog/classify-failure.js';
+import {
+  normalizeSdkPart,
+  normalizeStopReason,
+  addSdkUsage,
+  buildSdkUsage,
+  computeSdkCostUsd,
+  pricingFromCatalogueEntry,
+  type SdkLanguageModelUsage,
+  type SdkModelPricing,
+} from '../../../src/agents/sdk/event-normalizer.js';
+import type { ParsedEvent } from '../../../src/runlog/types.js';
+
+// A fabricated but realistic capture of one `ai` `fullStream`, shaped after
+// the #415 spike's real run against playbooks/hn-commenter.md: run_start,
+// two hn_search calls (trimmed from four for brevity), a drafts_create that
+// fails gracefully (the decision doc's "tool errors return to the model"
+// finding), and a run_finish. Framing parts (start, start-step, finish-step,
+// text-start/end, tool-input-*) are interleaved exactly as the SDK emits
+// them, to prove they're silently dropped rather than mistaken for content.
+function recordedStreamParts(): unknown[] {
+  return [
+    { type: 'start' },
+    { type: 'start-step', request: {}, warnings: [] },
+    { type: 'text-start', id: 't1' },
+    { type: 'text-delta', id: 't1', text: 'Looking for HN threads worth commenting on.' },
+    { type: 'text-end', id: 't1' },
+    { type: 'tool-input-start', id: 'call_1', toolName: 'run_start' },
+    { type: 'tool-input-delta', id: 'call_1', delta: '{"campaignId":42}' },
+    { type: 'tool-input-end', id: 'call_1' },
+    { type: 'tool-call', toolCallId: 'call_1', toolName: 'run_start', input: { campaignId: 42 } },
+    {
+      type: 'tool-result',
+      toolCallId: 'call_1',
+      toolName: 'run_start',
+      input: { campaignId: 42 },
+      output: { content: [{ type: 'text', text: '{"ok":true,"runId":901}' }], isError: false },
+    },
+    {
+      type: 'finish-step',
+      response: { id: 'resp_1', modelId: 'google/gemini-3.1-flash-lite' },
+      usage: { inputTokens: 1200, outputTokens: 40, inputTokenDetails: { cacheReadTokens: 0 } },
+      finishReason: 'tool-calls',
+      rawFinishReason: undefined,
+      performance: {},
+    },
+    { type: 'start-step', request: {}, warnings: [] },
+    { type: 'reasoning-delta', id: 'r1', text: 'Four candidate threads look promising.' },
+    {
+      type: 'tool-call',
+      toolCallId: 'call_2',
+      toolName: 'hn_search',
+      input: { query: 'AI agents' },
+    },
+    {
+      type: 'tool-result',
+      toolCallId: 'call_2',
+      toolName: 'hn_search',
+      input: { query: 'AI agents' },
+      output: {
+        content: [{ type: 'text', text: '[{"id":123,"title":"Show HN"}]' }],
+        isError: false,
+      },
+    },
+    {
+      type: 'finish-step',
+      response: { id: 'resp_2', modelId: 'google/gemini-3.1-flash-lite' },
+      usage: { inputTokens: 8600, outputTokens: 60, inputTokenDetails: { cacheReadTokens: 5200 } },
+      finishReason: 'tool-calls',
+      rawFinishReason: undefined,
+      performance: {},
+    },
+    { type: 'start-step', request: {}, warnings: [] },
+    {
+      type: 'tool-call',
+      toolCallId: 'call_3',
+      toolName: 'drafts_create',
+      input: { runId: 901, text: 'Nice project!' },
+    },
+    {
+      type: 'tool-error',
+      toolCallId: 'call_3',
+      toolName: 'drafts_create',
+      input: { runId: 901, text: 'Nice project!' },
+      error: new Error('campaign profile is not in the structured format'),
+    },
+    {
+      type: 'finish-step',
+      response: { id: 'resp_3', modelId: 'google/gemini-3.1-flash-lite' },
+      usage: { inputTokens: 9100, outputTokens: 30, inputTokenDetails: { cacheReadTokens: 8800 } },
+      finishReason: 'tool-calls',
+      rawFinishReason: undefined,
+      performance: {},
+    },
+    { type: 'start-step', request: {}, warnings: [] },
+    { type: 'text-delta', id: 't2', text: 'The campaign profile needs fixing, so I stopped here.' },
+    {
+      type: 'tool-call',
+      toolCallId: 'call_4',
+      toolName: 'run_finish',
+      input: { runId: 901, status: 'failed' },
+    },
+    {
+      type: 'tool-result',
+      toolCallId: 'call_4',
+      toolName: 'run_finish',
+      input: { runId: 901, status: 'failed' },
+      output: { content: [{ type: 'text', text: '{"ok":true}' }], isError: false },
+    },
+    {
+      type: 'finish-step',
+      response: { id: 'resp_4', modelId: 'google/gemini-3.1-flash-lite' },
+      usage: { inputTokens: 9400, outputTokens: 90, inputTokenDetails: { cacheReadTokens: 9100 } },
+      finishReason: 'stop',
+      rawFinishReason: undefined,
+      performance: {},
+    },
+    { type: 'finish', finishReason: 'stop', rawFinishReason: undefined, totalUsage: {} },
+  ];
+}
+
+function normalizeAll(parts: unknown[]): ParsedEvent[] {
+  const events: ParsedEvent[] = [];
+  let seq = 0;
+  for (const part of parts) {
+    const produced = normalizeSdkPart(part, JSON.stringify(part), seq);
+    for (const e of produced) events.push(e);
+    seq += produced.length;
+  }
+  return events;
+}
+
+describe('normalizeSdkPart: readable timeline', () => {
+  it('maps content parts to the expected kinds in order, and drops framing parts', () => {
+    const events = normalizeAll(recordedStreamParts());
+    expect(events.map((e) => e.kind)).toEqual([
+      'assistant', // "Looking for HN threads..."
+      'tool-call', // run_start
+      'tool-result', // run_start result
+      'thinking', // reasoning-delta
+      'tool-call', // hn_search
+      'tool-result', // hn_search result
+      'tool-call', // drafts_create
+      'tool-result', // drafts_create's tool-error, surfaced as an errored tool-result
+      'assistant', // "The campaign profile needs fixing..."
+      'tool-call', // run_finish
+      'tool-result', // run_finish result
+    ]);
+  });
+
+  it('assigns a strictly monotonic seq to every produced event', () => {
+    const events = normalizeAll(recordedStreamParts());
+    const seqs = events.map((e) => e.seq);
+    expect(seqs).toEqual(seqs.map((_, i) => i));
+  });
+
+  it('carries the tool name and parsed input through on a tool-call', () => {
+    const events = normalizeAll(recordedStreamParts());
+    const call = events.find((e) => e.kind === 'tool-call' && e.seq === 4)!;
+    expect(call.payload).toMatchObject({
+      type: 'tool-call',
+      name: 'hn_search',
+      input: { query: 'AI agents' },
+    });
+  });
+
+  it('renders a successful MCP tool-result from its content array, not the raw envelope', () => {
+    const events = normalizeAll(recordedStreamParts());
+    const result = events.find((e) => e.kind === 'tool-result' && e.seq === 2)!;
+    expect(result.payload).toMatchObject({
+      type: 'tool-result',
+      text: '{"ok":true,"runId":901}',
+      isError: false,
+    });
+  });
+
+  it('surfaces a tool-error as an errored tool-result carrying the error message, not a run failure', () => {
+    const events = normalizeAll(recordedStreamParts());
+    const result = events.find((e) => e.kind === 'tool-result' && e.seq === 7)!;
+    expect(result.payload).toMatchObject({
+      type: 'tool-result',
+      isError: true,
+      text: 'campaign profile is not in the structured format',
+    });
+  });
+
+  it('drops purely cosmetic parts (start, start-step, finish-step, tool-input-*, text-start/end)', () => {
+    const cosmetic = [
+      { type: 'start' },
+      { type: 'start-step', request: {}, warnings: [] },
+      { type: 'finish-step', response: {}, usage: {}, finishReason: 'stop' },
+      { type: 'tool-input-start', id: 'x', toolName: 'y' },
+      { type: 'tool-input-delta', id: 'x', delta: '{' },
+      { type: 'tool-input-end', id: 'x' },
+      { type: 'text-start', id: 't' },
+      { type: 'text-end', id: 't' },
+    ];
+    for (const part of cosmetic) {
+      expect(normalizeSdkPart(part, '', 0)).toEqual([]);
+    }
+  });
+});
+
+describe('normalizeSdkPart: provider error', () => {
+  it('maps an in-band error part to a marker the classifier can key on', () => {
+    const events = normalizeSdkPart({ type: 'error', error: new Error('upstream 503') }, '', 0);
+    expect(events).toHaveLength(1);
+    expect(events[0].raw).toContain('provider error');
+    expect(events[0].raw).toContain('upstream 503');
+  });
+});
+
+describe('normalizeStopReason', () => {
+  it('is the only reason that reports success', () => {
+    const usage = { inputTokens: 100, outputTokens: 20 };
+    for (const reason of [
+      'cancelled',
+      'timeout',
+      'error',
+      'max_turn_requests',
+      'refusal',
+    ] as const) {
+      const [event] = normalizeStopReason(reason, usage, '', 0);
+      expect(event.payload).toMatchObject({ type: 'result', success: false });
+    }
+    const [endTurn] = normalizeStopReason('end_turn', usage, '', 0);
+    expect(endTurn.payload).toMatchObject({ type: 'result', success: true });
+  });
+
+  it('carries usage through onto the closing result event regardless of outcome', () => {
+    const usage = {
+      inputTokens: 9400,
+      outputTokens: 90,
+      cacheReadTokens: 9100,
+      totalCostUsd: 0.0071,
+    };
+    const [event] = normalizeStopReason('max_turn_requests', usage, '', 0);
+    expect(event.payload).toMatchObject({
+      type: 'result',
+      inputTokens: 9400,
+      outputTokens: 90,
+      cacheReadTokens: 9100,
+      totalCostUsd: 0.0071,
+    });
+  });
+});
+
+describe('classifyFailure integration: SDK-specific reasons', () => {
+  const usage = { inputTokens: 500, outputTokens: 20 };
+
+  it('classifies a provider error as provider_error, never unknown', () => {
+    const events = normalizeStopReason('error', usage, '', 0);
+    expect(classifyFailure(events, 1)).toBe('provider_error');
+  });
+
+  it('classifies a client-aborted run as cancelled', () => {
+    const events = normalizeStopReason('cancelled', usage, '', 0);
+    expect(classifyFailure(events, 1)).toBe('cancelled');
+  });
+
+  it('classifies a step-ceiling exhaustion as step_limit_reached', () => {
+    const events = normalizeStopReason('max_turn_requests', usage, '', 0);
+    expect(classifyFailure(events, 1)).toBe('step_limit_reached');
+  });
+
+  it('classifies a timeout-aborted run as agent_timeout', () => {
+    const events = normalizeStopReason('timeout', usage, '', 0);
+    expect(classifyFailure(events, 1)).toBe('agent_timeout');
+  });
+
+  it('classifies a refusal as content_filtered', () => {
+    const events = normalizeStopReason('refusal', usage, '', 0);
+    expect(classifyFailure(events, 1)).toBe('content_filtered');
+  });
+
+  it('the four SDK markers stay distinct from each other', () => {
+    const reasons = ['error', 'cancelled', 'max_turn_requests', 'timeout', 'refusal'] as const;
+    const classified = reasons.map((r) => classifyFailure(normalizeStopReason(r, usage, '', 0), 1));
+    expect(new Set(classified).size).toBe(reasons.length);
+  });
+
+  it('a provider error whose own message is an auth failure still classifies as auth_expired', () => {
+    const events = normalizeStopReason('error', usage, 'HTTP 401 Unauthorized from upstream', 0);
+    expect(classifyFailure(events, 1)).toBe('auth_expired');
+  });
+});
+
+describe('usage + cost', () => {
+  const pricing: SdkModelPricing = {
+    // Roughly gemini-3.1-flash-lite's published per-token USD rates.
+    inputPerToken: 0.00000015,
+    outputPerToken: 0.0000006,
+    cachedInputPerToken: 0.0000000375,
+    cacheCreationPerToken: 0.00000015,
+  };
+
+  it('trusts the Gateway-reported cost when one is given', () => {
+    const usage: SdkLanguageModelUsage = { inputTokens: 42767, outputTokens: 576 };
+    const result = buildSdkUsage(usage, { reportedCostUsd: 0.0071, pricing });
+    expect(result).toMatchObject({
+      costUsd: 0.0071,
+      costReported: true,
+      inputTokens: 42767,
+      outputTokens: 576,
+    });
+  });
+
+  it('prices from the catalogue when the Gateway reports no cost, and cached input is cheaper than fresh', () => {
+    const allFresh: SdkLanguageModelUsage = {
+      inputTokens: 10000,
+      outputTokens: 0,
+      inputTokenDetails: { cacheReadTokens: 0 },
+    };
+    const mostlyCached: SdkLanguageModelUsage = {
+      inputTokens: 10000,
+      outputTokens: 0,
+      inputTokenDetails: { cacheReadTokens: 9000 },
+    };
+    const freshCost = buildSdkUsage(allFresh, { pricing });
+    const cachedCost = buildSdkUsage(mostlyCached, { pricing });
+    expect(freshCost.costReported).toBe(false);
+    expect(freshCost.costUsd).not.toBeNull();
+    expect(cachedCost.costUsd).not.toBeNull();
+    // Same total input tokens, but 9000 of them served from cache: strictly cheaper.
+    expect(cachedCost.costUsd!).toBeLessThan(freshCost.costUsd!);
+    // And matches the direct arithmetic: 1000 fresh + 9000 cached.
+    const expected = Number(
+      (1000 * pricing.inputPerToken + 9000 * pricing.cachedInputPerToken).toFixed(4),
+    );
+    expect(cachedCost.costUsd).toBe(expected);
+  });
+
+  it('records usage even on a call that failed after spending input tokens', () => {
+    // Step 1 completed and spent tokens; step 2's request errored before any
+    // response came back, so it contributes nothing - mirrors the real `ai`
+    // behaviour (a mid-loop error skips the terminal `finish` part entirely).
+    const step1: SdkLanguageModelUsage = {
+      inputTokens: 1200,
+      outputTokens: 40,
+      inputTokenDetails: { cacheReadTokens: 0 },
+    };
+    const total = addSdkUsage(step1, undefined);
+    const result = buildSdkUsage(total, { pricing });
+    expect(result.inputTokens).toBe(1200);
+    expect(result.outputTokens).toBe(40);
+    expect(result.costUsd).not.toBeNull();
+    expect(result.costUsd).toBeGreaterThan(0);
+  });
+
+  it('addSdkUsage sums step-level totals, including the cache-read subset', () => {
+    const a: SdkLanguageModelUsage = {
+      inputTokens: 100,
+      outputTokens: 10,
+      inputTokenDetails: { cacheReadTokens: 20 },
+    };
+    const b: SdkLanguageModelUsage = {
+      inputTokens: 200,
+      outputTokens: 30,
+      inputTokenDetails: { cacheReadTokens: 150 },
+    };
+    const sum = addSdkUsage(a, b);
+    expect(sum).toMatchObject({
+      inputTokens: 300,
+      outputTokens: 40,
+      inputTokenDetails: expect.objectContaining({ cacheReadTokens: 170 }),
+    });
+  });
+
+  it('leaves cost null rather than guessing when neither a reported cost nor pricing is available', () => {
+    const usage: SdkLanguageModelUsage = { inputTokens: 100, outputTokens: 10 };
+    const result = buildSdkUsage(usage, {});
+    expect(result).toMatchObject({ costUsd: null, costReported: false });
+  });
+
+  it('pricingFromCatalogueEntry falls back cache rates to the input rate when the catalogue omits them', () => {
+    const parsed = pricingFromCatalogueEntry({
+      pricing: { input: '0.000003', output: '0.000015' },
+    });
+    expect(parsed).toMatchObject({
+      inputPerToken: 0.000003,
+      cachedInputPerToken: 0.000003,
+      cacheCreationPerToken: 0.000003,
+    });
+  });
+
+  it('pricingFromCatalogueEntry returns undefined for a model with no catalogue pricing', () => {
+    expect(pricingFromCatalogueEntry({ pricing: null })).toBeUndefined();
+    expect(pricingFromCatalogueEntry(undefined)).toBeUndefined();
+  });
+
+  it('computeSdkCostUsd returns null without a pricing table, never a silent default', () => {
+    expect(
+      computeSdkCostUsd(
+        { inputTokens: 100, outputTokens: 10, cacheReadTokens: 0, cacheCreationTokens: 0 },
+        undefined,
+      ),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Normalizes the Vercel AI SDK's `streamText` output into the same `ParsedEvent` shape the ACP normalizer produces (`shared/src/agents/acp/event-normalizer.ts` is the reference), so the run view, the SSE feed and `dispatchRun`'s dedup keep working untouched once #416 wires this in. Non-goals: the runner itself (#416) and the MCP tool set (#417).

New module: `shared/src/agents/sdk/event-normalizer.ts`, exported as `@pitchbox/shared/agents/sdk/event-normalizer` (appended to `shared/package.json`'s exports map).

**Stream mapping**
- `normalizeSdkPart(part, raw, seq)` maps `ai`'s `TextStreamPart` union onto the existing `assistant`/`thinking`/`tool-call`/`tool-result` kinds: text/reasoning deltas, tool calls, and MCP tool results (parsed from the `CallToolResult.content` array, same shape ACP's `joinContent` already handles) or tool errors (surfaced as an errored `tool-result`, matching the #415 finding that a failed tool returns its error to the model instead of killing the loop). Framing-only parts (`start`, `start-step`, `finish-step`, `tool-input-*`, `text-start/end`, etc.) return `[]`.
- `normalizeStopReason(reason, usage, raw, seq)` mirrors ACP's function of the same name: only `'end_turn'` reports `success: true`. This is the direct fix for the #415 finding that an aborted `streamText` never throws (measured: `finishReason: 'other'` on a clean abort) - a runner reading "the stream ended" as success would record a cancelled run as completed. `SdkStopReasonKind` also covers `'timeout'`, `'error'`, `'max_turn_requests'` (the `stopWhen(stepCountIs(n))` ceiling) and `'refusal'`, each embedding a distinct marker into the closing event's `raw`/`text`.

**Usage + cost** (the issue's "more than a mapping"): `buildSdkUsage`/`computeSdkCostUsd`/`pricingFromCatalogueEntry` price a Gateway model from its own catalogue entry (`gateway.getAvailableModels()`'s per-token USD pricing, fetched by the runner - this module stays a pure function of its inputs) rather than the Claude-only table in `runlog/usage.ts`, with cached input priced separately from fresh input (reference: `~/projects/personal/canonry/packages/ai/src/usage.ts`'s split). A self-reported Gateway cost wins outright when given (`costReported: true`); otherwise it prices from the catalogue and only falls back to `null` when neither exists. `addSdkUsage` accumulates per-step usage across `finish-step` parts, since a mid-loop provider error closes `ai`'s `fullStream` via an `error` part with **no** top-level `finish` part (confirmed by reading `ai@7`'s source) - so a run that fails after spending input tokens still records what it spent instead of reporting zero.

**Failure taxonomy**: extended `shared/src/runlog/classify-failure.ts` with `cancelled`, `provider_error`, and `step_limit_reached` (new), and wired the previously-dead `agent_timeout` reason up for the SDK's own timeout path, each via a marker `normalizeStopReason` embeds. Ordering places these before the generic auth/quota/network checks except `provider_error`, which sits after them so a provider error whose own message is actually an auth/quota issue still gets the more specific existing reason (covered by a test). Nothing already-classified changed - `docs/runners.md`'s taxonomy table updated to match.

**Testing** (`shared/tests/agents/sdk/event-normalizer.test.ts`, 24 new tests, plus the existing `classify-failure.test.ts` still green at 9): a fabricated but realistic captured stream (shaped after the #415 spike's real hn-commenter run) normalizes into the expected kind sequence with strictly monotonic `seq`; cost tests cover the self-reported path, the catalogue path (asserting cached input is strictly cheaper than fresh for the same token count, with the exact arithmetic checked), and a failed-call-with-spent-tokens case; classify-failure integration tests feed `normalizeStopReason`'s real output through `classifyFailure` for all five new/newly-reachable reasons and assert none read as `unknown`.

Every new assertion was proven to bite: I broke each piece of the implementation in turn (wrong tool-call kind mapping, always-success stop reason, cache priced same as fresh input, `addSdkUsage` dropping its second operand, ignoring the self-reported cost, catalogue fallback defaulting to zero instead of the input rate, `tool-error` mapped to `isError: false`, the `cancelled` classify-failure check removed, and the `provider_error`/`auth_expired` priority order swapped), watched the exact assertion fail each time, and restored. No `unknown`/success misclassification survived any of the nine mutations.

#416 is coding against the `normalizeSdkPart`/`normalizeStopReason`/`SdkStopReasonKind`/`buildSdkUsage`/`pricingFromCatalogueEntry` contract already (confirmed over IRC before implementing). Their own accumulation loop should call `addSdkUsage` rather than duplicating it - flagged directly to them.

Not merging - reviewing per instructions.

Closes #418