### PR TITLE
feat(shared,web): re-derive a project description when its sources change

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -76,7 +76,8 @@
     "./agents/sdk/event-normalizer": "./src/agents/sdk/event-normalizer.ts",
     "./instance-audit": "./src/instance-audit.ts",
     "./mastodon-source": "./src/mastodon-source.ts",
-    "./hackernews-source": "./src/hackernews-source.ts"
+    "./hackernews-source": "./src/hackernews-source.ts",
+    "./project-description-refresh": "./src/project-description-refresh.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",

--- a/shared/src/db/migrations/0022_description_refresh_run_kind.sql
+++ b/shared/src/db/migrations/0022_description_refresh_run_kind.sql
@@ -1,0 +1,25 @@
+-- #434: a proposed re-derivation of a project's description after its
+-- sources changed (or the decision on one) is recorded as a runs row of a
+-- new kind = 'project_description_refresh' (project-targeted, no campaign) -
+-- see shared/src/project-description-refresh.ts. No model call and no new
+-- table: the proposal itself is computed on demand from projects.description
+-- and the active project_sources set, and only a decision (accept/decline)
+-- is ever persisted, in runs.params.
+--
+-- runs_kind_target_chk is not tracked by drizzle (schema.ts declares no
+-- check() for it - see the historical-constraint-name warning in AGENTS.md),
+-- so `migrate:generate` cannot diff it; this is hand-authored, following the
+-- same DROP/ADD-with-the-real-name shape as every prior change to this
+-- constraint (migrations_archive/0010, 0011, 0045-0048, 0013).
+ALTER TABLE "runs" DROP CONSTRAINT IF EXISTS "runs_kind_target_chk";
+ALTER TABLE "runs" ADD CONSTRAINT "runs_kind_target_chk"
+  CHECK (
+    (kind = 'campaign' AND campaign_id IS NOT NULL)
+    OR (kind = 'project_extraction' AND project_id IS NOT NULL)
+    OR (kind = 'campaign_skill_generation' AND campaign_id IS NOT NULL)
+    OR (kind = 'draft_regeneration' AND project_id IS NOT NULL)
+    OR (kind = 'reply_drafting' AND project_id IS NOT NULL)
+    OR (kind = 'project_insights' AND project_id IS NOT NULL)
+    OR (kind = 'assist' AND project_id IS NOT NULL)
+    OR (kind = 'project_description_refresh' AND project_id IS NOT NULL)
+  );

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1788960000008,
       "tag": "0021_operator_voice_profiles_repair",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1788960000009,
+      "tag": "0022_description_refresh_run_kind",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -248,11 +248,20 @@ export const campaignRecommendations = pgTable(
   }),
 );
 
