### PR TITLE
fix(extension): dedupe panel hosts by anchor across script instances

### DIFF
--- a/extension/src/content/shared/panel-host.ts
+++ b/extension/src/content/shared/panel-host.ts
@@ -38,9 +38,53 @@ import { reactiveProps } from './panel-props.svelte.js';
 // text goes into the shadow root and linkedin.com's <head> is never touched.
 import panelCss from '../panel.css?inline';
 import { ensurePanelFont } from './panel-fonts.js';
+import { ulid } from '../../lib/ulid.js';
 
 /** Marks a host element so a second mount on the same anchor is detectable. */
 const HOST_TAG = 'pitchbox-panel-host';
+
+/**
+ * Links a host to the anchor it was mounted for, and survives across a
+ * script-instance boundary a `WeakMap` cannot (#476).
+ *
+ * `mounted` below already refuses to stack a second panel when the *same*
+ * script instance calls `mountPanel` twice on one anchor - that covers a
+ * click handler firing twice, or a re-render re-arming the composer. It
+ * cannot cover a *different* instance: an extension reload leaves the
+ * pre-reload content script's isolated world running (`extensionContextAlive`
+ * in the assist scripts is exactly the tell for that), and a fresh
+ * post-reload injection gets its own new world with its own empty `mounted`.
+ * Both worlds share one DOM, though, so an attribute set on the anchor -
+ * real Element data, not a per-world JS wrapper property - is what a second
+ * instance can actually see. That is the "property, not patch" in #476:
+ * every previous form of this invariant lived in JS state that a second
+ * script instance never had access to.
+ */
+const ANCHOR_ID_ATTR = 'data-pitchbox-anchor-id';
+
+/** The stable id `anchor` is tagged with, assigning one on first use. */
+function anchorId(anchor: Element): string {
+  const existing = anchor.getAttribute(ANCHOR_ID_ATTR);
+  if (existing) return existing;
+  const id = ulid();
+  anchor.setAttribute(ANCHOR_ID_ATTR, id);
+  return id;
+}
+
+/**
+ * Removes any `pitchbox-panel-host` tagged for `id`, regardless of which
+ * script instance created it. A host from this instance is already caught by
+ * `mounted` before this runs; a host reaching here is either this instance's
+ * own record having gone missing (should not happen - `destroy()` always
+ * clears both) or another instance's, and neither case is one this instance
+ * can call `.destroy()` on, since that handle lives in a JS realm this code
+ * has no reference into. Removing the element is what actually matters for
+ * #476: it is what a human sees stacked on screen.
+ */
+function removeStaleHosts(id: string): void {
+  const stale = document.querySelectorAll(`${HOST_TAG}[${ANCHOR_ID_ATTR}="${id}"]`);
+  for (const el of stale) el.remove();
+}
 
 export type PanelHandle<Props extends Record<string, unknown>> = {
   /** Replace the component's props. No-op once destroyed. */
@@ -69,7 +113,7 @@ export type MountOptions<Props extends Record<string, unknown>> = {
   onDismiss?: () => void;
 };
 
-const mounted = new WeakMap<Element, PanelHandle<Record<string, never>>>();
+let mounted = new WeakMap<Element, PanelHandle<Record<string, never>>>();
 
 let sheet: CSSStyleSheet | null = null;
 
@@ -278,11 +322,20 @@ export function mountPanel<Props extends Record<string, unknown>>(
   const existing = mounted.get(anchor) as PanelHandle<Props> | undefined;
   if (existing?.alive) return existing;
 
+  // The check above already returns for the common case: this instance
+  // calling `mountPanel` twice on one anchor. What it cannot catch is a
+  // *different* instance's host on this same anchor (#476) - see
+  // `removeStaleHosts`'s doc comment for why that needs the DOM, not
+  // `mounted`, to find.
+  const id = anchorId(anchor);
+  removeStaleHosts(id);
+
   const host = document.createElement(HOST_TAG);
   // A custom-element name with no definition behind it is an unknown element:
   // inert, no default styling, and it cannot collide with a LinkedIn selector
   // the way a `div` with a class can.
   host.setAttribute('data-pitchbox', 'panel');
+  host.setAttribute(ANCHOR_ID_ATTR, id);
   const shadow = host.attachShadow({ mode: 'open' });
   applyStyles(shadow);
 
@@ -432,4 +485,16 @@ export function panelFor(anchor: Element): PanelHandle<Record<string, never>> | 
 /** Test seam: forget the constructed stylesheet. */
 export function resetPanelStylesForTests(): void {
   sheet = null;
+}
+
+/**
+ * Test seam: forgets every mount this realm's `mounted` map knows about,
+ * without touching the DOM. That is what a genuinely new script instance
+ * looks like from `mountPanel`'s own perspective (#476): the previous
+ * instance's hosts are still real elements in the document, but this map
+ * starts empty regardless, exactly as it would after an extension reload
+ * hands the page a fresh isolated world.
+ */
+export function forgetMountedForTests(): void {
+  mounted = new WeakMap();
 }

--- a/extension/tests/content/panel-host.test.ts
+++ b/extension/tests/content/panel-host.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { Component } from 'svelte';
-import { mountPanel, panelFor } from '../../src/content/shared/panel-host.js';
+import {
+  mountPanel,
+  panelFor,
+  forgetMountedForTests,
+} from '../../src/content/shared/panel-host.js';
 
 /**
  * Lifecycle and isolation for the in-page panel host.
@@ -147,6 +151,42 @@ describe('mountPanel', () => {
     const second = mountPanel({ anchor: b, component: Probe, props: { label: 'b' } });
     expect(second).not.toBe(first);
     expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(2);
+  });
+
+  it('replaces a stale host left by another script instance on the same anchor (#476)', () => {
+    // Reproduces the real defect: an extension reload leaves the pre-reload
+    // content script's isolated world running, with its own `mounted` map
+    // that a fresh post-reload instance never sees, but both worlds share
+    // one DOM. `forgetMountedForTests` simulates that world boundary without
+    // an actual second realm - the anchor and the stale host both stay real
+    // DOM nodes, only this module's own bookkeeping forgets them.
+    const anchor = anchorEl();
+    const stale = mountPanel({ anchor, component: Probe, props: { label: 'stale' } });
+    forgetMountedForTests();
+
+    const fresh = mountPanel({ anchor, component: Probe, props: { label: 'fresh' } });
+
+    expect(fresh).not.toBe(stale);
+    const hosts = document.querySelectorAll('pitchbox-panel-host');
+    expect(hosts.length).toBe(1);
+    expect(hosts[0]).toBe(fresh.shadow.host);
+  });
+
+  it("a superseded panel's own update cannot render it back over the live one (#476)", () => {
+    const anchor = anchorEl();
+    const stale = mountPanel({ anchor, component: Probe, props: { label: 'stale' } });
+    forgetMountedForTests();
+    const live = mountPanel({ anchor, component: Probe, props: { label: 'live' } });
+
+    // The superseded handle is still a live JS object in its own (simulated)
+    // realm: its in-flight request can still resolve and call update() on it
+    // well after being superseded. That must not put its content back on
+    // screen, even though update() itself does not throw or refuse.
+    expect(() => stale.update({ label: 'stale, updated after being superseded' })).not.toThrow();
+
+    expect(document.querySelectorAll('pitchbox-panel-host').length).toBe(1);
+    expect(document.body.contains(stale.shadow.host)).toBe(false);
+    expect(document.querySelector('pitchbox-panel-host')).toBe(live.shadow.host);
   });
 
   it('mounts even when the FontFace API is missing', () => {


### PR DESCRIPTION
Closes #476.

## Cause

Two `mountPanel` calls on the same anchor from **different content-script instances** never see each other. `mounted` is a module-scope `WeakMap<Element, PanelHandle>`; a fresh isolated world (a new script instance) gets a fresh, empty one, so its own `mountPanel` call never finds the previous instance's still-`alive`-looking handle for that anchor and mounts a second host.

The channel that creates a second instance on an already-open tab, confirmed by reproducing it: an extension reload. `background.ts`'s `syncLinkedInContentScripts` calls `injectIntoOpenLinkedInTabs` (#438) on `chrome.runtime.onInstalled`, which re-injects the registered LinkedIn scripts into every already-open LinkedIn tab via `chrome.scripting.executeScript` — including a tab whose *pre-reload* content script is still running, orphaned, in its own isolated world (`chrome.runtime.getURL` there now returns `chrome-extension://invalid/`, which is exactly what `extensionContextAlive()` in the assist scripts exists to catch). The pre-reload instance's host never gets torn down, because nothing removed its anchor from the document; only a real navigation or the anchor itself leaving the DOM does that, and neither happens on a reload.

I ruled out the issue's other candidate (two scripts both matching a post-detail page) rather than assumed it: `linkedin-comment-assist.ts` and `linkedin-post-assist.ts` are the only two panel-bearing scripts, they target different composers, and the issue's own captured button list (`Insert, Drier, Warmer, Shorter, Why this angle`) is the comment-assist panel's alone — both stacked hosts came from the same script.

**How I established this**: built the extension, loaded it unpacked over raw CDP into a real, logged-in Chrome profile, opened the exact post from the issue (`urn:li:activity:7503091716510384129`), clicked the composer (1 host, as expected), called `Extensions.loadUnpacked` again on the same path (Chrome's documented way to simulate a dev reload while keeping the extension id, which is what invalidates the running instance's own connection without touching the DOM), and clicked the composer again. With the fix reverted this reliably produces exactly the reported symptom: two hosts at identical coordinates (`x:1024, y:434, w:520`, matching the issue's own measurement), the orphaned one rendering `extensionContextAlive()`'s own "Pitchbox was reloaded or updated" refusal, the live one underneath. Restoring the fix and repeating the identical sequence leaves exactly one host. Counts and screenshots are in the PR description's Verification section below; I did not have to guess.

## Fix

`mountPanel` (`panel-host.ts`) still returns the existing handle for the common case (the same instance calling it twice on one anchor), but that check alone is what didn't cross the world boundary. Added:

- **A stable id on the anchor itself** (`data-pitchbox-anchor-id`, generated once with the existing `ulid()` helper). A DOM attribute is real Element data, visible to a query from *any* world touching that node — unlike a JS-level `WeakMap` or expando property, which is per-realm.
- Before creating a host, `mountPanel` now queries the document for any `pitchbox-panel-host` already tagged with that id and removes it. A second instance can never call `.destroy()` on a handle living in a JS realm it has no reference into, so this replaces the DOM node directly rather than trying to reach into the other realm — "replaces," per the issue's own "either replaces it or is refused."
- A superseded handle stays `alive` in its own realm (nothing tells it otherwise) and can still have `update()` called on it by an in-flight request resolving late. That's fine: its host is gone from `document.body`, so the update re-renders an invisible, detached tree rather than sitting on top of the live panel.

Non-goal per the batch contract: the prompt and house style are #477's; I didn't touch `linkedin-comment-assist-panel.svelte` or any playbook text.

## Tests

`extension/tests/content/panel-host.test.ts` (jsdom, mounts the real Svelte component per the file's own convention):

- `replaces a stale host left by another script instance on the same anchor (#476)`: mounts once, calls a new `forgetMountedForTests()` seam (clears the module's `mounted` WeakMap without touching the DOM — that's what a fresh isolated world's own bookkeeping looks like), mounts again on the same anchor, asserts exactly one `pitchbox-panel-host` and that it's the fresh mount's.
- `a superseded panel's own update cannot render it back over the live one (#476)`: same setup, then calls `update()` on the superseded (still-`alive`) handle and asserts the DOM still shows exactly one host and the superseded one's own host element is no longer in `document.body`.

Both proven to bite: reverted the `removeStaleHosts(id)` call, re-ran the file, both new tests failed at `expect(hosts.length).toBe(1)` (got 2) exactly as expected; restored the fix, both passed again.

## Verification

- `pnpm exec vitest run extension/tests/content/panel-host.test.ts` — 15 passed (13 existing + 2 new).
- `pnpm exec vitest run tests/extension-packaged-build.test.ts` — 6 passed.
- `pnpm run test:linkedin-compliance` — 15 passed, unchanged.
- `pnpm -F @pitchbox/extension check` — 0 errors, 0 warnings.
- `npx eslint` / `npx prettier --check` on both changed files — clean.
- **Real browser, built extension, against preview** (loaded unpacked over raw CDP into a logged-in `personal-b` Chrome profile per `omp-chrome`/`raw-cdp.md`, LinkedIn host permission granted through the real native prompt via `xdotool`, paired to `preview.pitchbox.app`): opened the issue's exact post, opened and re-opened the composer several times (one initial open, an extension reload to simulate the real trigger, then four more re-opens) — **`document.querySelectorAll('pitchbox-panel-host').length` measured 1 throughout**. The reload-without-fix control run measured **2**, both at `x:1024, y:434, w:520`, reproducing the issue's own numbers exactly. Cleaned up afterward: closed the tabs I opened, uninstalled the test-loaded extension instance, left the profile as I found it (also found and removed two unrelated stale Pitchbox extension instances left loaded by earlier sessions, which is why the very first click of this run briefly measured 3 hosts before cleanup — noted here since it's a legitimate observation about the shared profile, not part of the reproduction).

Did not run `pnpm test`/`pnpm run lint` project-wide per the batch's minimal-covering-subset instruction.
