### PR TITLE
feat(shared): an AgentRunner backed by the AI SDK through the Gateway

### DIFF
--- a/shared/src/agents/registry.ts
+++ b/shared/src/agents/registry.ts
@@ -1,5 +1,5 @@
 import { AcpRunner } from './acp/runner.js';
-import { CloudRunner } from './cloud.js';
+import { SdkRunner } from './sdk/runner.js';
 import type { AgentRunner } from './base.js';
 import type { AgentRunnerSlug } from './meta.js';
 import type { RunnerConfig } from './config.js';
@@ -18,7 +18,7 @@ export const AGENT_RUNNERS: Record<AgentRunnerSlug, (config?: RunnerConfig) => A
   copilot: acp('copilot'),
   opencode: acp('opencode'),
   'qwen-code': acp('qwen-code'),
-  cloud: (config) => new CloudRunner(config),
+  cloud: (config) => new SdkRunner({ config }),
 };
 
 export function createAgentRunner(slug: string, config?: RunnerConfig): AgentRunner {

--- a/shared/src/agents/sdk/runner.ts
+++ b/shared/src/agents/sdk/runner.ts
@@ -1,0 +1,356 @@
+// shared/src/agents/sdk/runner.ts
+//
+// The `cloud` runner's real implementation (#415/#416): an ordinary
+// `AgentRunner` that drives the model loop in this process, with the AI
+// Gateway as its only remote. No separate compute service, no WebSocket relay
+// - see docs/cloud-runner.md's "decided 2026-09-08" section for why that
+// design was dropped and what replaced it.
+import { mkdirSync, writeFileSync, appendFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { streamText, stepCountIs, type ToolSet } from 'ai';
+import {
+  createGateway,
+  type GatewayProvider,
+  type GatewayLanguageModelEntry,
+} from '@ai-sdk/gateway';
+import type { AgentRunHandle, AgentRunOptions, AgentRunResult, AgentRunner } from '../base.js';
+import type { RunnerConfig } from '../config.js';
+import type { ParsedEvent } from '../../runlog/types.js';
+import { createPitchboxToolSet, type PitchboxToolSet } from './tools.js';
+import {
+  normalizeSdkPart,
+  normalizeStopReason,
+  pricingFromCatalogueEntry,
+  buildSdkUsage,
+  addSdkUsage,
+  type SdkStopReasonKind,
+  type SdkUsage,
+  type SdkLanguageModelUsage,
+  type SdkModelPricing,
+} from './event-normalizer.js';
+
+export interface SdkRunnerOptions {
+  config?: RunnerConfig;
+  logDir?: string;
+  /**
+   * Step ceiling for `stopWhen(stepCountIs(n))`. #415's probe drove
+   * `playbooks/hn-commenter.md` to completion in 7 steps (run_start, four
+   * hn_search calls, drafts_create, run_finish) against a ceiling of 12;
+   * kept as the default here for the same reason it worked there - generous
+   * enough that a busier playbook (more candidates, a retried tool call)
+   * still reaches its finish tool, tight enough that a model stuck calling
+   * the same tool in a loop does not run unbounded. A playbook that
+   * genuinely needs more is a per-scenario override, not a reason to raise
+   * the shared default (docs/cloud-runner.md, decision #3).
+   */
+  stepCeiling?: number;
+  /** Test-only: replace the AI SDK's `streamText` with a fake. */
+  streamTextFn?: typeof streamText;
+  /** Test-only: replace `createGateway` with a fake. */
+  createGatewayFn?: typeof createGateway;
+  /** Test-only: replace `createPitchboxToolSet` with a fake. */
+  createToolSetFn?: typeof createPitchboxToolSet;
+}
+
+const DEFAULT_STEP_CEILING = 12;
+
+// Gateway model catalogue (for per-token pricing) is fetched once per
+// process and reused - it changes on the Gateway's own release cadence, not
+// per run, and fetching it per run would add a network round trip to every
+// dispatch for a number a five-minute-old cache answers just as well.
+const MODEL_CATALOGUE_TTL_MS = 5 * 60 * 1000;
+let modelCatalogueCache: { value: GatewayLanguageModelEntry[]; expiresAt: number } | null = null;
+
+async function loadModelCatalogue(gateway: GatewayProvider): Promise<GatewayLanguageModelEntry[]> {
+  const now = Date.now();
+  if (modelCatalogueCache && modelCatalogueCache.expiresAt > now) return modelCatalogueCache.value;
+  try {
+    const response = await gateway.getAvailableModels();
+    modelCatalogueCache = { value: response.models, expiresAt: now + MODEL_CATALOGUE_TTL_MS };
+    return response.models;
+  } catch {
+    // Pricing is best-effort: a catalogue hiccup should not fail the run,
+    // only leave its cost unpriced (buildSdkUsage then returns costUsd: null).
+    return [];
+  }
+}
+
+function posInt(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+export class SdkRunner implements AgentRunner {
+  readonly slug = 'cloud';
+  private readonly config: RunnerConfig;
+  private readonly logDir: string;
+  private readonly stepCeiling: number;
+  private readonly streamTextFn: typeof streamText;
+  private readonly createGatewayFn: typeof createGateway;
+  private readonly createToolSetFn: typeof createPitchboxToolSet;
+
+  constructor(opts: SdkRunnerOptions = {}) {
+    this.config = opts.config ?? {};
+    this.logDir = opts.logDir ?? join(process.cwd(), 'daemon', 'logs');
+    this.stepCeiling = opts.stepCeiling ?? DEFAULT_STEP_CEILING;
+    this.streamTextFn = opts.streamTextFn ?? streamText;
+    this.createGatewayFn = opts.createGatewayFn ?? createGateway;
+    this.createToolSetFn = opts.createToolSetFn ?? createPitchboxToolSet;
+  }
+
+  run(opts: AgentRunOptions): AgentRunHandle {
+    const controller = new AbortController();
+    // Which AbortSignal fired, decided by us and nobody else: an aborted
+    // `streamText` does not throw, it ends the stream cleanly with
+    // `finishReason: 'other'` (docs/cloud-runner.md #415, measured against
+    // the real Gateway). Reading that finish reason as success would record
+    // a cancelled or timed-out run as completed, so the outcome comes from
+    // this flag, never from whether the loop below threw.
+    let outcome: 'cancel' | 'timeout' | null = null;
+
+    const cancelFn = () => {
+      if (outcome) return; // already terminal - a second cancel is a no-op
+      outcome = 'cancel';
+      controller.abort();
+    };
+
+    const result: Promise<AgentRunResult> = (async () => {
+      mkdirSync(this.logDir, { recursive: true });
+      const logPath = join(this.logDir, `run-${Date.now()}-sdk.log`);
+      writeFileSync(logPath, `# sdk run started ${new Date().toISOString()}\n`, 'utf8');
+      const log = (line: string) => appendFileSync(logPath, `${line}\n`, 'utf8');
+
+      // Fail loudly and immediately when the deployment has no Gateway
+      // credential, rather than let the first streamText call surface an
+      // opaque provider auth error at the first token.
+      const apiKey = process.env.AI_GATEWAY_API_KEY;
+      if (!apiKey) {
+        throw new Error(
+          'AI_GATEWAY_API_KEY is not set: the SDK runner has no Gateway key to reach any model. ' +
+            'Set it in this deployment\u2019s environment before dispatching a cloud-runner run.',
+        );
+      }
+
+      // Model resolution is entirely #411's job (resolveFunctionModel /
+      // resolveModelForRun in shared/src/ai/model-functions.ts) - the
+      // dispatcher resolves it and writes it into this runner's
+      // `RunnerConfig.model` before construction (see
+      // `runnerTakesGatewayModel` / `web/src/lib/server/runner.ts`). This
+      // runner never resolves or defaults one itself.
+      const modelId = this.config.model?.trim();
+      if (!modelId) {
+        throw new Error(
+          'SdkRunner has no resolved Gateway model id (config.model). The caller should have set ' +
+            'this via resolveModelForRun before constructing the runner.',
+        );
+      }
+
+      // A direct `prompt` wins over `playbookPath`, matching AcpRunner: one
+      // of the two is required, since prompting with nothing burns a call
+      // and returns nothing. Unlike ACP, the playbook becomes the *system*
+      // prompt and the task line is the user turn (docs/cloud-runner.md
+      // decision #3) rather than one concatenated blob.
+      let system: string | undefined;
+      let userText: string;
+      if (opts.prompt != null) {
+        userText = opts.prompt;
+      } else if (opts.playbookPath) {
+        system = await readFile(opts.playbookPath, 'utf8');
+        // The one line ACP's `buildPrompt` prepends to the whole prompt,
+        // relocated to the user turn now that the playbook itself is the
+        // system prompt (docs/cloud-runner.md decision #3).
+        userText = `You are running the Pitchbox playbook '${opts.slug}' for campaign ${opts.env.PITCHBOX_CAMPAIGN_ID ?? ''}.`;
+      } else {
+        throw new Error('SdkRunner.run needs either a prompt or a playbookPath');
+      }
+
+      const gateway = this.createGatewayFn({ apiKey });
+      const model = gateway(modelId);
+
+      // `attachMcp: false` (the in-page suggestion path) gets no tools at
+      // all - nothing for it to write, and a tool loop is what a real-time
+      // path cannot afford (mirrors AcpRunner's `mcpServers: []` case).
+      let toolSet: PitchboxToolSet | undefined;
+      if (opts.attachMcp !== false) {
+        // Session binding read from the per-run env `dispatchRun` builds
+        // (PITCHBOX_RUN_ID etc, web/src/lib/server/runner.ts) - there is no
+        // child process to forward it to here, unlike the ACP backend, and
+        // an explicit context wins over `createPitchboxMcpServer`'s own
+        // `process.env` fallback (cli/src/mcp/server.ts), which matters
+        // because this runner shares a process with every other run.
+        toolSet = await this.createToolSetFn({
+          runId: posInt(opts.env.PITCHBOX_RUN_ID),
+          campaignId: posInt(opts.env.PITCHBOX_CAMPAIGN_ID),
+          projectId: posInt(opts.env.PITCHBOX_PROJECT_ID) ?? posInt(opts.env.PROJECT_ID),
+        });
+      }
+
+      let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        timeoutTimer = setTimeout(() => {
+          if (!outcome) {
+            outcome = 'timeout';
+            controller.abort();
+          }
+        }, opts.timeoutMs);
+
+        // Buffers for streamed assistant/thinking text, coalesced into one
+        // ParsedEvent per message instead of one per delta - otherwise every
+        // generated token/group would produce its own runlog row, the same
+        // problem AcpRunner's `pendingAssistantText` buffer avoids for ACP's
+        // `agent_message_chunk`. Flushed through `normalizeSdkPart` with a
+        // synthetic single-part `text-delta`/`reasoning-delta`, the same
+        // shape it already builds for the real per-chunk case.
+        let seq = 0;
+        let pendingAssistantText = '';
+        let pendingThinkingText = '';
+
+        const flushPendingText = () => {
+          const events: ParsedEvent[] = [];
+          if (pendingAssistantText) {
+            events.push(
+              ...normalizeSdkPart({ type: 'text-delta', text: pendingAssistantText }, '', seq),
+            );
+            seq += 1;
+            pendingAssistantText = '';
+          }
+          if (pendingThinkingText) {
+            events.push(
+              ...normalizeSdkPart({ type: 'reasoning-delta', text: pendingThinkingText }, '', seq),
+            );
+            seq += 1;
+            pendingThinkingText = '';
+          }
+          if (events.length > 0) void opts.onParsedEvents?.(events);
+        };
+
+        let sawErrorPart = false;
+        let stepCount = 0;
+        // Accumulated across `finish-step` parts as the loop runs, not read
+        // once at the end: a mid-loop provider error closes the stream with
+        // an `error` part and no top-level `finish` part at all (confirmed
+        // against `ai`'s own streamText source), so `result.totalUsage`
+        // alone would report zero for a run that still spent real tokens.
+        let stepUsage: SdkLanguageModelUsage | undefined;
+        let finishUsage: SdkLanguageModelUsage | undefined;
+        let finishReason: string | undefined;
+
+        try {
+          const streamResult = this.streamTextFn({
+            model,
+            system,
+            messages: [{ role: 'user', content: userText }],
+            tools: toolSet?.tools as ToolSet | undefined,
+            stopWhen: stepCountIs(this.stepCeiling),
+            abortSignal: controller.signal,
+          });
+
+          try {
+            for await (const part of streamResult.fullStream) {
+              const raw = JSON.stringify(part);
+              log(`[part] ${raw}`);
+              opts.onRawLine?.(raw);
+
+              if (part.type === 'text-delta') {
+                const text = part.text ?? '';
+                pendingAssistantText += text;
+                if (text) opts.onTextChunk?.(text);
+                continue;
+              }
+              if (part.type === 'reasoning-delta') {
+                pendingThinkingText += part.text ?? '';
+                continue;
+              }
+              flushPendingText();
+
+              if (part.type === 'finish-step') {
+                stepCount += 1;
+                stepUsage = addSdkUsage(stepUsage, part.usage);
+              } else if (part.type === 'finish') {
+                finishUsage = part.totalUsage;
+                finishReason = part.finishReason;
+              } else if (part.type === 'error') {
+                sawErrorPart = true;
+              }
+
+              const produced = normalizeSdkPart(part, raw, seq);
+              seq += Math.max(produced.length, 1);
+              if (produced.length > 0) void opts.onParsedEvents?.(produced);
+            }
+          } catch (err) {
+            // A genuine mid-run failure (network error, provider fetch
+            // throw) that is NOT our own abort - a self-requested abort is
+            // handled entirely through `outcome`, set above, and never
+            // reaches here as a reason to reclassify the run.
+            if (!outcome) {
+              sawErrorPart = true;
+              log(
+                `[loop-error] ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
+              );
+            }
+          }
+        } finally {
+          flushPendingText();
+        }
+
+        const stopReasonKind: SdkStopReasonKind =
+          outcome === 'cancel'
+            ? 'cancelled'
+            : outcome === 'timeout'
+              ? 'timeout'
+              : sawErrorPart || finishReason === 'error'
+                ? 'error'
+                : finishReason === 'content-filter'
+                  ? 'refusal'
+                  : finishReason === 'tool-calls' && stepCount >= this.stepCeiling
+                    ? 'max_turn_requests'
+                    : 'end_turn';
+
+        // Only a genuine runner-level failure is a non-zero exit: whether
+        // the agent actually finished its job (called the playbook's finish
+        // tool) is `playbookContractError`'s job downstream
+        // (web/src/lib/server/runner.ts), exactly as it already is for
+        // AcpRunner, whose exit code reflects the CLI process, not the
+        // model's own verdict on itself.
+        const exitCode =
+          stopReasonKind === 'cancelled' ||
+          stopReasonKind === 'timeout' ||
+          stopReasonKind === 'error'
+            ? 1
+            : 0;
+
+        const usage = finishUsage ?? stepUsage ?? {};
+        const entries = await loadModelCatalogue(gateway);
+        const pricing: SdkModelPricing | undefined = pricingFromCatalogueEntry(
+          entries.find((m) => m.id === modelId),
+        );
+        const usageResult = buildSdkUsage(usage, { pricing });
+        const tokensUsed = usageResult.inputTokens + usageResult.outputTokens;
+
+        const sdkUsageForEvent: SdkUsage = {
+          inputTokens: usageResult.inputTokens,
+          outputTokens: usageResult.outputTokens,
+          cacheReadTokens: usageResult.cacheReadTokens,
+          cacheCreationTokens: usageResult.cacheCreationTokens,
+          totalCostUsd: usageResult.costUsd ?? undefined,
+        };
+        const tail = normalizeStopReason(stopReasonKind, sdkUsageForEvent, '', seq);
+        seq += tail.length;
+        if (tail.length > 0) void opts.onParsedEvents?.(tail);
+
+        log(
+          `# sdk run finished ${new Date().toISOString()} stopReason=${stopReasonKind} exitCode=${exitCode}`,
+        );
+
+        return { exitCode, logPath, tokensUsed, usage: usageResult };
+      } finally {
+        clearTimeout(timeoutTimer);
+        await toolSet?.close().catch(() => {});
+      }
+    })();
+
+    return { result, cancel: () => cancelFn() };
+  }
+}

--- a/shared/tests/agents/sdk/runner.test.ts
+++ b/shared/tests/agents/sdk/runner.test.ts
@@ -1,0 +1,348 @@
+// shared/tests/agents/sdk/runner.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+import type { streamText } from 'ai';
+import type { createGateway } from '@ai-sdk/gateway';
+import { SdkRunner } from '../../../src/agents/sdk/runner.js';
+import type { ParsedEvent } from '../../../src/runlog/types.js';
+import type { PitchboxToolSet } from '../../../src/agents/sdk/tools.js';
+
+function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}
+
+// Fake `streamText`: every test supplies just the stream parts it cares
+// about via an async generator, closing over the `abortSignal` the runner
+// passes in so cancel/timeout tests can react to it exactly like the real
+// AI SDK does - by ending the stream, never by throwing (docs/cloud-runner.md
+// #415's "an aborted streamText does not throw" finding).
+function fakeStreamText(parts: (signal: AbortSignal) => AsyncGenerator<unknown>) {
+  return vi.fn((opts: { abortSignal?: AbortSignal }) => ({
+    fullStream: parts(opts.abortSignal ?? new AbortController().signal),
+  })) as unknown as typeof streamText;
+}
+
+async function* gen(...parts: unknown[]): AsyncGenerator<unknown> {
+  for (const p of parts) yield p;
+}
+
+function fakeToolSet(): { fn: () => Promise<PitchboxToolSet>; closeCalls: number[] } {
+  const closeCalls: number[] = [];
+  const fn = async (): Promise<PitchboxToolSet> => ({
+    tools: { a_tool: {} },
+    close: async () => {
+      closeCalls.push(closeCalls.length);
+    },
+  });
+  return { fn, closeCalls };
+}
+
+function fakeGateway() {
+  const getAvailableModels = vi.fn(async () => ({ models: [] }));
+  const gateway = Object.assign(
+    vi.fn((id: string) => ({ modelId: id }) as never),
+    {
+      getAvailableModels,
+    },
+  );
+  return vi.fn(() => gateway) as unknown as typeof createGateway;
+}
+
+function tmpLogDir(): string {
+  return mkdtempSync(join(tmpdir(), 'sdk-runner-test-'));
+}
+
+let logDir: string;
+
+beforeEach(() => {
+  logDir = tmpLogDir();
+  process.env.AI_GATEWAY_API_KEY = 'test-key';
+});
+
+afterEach(() => {
+  delete process.env.AI_GATEWAY_API_KEY;
+  rmSync(logDir, { recursive: true, force: true });
+  vi.useRealTimers();
+});
+
+const baseOpts = () => ({
+  slug: 'hn-commenter',
+  env: { PITCHBOX_RUN_ID: '7', PITCHBOX_CAMPAIGN_ID: '3' },
+  cwd: '/tmp',
+  timeoutMs: 60_000,
+});
+
+describe('SdkRunner', () => {
+  it('rejects with a message naming the missing key when AI_GATEWAY_API_KEY is unset', async () => {
+    delete process.env.AI_GATEWAY_API_KEY;
+    const runner = new SdkRunner({ config: { model: 'google/gemini-3.1-flash-lite' }, logDir });
+    const handle = runner.run({ ...baseOpts(), prompt: 'hi' });
+    await expect(handle.result).rejects.toThrow(/AI_GATEWAY_API_KEY/);
+  });
+
+  it('rejects with a clear message when no model was resolved onto config.model', async () => {
+    const { fn: createToolSetFn } = fakeToolSet();
+    const runner = new SdkRunner({ config: {}, logDir, createToolSetFn });
+    const handle = runner.run({ ...baseOpts(), prompt: 'hi' });
+    await expect(handle.result).rejects.toThrow(/resolved Gateway model/);
+  });
+
+  it('rejects when neither prompt nor playbookPath is given', async () => {
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn: fakeToolSet().fn,
+      streamTextFn: fakeStreamText(() => gen()),
+    });
+    const handle = runner.run(baseOpts());
+    await expect(handle.result).rejects.toThrow(/prompt or a playbookPath/);
+  });
+
+  it('runs a prompt-only turn to completion with attachMcp:false, skipping the tool set entirely', async () => {
+    const createToolSetSpy = vi.fn(fakeToolSet().fn);
+    const chunks: string[] = [];
+    const events: ParsedEvent[] = [];
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn: createToolSetSpy,
+      streamTextFn: fakeStreamText(() =>
+        gen(
+          { type: 'text-delta', id: '1', text: 'Hello' },
+          { type: 'text-delta', id: '1', text: ' there' },
+          {
+            type: 'finish-step',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 5, inputTokenDetails: {} },
+          },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            totalUsage: { inputTokens: 10, outputTokens: 5 },
+          },
+        ),
+      ),
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'suggest a reply',
+      attachMcp: false,
+      onTextChunk: (t) => chunks.push(t),
+      onParsedEvents: (evs) => {
+        events.push(...evs);
+      },
+    });
+    const res = await handle.result;
+    expect(res.exitCode).toBe(0);
+    expect(createToolSetSpy).not.toHaveBeenCalled();
+    expect(chunks.join('')).toBe('Hello there');
+    // One coalesced assistant event (not one per delta), plus the closing result event.
+    const assistantEvents = events.filter((e) => e.kind === 'assistant');
+    expect(assistantEvents).toHaveLength(1);
+    expect(assistantEvents[0].payload).toMatchObject({ type: 'assistant', text: 'Hello there' });
+    const resultEvent = events.find((e) => e.kind === 'result');
+    expect(resultEvent?.payload).toMatchObject({ type: 'result', success: true });
+  });
+
+  it('attaches the MCP tool set (bound to the run/campaign ids from opts.env) when attachMcp is not false', async () => {
+    const createToolSetSpy = vi.fn(fakeToolSet().fn);
+    const playbookPath = join(logDir, 'playbook.md');
+    await writeFile(playbookPath, '# Playbook\nDo the thing.', 'utf8');
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn: createToolSetSpy,
+      streamTextFn: fakeStreamText(() =>
+        gen({
+          type: 'finish',
+          finishReason: 'stop',
+          totalUsage: { inputTokens: 1, outputTokens: 1 },
+        }),
+      ),
+    });
+    const handle = runner.run({ ...baseOpts(), playbookPath });
+    await handle.result;
+    expect(createToolSetSpy).toHaveBeenCalledWith({
+      runId: 7,
+      campaignId: 3,
+      projectId: undefined,
+    });
+  });
+
+  it('ends a cancelled run as cancelled, from the abort signal state rather than a thrown error', async () => {
+    const { fn: createToolSetFn } = fakeToolSet();
+    const events: ParsedEvent[] = [];
+    let resolveFirstChunk: () => void;
+    const gotFirstChunk = new Promise<void>((resolve) => {
+      resolveFirstChunk = resolve;
+    });
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn,
+      streamTextFn: fakeStreamText(function (signal) {
+        return (async function* () {
+          yield { type: 'text-delta', id: '1', text: 'partial' };
+          // The real AI SDK ends the stream cleanly on abort - it does not
+          // throw. Wait for the signal, then simply stop yielding, exactly
+          // that behaviour.
+          await waitForAbort(signal);
+        })();
+      }),
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'hi',
+      attachMcp: false,
+      onTextChunk: () => resolveFirstChunk(),
+      onParsedEvents: (evs) => {
+        events.push(...evs);
+      },
+    });
+    // Cancel only once the fake stream has actually started (deterministic:
+    // wait on the runner's own callback, not a guessed real-time delay).
+    await gotFirstChunk;
+    handle.cancel();
+    const res = await handle.result;
+    expect(res.exitCode).toBe(1);
+    const resultEvent = events.find((e) => e.kind === 'result');
+    expect(resultEvent?.payload).toMatchObject({ type: 'result', success: false });
+    expect(resultEvent?.raw).toMatch(/cancelled/);
+  });
+
+  it('ends a run that hits its own timeout as timed out, not hanging and not cancelled', async () => {
+    vi.useFakeTimers();
+    const { fn: createToolSetFn } = fakeToolSet();
+    const events: ParsedEvent[] = [];
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn,
+      streamTextFn: fakeStreamText(function (signal) {
+        // This fixture models a stream with no output at all until the
+        // runner's own timeout aborts it.
+        // eslint-disable-next-line require-yield
+        return (async function* () {
+          // Never yields again on its own - only the runner's timeout should
+          // move this forward, by aborting the signal.
+          await waitForAbort(signal);
+        })();
+      }),
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'hi',
+      attachMcp: false,
+      timeoutMs: 20,
+      onParsedEvents: (evs) => {
+        events.push(...evs);
+      },
+    });
+    await vi.advanceTimersByTimeAsync(20);
+    const res = await handle.result;
+    expect(res.exitCode).toBe(1);
+    const resultEvent = events.find((e) => e.kind === 'result');
+    expect(resultEvent?.raw).toMatch(/timed out/);
+    expect(resultEvent?.raw).not.toMatch(/cancelled/);
+  });
+
+  it('turns an in-band provider error part into a failed run instead of an empty success', async () => {
+    const { fn: createToolSetFn } = fakeToolSet();
+    const events: ParsedEvent[] = [];
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn,
+      streamTextFn: fakeStreamText(() =>
+        gen({ type: 'error', error: new Error('502 Bad Gateway') }),
+      ),
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'hi',
+      attachMcp: false,
+      onParsedEvents: (evs) => {
+        events.push(...evs);
+      },
+    });
+    const res = await handle.result;
+    expect(res.exitCode).toBe(1);
+    const providerErrorEvent = events.find(
+      (e) => e.kind === 'unknown' && e.raw.includes('502 Bad Gateway'),
+    );
+    expect(providerErrorEvent).toBeDefined();
+    const resultEvent = events.find((e) => e.kind === 'result');
+    expect(resultEvent?.payload).toMatchObject({ type: 'result', success: false });
+  });
+
+  it('closes the MCP tool set exactly once even when the run ends in error', async () => {
+    const { fn: createToolSetFn, closeCalls } = fakeToolSet();
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn,
+      streamTextFn: fakeStreamText(() => gen({ type: 'error', error: new Error('boom') })),
+    });
+    const handle = runner.run({ ...baseOpts(), prompt: 'hi' });
+    await handle.result;
+    expect(closeCalls).toHaveLength(1);
+  });
+
+  it('reaching the step ceiling with more tool calls pending stops as max_turn_requests, not a crash', async () => {
+    const { fn: createToolSetFn } = fakeToolSet();
+    const events: ParsedEvent[] = [];
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      stepCeiling: 2,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn,
+      streamTextFn: fakeStreamText(() =>
+        gen(
+          {
+            type: 'finish-step',
+            finishReason: 'tool-calls',
+            usage: { inputTokens: 5, outputTokens: 5, inputTokenDetails: {} },
+          },
+          {
+            type: 'finish-step',
+            finishReason: 'tool-calls',
+            usage: { inputTokens: 5, outputTokens: 5, inputTokenDetails: {} },
+          },
+          {
+            type: 'finish',
+            finishReason: 'tool-calls',
+            totalUsage: { inputTokens: 10, outputTokens: 10 },
+          },
+        ),
+      ),
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'hi',
+      attachMcp: false,
+      onParsedEvents: (evs) => {
+        events.push(...evs);
+      },
+    });
+    const res = await handle.result;
+    // Not a runner-level failure: whether the playbook actually finished is
+    // playbookContractError's job downstream, exactly as for AcpRunner.
+    expect(res.exitCode).toBe(0);
+    const resultEvent = events.find((e) => e.kind === 'result');
+    expect(resultEvent?.raw).toMatch(/step limit/);
+  });
+});