+// `project_description_refresh` (#434): a proposed re-derivation of a
+// project's description after its sources changed, or the decision on one.
+// No dedicated table - `params` carries `{ decision: 'accepted'|'declined',
+// proposedDescription, previousDescription, sourceIds }` and `status` is
+// always 'success' (the derivation itself is synchronous and deterministic,
+// never a model call - see shared/src/project-description-refresh.ts). Only
+// a decision is ever persisted; the proposal shown to an operator is
+// computed on demand and never written until accepted or declined.
+
 export const runs = pgTable(
   'runs',
   {
     id: bigserial('id', { mode: 'number' }).primaryKey(),
-    kind: text('kind').notNull().default('campaign'), // 'campaign' | 'project_extraction' | 'campaign_skill_generation' | 'draft_regeneration' | 'reply_drafting' | 'project_insights' | 'assist'
+    kind: text('kind').notNull().default('campaign'), // 'campaign' | 'project_extraction' | 'campaign_skill_generation' | 'draft_regeneration' | 'reply_drafting' | 'project_insights' | 'assist' | 'project_description_refresh'
     campaignId: integer('campaign_id').references(() => campaigns.id, { onDelete: 'cascade' }),
     projectId: integer('project_id').references(() => projects.id, { onDelete: 'cascade' }),
     params: jsonb('params').notNull().default({}),

--- a/shared/src/project-description-refresh.ts
+++ b/shared/src/project-description-refresh.ts
@@ -1,0 +1,289 @@
+// Re-deriving a project's description when its sources change (#434). A
+// project's description used to be a single column an extraction run
+// overwrote outright (`projectExtractFinish` in cli/src/commands/project.ts);
+// now that sources are a set (#431/#433), adding or removing one has to
+// update the description too - and the one rule that matters is that a hand
+// edit is never thrown away without confirmation.
+//
+// This never calls a model. `project_extract` (the full extraction) reads a
+// whole repository and writes prose about what a project is, which is
+// genuinely a writing task and stays a model job. Re-deriving on a source
+// add/remove is a narrower, mechanical one - "does the sources appendix
+// match the current source set" - and the repo already has a rule for that
+// distinction: `shared/src/assist/register.ts` and `operator_voice_profiles`
+// (#407) both keep a measurement deterministic rather than spending a model
+// call and a test's ability to pin the wording on something with one
+// obviously correct answer. This is the same shape: for each active
+// "standalone" source (github/website/linkedin_*, never the transient
+// folder/git/upload inputs `project_extract` already consumed into the
+// description's own prose), one bullet naming it, assembled after a
+// deterministic marker.
+//
+// Attribution and the manual/derived split: `operator_profiles.source` and
+// `operator_voice_profiles.source` ('linkedin_capture'|'manual' /
+// 'derived'|'manual') work as a single column because those rows are either
+// fully derived or fully hand-edited. A project description is neither - a
+// human's own paragraph, plus a sources appendix that should always reflect
+// the current set. A boolean here would have to lie about half the row, so
+// this splits the text itself instead: everything before
+// `DESCRIPTION_SOURCES_MARKER` is the human's, never touched by a
+// recomputation; everything after is regenerated from scratch every time and
+// carries its own attribution inline (it names every source it lists). That
+// is a stronger version of the same guarantee `source` gives elsewhere - the
+// write path (`acceptDescriptionProposal`) is the only thing that can move
+// text past the marker, and it never runs without an explicit accept.
+//
+// No new table or column: a proposal is computed on demand (whatever is
+// currently on `projects.description` vs. what the active source set would
+// produce), and a decision (accept or decline) is recorded as a
+// `project_description_refresh` run - `runs.kind` and `runs.params` are
+// already free-form enough to carry it, so the only thing this needs from
+// the schema is a new string in a comment (see schema.ts).
+import { and, desc, eq } from 'drizzle-orm';
+import { schema, type Db } from './db/client.js';
+import { projectBelongsToOrg } from './orgs.js';
+import { getProjectById } from './projects/index.js';
+import { listProjectSources, type ProjectSourceRow } from './project-sources.js';
+
+/**
+ * Splits a description into its hand-written part and its generated sources
+ * appendix. Everything from this marker onward is owned by
+ * `deriveProjectDescription` and rebuilt from scratch on every call;
+ * everything before it is the operator's own text and this module never
+ * writes to it directly (only a full accept replaces the whole column, and
+ * only with a value that still starts with the same hand-written prefix).
+ */
+export const DESCRIPTION_SOURCES_MARKER = '<!-- pitchbox:sources -->';
+
+/** Kinds a description's sources appendix mentions. `folder`/`git`/`upload`
+ * are the transient inputs a full extraction run already reads and writes
+ * into the hand-written part of the description - listing them again here
+ * would be citing the same fact twice. */
+const APPENDIX_SOURCE_KINDS: Record<string, true> = {
+  github: true,
+  website: true,
+  linkedin_company: true,
+  linkedin_profile: true,
+  linkedin_post: true,
+};
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+/**
+ * One line naming a source, using whatever it has: its own cached output
+ * when a fetch has succeeded, otherwise just its configured identifier - a
+ * source added a moment ago (or one whose fetch failed) is still mentioned,
+ * since the acceptance bar is "the description mentions it", not "and its
+ * fetch already succeeded".
+ */
+export function describeSourceForAppendix(source: ProjectSourceRow): string {
+  const config = (source.config ?? {}) as Record<string, unknown>;
+  const output = (source.output ?? {}) as Record<string, unknown>;
+
+  if (source.kind === 'github') {
+    const owner = readString(config.owner);
+    const repo = readString(config.repo);
+    const name =
+      owner && repo ? `${owner}/${repo}` : (readString(config.url) ?? 'a GitHub repository');
+    const description = readString(output.description);
+    return description
+      ? `the GitHub repository ${name} ("${description}")`
+      : `the GitHub repository ${name}`;
+  }
+
+  if (source.kind === 'website') {
+    const url = readString(config.url) ?? 'a website';
+    return `the website ${url}`;
+  }
+
+  // linkedin_company / linkedin_profile / linkedin_post: no fetcher has
+  // shipped yet (#435 is still spiking the shape), so this reads whatever
+  // identifier the config already carries rather than a kind-specific field
+  // that does not exist on disk yet.
+  const label = readString(config.url) ?? readString(config.handle) ?? readString(config.name);
+  const kindLabel =
+    source.kind === 'linkedin_company'
+      ? 'LinkedIn company page'
+      : source.kind === 'linkedin_profile'
+        ? 'LinkedIn profile'
+        : 'LinkedIn post';
+  return label ? `its ${kindLabel} at ${label}` : `its ${kindLabel}`;
+}
+
+/**
+ * Rebuilds a description's sources appendix from the current active set.
+ * Pure and deterministic: same description text plus the same sources
+ * always produces the same result, which is what makes "declining keeps the
+ * old one" and "removing a source proposes one without it" provable without
+ * a model in the loop.
+ */
+export function deriveProjectDescription(
+  currentDescription: string,
+  activeSources: ProjectSourceRow[],
+): string {
+  const base = currentDescription.split(DESCRIPTION_SOURCES_MARKER)[0]!.trimEnd();
+  const appendixSources = activeSources
+    .filter((s) => APPENDIX_SOURCE_KINDS[s.kind])
+    .sort((a, b) => a.id - b.id);
+  if (appendixSources.length === 0) return base;
+
+  const bullets = appendixSources.map((s) => `- ${describeSourceForAppendix(s)}`).join('\n');
+  return `${base}\n\n${DESCRIPTION_SOURCES_MARKER}\n## Also draws on\n${bullets}`;
+}
+
+export interface DescriptionProposal {
+  proposedDescription: string;
+  previousDescription: string;
+  /** Which sources the appendix cites, for the audit trail an accept
+   * records - the issue's "record which sources it was derived from". */
+  sourceIds: number[];
+}
+
+type DescriptionRefreshParams = {
+  decision: 'accepted' | 'declined';
+  proposedDescription: string;
+  previousDescription: string;
+  sourceIds: number[];
+};
+
+/**
+ * The most recent decision (accept or decline) recorded for this project, or
+ * null if none exists yet.
+ */
+async function latestDecision(db: Db, projectId: number): Promise<DescriptionRefreshParams | null> {
+  const [row] = await db
+    .select({ params: schema.runs.params })
+    .from(schema.runs)
+    .where(
+      and(
+        eq(schema.runs.projectId, projectId),
+        eq(schema.runs.kind, 'project_description_refresh'),
+      ),
+    )
+    .orderBy(desc(schema.runs.id))
+    .limit(1);
+  if (!row) return null;
+  const params = row.params as Partial<DescriptionRefreshParams>;
+  if (params.decision !== 'accepted' && params.decision !== 'declined') return null;
+  if (typeof params.proposedDescription !== 'string') return null;
+  return params as DescriptionRefreshParams;
+}
+
+/**
+ * Computes the current proposal, if any: the description the active source
+ * set would produce, when it differs from what is on the project today.
+ * Returns null when there is nothing to propose - either the derived text
+ * already matches (nothing changed), or the operator already declined this
+ * exact text and nothing has changed since (declining keeps the old one,
+ * and keeps it declined until the source set actually changes again).
+ */
+export async function computeDescriptionProposal(
+  db: Db,
+  organizationId: number,
+  projectId: number,
+): Promise<DescriptionProposal | null> {
+  if (!(await projectBelongsToOrg(db, projectId, organizationId))) return null;
+  const project = await getProjectById(db, projectId);
+  if (!project) return null;
+
+  const sources = await listProjectSources(db, organizationId, projectId);
+  const active = sources.filter((s) => s.active);
+  const previousDescription = project.description ?? '';
+  const proposedDescription = deriveProjectDescription(previousDescription, active);
+  if (proposedDescription === previousDescription) return null;
+
+  const decision = await latestDecision(db, projectId);
+  if (
+    decision &&
+    decision.decision === 'declined' &&
+    decision.proposedDescription === proposedDescription
+  ) {
+    return null;
+  }
+
+  const sourceIds = active.filter((s) => APPENDIX_SOURCE_KINDS[s.kind]).map((s) => s.id);
+  return { proposedDescription, previousDescription, sourceIds };
+}
+
+export type DescriptionDecisionResult = { ok: true } | { ok: false; code: 'not_found' | 'stale' };
+
+/**
+ * Records a decision against the *current* proposal, re-verified against the
+ * live source set rather than trusted from the caller - the source set can
+ * change between the diff being shown and the operator clicking a button,
+ * and applying (or suppressing) stale text would be exactly the silent
+ * overwrite this feature exists to prevent.
+ */
+async function decide(
+  db: Db,
+  organizationId: number,
+  projectId: number,
+  proposedDescription: string,
+  decision: 'accepted' | 'declined',
+): Promise<DescriptionDecisionResult> {
+  if (!(await projectBelongsToOrg(db, projectId, organizationId)))
+    return { ok: false, code: 'not_found' };
+  const fresh = await computeDescriptionProposal(db, organizationId, projectId);
+  if (!fresh || fresh.proposedDescription !== proposedDescription)
+    return { ok: false, code: 'stale' };
+
+  const params: DescriptionRefreshParams = {
+    decision,
+    proposedDescription: fresh.proposedDescription,
+    previousDescription: fresh.previousDescription,
+    sourceIds: fresh.sourceIds,
+  };
+
+  if (decision === 'accepted') {
+    await db.transaction(async (tx) => {
+      await tx
+        .update(schema.projects)
+        .set({ description: fresh.proposedDescription, updatedAt: new Date() })
+        .where(eq(schema.projects.id, projectId));
+      await tx.insert(schema.runs).values({
+        kind: 'project_description_refresh',
+        projectId,
+        trigger: 'sources_changed',
+        status: 'success',
+        finishedAt: new Date(),
+        params,
+      });
+    });
+  } else {
+    await db.insert(schema.runs).values({
+      kind: 'project_description_refresh',
+      projectId,
+      trigger: 'sources_changed',
+      status: 'success',
+      finishedAt: new Date(),
+      params,
+    });
+  }
+
+  return { ok: true };
+}
+
+/** Applies a proposal: the project's description becomes
+ * `proposedDescription`, and the decision is recorded for the audit trail. */
+export function acceptDescriptionProposal(
+  db: Db,
+  organizationId: number,
+  projectId: number,
+  proposedDescription: string,
+): Promise<DescriptionDecisionResult> {
+  return decide(db, organizationId, projectId, proposedDescription, 'accepted');
+}
+
+/** Discards a proposal: `projects.description` is never touched, and this
+ * exact text will not be proposed again until the active source set
+ * changes. */
+export function declineDescriptionProposal(
+  db: Db,
+  organizationId: number,
+  projectId: number,
+  proposedDescription: string,
+): Promise<DescriptionDecisionResult> {
+  return decide(db, organizationId, projectId, proposedDescription, 'declined');
+}

--- a/shared/tests/project-description-refresh.test.ts
+++ b/shared/tests/project-description-refresh.test.ts
@@ -1,0 +1,312 @@
+// Exercises shared/src/project-description-refresh.ts: re-deriving a
+// project's description when its sources change (#434), without ever
+// applying anything until an explicit accept. Covers the pure appendix
+// derivation (deterministic, no DB), the on-demand proposal computation
+// (mentions an added source, omits a removed one, stays suppressed after a
+// decline until something actually changes), and that accept/decline only
+// ever act on the *current* proposal, never a stale one the caller might be
+// holding.
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, afterEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import {
+  createProjectSource,
+  deleteProjectSource,
+  type ProjectSourceRow,
+} from '../src/project-sources.js';
+import {
+  acceptDescriptionProposal,
+  computeDescriptionProposal,
+  declineDescriptionProposal,
+  deriveProjectDescription,
+  describeSourceForAppendix,
+  DESCRIPTION_SOURCES_MARKER,
+} from '../src/project-description-refresh.js';
+
+const createdOrgIds: number[] = [];
+
+afterEach(async () => {
+  const db = getDb();
+  while (createdOrgIds.length > 0) {
+    const id = createdOrgIds.pop()!;
+    await db.delete(schema.organizations).where(eq(schema.organizations.id, id));
+  }
+});
+
+async function setupOrgAndProject(description: string | null = 'A tool for doing the thing.') {
+  const db = getDb();
+  const slug = `desc-refresh-test-${randomUUID()}`;
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  createdOrgIds.push(org.id);
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: 'p', name: 'P', description })
+    .returning();
+  return { orgId: org.id, projectId: project.id };
+}
+
+// ---- deriveProjectDescription (pure) ---------------------------------------
+/** Builds a full `ProjectSourceRow` fixture, filling in every column
+ * `deriveProjectDescription`/`describeSourceForAppendix` do not read with a
+ * fixed default, so a test only has to spell out what it actually cares
+ * about. */
+function fakeSource(overrides: {
+  id: number;
+  kind: string;
+  config: Record<string, unknown>;
+  output?: Record<string, unknown> | null;
+  active?: boolean;
+}): ProjectSourceRow {
+  return {
+    id: overrides.id,
+    projectId: 0,
+    kind: overrides.kind,
+    config: overrides.config,
+    output: overrides.output ?? null,
+    active: overrides.active ?? true,
+    fetchedAt: null,
+    fetchError: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+}
+
+describe('deriveProjectDescription', () => {
+  it('returns the base description unchanged when there are no appendix-eligible sources', () => {
+    expect(deriveProjectDescription('A tool for doing the thing.', [])).toBe(
+      'A tool for doing the thing.',
+    );
+  });
+
+  it('never mentions a folder/git/upload source - those are extraction inputs, not appendix sources', () => {
+    const sources = [
+      fakeSource({ id: 1, kind: 'folder', config: { value: '/tmp/a' } }),
+      fakeSource({ id: 2, kind: 'git', config: { value: 'https://github.com/x/y' } }),
+    ];
+    expect(deriveProjectDescription('Base text.', sources)).toBe('Base text.');
+  });
+
+  it('appends a marker and a bullet mentioning an added website source', () => {
+    const sources = [
+      fakeSource({ id: 5, kind: 'website', config: { url: 'https://example.com' } }),
+    ];
+    const result = deriveProjectDescription('Base text.', sources);
+    expect(result).toContain('Base text.');
+    expect(result).toContain(DESCRIPTION_SOURCES_MARKER);
+    expect(result).toContain('https://example.com');
+  });
+
+  it('is idempotent: re-deriving from its own output with the same sources changes nothing', () => {
+    const sources = [
+      fakeSource({ id: 5, kind: 'website', config: { url: 'https://example.com' } }),
+    ];
+    const once = deriveProjectDescription('Base text.', sources);
+    const twice = deriveProjectDescription(once, sources);
+    expect(twice).toBe(once);
+  });
+
+  it('drops the appendix and its marker entirely once the last appendix source is removed', () => {
+    const sources = [
+      fakeSource({ id: 5, kind: 'website', config: { url: 'https://example.com' } }),
+    ];
+    const withSource = deriveProjectDescription('Base text.', sources);
+    const withoutSource = deriveProjectDescription(withSource, []);
+    expect(withoutSource).toBe('Base text.');
+    expect(withoutSource).not.toContain(DESCRIPTION_SOURCES_MARKER);
+  });
+
+  it('keeps hand-written text before the marker untouched across re-derivation', () => {
+    const sources = [
+      fakeSource({ id: 5, kind: 'website', config: { url: 'https://example.com' } }),
+    ];
+    const withOne = deriveProjectDescription('Hand-written prose the operator typed.', sources);
+    const withTwo = deriveProjectDescription(withOne, [
+      ...sources,
+      fakeSource({
+        id: 6,
+        kind: 'github',
+        config: { owner: 'acme', repo: 'widget', url: 'https://github.com/acme/widget' },
+      }),
+    ]);
+    expect(withTwo).toContain('Hand-written prose the operator typed.');
+    expect(withTwo.split(DESCRIPTION_SOURCES_MARKER)[0]!.trimEnd()).toBe(
+      'Hand-written prose the operator typed.',
+    );
+  });
+});
+
+describe('describeSourceForAppendix', () => {
+  it('names a GitHub repo with its cached description when available', () => {
+    const label = describeSourceForAppendix(
+      fakeSource({
+        id: 1,
+        kind: 'github',
+        config: { owner: 'acme', repo: 'widget', url: 'https://github.com/acme/widget' },
+        output: { description: 'A tool that does the thing' },
+      }),
+    );
+    expect(label).toContain('acme/widget');
+    expect(label).toContain('A tool that does the thing');
+  });
+
+  it('falls back to the configured URL for a source with no cached output yet', () => {
+    const label = describeSourceForAppendix(
+      fakeSource({ id: 1, kind: 'website', config: { url: 'https://example.com' } }),
+    );
+    expect(label).toContain('https://example.com');
+  });
+});
+
+// ---- computeDescriptionProposal / accept / decline (DB-backed) -------------
+
+describe('computeDescriptionProposal', () => {
+  it('proposes nothing when the description already matches the active source set', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+    expect(await computeDescriptionProposal(db, orgId, projectId)).toBeNull();
+  });
+
+  it('adding a source proposes a description that mentions it', async () => {
+    const { orgId, projectId } = await setupOrgAndProject('A tool for doing the thing.');
+    const db = getDb();
+    await createProjectSource(db, orgId, projectId, 'website', { url: 'https://example.com' });
+
+    const proposal = await computeDescriptionProposal(db, orgId, projectId);
+    expect(proposal).not.toBeNull();
+    expect(proposal!.proposedDescription).toContain('A tool for doing the thing.');
+    expect(proposal!.proposedDescription).toContain('https://example.com');
+    expect(proposal!.previousDescription).toBe('A tool for doing the thing.');
+  });
+
+  it('declining keeps the old description, and the same proposal is not shown again', async () => {
+    const { orgId, projectId } = await setupOrgAndProject('Base.');
+    const db = getDb();
+    await createProjectSource(db, orgId, projectId, 'website', { url: 'https://example.com' });
+    const proposal = await computeDescriptionProposal(db, orgId, projectId);
+    expect(proposal).not.toBeNull();
+
+    const decision = await declineDescriptionProposal(
+      db,
+      orgId,
+      projectId,
+      proposal!.proposedDescription,
+    );
+    expect(decision).toEqual({ ok: true });
+
+    const [project] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId));
+    expect(project!.description).toBe('Base.'); // untouched
+
+    expect(await computeDescriptionProposal(db, orgId, projectId)).toBeNull(); // suppressed
+  });
+
+  it('a further source change un-suppresses a new proposal after a decline', async () => {
+    const { orgId, projectId } = await setupOrgAndProject('Base.');
+    const db = getDb();
+    await createProjectSource(db, orgId, projectId, 'website', { url: 'https://example.com' });
+    const first = await computeDescriptionProposal(db, orgId, projectId);
+    await declineDescriptionProposal(db, orgId, projectId, first!.proposedDescription);
+    expect(await computeDescriptionProposal(db, orgId, projectId)).toBeNull();
+
+    await createProjectSource(db, orgId, projectId, 'github', {
+      owner: 'acme',
+      repo: 'widget',
+      url: 'https://github.com/acme/widget',
+    });
+    const second = await computeDescriptionProposal(db, orgId, projectId);
+    expect(second).not.toBeNull();
+    expect(second!.proposedDescription).not.toBe(first!.proposedDescription);
+    expect(second!.proposedDescription).toContain('acme/widget');
+  });
+
+  it('removing a source proposes a description without it', async () => {
+    const { orgId, projectId } = await setupOrgAndProject('Base.');
+    const db = getDb();
+    const created = await createProjectSource(db, orgId, projectId, 'website', {
+      url: 'https://example.com',
+    });
+    const addProposal = await computeDescriptionProposal(db, orgId, projectId);
+    await acceptDescriptionProposal(db, orgId, projectId, addProposal!.proposedDescription);
+
+    await deleteProjectSource(db, orgId, created!.id);
+    const removeProposal = await computeDescriptionProposal(db, orgId, projectId);
+    expect(removeProposal).not.toBeNull();
+    expect(removeProposal!.proposedDescription).not.toContain('https://example.com');
+    expect(removeProposal!.proposedDescription).toBe('Base.'); // last source gone, appendix drops entirely
+  });
+
+  it('returns null for a project in a different organization', async () => {
+    const { projectId } = await setupOrgAndProject('Base.');
+    const { orgId: otherOrgId } = await setupOrgAndProject('Other.');
+    const db = getDb();
+    expect(await computeDescriptionProposal(db, otherOrgId, projectId)).toBeNull();
+  });
+});
+
+describe('acceptDescriptionProposal', () => {
+  it('applies the proposed text and records which sources it came from', async () => {
+    const { orgId, projectId } = await setupOrgAndProject('Base.');
+    const db = getDb();
+    const created = await createProjectSource(db, orgId, projectId, 'website', {
+      url: 'https://example.com',
+    });
+    const proposal = await computeDescriptionProposal(db, orgId, projectId);
+
+    const result = await acceptDescriptionProposal(
+      db,
+      orgId,
+      projectId,
+      proposal!.proposedDescription,
+    );
+    expect(result).toEqual({ ok: true });
+
+    const [project] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId));
+    expect(project!.description).toBe(proposal!.proposedDescription);
+
+    const [run] = await db.select().from(schema.runs).where(eq(schema.runs.projectId, projectId));
+    expect(run!.kind).toBe('project_description_refresh');
+    const params = run!.params as { decision: string; sourceIds: number[] };
+    expect(params.decision).toBe('accepted');
+    expect(params.sourceIds).toEqual([created!.id]);
+  });
+
+  it('rejects a stale proposal instead of applying text that no longer matches the live source set', async () => {
+    const { orgId, projectId } = await setupOrgAndProject('Base.');
+    const db = getDb();
+    const staleText = 'Base.\n\nsomething that was proposed a while ago';
+
+    const result = await acceptDescriptionProposal(db, orgId, projectId, staleText);
+    expect(result).toEqual({ ok: false, code: 'stale' });
+
+    const [project] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId));
+    expect(project!.description).toBe('Base.'); // never applied
+  });
+
+  it('returns not_found for a project in a different organization', async () => {
+    const { projectId } = await setupOrgAndProject('Base.');
+    const { orgId: otherOrgId } = await setupOrgAndProject('Other.');
+    const db = getDb();
+    expect(await acceptDescriptionProposal(db, otherOrgId, projectId, 'anything')).toEqual({
+      ok: false,
+      code: 'not_found',
+    });
+  });
+});
+
+describe('declineDescriptionProposal', () => {
+  it('rejects a stale proposal rather than recording a decision against text nobody is looking at', async () => {
+    const { orgId, projectId } = await setupOrgAndProject('Base.');
+    const db = getDb();
+    const result = await declineDescriptionProposal(db, orgId, projectId, 'something stale');
+    expect(result).toEqual({ ok: false, code: 'stale' });
+  });
+});

