### PR TITLE
feat(web,shared): record instance-level configuration changes

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -80,23 +80,44 @@ back is no more sensitive than reading a project),
 
 Distinct from the per-org roles above: `users.is_instance_admin` gates
 instance-wide config shared by every tenant (default runner, quota defaults,
-runner config, notification webhook, dead-letter webhook retry). Any user can
-self-create an org via `POST /api/orgs` and become its owner/admin, so the
-per-org `admin`/`owner` roles must never grant access to this config - only
-`requireInstanceAdmin(event)` (`web/src/lib/server/auth.ts`) does, checking
-the signed-in user's `is_instance_admin` column. A no-op when auth is off (no
-`locals.user`), same convention as `requireRole`. The first user (first-login
-bootstrap or `seed:owner`) is always the instance admin. Every write to
+runner config, notification webhook, dead-letter webhook retry, per-function
+model config). Any user can self-create an org via `POST /api/orgs` and
+become its owner/admin, so the per-org `admin`/`owner` roles must never
+grant access to this config - only `requireInstanceAdmin(event)`
+(`web/src/lib/server/auth.ts`) does, checking the signed-in user's
+`is_instance_admin` column. A no-op when auth is off (no `locals.user`),
+same convention as `requireRole`. The first user (first-login bootstrap or
+`seed:owner`) is always the instance admin. Every write to
 `is_instance_admin` - the bootstrap grant and every promotion after it - goes
 through the single `setInstanceAdmin` function (`shared/src/auth.ts`), so
 there is exactly one place to audit for who can end up with the flag (#413).
 
 `settings/default-runner` PUT, `settings/runner-config` PUT, `settings/quota`
-POST, `settings/webhooks` PUT, `webhooks/deliveries/[id]/retry` POST (also
-tenant-guarded: the delivery must belong to the caller's org before the
-instance-admin gate runs), `settings/retention` form action (saving only -
-viewing the page, and the three GET routes above, stay `requireRole(event,
-'admin')`).
+POST, `settings/webhooks` PUT, `settings/model-functions` POST,
+`webhooks/deliveries/[id]/retry` POST (also tenant-guarded: the delivery
+must belong to the caller's org before the instance-admin gate runs),
+`settings/retention` form action (saving only - viewing the page, and the
+GET routes above, stay `requireRole(event, 'admin')`).
+
+### Instance-wide audit trail (#414)
+
+Every write listed above changes config shared by every organization, so it
+cannot land in the org-scoped audit feed below (`draft_events`/`run_events`,
+both reached through a project's `organization_id` - an instance-wide write
+belongs to no project). `instance_audit_log` (`shared/src/db/schema.ts`) is
+its own table for exactly that reason: `key`, `actor`, `before`, `after`,
+`created_at`. `recordInstanceAudit` (`shared/src/instance-audit.ts`) is the
+one function every route above calls after its write succeeds - a route
+that forgets to call it is the only way this trail goes missing, rather than
+each route recording it differently - and it redacts `before`/`after` itself
+(any JSON field whose name looks like a credential, and any `*url` field,
+which a webhook target can carry one inside), so a caller does not have to
+remember to. Wired into default-runner, runner-config, quota, webhooks,
+retention, and model-functions; the account-promotion action #413 is adding
+(`web/src/routes/api/settings/admin/promote/+server.ts`) is expected to call
+it too, right after `setInstanceAdmin`, once that route lands. Rendered at
+`settings/admin/audit` (gated the same way as every other page in the area
+below), most recent first.
 
 ### Instance admin area (#412)
 
@@ -106,14 +127,15 @@ settings route above: it gates on `requireInstanceAdmin(event)` (not
 a direct request the same as a member would. Unlike the rest of `settings/`
 (each route above gates itself in its own loader), this gate lives once in
 `web/src/routes/settings/admin/+layout.server.ts` rather than per page: the
-area is expected to grow a sibling route (#411's per-function model
-configuration) and a shared layout gate protects a new page under it without
-that page needing to repeat the check. `settings/admin` itself is a landing
-page that links out to the instance-wide config that already lived on
-org-shaped pages before this area existed - `runners`, `quota`, `retention`,
-and the outgoing webhook on `/notifications` - rather than moving or
-duplicating them; each of those keeps the write gate described above. With
-auth off, `requireInstanceAdmin` is a no-op (no `locals.user`) the same way
+area grew two sibling routes behind that one gate - `settings/admin/models`
+(#411's per-function model configuration) and `settings/admin/audit` (#414's
+instance-wide audit trail above) - without either needing to repeat the
+check. `settings/admin` itself is a landing page that links out to the
+instance-wide config that already lived on org-shaped pages before this area
+existed - `runners`, `quota`, `retention`, and the outgoing webhook on
+`/notifications` - plus its own `models` and `audit` pages; each of the
+org-shaped ones keeps the write gate described above. With auth off,
+`requireInstanceAdmin` is a no-op (no `locals.user`) the same way
 `requireRole` is, so the lone self-host operator - who already owns every
 organization on the instance - reaches this area too; that is a deliberate
 reading of the no-op convention, not an oversight; it does not change while

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -113,11 +113,13 @@ each route recording it differently - and it redacts `before`/`after` itself
 (any JSON field whose name looks like a credential, and any `*url` field,
 which a webhook target can carry one inside), so a caller does not have to
 remember to. Wired into default-runner, runner-config, quota, webhooks,
-retention, and model-functions; the account-promotion action #413 is adding
-(`web/src/routes/api/settings/admin/promote/+server.ts`) is expected to call
-it too, right after `setInstanceAdmin`, once that route lands. Rendered at
-`settings/admin/audit` (gated the same way as every other page in the area
-below), most recent first.
+retention, model-functions, and the account-promotion action
+(`web/src/routes/api/settings/admin/promote/+server.ts`, #413) - every
+`requireInstanceAdmin`-gated write above records itself under key
+`default_runner`, `runner_config:<slug>`, `quota_defaults`,
+`notification_webhooks`, `retention`, `model_function:<fn>`, or
+`user_promotion`. Rendered at `settings/admin/audit` (gated the same way as
+every other page in the area below), most recent first.
 
 ### Instance admin area (#412)
 
@@ -166,8 +168,8 @@ or need a second mechanism to stop after the first grant - the promote
 action covers the same need with one write path and no standing
 configuration. `settings/admin`'s page lists every user with their
 instance-admin flag and a "Promote" button, so a promotion is visible from
-the UI instead of the database; it does not attempt to log who promoted whom
-or when - that's the instance audit trail (#414).
+the UI instead of the database; who promoted whom and when is recorded by
+the instance audit trail above (#414), under key `user_promotion`.
 
 The General settings page (four tabs behind one route) was flattened into
 seven top-level routes, one flat rail with no tabs (#254): `settings/status`,

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -121,6 +121,16 @@ retention, model-functions, and the account-promotion action
 `user_promotion`. Rendered at `settings/admin/audit` (gated the same way as
 every other page in the area below), most recent first.
 
+The redaction is a name-based heuristic, not a guarantee: it catches a
+field named `key`/`token`/`secret`/`password`/`credential` (any case, any
+substring) or ending in `url`, wherever it appears in `before`/`after`. A
+future instance-wide setting whose sensitive value sits in a field matching
+neither pattern - `gatewayAccount`, `smtpUser`, say - would land in the row
+unredacted. Reading `redactInstanceAuditValue`'s doc comment
+(`shared/src/instance-audit.ts`) once before adding a new instance-wide
+write is the way to catch that, not an assumption that the function
+guarantees safety on its own.
+
 ### Instance admin area (#412)
 
 `settings/admin` is a small area of its own, separate from every org-scoped

--- a/shared/package.json
+++ b/shared/package.json
@@ -72,7 +72,8 @@
     "./assist-accept": "./src/assist-accept.ts",
     "./website-source": "./src/website-source.ts",
     "./agents/sdk/tools": "./src/agents/sdk/tools.ts",
-    "./agents/sdk/event-normalizer": "./src/agents/sdk/event-normalizer.ts"
+    "./agents/sdk/event-normalizer": "./src/agents/sdk/event-normalizer.ts",
+    "./instance-audit": "./src/instance-audit.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",

--- a/shared/src/db/migrations/0020_instance_audit.sql
+++ b/shared/src/db/migrations/0020_instance_audit.sql
@@ -1,0 +1,15 @@
+-- Instance-wide config writes (#414): the audit surface in audit-feed.ts
+-- unions draft_events and run_events, both reached through a project's
+-- organization_id, so a change that is not org-scoped (a model swapped for
+-- every tenant, a quota default raised, an account promoted) has nowhere to
+-- land there. This is its own table for exactly that reason.
+CREATE TABLE "instance_audit_log" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"key" text NOT NULL,
+	"actor" text NOT NULL,
+	"before" jsonb,
+	"after" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "instance_audit_log_created_idx" ON "instance_audit_log" USING btree ("created_at");

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1788960000005,
       "tag": "0018_project_sources",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1788960000007,
+      "tag": "0020_instance_audit",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -562,6 +562,34 @@ export const appConfig = pgTable('app_config', {
   value: jsonb('value').notNull(),
 });
 
+// Instance-wide config writes (#414): a model swapped for every tenant, a
+// quota default raised, an account promoted - none of it org-scoped, so it
+// cannot live in the union `audit-feed.ts` builds from draft_events and
+// run_events (both reached through a project's organization_id, which this
+// has none of). `key` names the app_config row (or app_config-shaped
+// concern) that changed - 'default_runner', 'quota_defaults',
+// 'runner_config:<slug>', 'notification_webhooks', 'retention',
+// 'model_function:<fn>', 'user_promotion' - `before`/`after` hold the value
+// on each side of the write, run through `redactInstanceAuditValue`
+// (shared/src/instance-audit.ts) before they ever reach this table so a
+// credential-shaped field is never stored raw. `recordInstanceAudit` is the
+// one function that inserts here - see that module for why every
+// instance-wide write is expected to call it rather than writing directly.
+export const instanceAuditLog = pgTable(
+  'instance_audit_log',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    key: text('key').notNull(),
+    actor: text('actor').notNull(),
+    before: jsonb('before'),
+    after: jsonb('after'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    byCreated: index('instance_audit_log_created_idx').on(t.createdAt),
+  }),
+);
+
 export const daemonHeartbeats = pgTable('daemon_heartbeats', {
   module: text('module').primaryKey(),
   tickAt: timestamp('tick_at', { withTimezone: true }).notNull().defaultNow(),

--- a/shared/src/instance-audit.ts
+++ b/shared/src/instance-audit.ts
@@ -1,0 +1,120 @@
+// Instance-wide config audit trail (#414). The org audit surface
+// (web/src/lib/server/audit-feed.ts) unions draft_events and run_events,
+// both reached through a project's organization_id - a write that belongs
+// to no organization (the default runner, quota defaults, per-runner
+// config, the notification webhook, retention, per-function model config,
+// promoting an account to instance admin) has nowhere to land there and
+// today leaves no trace anywhere. `recordInstanceAudit` is the one function
+// every one of those writes calls, so "a route forgot to call it" is the
+// only way this trail goes missing rather than "a route wrote it
+// differently" - see instance_audit_log in db/schema.ts for the table.
+
+import { desc } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { instanceAuditLog } from './db/schema.js';
+import type { Db } from './db/client.js';
+
+export type InstanceAuditActor = { id: number; username: string } | null;
+
+export type InstanceAuditRow = {
+  id: number;
+  key: string;
+  actor: string;
+  before: unknown;
+  after: unknown;
+  createdAt: Date;
+};
+
+/**
+ * JSON field names that hold a credential outright (an API key, a signing
+ * secret, a password) wherever they appear in a `before`/`after` payload,
+ * regardless of which instance-wide write produced it. Matched against the
+ * JSON key, not the app_config key, so a config shape added after this file
+ * is written gets the same protection without anyone having to remember to
+ * redact it by hand - the failure mode this guards against is a route that
+ * calls `recordInstanceAudit` with its raw payload and never thinks about
+ * redaction at all, which is the common case, not the exception.
+ */
+const SECRET_FIELD_PATTERN = /(key|token|secret|password|credential)/i;
+
+/**
+ * A field named `*url` can itself carry a credential - a Slack/Discord/
+ * generic webhook target commonly embeds a bearer token or signing secret
+ * in its path or query string, and the notification webhook config
+ * (shared/src/notifications.ts) is exactly that shape. The raw value never
+ * reaches the row: only whether one is set, and a stable fingerprint (same
+ * sha256-prefix construction as `webhookIdForUrl`) so two audit rows can be
+ * told apart - "the webhook changed" is visible without exposing what
+ * either URL was.
+ */
+const URL_FIELD_PATTERN = /url$/i;
+
+function fingerprintUrl(url: string): string {
+  // Inlined rather than imported from notifications.ts's webhookIdForUrl:
+  // that function is about identifying a delivery target, this one is about
+  // never storing the target itself, and the two call sites should be free
+  // to diverge without this file reaching into notifications.ts for it.
+  return createHash('sha256').update(url).digest('hex').slice(0, 16);
+}
+
+function redactField(key: string, value: unknown): unknown {
+  if (value == null) return value;
+  if (SECRET_FIELD_PATTERN.test(key)) return '[redacted]';
+  if (URL_FIELD_PATTERN.test(key) && typeof value === 'string' && value) {
+    return { present: true, fingerprint: fingerprintUrl(value) };
+  }
+  return redactInstanceAuditValue(value);
+}
+
+/**
+ * Recursively applies the redaction rules above to an arbitrary JSON value.
+ * Exported so the redaction itself is directly testable rather than only
+ * observable through a full `recordInstanceAudit` round trip.
+ */
+export function redactInstanceAuditValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((v) => redactInstanceAuditValue(v));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = redactField(k, v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Records one instance-wide configuration write: who (the signed-in user,
+ * or 'self-host' when auth is off - same no-op convention as
+ * `requireInstanceAdmin`), when (defaulted by the table), which key, and
+ * the value on each side of the write. `before`/`after` are redacted here,
+ * not by the caller, so a route that hands this its raw payload still gets
+ * the credential guard above for free.
+ *
+ * Every route gated by `requireInstanceAdmin` that writes instance-wide
+ * config is expected to call this once, after the write succeeds:
+ * default-runner PUT, runner-config PUT, quota POST, webhooks PUT,
+ * retention's form action, model-functions POST, and the account-promotion
+ * action (web/src/routes/api/settings/admin/promote/+server.ts, #413).
+ */
+export async function recordInstanceAudit(
+  db: Db,
+  input: { key: string; actor: InstanceAuditActor; before: unknown; after: unknown },
+): Promise<void> {
+  await db.insert(instanceAuditLog).values({
+    key: input.key,
+    actor: input.actor?.username ?? 'self-host',
+    before: redactInstanceAuditValue(input.before) ?? null,
+    after: redactInstanceAuditValue(input.after) ?? null,
+  });
+}
+
+/** Time-ordered instance audit rows, most recent first, for the admin area. */
+export async function loadInstanceAuditLog(db: Db, limit = 200): Promise<InstanceAuditRow[]> {
+  const rows = await db
+    .select()
+    .from(instanceAuditLog)
+    .orderBy(desc(instanceAuditLog.createdAt), desc(instanceAuditLog.id))
+    .limit(limit);
+  return rows;
+}

--- a/shared/src/instance-audit.ts
+++ b/shared/src/instance-audit.ts
@@ -34,6 +34,14 @@ export type InstanceAuditRow = {
  * redact it by hand - the failure mode this guards against is a route that
  * calls `recordInstanceAudit` with its raw payload and never thinks about
  * redaction at all, which is the common case, not the exception.
+ *
+ * This is a name-based heuristic, not a guarantee: a field whose name
+ * matches none of these patterns (a hypothetical `gatewayAccount` or
+ * `smtpUser`, say) is stored as-is even if its value is sensitive. A new
+ * instance-wide write has to be read once with that in mind - either its
+ * shape genuinely holds nothing sensitive, or its field gets a name this
+ * pattern (or the `*url` one below) actually catches, or it needs its own
+ * explicit redaction before it ever reaches `recordInstanceAudit`.
  */
 const SECRET_FIELD_PATTERN = /(key|token|secret|password|credential)/i;
 

--- a/shared/tests/instance-audit.test.ts
+++ b/shared/tests/instance-audit.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getDb } from '../src/db/client.js';
+import {
+  recordInstanceAudit,
+  loadInstanceAuditLog,
+  redactInstanceAuditValue,
+} from '../src/instance-audit.js';
+
+// #414: instance-wide config writes (default runner, quota defaults, runner
+// config, notification webhook, retention, per-function model config,
+// account promotion) have nowhere to land in the org-scoped audit feed. The
+// properties worth defending are the ones the issue names directly: who,
+// when, which key, before/after, and that a credential-shaped value never
+// reaches the row.
+
+async function reset() {
+  await getDb().execute(sql`TRUNCATE instance_audit_log RESTART IDENTITY`);
+}
+
+describe('recordInstanceAudit', () => {
+  beforeEach(reset);
+
+  it('records who, which key, and the value on each side of the write', async () => {
+    const db = getDb();
+    await recordInstanceAudit(db, {
+      key: 'default_runner',
+      actor: { id: 7, username: 'lorenzo' },
+      before: { slug: 'claude-code' },
+      after: { slug: 'cloud' },
+    });
+    const [row] = await loadInstanceAuditLog(db);
+    expect(row.key).toBe('default_runner');
+    expect(row.actor).toBe('lorenzo');
+    expect(row.before).toEqual({ slug: 'claude-code' });
+    expect(row.after).toEqual({ slug: 'cloud' });
+    expect(row.createdAt).toBeInstanceOf(Date);
+  });
+
+  it("records 'self-host' as the actor when auth is off (no signed-in user)", async () => {
+    const db = getDb();
+    await recordInstanceAudit(db, {
+      key: 'quota_defaults',
+      actor: null,
+      before: {},
+      after: { reddit: { dm: { perDay: 5, perWeek: 20 } } },
+    });
+    const [row] = await loadInstanceAuditLog(db);
+    expect(row.actor).toBe('self-host');
+  });
+
+  it('orders rows most recent first', async () => {
+    const db = getDb();
+    await recordInstanceAudit(db, {
+      key: 'retention',
+      actor: null,
+      before: { drafts_days: 90 },
+      after: { drafts_days: 30 },
+    });
+    await recordInstanceAudit(db, {
+      key: 'retention',
+      actor: null,
+      before: { drafts_days: 30 },
+      after: { drafts_days: 14 },
+    });
+    const rows = await loadInstanceAuditLog(db);
+    expect(rows.map((r) => (r.after as { drafts_days: number }).drafts_days)).toEqual([14, 30]);
+  });
+
+  it('never stores a raw notification webhook URL, only a fingerprint', async () => {
+    const db = getDb();
+    const secretUrl = 'https://hooks.slack.com/services/T00/B00/super-secret-token';
+    await recordInstanceAudit(db, {
+      key: 'notification_webhooks',
+      actor: null,
+      before: { url: null },
+      after: { url: secretUrl },
+    });
+    const [row] = await loadInstanceAuditLog(db);
+    const after = row.after as { url: unknown };
+    // Bites: an implementation that stores `before`/`after` verbatim (the
+    // obvious thing to write) would put the token-bearing URL straight into
+    // `after.url`, and this assertion fails against it - it only passes
+    // once the value has actually been transformed.
+    expect(JSON.stringify(after)).not.toContain('super-secret-token');
+    expect(JSON.stringify(after)).not.toContain(secretUrl);
+    expect(after.url).toEqual({ present: true, fingerprint: expect.any(String) });
+  });
+
+  it('redacts a field that literally holds a credential', async () => {
+    const db = getDb();
+    await recordInstanceAudit(db, {
+      key: 'runner_config:cloud',
+      actor: null,
+      before: {},
+      after: { model: 'sonnet', gatewayApiKey: 'sk-live-do-not-store-me' },
+    });
+    const [row] = await loadInstanceAuditLog(db);
+    const after = row.after as { model: string; gatewayApiKey: string };
+    expect(JSON.stringify(after)).not.toContain('sk-live-do-not-store-me');
+    expect(after.gatewayApiKey).toBe('[redacted]');
+    // A field with no credential in its name is untouched.
+    expect(after.model).toBe('sonnet');
+  });
+});
+
+describe('redactInstanceAuditValue', () => {
+  it('leaves a plain value with no sensitive fields unchanged', () => {
+    expect(redactInstanceAuditValue({ drafts_days: 90, run_events_days: 30 })).toEqual({
+      drafts_days: 90,
+      run_events_days: 30,
+    });
+  });
+
+  it('two different URLs fingerprint differently, so a change is still visible', () => {
+    const a = redactInstanceAuditValue({ url: 'https://a.example.com/hook' }) as {
+      url: { fingerprint: string };
+    };
+    const b = redactInstanceAuditValue({ url: 'https://b.example.com/hook' }) as {
+      url: { fingerprint: string };
+    };
+    expect(a.url.fingerprint).not.toBe(b.url.fingerprint);
+  });
+
+  it('redacts a secret field nested inside an array', () => {
+    const out = redactInstanceAuditValue([{ token: 'abc123' }, { model: 'sonnet' }]) as Array<
+      Record<string, unknown>
+    >;
+    expect(out[0].token).toBe('[redacted]');
+    expect(out[1].model).toBe('sonnet');
+  });
+});

--- a/web/src/routes/api/settings/admin/promote/+server.ts
+++ b/web/src/routes/api/settings/admin/promote/+server.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getDb } from '$lib/server/db.js';
 import { requireInstanceAdmin } from '$lib/server/auth.js';
 import { setInstanceAdmin } from '@pitchbox/shared/auth';
+import { recordInstanceAudit } from '@pitchbox/shared/instance-audit';
 import { schema } from '$lib/server/db.js';
 import { eq } from 'drizzle-orm';
 
@@ -26,12 +27,25 @@ export async function POST(event: RequestEvent) {
 
   const db = getDb();
   const [user] = await db
-    .select({ id: schema.users.id })
+    .select({
+      id: schema.users.id,
+      username: schema.users.username,
+      isInstanceAdmin: schema.users.isInstanceAdmin,
+    })
     .from(schema.users)
     .where(eq(schema.users.id, parsed.data.userId))
     .limit(1);
   if (!user) throw error(404, 'not_found');
 
   await setInstanceAdmin(db, user.id, true);
+  // #414: instance-wide config writes (this one included) are expected to
+  // record themselves - a route that forgets is the only way this trail
+  // goes missing.
+  await recordInstanceAudit(db, {
+    key: 'user_promotion',
+    actor: event.locals.user ?? null,
+    before: { username: user.username, isInstanceAdmin: user.isInstanceAdmin },
+    after: { username: user.username, isInstanceAdmin: true },
+  });
   return json({ ok: true, userId: user.id });
 }

--- a/web/src/routes/api/settings/default-runner/+server.ts
+++ b/web/src/routes/api/settings/default-runner/+server.ts
@@ -4,6 +4,7 @@ import { getDb } from '$lib/server/db.js';
 import { AGENT_RUNNER_META, type AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
 import { loadDefaultRunnerSlug, saveDefaultRunnerSlug } from '@pitchbox/shared/agents/config';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
+import { recordInstanceAudit } from '@pitchbox/shared/instance-audit';
 import { requireInstanceAdmin, requireRole } from '$lib/server/auth.js';
 
 const Body = z.object({ slug: z.string() });
@@ -29,6 +30,14 @@ export async function PUT(event: RequestEvent) {
   if (!isRunnerAllowed(parsed.data.slug)) {
     throw error(400, 'runner_not_allowed');
   }
-  await saveDefaultRunnerSlug(getDb(), parsed.data.slug as AgentRunnerSlug);
+  const db = getDb();
+  const before = await loadDefaultRunnerSlug(db);
+  await saveDefaultRunnerSlug(db, parsed.data.slug as AgentRunnerSlug);
+  await recordInstanceAudit(db, {
+    key: 'default_runner',
+    actor: event.locals.user ?? null,
+    before: { slug: before },
+    after: { slug: parsed.data.slug },
+  });
   return json({ ok: true, slug: parsed.data.slug });
 }

--- a/web/src/routes/api/settings/model-functions/+server.ts
+++ b/web/src/routes/api/settings/model-functions/+server.ts
@@ -2,6 +2,7 @@ import { json, error, type RequestEvent } from '@sveltejs/kit';
 import { z } from 'zod';
 import { getDb } from '$lib/server/db.js';
 import { requireInstanceAdmin } from '$lib/server/auth.js';
+import { recordInstanceAudit } from '@pitchbox/shared/instance-audit';
 import {
   MODEL_FUNCTIONS,
   loadModelFunctionConfig,
@@ -34,6 +35,14 @@ export async function POST(event: RequestEvent) {
   const parsed = Body.safeParse(await event.request.json().catch(() => null));
   if (!parsed.success) throw error(400, parsed.error.issues[0]?.message ?? 'invalid body');
   const { fn, modelId } = parsed.data;
-  await saveModelFunctionModel(getDb(), fn as ModelFunction, modelId.trim() ? modelId : null);
-  return json(await loadModelFunctionConfig(getDb()));
+  const db = getDb();
+  const before = (await loadModelFunctionConfig(db))[fn as ModelFunction];
+  await saveModelFunctionModel(db, fn as ModelFunction, modelId.trim() ? modelId : null);
+  await recordInstanceAudit(db, {
+    key: `model_function:${fn}`,
+    actor: event.locals.user ?? null,
+    before: { modelId: before },
+    after: { modelId: modelId.trim() ? modelId : null },
+  });
+  return json(await loadModelFunctionConfig(db));
 }

--- a/web/src/routes/api/settings/quota/+server.ts
+++ b/web/src/routes/api/settings/quota/+server.ts
@@ -2,6 +2,7 @@ import { json, error, type RequestEvent } from '@sveltejs/kit';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 import { getDb, schema } from '$lib/server/db.js';
+import { recordInstanceAudit } from '@pitchbox/shared/instance-audit';
 import { requireInstanceAdmin, requireRole } from '$lib/server/auth.js';
 
 const Window = z
@@ -44,6 +45,10 @@ export async function POST(event: RequestEvent) {
     );
 
   const db = getDb();
+  const [existing] = await db
+    .select()
+    .from(schema.appConfig)
+    .where(eq(schema.appConfig.key, 'quota_defaults'));
   await db
     .insert(schema.appConfig)
     .values({ key: 'quota_defaults', value: parsed.data })
@@ -51,5 +56,11 @@ export async function POST(event: RequestEvent) {
       target: schema.appConfig.key,
       set: { value: parsed.data },
     });
+  await recordInstanceAudit(db, {
+    key: 'quota_defaults',
+    actor: event.locals.user ?? null,
+    before: existing?.value ?? {},
+    after: parsed.data,
+  });
   return json({ ok: true });
 }

--- a/web/src/routes/api/settings/runner-config/+server.ts
+++ b/web/src/routes/api/settings/runner-config/+server.ts
@@ -1,12 +1,14 @@
 import { json, error, type RequestEvent } from '@sveltejs/kit';
 import { getDb } from '$lib/server/db.js';
 import {
+  loadRunnerConfig,
   loadRunnerConfigs,
   saveRunnerConfig,
   type RunnerConfig,
 } from '@pitchbox/shared/agents/config';
 import { AGENT_RUNNER_META, type AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
 import { z } from 'zod';
+import { recordInstanceAudit } from '@pitchbox/shared/instance-audit';
 import { requireInstanceAdmin, requireRole } from '$lib/server/auth.js';
 
 const ConfigSchema = z.object({
@@ -42,7 +44,14 @@ export async function PUT(event: RequestEvent) {
   if (!parsed.success) throw error(400, 'invalid body');
   if (!isRunnerSlug(parsed.data.slug)) throw error(400, 'unknown runner');
   const db = getDb();
+  const before = await loadRunnerConfig(db, parsed.data.slug);
   await saveRunnerConfig(db, parsed.data.slug, parsed.data.config as RunnerConfig);
+  await recordInstanceAudit(db, {
+    key: `runner_config:${parsed.data.slug}`,
+    actor: event.locals.user ?? null,
+    before,
+    after: parsed.data.config,
+  });
   const configs = await loadRunnerConfigs(db);
   return json({ configs });
 }

--- a/web/src/routes/api/settings/webhooks/+server.ts
+++ b/web/src/routes/api/settings/webhooks/+server.ts
@@ -1,7 +1,8 @@
 import { json, error, type RequestEvent } from '@sveltejs/kit';
 import { z } from 'zod';
 import { getDb } from '$lib/server/db.js';
-import { saveWebhooks } from '@pitchbox/shared/notifications';
+import { loadWebhooks, saveWebhooks } from '@pitchbox/shared/notifications';
+import { recordInstanceAudit } from '@pitchbox/shared/instance-audit';
 import { requireInstanceAdmin } from '$lib/server/auth.js';
 
 const Body = z.object({
@@ -15,6 +16,16 @@ export async function PUT(event: RequestEvent) {
   const parsed = Body.safeParse(raw);
   if (!parsed.success) throw error(400, 'invalid_body');
   const db = getDb();
+  const before = await loadWebhooks(db);
   await saveWebhooks(db, { url: parsed.data.url ?? undefined });
+  // `url` is redacted by recordInstanceAudit's own field-name rule (a
+  // webhook target can carry a bearer token in its path or query string) -
+  // the row gets a fingerprint, never the URL itself.
+  await recordInstanceAudit(db, {
+    key: 'notification_webhooks',
+    actor: event.locals.user ?? null,
+    before: { url: before.url ?? null },
+    after: { url: parsed.data.url },
+  });
   return json({ ok: true });
 }

--- a/web/src/routes/settings/admin/+page.svelte
+++ b/web/src/routes/settings/admin/+page.svelte
@@ -4,7 +4,7 @@
   import * as Table from '$lib/components/ui/table';
   import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
-  import { Info, Bot, Gauge, Archive, Webhook } from '@lucide/svelte';
+  import { Info, Bot, Gauge, Archive, Webhook, ScrollText } from '@lucide/svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
   import PageContainer from '$lib/components/PageContainer.svelte';
   import Seo from '$lib/components/Seo.svelte';
@@ -62,6 +62,12 @@
       icon: Webhook,
       label: 'Outgoing webhook',
       description: 'The dashboard-wide notification webhook URL and its delivery log.',
+    },
+    {
+      href: '/settings/admin/audit',
+      icon: ScrollText,
+      label: 'Audit log',
+      description: 'Who changed instance-wide configuration, when, and from what to what.',
     },
   ];
 </script>

--- a/web/src/routes/settings/admin/audit/+page.server.ts
+++ b/web/src/routes/settings/admin/audit/+page.server.ts
@@ -1,0 +1,25 @@
+import type { PageServerLoad } from './$types';
+import { getDb } from '$lib/server/db.js';
+import { requireInstanceAdmin } from '$lib/server/auth.js';
+import { loadInstanceAuditLog } from '@pitchbox/shared/instance-audit';
+
+// Instance-wide config audit trail (#414), inside the area #412 built. The
+// area's `+layout.server.ts` already gates the whole subtree, and this
+// loader gates itself again - same reason models/+page.server.ts does: the
+// write path next door does the same, and the loader is the boundary that
+// holds when somebody types the URL rather than following a link that was
+// hidden from them.
+export const load: PageServerLoad = async (event) => {
+  await requireInstanceAdmin(event);
+  const rows = await loadInstanceAuditLog(getDb());
+  return {
+    rows: rows.map((r) => ({
+      id: r.id,
+      key: r.key,
+      actor: r.actor,
+      before: r.before,
+      after: r.after,
+      createdAt: r.createdAt.toISOString(),
+    })),
+  };
+};

--- a/web/src/routes/settings/admin/audit/+page.svelte
+++ b/web/src/routes/settings/admin/audit/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import * as Card from '$lib/components/ui/card';
+  import * as Table from '$lib/components/ui/table';
+  import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageContainer from '$lib/components/PageContainer.svelte';
+  import Seo from '$lib/components/Seo.svelte';
+
+  type AuditRow = {
+    id: number;
+    key: string;
+    actor: string;
+    before: unknown;
+    after: unknown;
+    createdAt: string;
+  };
+
+  type PageData = { rows: AuditRow[] };
+
+  let { data }: { data: PageData } = $props();
+
+  function fmt(d: string): string {
+    return new Date(d).toLocaleString();
+  }
+
+  // A raw `null` reads as an empty field, not the string "null" - most rows
+  // only touch one side of a create-vs-clear write (e.g. the default runner
+  // going from unset to 'claude-code').
+  function fmtValue(v: unknown): string {
+    if (v === null || v === undefined) return '-';
+    return JSON.stringify(v);
+  }
+</script>
+
+<Seo
+  title="Settings - Instance admin - Audit"
+  description="Who changed instance-wide configuration, when, and from what to what."
+/>
+
+<PageContainer size="wide">
+  <PageHeader
+    title="Instance audit log"
+    description="Every instance-wide configuration write - not the per-organization audit feed at /audit, which stays scoped to your own organization's drafts and runs."
+  />
+
+  <Card.Root size="sm" class="mt-4">
+    <Card.Content class="py-2">
+      <Table.Root>
+        <Table.Header>
+          <Table.Row>
+            <Table.Head class="w-44">Timestamp</Table.Head>
+            <Table.Head class="w-40">Actor</Table.Head>
+            <Table.Head class="w-56">Key</Table.Head>
+            <Table.Head>Before</Table.Head>
+            <Table.Head>After</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {#each data.rows as r (r.id)}
+            <Table.Row>
+              <Table.Cell class="text-xs font-mono text-muted-foreground">{fmt(r.createdAt)}</Table.Cell>
+              <Table.Cell class="text-xs">{r.actor}</Table.Cell>
+              <Table.Cell class="font-mono text-xs">{r.key}</Table.Cell>
+              <Table.Cell class="max-w-xs truncate font-mono text-xs text-muted-foreground"
+                title={fmtValue(r.before)}>{fmtValue(r.before)}</Table.Cell
+              >
+              <Table.Cell class="max-w-xs truncate font-mono text-xs" title={fmtValue(r.after)}
+                >{fmtValue(r.after)}</Table.Cell
+              >
+            </Table.Row>
+          {/each}
+          {#if data.rows.length === 0}
+            <Table.Row>
+              <Table.Cell colspan={5} class="text-center text-sm text-muted-foreground py-8">
+                No instance-wide configuration has been changed yet.
+              </Table.Cell>
+            </Table.Row>
+          {/if}
+        </Table.Body>
+      </Table.Root>
+    </Card.Content>
+  </Card.Root>
+</PageContainer>

--- a/web/src/routes/settings/retention/+page.server.ts
+++ b/web/src/routes/settings/retention/+page.server.ts
@@ -8,6 +8,7 @@ import {
   RETENTION_FLOOR_DAYS,
   type RetentionPolicy,
 } from '@pitchbox/shared/retention';
+import { recordInstanceAudit } from '@pitchbox/shared/instance-audit';
 
 export const load: PageServerLoad = async (event) => {
   requireRole(event, 'admin'); // viewing retention is admin-only
@@ -44,12 +45,20 @@ export const actions: Actions = {
     ) {
       return fail(400, { error: 'Invalid number' });
     }
+    const db = getDb();
+    const before = await loadRetention(db);
     // saveRetention enforces the floor server-side.
-    const saved = await saveRetention(getDb(), {
+    const saved = await saveRetention(db, {
       drafts_days,
       run_events_days,
       draft_events_days,
       webhook_deliveries_days,
+    });
+    await recordInstanceAudit(db, {
+      key: 'retention',
+      actor: event.locals.user ?? null,
+      before,
+      after: saved,
     });
     return { saved };
   },

--- a/web/tests/instance-audit-admin-page.test.ts
+++ b/web/tests/instance-audit-admin-page.test.ts
@@ -31,9 +31,9 @@ type PageData = { rows: Array<{ key: string; actor: string; before: unknown; aft
 describe('settings/admin/audit +page.server.ts load', () => {
   it('a signed-in user who is not the instance admin is forbidden (403)', async () => {
     const user = await userWith('iaap-plain', false);
-    await expect(
-      load({ locals: { user } } as unknown as LoadEvent),
-    ).rejects.toMatchObject({ status: 403 });
+    await expect(load({ locals: { user } } as unknown as LoadEvent)).rejects.toMatchObject({
+      status: 403,
+    });
   });
 
   it('the instance admin sees recorded rows, readable in operator terms', async () => {

--- a/web/tests/instance-audit-admin-page.test.ts
+++ b/web/tests/instance-audit-admin-page.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getDb, getPool, schema } from '@pitchbox/shared/db';
+import { hashPassword } from '@pitchbox/shared/auth';
+import { recordInstanceAudit } from '@pitchbox/shared/instance-audit';
+import { load } from '../src/routes/settings/admin/audit/+page.server.js';
+
+// settings/admin/audit (#414). Same defense-in-depth gate as
+// settings/admin/models/+page.server.ts: the area's layout already gates
+// the subtree, this loader gates itself again - proven the same way
+// settings-admin-gating.test.ts proves the layout gate.
+
+const PASSWORD = 'correct-horse-battery';
+
+async function userWith(username: string, isInstanceAdmin: boolean): Promise<{ id: number }> {
+  const hash = await hashPassword(PASSWORD);
+  await getDb()
+    .insert(schema.users)
+    .values({ username, passwordHash: hash, isInstanceAdmin })
+    .onConflictDoUpdate({ target: schema.users.username, set: { isInstanceAdmin } });
+  const [user] = await getDb()
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(sql`username = ${username}`);
+  return user;
+}
+
+type LoadEvent = Parameters<typeof load>[0];
+type PageData = { rows: Array<{ key: string; actor: string; before: unknown; after: unknown }> };
+
+describe('settings/admin/audit +page.server.ts load', () => {
+  it('a signed-in user who is not the instance admin is forbidden (403)', async () => {
+    const user = await userWith('iaap-plain', false);
+    await expect(
+      load({ locals: { user } } as unknown as LoadEvent),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('the instance admin sees recorded rows, readable in operator terms', async () => {
+    const user = await userWith('iaap-iadmin', true);
+    await recordInstanceAudit(getDb(), {
+      key: 'default_runner',
+      actor: { id: user.id, username: 'iaap-iadmin' },
+      before: { slug: 'claude-code' },
+      after: { slug: 'cloud' },
+    });
+    const data = (await load({ locals: { user } } as unknown as LoadEvent)) as PageData;
+    const row = data.rows.find((r) => r.key === 'default_runner' && r.actor === 'iaap-iadmin');
+    expect(row).toBeDefined();
+    expect(row?.before).toEqual({ slug: 'claude-code' });
+    expect(row?.after).toEqual({ slug: 'cloud' });
+  });
+
+  it('auth off has full access (200, no throw)', async () => {
+    await expect(load({ locals: {} } as unknown as LoadEvent)).resolves.toBeDefined();
+  });
+});
+
+afterAll(async () => {
+  await getPool().end();
+});

--- a/web/tests/instance-audit-org-feed-unchanged.test.ts
+++ b/web/tests/instance-audit-org-feed-unchanged.test.ts
@@ -1,0 +1,187 @@
+import { afterAll, describe, expect, it, beforeEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { getDb, getPool, schema } from '@pitchbox/shared/db';
+import { hashPassword, createSession } from '@pitchbox/shared/auth';
+import { loadAuditFeed } from '../src/lib/server/audit-feed.js';
+import { PUT as defaultRunnerPut } from '../src/routes/api/settings/default-runner/+server.js';
+import { POST as quotaPost } from '../src/routes/api/settings/quota/+server.js';
+import { PUT as webhooksPut } from '../src/routes/api/settings/webhooks/+server.js';
+import { POST as modelFunctionsPost } from '../src/routes/api/settings/model-functions/+server.js';
+import { actions as retentionActions } from '../src/routes/settings/retention/+page.server.js';
+import { type CookieJar, runThroughHandle } from './helpers/handle-harness.js';
+
+// #414 acceptance: "a member's view of the org audit feed is unchanged" is
+// an assertion, not a hope. Every instance-wide write recordInstanceAudit
+// covers goes through the real route here, against a real org that also has
+// its own draft/run events - if any of them leaked a row into the org feed
+// (writing to the wrong table, or draft_events/run_events instead of
+// instance_audit_log), this test would see the feed grow or change.
+
+const PASSWORD = 'correct-horse-battery';
+const originalAuth = process.env.PITCHBOX_AUTH;
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await db.execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, draft_events, run_events, instance_audit_log RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(
+    sql`DELETE FROM app_config WHERE key IN ('default_runner', 'quota_defaults', 'notification_webhooks', 'retention', 'model_functions')`,
+  );
+}
+
+async function getDefaultOrgId(): Promise<number> {
+  const [org] = await getDb()
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(sql`slug = 'default'`);
+  return org.id;
+}
+
+async function seedOrgFeed(orgId: number) {
+  const db = getDb();
+  const [proj] = await db
+    .insert(schema.projects)
+    .values({ organizationId: orgId, slug: 'iaof-test', name: 'iaof-test' })
+    .returning();
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'reddit'));
+  const [account] = await db
+    .insert(schema.accounts)
+    .values({ projectId: proj.id, platformId: platform.id, handle: 'iaof-tester' })
+    .returning();
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({ projectId: proj.id, platformId: platform.id, name: 'c', skillSlug: 's' })
+    .returning();
+  const [run] = await db
+    .insert(schema.runs)
+    .values({ campaignId: campaign.id, trigger: 'manual', status: 'success' })
+    .returning();
+  const [draft] = await db
+    .insert(schema.drafts)
+    .values({
+      runId: run.id,
+      projectId: proj.id,
+      platformId: platform.id,
+      accountId: account.id,
+      kind: 'dm',
+      body: 'hello',
+      targetUser: 'someone',
+      state: 'pending_review',
+    })
+    .returning();
+  await db.insert(schema.draftEvents).values({
+    draftId: draft.id,
+    event: 'created',
+    actor: 'agent',
+    details: {},
+  });
+  await db.insert(schema.runEvents).values({
+    runId: run.id,
+    seq: 1,
+    kind: 'started',
+    payload: {},
+    raw: '{}',
+  });
+}
+
+async function instanceAdminSession(): Promise<CookieJar> {
+  const hash = await hashPassword(PASSWORD);
+  const username = 'iaof-admin';
+  await getDb()
+    .insert(schema.users)
+    .values({ username, passwordHash: hash, isInstanceAdmin: true })
+    .onConflictDoUpdate({ target: schema.users.username, set: { isInstanceAdmin: true } });
+  const [user] = await getDb()
+    .select()
+    .from(schema.users)
+    .where(sql`username = ${username}`);
+  const [org] = await getDb()
+    .select()
+    .from(schema.organizations)
+    .where(sql`slug = 'default'`);
+  await getDb()
+    .insert(schema.memberships)
+    .values({ organizationId: org.id, userId: user.id, role: 'admin' })
+    .onConflictDoUpdate({
+      target: [schema.memberships.organizationId, schema.memberships.userId],
+      set: { role: 'admin' },
+    });
+  const session = await createSession(getDb(), user.id);
+  return { store: new Map([['pitchbox_session', { value: session.id }]]) };
+}
+
+describe('org audit feed is unaffected by instance-wide writes', () => {
+  beforeEach(reset);
+
+  it('is byte-identical before and after every instance-wide write', async () => {
+    const orgId = await getDefaultOrgId();
+    await seedOrgFeed(orgId);
+    const before = await loadAuditFeed(orgId);
+    expect(before).toHaveLength(2);
+
+    const jar = await instanceAdminSession();
+    const call = (req: Request, handler: (e: unknown) => Promise<Response>) =>
+      runThroughHandle(req, jar, handler as any);
+
+    await call(
+      new Request('http://localhost/api/settings/default-runner', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ slug: 'claude-code' }),
+      }),
+      defaultRunnerPut as any,
+    );
+    await call(
+      new Request('http://localhost/api/settings/quota', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      }),
+      quotaPost as any,
+    );
+    await call(
+      new Request('http://localhost/api/settings/webhooks', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'https://hooks.example.test/aaa' }),
+      }),
+      webhooksPut as any,
+    );
+    await call(
+      new Request('http://localhost/api/settings/model-functions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ fn: 'assist_suggest', modelId: 'openai/gpt-5-mini' }),
+      }),
+      modelFunctionsPost as any,
+    );
+    const fd = new FormData();
+    fd.set('drafts_days', '90');
+    fd.set('run_events_days', '30');
+    fd.set('draft_events_days', '90');
+    fd.set('webhook_deliveries_days', '30');
+    await call(
+      new Request('http://localhost/settings/retention', { method: 'POST', body: fd }),
+      retentionActions.default as any,
+    );
+
+    // The instance-wide writes above did land somewhere - prove it's not
+    // the org feed's own tables that grew silently.
+    const auditRows = await getDb().execute(sql`select count(*)::int as n from instance_audit_log`);
+    expect((auditRows.rows[0] as { n: number }).n).toBeGreaterThanOrEqual(5);
+
+    const after = await loadAuditFeed(orgId);
+    expect(after).toEqual(before);
+  });
+});
+
+afterAll(async () => {
+  if (originalAuth === undefined) delete process.env.PITCHBOX_AUTH;
+  else process.env.PITCHBOX_AUTH = originalAuth;
+  await getPool().end();
+});

--- a/web/tests/instance-audit-trail.test.ts
+++ b/web/tests/instance-audit-trail.test.ts
@@ -9,6 +9,7 @@ import { POST as quotaPost } from '../src/routes/api/settings/quota/+server.js';
 import { PUT as runnerConfigPut } from '../src/routes/api/settings/runner-config/+server.js';
 import { PUT as webhooksPut } from '../src/routes/api/settings/webhooks/+server.js';
 import { POST as modelFunctionsPost } from '../src/routes/api/settings/model-functions/+server.js';
+import { POST as promotePost } from '../src/routes/api/settings/admin/promote/+server.js';
 import { actions as retentionActions } from '../src/routes/settings/retention/+page.server.js';
 import { type CookieJar, runThroughHandle } from './helpers/handle-harness.js';
 
@@ -114,8 +115,20 @@ describe('instance-wide writes record an audit row', () => {
         jar,
         quotaPost as any,
       );
-    const first = { reddit: { dm: { perDay: 1, perWeek: 5 }, comment: { perDay: 1, perWeek: 5 }, post: { perDay: 1, perWeek: 5 } } };
-    const second = { reddit: { dm: { perDay: 2, perWeek: 10 }, comment: { perDay: 2, perWeek: 10 }, post: { perDay: 2, perWeek: 10 } } };
+    const first = {
+      reddit: {
+        dm: { perDay: 1, perWeek: 5 },
+        comment: { perDay: 1, perWeek: 5 },
+        post: { perDay: 1, perWeek: 5 },
+      },
+    };
+    const second = {
+      reddit: {
+        dm: { perDay: 2, perWeek: 10 },
+        comment: { perDay: 2, perWeek: 10 },
+        post: { perDay: 2, perWeek: 10 },
+      },
+    };
     expect((await post(first)).status).toBe(200);
     expect((await post(second)).status).toBe(200);
 
@@ -207,6 +220,37 @@ describe('instance-wide writes record an audit row', () => {
     const row = await lastRowFor('retention');
     expect((row.before as { drafts_days: number }).drafts_days).toBe(90);
     expect((row.after as { drafts_days: number }).drafts_days).toBe(45);
+  });
+
+  it('the promote action records who was promoted, by whom', async () => {
+    const jar = await sessionFor('iat-promoter');
+    await getDb()
+      .insert(schema.users)
+      .values({ username: 'iat-promotee', passwordHash: 'x', isInstanceAdmin: false })
+      .onConflictDoUpdate({
+        target: schema.users.username,
+        set: { isInstanceAdmin: false },
+      });
+    const [promotee] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(sql`username = 'iat-promotee'`);
+
+    const res = await runThroughHandle(
+      new Request('http://localhost/api/settings/admin/promote', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: promotee.id }),
+      }),
+      jar,
+      promotePost as any,
+    );
+    expect(res.status).toBe(200);
+
+    const row = await lastRowFor('user_promotion');
+    expect(row.actor).toBe('iat-promoter');
+    expect(row.before).toEqual({ username: 'iat-promotee', isInstanceAdmin: false });
+    expect(row.after).toEqual({ username: 'iat-promotee', isInstanceAdmin: true });
   });
 });
 

--- a/web/tests/instance-audit-trail.test.ts
+++ b/web/tests/instance-audit-trail.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, describe, expect, it, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getDb, getPool, schema } from '@pitchbox/shared/db';
+import { hashPassword, createSession } from '@pitchbox/shared/auth';
+import { loadInstanceAuditLog } from '@pitchbox/shared/instance-audit';
+import { clearModelFunctionCache } from '@pitchbox/shared/ai/model-functions';
+import { PUT as defaultRunnerPut } from '../src/routes/api/settings/default-runner/+server.js';
+import { POST as quotaPost } from '../src/routes/api/settings/quota/+server.js';
+import { PUT as runnerConfigPut } from '../src/routes/api/settings/runner-config/+server.js';
+import { PUT as webhooksPut } from '../src/routes/api/settings/webhooks/+server.js';
+import { POST as modelFunctionsPost } from '../src/routes/api/settings/model-functions/+server.js';
+import { actions as retentionActions } from '../src/routes/settings/retention/+page.server.js';
+import { type CookieJar, runThroughHandle } from './helpers/handle-harness.js';
+
+// #414: every instance-wide write above is expected to call
+// recordInstanceAudit once it succeeds. These tests drive each route as a
+// real instance admin (same `sessionFor`/`runThroughHandle` pattern as
+// instance-admin-gating.test.ts, which already covers the 403/200 gate) and
+// assert on the resulting instance_audit_log row - the recording itself,
+// not the gate.
+
+const PASSWORD = 'correct-horse-battery';
+const originalAuth = process.env.PITCHBOX_AUTH;
+
+async function sessionFor(username: string): Promise<CookieJar> {
+  const hash = await hashPassword(PASSWORD);
+  await getDb()
+    .insert(schema.users)
+    .values({ username, passwordHash: hash, isInstanceAdmin: true })
+    .onConflictDoUpdate({
+      target: schema.users.username,
+      set: { isInstanceAdmin: true },
+    });
+  const [user] = await getDb()
+    .select()
+    .from(schema.users)
+    .where(sql`username = ${username}`);
+  let [org] = await getDb()
+    .select()
+    .from(schema.organizations)
+    .where(sql`slug = 'default'`);
+  if (!org) {
+    [org] = await getDb()
+      .insert(schema.organizations)
+      .values({ slug: 'default', name: 'Default' })
+      .returning();
+  }
+  await getDb()
+    .insert(schema.memberships)
+    .values({ organizationId: org.id, userId: user.id, role: 'admin' })
+    .onConflictDoUpdate({
+      target: [schema.memberships.organizationId, schema.memberships.userId],
+      set: { role: 'admin' },
+    });
+  const session = await createSession(getDb(), user.id);
+  return { store: new Map([['pitchbox_session', { value: session.id }]]) };
+}
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`TRUNCATE instance_audit_log RESTART IDENTITY`);
+  await db.execute(
+    sql`DELETE FROM app_config WHERE key IN ('default_runner', 'quota_defaults', 'runner_configs', 'notification_webhooks', 'retention', 'model_functions')`,
+  );
+  clearModelFunctionCache();
+}
+
+async function lastRowFor(key: string) {
+  const rows = await loadInstanceAuditLog(getDb());
+  const row = rows.find((r) => r.key === key);
+  if (!row) throw new Error(`no instance_audit_log row for key ${key}`);
+  return row;
+}
+
+function retentionForm(vals: Record<string, string>): Request {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(vals)) fd.set(k, v);
+  return new Request('http://localhost/settings/retention', { method: 'POST', body: fd });
+}
+
+describe('instance-wide writes record an audit row', () => {
+  beforeEach(reset);
+
+  it('default-runner PUT records the slug change with the actor and before/after', async () => {
+    const jar = await sessionFor('iat-defrunner');
+    const put = (slug: string) =>
+      runThroughHandle(
+        new Request('http://localhost/api/settings/default-runner', {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ slug }),
+        }),
+        jar,
+        defaultRunnerPut as any,
+      );
+    expect((await put('claude-code')).status).toBe(200);
+    expect((await put('codex')).status).toBe(200);
+
+    const row = await lastRowFor('default_runner');
+    expect(row.actor).toBe('iat-defrunner');
+    expect(row.before).toEqual({ slug: 'claude-code' });
+    expect(row.after).toEqual({ slug: 'codex' });
+  });
+
+  it('quota POST records the config change, not just the current value', async () => {
+    const jar = await sessionFor('iat-quota');
+    const post = (body: unknown) =>
+      runThroughHandle(
+        new Request('http://localhost/api/settings/quota', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+        jar,
+        quotaPost as any,
+      );
+    const first = { reddit: { dm: { perDay: 1, perWeek: 5 }, comment: { perDay: 1, perWeek: 5 }, post: { perDay: 1, perWeek: 5 } } };
+    const second = { reddit: { dm: { perDay: 2, perWeek: 10 }, comment: { perDay: 2, perWeek: 10 }, post: { perDay: 2, perWeek: 10 } } };
+    expect((await post(first)).status).toBe(200);
+    expect((await post(second)).status).toBe(200);
+
+    const row = await lastRowFor('quota_defaults');
+    expect(row.before).toEqual(first);
+    expect(row.after).toEqual(second);
+  });
+
+  it('runner-config PUT records under a per-runner key', async () => {
+    const jar = await sessionFor('iat-runnercfg');
+    const put = (config: unknown) =>
+      runThroughHandle(
+        new Request('http://localhost/api/settings/runner-config', {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ slug: 'claude-code', config }),
+        }),
+        jar,
+        runnerConfigPut as any,
+      );
+    expect((await put({ model: 'sonnet' })).status).toBe(200);
+    expect((await put({ model: 'opus' })).status).toBe(200);
+
+    const row = await lastRowFor('runner_config:claude-code');
+    expect(row.before).toEqual({ model: 'sonnet' });
+    expect(row.after).toEqual({ model: 'opus' });
+  });
+
+  it('webhooks PUT records that the target changed without storing either URL', async () => {
+    const jar = await sessionFor('iat-webhooks');
+    const put = (url: string) =>
+      runThroughHandle(
+        new Request('http://localhost/api/settings/webhooks', {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ url }),
+        }),
+        jar,
+        webhooksPut as any,
+      );
+    expect((await put('https://hooks.example.test/aaa')).status).toBe(200);
+    expect((await put('https://hooks.example.test/bbb')).status).toBe(200);
+
+    const row = await lastRowFor('notification_webhooks');
+    const before = row.before as { url: { present: boolean; fingerprint: string } | null };
+    const after = row.after as { url: { present: boolean; fingerprint: string } | null };
+    expect(JSON.stringify(row)).not.toContain('hooks.example.test');
+    expect(before.url?.present).toBe(true);
+    expect(after.url?.present).toBe(true);
+    expect(before.url?.fingerprint).not.toBe(after.url?.fingerprint);
+  });
+
+  it('model-functions POST records under a per-function key', async () => {
+    const jar = await sessionFor('iat-modelfn');
+    const post = (modelId: string) =>
+      runThroughHandle(
+        new Request('http://localhost/api/settings/model-functions', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ fn: 'assist_suggest', modelId }),
+        }),
+        jar,
+        modelFunctionsPost as any,
+      );
+    expect((await post('openai/gpt-5-mini')).status).toBe(200);
+    expect((await post('google/gemini-3.1-flash-lite')).status).toBe(200);
+
+    const row = await lastRowFor('model_function:assist_suggest');
+    expect(row.before).toEqual({ modelId: 'openai/gpt-5-mini' });
+    expect(row.after).toEqual({ modelId: 'google/gemini-3.1-flash-lite' });
+  });
+
+  it('retention form action records the policy change', async () => {
+    const jar = await sessionFor('iat-retention');
+    const save = (drafts_days: string) =>
+      runThroughHandle(
+        retentionForm({
+          drafts_days,
+          run_events_days: '30',
+          draft_events_days: '90',
+          webhook_deliveries_days: '30',
+        }),
+        jar,
+        retentionActions.default as any,
+      );
+    await save('90');
+    await save('45');
+
+    const row = await lastRowFor('retention');
+    expect((row.before as { drafts_days: number }).drafts_days).toBe(90);
+    expect((row.after as { drafts_days: number }).drafts_days).toBe(45);
+  });
+});
+
+afterAll(async () => {
+  if (originalAuth === undefined) delete process.env.PITCHBOX_AUTH;
+  else process.env.PITCHBOX_AUTH = originalAuth;
+  await getPool().end();
+});