### PR DESCRIPTION
Closes #416.

Implements the `cloud` runner's real model loop: an ordinary `AgentRunner` that drives `streamText` against the AI Gateway in this process, bounded by `stopWhen(stepCountIs(12))`.

**Step ceiling: 12.** The #415 probe finished `playbooks/hn-commenter.md` in 7 steps at that ceiling - generous enough for a busier playbook (more candidates, a retried tool call) to still reach its finish tool, tight enough that a model stuck in a loop still terminates.

**Model resolution goes entirely through #411.** `dispatchRun` already resolves the Gateway model id onto `RunnerConfig.model` before construction (`resolveModelForRun` / `runnerTakesGatewayModel`), so this runner only reads `config.model` and throws a clear error if it is missing rather than defaulting or resolving a second time.

**The trap the issue calls out, handled:** an aborted `streamText` does not throw - it ends the stream cleanly (docs/cloud-runner.md #415's measured finding). The runner tracks which `AbortSignal` fired (`cancel` vs its own `timeoutMs` timer) in a local `outcome` flag and decides the run's outcome from that, never from the absence of a throw or from the stream's own `finishReason`. A provider error arrives in-band as an `error` stream part, not a throw; that's tracked the same way and turns into a failed run instead of an empty success.

Registered as the `cloud` slug in `registry.ts` - one line, since `runnerTakesGatewayModel` and the edition guard already expect it. `shared/src/agents/cloud.ts` and the private adapter are untouched (#420 removes them).

### This branch is red on purpose right now

It imports `./tools.js` (#417, `createPitchboxToolSet`) and `./event-normalizer.js` (#418, `normalizeSdkPart` / `normalizeStopReason` / `buildSdkUsage` / `pricingFromCatalogueEntry` / `addSdkUsage`) by the signatures we agreed on over IRC before either PR was merged. Neither file exists on this branch yet, so `shared`'s typecheck currently fails on two missing modules. I verified all of the below locally against both siblings' real implementations (pulled from their worktrees before either was merged) and then removed those files again before committing, so my diff stays exactly my own three files plus the one-line registry change. Once #417 and #418 merge I'll rebase and re-verify.

`shared/package.json` gains `ai` as a direct dependency (`streamText`, `stepCountIs`). #417 adds the identical line for its own file - this will collide and resolve trivially on rebase.

### Real run against the Gateway

`playbooks/hn-commenter.md`, `google/gemini-3.1-flash-lite`, a real campaign row with a config validating against `getSchema('hn-commenter')`:

- Tool calls: `run_start` → `hn_search` ×3 → `drafts_create` → `run_finish`
- 57,761 tokens (57,200 in, of which 34,244 were cache reads; 561 out), $0.0076
- Runner result: `{ exitCode: 0, usage: {...} }`
- Run row: `status: 'success'`, `finishedAt` set
- A real draft was inserted (fit score 5, quality score 90, real body text)

### Cancel, observed

Prompt-only run (no MCP), cancelled after the first streamed text chunk, against the real Gateway:

- `handle.cancel()` called ~1 chunk in
- Runner result: `exitCode: 1`
- Closing `result` event: `success: false`, text `"run cancelled: aborted by the client"`
- Settled in ~2s, not hanging

### Timeout, observed

Same prompt, `timeoutMs: 800`, no explicit cancel, against the real Gateway:

- Runner result: `exitCode: 1`
- Settled in ~930ms (not hanging, and distinct from the cancelled case - the closing event's `raw` says `"run timed out"`, never `"cancelled"`)

### Unit tests (no network)

`shared/tests/agents/sdk/runner.test.ts`, 10 tests, all injecting a fake `streamText`/`createGateway`/`createPitchboxToolSet` via constructor options (mirrors `AcpRunner`'s injectable `spawn`). Every assertion proven to bite: I mutated the corresponding source line (disabled a guard, collapsed `outcome==='timeout'` into `'cancelled'`, removed the `continue` that buffers text deltas, dropped the `toolSet.close()` call, etc.), watched the exact assertion fail, then restored. Covers: missing Gateway key names the key; missing resolved model gives a clear message; missing prompt/playbookPath rejects; `attachMcp: false` never touches the tool set; `attachMcp` (default) binds the tool set to the run/campaign ids parsed from `opts.env`; cancel ends the run `cancelled` from the abort state, not a throw; timeout ends it `timeout`, distinct from `cancelled`; an in-band `error` part fails the run instead of succeeding empty; the tool set closes exactly once even on error; hitting the step ceiling with more tool calls pending stops as `max_turn_requests` with `exitCode: 0` (not a runner-level failure - `playbookContractError` downstream is what actually judges whether the playbook finished, exactly as it already does for `AcpRunner`).

### Verification run

```
pnpm exec vitest run shared/tests/agents/sdk/runner.test.ts   # 10 passed (against materialized sibling files, then removed)
pnpm -F @pitchbox/shared typecheck                             # clean against materialized siblings; currently fails on the two missing modules, as expected
npx eslint shared/src/agents/sdk/runner.ts shared/tests/agents/sdk/runner.test.ts
npx prettier --check shared/src/agents/sdk/runner.ts shared/tests/agents/sdk/runner.test.ts
```

Not merging - report and wait per the batch instructions.