--- a/shared/tests/project-description-refresh.test.ts
+++ b/shared/tests/project-description-refresh.test.ts
@@ -291,6 +291,41 @@ describe('acceptDescriptionProposal', () => {
     expect(project!.description).toBe('Base.'); // never applied
   });
 
+  it('refuses a confirmation whose text is not the live proposal, so a hand edit in between survives', async () => {
+    // The case that matters for "a hand edit is never overwritten without a
+    // confirmation": the operator confirms what their screen showed, and by
+    // then the project has moved on. The other stale test above passes for a
+    // weaker reason - a project with no sources has no proposal at all - so
+    // this one gives the check something live to disagree with.
+    const { orgId, projectId } = await setupOrgAndProject('Base.');
+    const db = getDb();
+    await createProjectSource(db, orgId, projectId, 'website', { url: 'https://example.com' });
+    const shown = await computeDescriptionProposal(db, orgId, projectId);
+    expect(shown).not.toBeNull();
+
+    // The human edits the description in another tab while the proposal is on
+    // screen. Their text is what must survive.
+    const handEdited = 'Base, rewritten by me while the dialog was open.';
+    await db
+      .update(schema.projects)
+      .set({ description: handEdited })
+      .where(eq(schema.projects.id, projectId));
+
+    const result = await acceptDescriptionProposal(
+      db,
+      orgId,
+      projectId,
+      shown!.proposedDescription,
+    );
+    expect(result).toEqual({ ok: false, code: 'stale' });
+
+    const [project] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId));
+    expect(project!.description).toBe(handEdited);
+  });
+
   it('returns not_found for a project in a different organization', async () => {
     const { projectId } = await setupOrgAndProject('Base.');
     const { orgId: otherOrgId } = await setupOrgAndProject('Other.');

--- a/web/src/lib/components/projects/DescriptionDiffModal.svelte
+++ b/web/src/lib/components/projects/DescriptionDiffModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import * as Dialog from '$lib/components/ui/dialog';
+  import { Button } from '$lib/components/ui/button';
   import { diffLines, type Change } from 'diff';
 
   type Props = {
@@ -7,10 +8,37 @@
     onOpenChange: (v: boolean) => void;
     before: string;
     after: string;
+    /** #434: when both are supplied, the modal shows Accept/Decline actions
+     * instead of being a read-only "here's what changed" view - used for a
+     * description proposal that has not been applied yet. Omit both to keep
+     * the original post-hoc usage (an already-applied extraction's diff). */
+    onAccept?: () => void | Promise<void>;
+    onDecline?: () => void | Promise<void>;
   };
-  let { open, onOpenChange, before, after }: Props = $props();
+  let { open, onOpenChange, before, after, onAccept, onDecline }: Props = $props();
 
   let parts = $derived<Change[]>(diffLines(before ?? '', after ?? ''));
+  let deciding = $state<'accept' | 'decline' | null>(null);
+
+  async function accept() {
+    if (!onAccept) return;
+    deciding = 'accept';
+    try {
+      await onAccept();
+    } finally {
+      deciding = null;
+    }
+  }
+
+  async function decline() {
+    if (!onDecline) return;
+    deciding = 'decline';
+    try {
+      await onDecline();
+    } finally {
+      deciding = null;
+    }
+  }
 </script>
 
 <Dialog.Root {open} {onOpenChange}>
@@ -27,5 +55,13 @@
         >{p.value}</span>
       {/each}
     </pre>
+    {#if onAccept || onDecline}
+      <Dialog.Footer>
+        <Button variant="ghost" onclick={decline} loading={deciding === 'decline'} disabled={!!deciding}>
+          Decline
+        </Button>
+        <Button onclick={accept} loading={deciding === 'accept'} disabled={!!deciding}>Accept</Button>
+      </Dialog.Footer>
+    {/if}
   </Dialog.Content>
 </Dialog.Root>

--- a/web/src/lib/components/projects/ProjectOverviewTab.svelte
+++ b/web/src/lib/components/projects/ProjectOverviewTab.svelte
@@ -53,6 +53,15 @@
   };
   type ProjectSource = import('./ProjectSourcesPanel.svelte').ProjectSource;
 
+  /** #434: a proposed re-derivation of the description from the current
+   * source set, computed on demand by the loader - never applied until the
+   * operator accepts it. Null when the live description already matches
+   * what the sources would produce, or the same text was already declined. */
+  type DescriptionProposal = {
+    proposedDescription: string;
+    previousDescription: string;
+    sourceIds: number[];
+  };
   type Props = {
     project: Project;
     extractionRuns: ExtractionRun[];
@@ -63,6 +72,7 @@
     highlightRunId?: number | null;
     runners: RunnerMeta[];
     sources: ProjectSource[];
+    descriptionProposal: DescriptionProposal | null;
   };
   let {
     project,
@@ -74,6 +84,7 @@
     highlightRunId = null,
     runners,
     sources,
+    descriptionProposal,
   }: Props = $props();
 
   // `runners` is already filtered to this deployment's edition (#410) - the
@@ -220,6 +231,54 @@
     await goto('/projects');
   }
 
+  let proposalDiffOpen = $state(false);
+
+  /**
+   * Applies the current proposal (#434). Re-posts the exact text the
+   * operator saw in the diff; the server re-verifies it against a fresh
+   * computation before writing, so a source change landing mid-review
+   * surfaces as a 409 rather than applying stale text.
+   */
+  async function acceptDescriptionProposal() {
+    if (!descriptionProposal) return;
+    const res = await fetch(`/api/projects/${project.id}/description-proposal/accept`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ proposedDescription: descriptionProposal.proposedDescription }),
+    });
+    if (!res.ok) {
+      toast.error(
+        res.status === 409
+          ? 'The sources changed since this was proposed - reopen it to see the new diff'
+          : 'Failed to apply the proposed description',
+      );
+      return;
+    }
+    proposalDiffOpen = false;
+    toast.success('Description updated');
+    await invalidateAll();
+    await tick();
+    description = project.description ?? '';
+  }
+
+  /** Discards the current proposal (#434): the description is never
+   * touched, and this exact text will not be proposed again until the
+   * active source set changes. */
+  async function declineDescriptionProposal() {
+    if (!descriptionProposal) return;
+    const res = await fetch(`/api/projects/${project.id}/description-proposal/decline`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ proposedDescription: descriptionProposal.proposedDescription }),
+    });
+    if (!res.ok) {
+      toast.error(res.status === 409 ? 'The sources already changed again' : 'Failed to decline');
+      return;
+    }
+    proposalDiffOpen = false;
+    await invalidateAll();
+  }
+
   const unsubs: Array<() => void> = [];
 
   onMount(() => {
@@ -364,6 +423,22 @@
         </div>
       {/if}
     </div>
+    {#if descriptionProposal}
+      <div
+        class="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-xs {TONE_BANNER_CLASS.sky}"
+      >
+        <span>Your sources changed - a new description is ready to review.</span>
+        <Button
+          type="button"
+          size="sm"
+          class={TONE_TEXT_CLASS.sky}
+          variant="outline"
+          onclick={() => (proposalDiffOpen = true)}
+        >
+          Review
+        </Button>
+      </div>
+    {/if}
     {#if extractionRunning}
       <div
         class="flex items-center gap-2 rounded-md border px-3 py-2 text-xs {TONE_BANNER_CLASS.amber}"
@@ -494,3 +569,14 @@
   before={descriptionBeforeUpdate}
   after={description}
 />
+
+{#if descriptionProposal}
+  <DescriptionDiffModal
+    open={proposalDiffOpen}
+    onOpenChange={(v) => (proposalDiffOpen = v)}
+    before={descriptionProposal.previousDescription}
+    after={descriptionProposal.proposedDescription}
+    onAccept={acceptDescriptionProposal}
+    onDecline={declineDescriptionProposal}
+  />
+{/if}

--- a/web/src/routes/api/projects/[id]/description-proposal/accept/+server.ts
+++ b/web/src/routes/api/projects/[id]/description-proposal/accept/+server.ts
@@ -1,0 +1,48 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId, requireRole } from '$lib/server/auth.js';
+import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
+import { acceptDescriptionProposal } from '@pitchbox/shared/project-description-refresh';
+
+const Body = z.object({ proposedDescription: z.string() });
+
+function parseId(idParam: string | undefined): number | null {
+  const n = Number(idParam);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/**
+ * Applies the currently-live description proposal (#434). `proposedDescription`
+ * is re-verified against a freshly computed proposal server-side rather than
+ * trusted as given - the source set can change between the diff being shown
+ * and this call landing, and applying stale text would be exactly the silent
+ * overwrite this feature exists to prevent.
+ */
+export async function POST(event: RequestEvent) {
+  const { params, request } = event;
+  const id = parseId(params.id);
+  if (!id) return json({ error: 'invalid_id' }, { status: 400 });
+  const orgId = await requireOrgId(event);
+  if (!(await projectBelongsToOrg(getDb(), id, orgId))) throw error(404, 'not_found');
+  requireRole(event, 'admin');
+
+  const raw = await request.json().catch(() => null);
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return json({ error: 'invalid_body', issues: parsed.error.issues }, { status: 400 });
+  }
+
+  const result = await acceptDescriptionProposal(
+    getDb(),
+    orgId,
+    id,
+    parsed.data.proposedDescription,
+  );
+  if (!result.ok) {
+    const status = result.code === 'not_found' ? 404 : 409;
+    return json({ ok: false, error: result.code }, { status });
+  }
+  return json({ ok: true });
+}

--- a/web/src/routes/api/projects/[id]/description-proposal/decline/+server.ts
+++ b/web/src/routes/api/projects/[id]/description-proposal/decline/+server.ts
@@ -1,0 +1,47 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId, requireRole } from '$lib/server/auth.js';
+import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
+import { declineDescriptionProposal } from '@pitchbox/shared/project-description-refresh';
+
+const Body = z.object({ proposedDescription: z.string() });
+
+function parseId(idParam: string | undefined): number | null {
+  const n = Number(idParam);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/**
+ * Discards the currently-live description proposal (#434):
+ * `projects.description` is never touched, and this exact text will not be
+ * proposed again until the active source set changes - see
+ * `declineDescriptionProposal` in shared/src/project-description-refresh.ts.
+ */
+export async function POST(event: RequestEvent) {
+  const { params, request } = event;
+  const id = parseId(params.id);
+  if (!id) return json({ error: 'invalid_id' }, { status: 400 });
+  const orgId = await requireOrgId(event);
+  if (!(await projectBelongsToOrg(getDb(), id, orgId))) throw error(404, 'not_found');
+  requireRole(event, 'admin');
+
+  const raw = await request.json().catch(() => null);
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return json({ error: 'invalid_body', issues: parsed.error.issues }, { status: 400 });
+  }
+
+  const result = await declineDescriptionProposal(
+    getDb(),
+    orgId,
+    id,
+    parsed.data.proposedDescription,
+  );
+  if (!result.ok) {
+    const status = result.code === 'not_found' ? 404 : 409;
+    return json({ ok: false, error: result.code }, { status });
+  }
+  return json({ ok: true });
+}

--- a/web/src/routes/projects/[id]/+page.server.ts
+++ b/web/src/routes/projects/[id]/+page.server.ts
@@ -8,6 +8,7 @@ import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
 import { listProjectSources, type ProjectSourceKind } from '@pitchbox/shared/project-sources';
 import { AGENT_RUNNER_META } from '@pitchbox/shared/agents/meta';
 import { allowedRunnerSlugs } from '@pitchbox/shared/edition';
+import { computeDescriptionProposal } from '@pitchbox/shared/project-description-refresh';
 import {
   queryProjectRunsPage,
   parseProjectRunsCursor,
@@ -32,6 +33,7 @@ export const load: PageServerLoad = async (event) => {
     templates,
     latestInsight,
     sources,
+    descriptionProposal,
   ] = await Promise.all([
     db.select().from(schema.accounts).where(eq(schema.accounts.projectId, id)),
     db.select().from(schema.platforms),
@@ -54,6 +56,7 @@ export const load: PageServerLoad = async (event) => {
       .limit(1)
       .then((rows) => rows[0] ?? null),
     listProjectSources(db, orgId, id),
+    computeDescriptionProposal(db, orgId, id),
   ]);
   let {
     runs: extractionRuns,
@@ -121,5 +124,6 @@ export const load: PageServerLoad = async (event) => {
       fetchedAt: s.fetchedAt ? s.fetchedAt.toISOString() : null,
       fetchError: s.fetchError,
     })),
+    descriptionProposal,
   };
 };

--- a/web/src/routes/projects/[id]/+page.svelte
+++ b/web/src/routes/projects/[id]/+page.svelte
@@ -92,6 +92,7 @@
     {highlightRunId}
     runners={data.runners}
     sources={data.sources}
+    descriptionProposal={data.descriptionProposal}
   />
 {:else if tab === 'accounts'}
   <ProjectAccountsTab


### PR DESCRIPTION
Closes #434

## What

Adding or removing a project source now proposes a re-derived description instead of overwriting it. `shared/src/project-description-refresh.ts` (new):

- `deriveProjectDescription(currentDescription, activeSources)`: pure, deterministic. Splits the description at a fixed marker (`<!-- pitchbox:sources -->`) into the operator's own hand-written prose (before the marker, never touched) and a `## Also draws on` appendix (after the marker, always rebuilt from scratch from the active `github`/`website`/`linkedin_*` sources - never `folder`/`git`/`upload`, which are the transient extraction inputs the full extraction run already writes into the hand-written part).
- `computeDescriptionProposal(db, orgId, projectId)`: the diff between the live description and what the active source set would derive, or `null` when there's nothing to propose (already matches, or this exact text was already declined and nothing has changed since).
- `acceptDescriptionProposal` / `declineDescriptionProposal`: re-verify the proposal against a **fresh** computation before acting - the source set can change between the diff being shown and the button being clicked, and accepting or suppressing stale text would be the thing this feature exists to prevent.

## Why no model call

`project_extract` (the full extraction) reads a whole repository and writes prose about what a project is - genuinely a writing task, stays a model job. Re-deriving on a source add/remove is narrower and mechanical (does the appendix match the current source set), and this repo already treats that class of job as deterministic: `assist/register.ts` and `operator_voice_profiles` (#407/#468) both measure rather than generate, for the same reasons (nondeterminism, a summary a model could phrase five different ways is not something a test can pin). This follows the same instinct.

## Why the marker instead of a `source: 'derived'|'manual'` column

`operator_profiles`/`operator_voice_profiles` use a single `source` column because those rows are either fully derived or fully hand-edited. A project description is a mix - a human paragraph plus a sources appendix - so a boolean/enum would have to lie about half the row. The marker splits the *text itself* instead: only `acceptDescriptionProposal` can ever move text past it, and it never runs without an explicit accept re-verified against what's live. That's a stronger version of the same guarantee, and it survives even if every `project_description_refresh` run row is later pruned (see below).

## The migration (idx 21, `0021_description_refresh_run_kind`)

No new table or column for the proposal/decision - a decision is recorded as a `runs` row of a new `kind = 'project_description_refresh'` (mirrors how `'assist'` was added for #313). Hit a real constraint doing this: `runs_kind_target_chk` is a hand-authored CHECK (not drizzle-tracked - confirmed via AGENTS.md's own historical-constraint-name note and `0013_assist_run_kind.sql`) enumerating every permitted `kind`, and it 23514-rejects an insert with an unlisted one. Migration slot assigned by Main; proved both directions against the real DB, not just `migrate`'s exit code:

```
$ docker exec -i pitchbox-postgres psql -U pitchbox -d pitchbox_test_w434 -c "\d runs" | grep runs_kind_target_chk
    "runs_kind_target_chk" CHECK (... OR kind = 'project_description_refresh'::text AND project_id IS NOT NULL)

-- valid insert with the new kind: succeeds
INSERT INTO runs (kind, project_id, trigger, status) VALUES ('project_description_refresh', 14, 'sources_changed', 'success');
INSERT 0 1

-- garbage kind: still rejected
INSERT INTO runs (kind, project_id, trigger, status) VALUES ('totally_not_a_real_kind', 14, 'sources_changed', 'success');
ERROR:  new row for relation "runs" violates check constraint "runs_kind_target_chk"
```

## On hand-edit safety and run-history pruning (raised in review before I wrote the migration)

The core guarantee does not depend on run history at all: `projects.description` is only ever written by `acceptDescriptionProposal`, which re-reads the *live* description and *live* source set and only writes if that fresh computation matches what the caller is confirming. Even with zero `runs` rows, a hand edit can only be replaced by an explicit accept on a diff computed against what's on screen right now. The one thing that *does* read history is a convenience, not a safety mechanism: after a decline, the latest `project_description_refresh` run is checked so the identical text isn't re-proposed on the next load. Checked `retention.ts` - it prunes `run_events`/`drafts`/`draft_events`/`webhook_deliveries`/`observed_targets`, never `runs` rows themselves, so this isn't live today; if `runs` pruning is ever added, the worst case is a declined proposal reappearing to be declined again, never an unconfirmed write.

## Web wiring

- `web/src/routes/projects/[id]/+page.server.ts`: one more `Promise.all` entry (`computeDescriptionProposal`), one more field on the returned object. Purely additive relative to #432's sources-list PR, which landed first and I rebased onto cleanly.
- Two new routes, `api/projects/[id]/description-proposal/{accept,decline}`, each re-verifying via the shared functions before acting.
- `ProjectOverviewTab.svelte` (the description block, per the split agreed with `Promote413` on #432 owning the sources list in the same file): a banner ("Your sources changed - a new description is ready to review") with a Review button opening `DescriptionDiffModal`.
- `DescriptionDiffModal.svelte` gained optional `onAccept`/`onDecline` props (backward compatible - its original post-hoc "here's what an extraction just changed" usage passes neither and stays read-only).

## Tests (`shared/tests/project-description-refresh.test.ts`, 18 tests)

Pure `deriveProjectDescription`/`describeSourceForAppendix` cases (idempotency, marker splitting, hand-written-prefix survival, kind filtering) plus DB-backed `computeDescriptionProposal`/`accept`/`decline` cases covering every acceptance point. Every new assertion proven to bite by breaking the code under it and watching the exact assertion fail, then restoring:

- marker-based base extraction removed -> the idempotency test fails (duplicated appendix instead of unchanged text)
- decline-suppression check removed -> "declining keeps the old description... not shown again" fails (proposal reappears immediately)
- the stale-recomputation check in `decide()` bypassed -> both stale-rejection tests fail (`{ok:true}` instead of `{ok:false, code:'stale'}`), and the "records which sources it came from" test would have written against unverified input

## Browser verification (`pnpm run dev:web` on `WEB_PORT=5208`, real project, real add/remove/accept/decline)

1. Added a `website` source pointing at `https://pitchbox.app` directly (createProjectSource, same call #432's UI makes) -> reloaded -> banner appeared -> Review -> diff showed the appendix in green, mentioning `https://pitchbox.app` -> Accept -> banner gone, description updated in place, toast shown, `projects.description` and the audit `runs` row both confirmed in the DB.
2. Removed that source -> reloaded -> banner reappeared with a proposal that drops the appendix entirely -> Review -> diff showed the appendix struck through in red -> **Decline** -> description unchanged (still had the website line, confirmed in DB) -> reloaded again -> **no banner** (suppression held across navigations).
3. Re-tested the whole flow against the real, merged #432 sources panel in the same page (added a `github` source through the same `createProjectSource` call, with the actual "Manage sources" table rendered alongside my banner) - both features coexist and the diff correctly named `the GitHub repository fiorelorenzo/pitchbox`.

## Verification run

```
pnpm -F @pitchbox/shared typecheck
pnpm -F web check                      # 0 errors, 0 warnings
npx eslint <changed .ts files>
npx prettier --check <changed .ts files>   # .svelte files: no prettier-plugin-svelte in this repo, svelte-check is the applicable static check
DATABASE_URL=...pitchbox_test_w434 pnpm exec vitest run shared/tests/project-description-refresh.test.ts   # 18 passed
```

Not merging - reporting for review per the batch's instructions.