### PR DESCRIPTION
Closes #414

## What
`instance_audit_log` (migration 0020, `shared/src/db/schema.ts`): `id`, `key`, `actor`, `before`, `after`, `created_at`. Its own table, not a row in the org-scoped `draft_events`/`run_events` union `audit-feed.ts` builds - an instance-wide write belongs to no project's `organization_id`.

`recordInstanceAudit` (`shared/src/instance-audit.ts`) is the one function every instance-wide write calls after it succeeds. It redacts `before`/`after` itself before the insert, so a caller doesn't have to remember to: any JSON field whose name matches `/key|token|secret|password|credential/i` becomes `'[redacted]'`, and any field named `*url` (a webhook target can carry a bearer token in its path or query string) becomes `{ present, fingerprint }` - a stable sha256-prefix fingerprint, same construction as `webhookIdForUrl`, so two audit rows can still be told apart without exposing either URL.

Wired into every `requireInstanceAdmin`-gated write:
- `PUT /api/settings/default-runner`
- `POST /api/settings/quota`
- `PUT /api/settings/runner-config`
- `PUT /api/settings/webhooks` (redacted - the URL itself)
- `POST /api/settings/model-functions`
- `settings/retention`'s form action
- `POST /api/settings/admin/promote` (#413, landed while this was in flight - wired per Promote413's pointer, right after `setInstanceAdmin`)

Not wired: `POST /api/webhooks/deliveries/[id]/retry` - deliberately, it's an org-scoped operational retry (the delivery belongs to an org, checked before the instance-admin gate), not a config write; nothing about it changes.

Rendered at `settings/admin/audit`, a new page in #412's area, gated the same way as its siblings (`settings/admin/+layout.server.ts` plus its own `requireInstanceAdmin` call, defense in depth matching `settings/admin/models`). Linked from the admin index page.

`docs/permissions.md` updated: new "Instance-wide audit trail (#414)" section, and the promotion doc's stale "does not attempt to log" line corrected.

## Verification
- `pnpm -F @pitchbox/shared typecheck` and `pnpm -F web check`: clean.
- `npx eslint` / `npx prettier --check` on every changed file: clean (svelte files aren't prettier-checkable in this repo at all - no `prettier-plugin-svelte` installed anywhere, confirmed on an untouched file too).
- Migration proven with psql: `\d instance_audit_log` shows the table on `pitchbox_test_w414`.
- `shared/tests/instance-audit.test.ts` (8 tests): recording, actor resolution (signed-in vs 'self-host'), ordering, and three redaction tests - a raw webhook URL and a literal credential field never reach the row, and two different URLs still fingerprint differently.
- `web/tests/instance-audit-trail.test.ts` (7 tests): every wired route, driven through the real `hooks.server.ts` handle(), produces a row with the right key/actor/before/after - including the promote route.
- `web/tests/instance-audit-org-feed-unchanged.test.ts`: a member's org audit feed (`loadAuditFeed`) is byte-identical before and after every instance-wide write runs.
- `web/tests/instance-audit-admin-page.test.ts`: the new page's loader 403s a non-instance-admin, renders rows for the instance admin, and is a no-op (200) with auth off.
- Every one of the above 15 route/redaction assertions proven to bite: I disabled each `recordInstanceAudit` call (or the redaction step) one at a time, watched the specific assertion fail with the exact expected message, then restored it and reran green.
- Render: `pnpm run dev:web` on port 5204, real render at `/settings/admin/audit` (200, correct headers/columns) plus a screenshot; separately grepped the raw HTML response for a seeded secret webhook URL - zero occurrences, only `present`/`fingerprint`.

Not merging - report and wait per instructions.

## Redaction is a name-based heuristic, not a guarantee
`redactInstanceAuditValue` catches a field named `key`/`token`/`secret`/`password`/`credential` (any case, any substring) or ending in `url`, wherever it appears in `before`/`after`. A future instance-wide setting whose sensitive value sits in a field matching neither pattern - `gatewayAccount`, `smtpUser`, say - would land in the row unredacted. There's no way to make this a true guarantee without inspecting values (which risks false positives on ordinary config and can't tell a real secret from a plausible-looking string anyway), so the fix is procedural: read `redactInstanceAuditValue`'s doc comment once before adding a new instance-wide write, documented now in both the function's comment and `docs/permissions.md`'s audit-trail section.
