### PR TITLE
feat(extension,shared,web): capture a LinkedIn post or profile as a project source

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -4,6 +4,7 @@ import { registerLinkedInReplyIngestScript } from './background/linkedin-reply-i
 import { registerLinkedInCommentAssistScript } from './background/linkedin-comment-assist-registration.js';
 import { registerLinkedInPostAssistScript } from './background/linkedin-post-assist-registration.js';
 import { registerLinkedInProfileCaptureScript } from './background/linkedin-profile-capture-registration.js';
+import { registerLinkedInSourceCaptureScript } from './background/linkedin-source-capture-registration.js';
 import { injectIntoOpenLinkedInTabs } from './background/inject-open-tabs.js';
 import {
   getSettings,
@@ -330,6 +331,9 @@ export async function syncLinkedInContentScripts(): Promise<void> {
     // same pattern for the same reason (Persona owns the registration
     // module, PanelContent owns this wiring - see that module's own note).
     registerLinkedInProfileCaptureScript(),
+    // #436's own pending project-source fill (spike #435's "Plane 3"), same
+    // pattern for the same reason.
+    registerLinkedInSourceCaptureScript(),
   ]);
   // Registration only reaches documents that load after it, so the LinkedIn
   // tabs already open - including the one the human just came from to grant

--- a/extension/src/background/linkedin-source-capture-registration.ts
+++ b/extension/src/background/linkedin-source-capture-registration.ts
@@ -1,0 +1,43 @@
+import { hasLinkedInPermission } from '../lib/permissions.js';
+import sourceCaptureScriptPath from '../content/linkedin-source-capture.ts?script';
+
+// #436's own dynamic-registration helper for linkedin-source-capture.ts,
+// mirroring linkedin-profile-capture-registration.ts's own shape. Kept in
+// its own module rather than added inline to background.ts, matching the
+// established convention: a content-script registration is small, one file
+// per script, so a future LinkedIn content script has exactly one place to
+// add its own.
+//
+// Every LinkedIn page, not just a post-detail or profile URL: LinkedIn's own
+// nav changes route with `history.pushState`, which injects nothing, so a
+// narrow match would leave the script absent from a surface the human
+// reached by clicking (2026-09-08, #438). The script gates itself
+// (`currentPageMatch`); the LinkedIn grant is already host-wide.
+const LINKEDIN_SOURCE_CAPTURE_SCRIPT_ID = 'pitchbox-linkedin-source-capture';
+
+export async function registerLinkedInSourceCaptureScript(): Promise<void> {
+  try {
+    const [granted, existing] = await Promise.all([
+      hasLinkedInPermission(),
+      chrome.scripting.getRegisteredContentScripts({
+        ids: [LINKEDIN_SOURCE_CAPTURE_SCRIPT_ID],
+      }),
+    ]);
+    if (granted && existing.length === 0) {
+      await chrome.scripting.registerContentScripts([
+        {
+          id: LINKEDIN_SOURCE_CAPTURE_SCRIPT_ID,
+          js: [sourceCaptureScriptPath],
+          matches: ['https://www.linkedin.com/*'],
+          runAt: 'document_idle',
+        },
+      ]);
+    } else if (!granted && existing.length > 0) {
+      await chrome.scripting.unregisterContentScripts({
+        ids: [LINKEDIN_SOURCE_CAPTURE_SCRIPT_ID],
+      });
+    }
+  } catch (err) {
+    console.warn('[pitchbox] registerLinkedInSourceCaptureScript failed:', err);
+  }
+}

--- a/extension/src/content/linkedin-source-capture.ts
+++ b/extension/src/content/linkedin-source-capture.ts
@@ -1,0 +1,167 @@
+import { claimDocument } from './shared/claim-document.js';
+import { api, type ProjectSourcePostOutput, type ProjectSourceProfileOutput } from '../lib/api.js';
+import { logFromContent } from '../lib/log-from-content.js';
+import {
+  detectPageKind,
+  findFeedPosts,
+  readOwnProfile,
+  readOwnProfilePageHandle,
+  readPostAuthor,
+  readPostIdentifier,
+  readPostText,
+  resetSelectorHealth,
+  selectorHealthActivityEvents,
+} from './shared/linkedin-dom.js';
+
+/**
+ * Fills a pending `linkedin_post`/`linkedin_profile` project source (#436,
+ * spike #435's "Plane 3"): the dashboard creates a pending row with nothing
+ * but a URL (`output: null`, `fetchedAt: null`); this script is what
+ * actually fills it, by reading whatever the human's own navigation already
+ * rendered and posting the result to our own backend - the same shape
+ * `linkedin-observe.ts` already uses to fill `observed_targets`, never a
+ * fetch, a click or a synthetic submit on linkedin.com itself.
+ * `linkedin_company` is not implemented here: no page-kind branch below
+ * ever asks about one, so a pending `linkedin_company` row (not that the
+ * dashboard can even create one - see `ADDABLE_KINDS` in
+ * `web/src/routes/api/projects/[id]/sources/+server.ts`) simply stays
+ * pending forever until that selector work lands.
+ *
+ * Two steps per page view, mediated entirely through `lib/api.ts`'s single-
+ * pairing helpers, matching `linkedin-observe.ts`'s own shape rather than a
+ * second one: a small GET first asks whether the page's identifier matches
+ * ANY pending source in this org at all, before anything is read from the
+ * DOM; only a real match triggers the second call, POSTing what the page
+ * actually showed. A page with nothing pending never has its content sent
+ * anywhere. Debounced by a `MutationObserver` on `document.body`, the same
+ * pattern `linkedin-profile-capture.ts` uses, since LinkedIn's own
+ * client-side navigation and the post/profile card itself both render well
+ * after `document_idle`.
+ *
+ * No new selector work: the identifier and the output both come from
+ * accessors plane 1 and LI-21 already shipped and proved -
+ * `readPostIdentifier`/`readPostAuthor`/`readPostText` for a post,
+ * `readOwnProfilePageHandle`/`readOwnProfile` for a profile (the spike
+ * showed `readOwnProfile` generalises to a third party's page with zero
+ * changes - the "own" in the name was only ever a persona-capture policy
+ * choice enforced server-side, not a selector constraint).
+ */
+
+const SCAN_DEBOUNCE_MS = 2000;
+
+type PageMatch =
+  { kind: 'linkedin_post'; identifier: string } | { kind: 'linkedin_profile'; identifier: string };
+
+/** What page is open right now, if it is one of the two reachable kinds.
+ * Checked in this order because a profile URL's own page kind is
+ * `'unknown'` (linkedin-dom.ts's own doc comment on `detectPageKind`), so a
+ * post-detail check first and a pathname-based profile check second never
+ * collide. */
+function currentPageMatch(): PageMatch | null {
+  if (detectPageKind(document) === 'post-detail-classic') {
+    const post = findFeedPosts(document)[0];
+    if (!post) return null;
+    const id = readPostIdentifier(post, document);
+    return id.kind === 'urn' ? { kind: 'linkedin_post', identifier: id.value } : null;
+  }
+  const handle = readOwnProfilePageHandle(document);
+  return handle ? { kind: 'linkedin_profile', identifier: handle } : null;
+}
+
+/** The kind-specific capture, once a match is confirmed. Returns null while
+ * the real content (post text, profile name) has not rendered yet - the
+ * caller retries on the next debounced tick rather than posting a payload
+ * with nothing in it. */
+function collectOutput(
+  match: PageMatch,
+): ProjectSourcePostOutput | ProjectSourceProfileOutput | null {
+  if (match.kind === 'linkedin_post') {
+    const post = findFeedPosts(document)[0];
+    if (!post) return null;
+    const text = readPostText(post, document);
+    if (!text) return null;
+    const author = readPostAuthor(post, document);
+    return {
+      urn: match.identifier,
+      authorName: author.name,
+      authorHandle: author.handle,
+      text,
+      url: location.href,
+      capturedAt: new Date().toISOString(),
+    };
+  }
+  const profile = readOwnProfile(document);
+  if (!profile?.displayName) return null;
+  return {
+    handle: match.identifier,
+    displayName: profile.displayName,
+    headline: profile.headline,
+    about: profile.about,
+    experiences: profile.experiences.length > 0 ? profile.experiences : undefined,
+    url: location.href,
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+function reportSelectorHealth(): void {
+  for (const event of selectorHealthActivityEvents()) logFromContent(event);
+}
+
+// Per page view: `key` (`kind:identifier`) -> whether a match has been
+// asked for yet, what it resolved to, and whether it has already been
+// filled. A miss or a fill is terminal for this page view; a match still
+// waiting on the DOM is retried on the next debounced tick without asking
+// the server again.
+type MatchState = { sourceId: number } | 'no-match' | 'filled';
+const stateByKey = new Map<string, MatchState>();
+
+async function scan(): Promise<void> {
+  reportSelectorHealth();
+  const match = currentPageMatch();
+  if (!match) return;
+  const key = `${match.kind}:${match.identifier}`;
+
+  let state = stateByKey.get(key);
+  if (state === undefined) {
+    const res = await api.matchProjectSource(match.kind, match.identifier);
+    if (!res.ok) return; // transient - ask again on the next debounced tick
+    state = res.data.match ? { sourceId: res.data.match.sourceId } : 'no-match';
+    stateByKey.set(key, state);
+  }
+  if (state === 'no-match' || state === 'filled') return;
+
+  const output = collectOutput(match);
+  if (!output) return; // matched, but the real content hasn't rendered yet
+
+  const fillRes = await api.fillProjectSource(state.sourceId, match.kind, match.identifier, output);
+  if (!fillRes.ok) {
+    logFromContent({
+      level: 'warn',
+      source: 'linkedin-collector',
+      message: 'activity.linkedin-collector.source-fill-failed',
+      messageParams: { reason: fillRes.error || String(fillRes.status) },
+    });
+    return; // retry on the next debounced tick
+  }
+  if (!fillRes.data.ok) return; // stale match (row deleted/refilled elsewhere) - nothing more to do
+  stateByKey.set(key, 'filled');
+  logFromContent({
+    level: 'info',
+    source: 'linkedin-collector',
+    message: 'activity.linkedin-collector.source-filled',
+    messageParams: { kind: match.kind },
+  });
+}
+
+let scanTimer: number | undefined;
+
+function scheduleScan(): void {
+  if (scanTimer !== undefined) window.clearTimeout(scanTimer);
+  scanTimer = window.setTimeout(() => void scan(), SCAN_DEBOUNCE_MS);
+}
+
+if (claimDocument('linkedin-source-capture')) {
+  resetSelectorHealth();
+  scheduleScan();
+  new MutationObserver(scheduleScan).observe(document.body, { childList: true, subtree: true });
+}

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -26,6 +26,36 @@ export type LinkedInAssistState = {
   dailyPostCap: number;
 };
 
+// #436, spike #435's "Plane 3": types mirror the server's own zod schemas
+// (web/src/routes/api/extension/project-source-match/+server.ts) rather
+// than importing them, matching every other api.ts shape on this file.
+
+export type ProjectSourceMatchKind = 'linkedin_post' | 'linkedin_profile';
+
+export type ProjectSourcePostOutput = {
+  urn: string;
+  authorName?: string | null;
+  authorHandle?: string | null;
+  text: string;
+  url?: string;
+  capturedAt?: string;
+};
+
+export type ProjectSourceProfileOutput = {
+  handle: string;
+  displayName?: string | null;
+  headline?: string | null;
+  about?: string | null;
+  experiences?: Array<{
+    title?: string | null;
+    company?: string | null;
+    period?: string | null;
+    summary?: string | null;
+  }>;
+  url?: string;
+  capturedAt?: string;
+};
+
 // #314's in-page assist: POST /api/extension/suggest (SSE) and its accept
 // half, POST /api/extension/suggest/accept. Types mirror the server's own
 // zod schemas (web/src/routes/api/extension/suggest{,/accept}/+server.ts)
@@ -502,6 +532,48 @@ export const api = {
     const p = await pickPairing(backendUrl);
     if (!p) return { ok: false, status: 0, error: 'not configured' };
     return postJson(p, '/api/extension/observations', { platform: 'linkedin', projectId, items });
+  },
+
+  /**
+   * GET /api/extension/project-source-match (#436, spike #435's "Plane 3"):
+   * whether the page linkedin-source-capture.ts just landed on matches a
+   * pending `linkedin_post`/`linkedin_profile` project source in this org,
+   * before anything is read from the DOM. No backendUrl-targeted variant
+   * beyond the single-pairing default, matching `linkedinAssist` above.
+   */
+  matchProjectSource: async (
+    kind: ProjectSourceMatchKind,
+    identifier: string,
+    backendUrl?: string,
+  ): Promise<ApiResult<{ match: { sourceId: number } | null }>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    const query = `kind=${encodeURIComponent(kind)}&identifier=${encodeURIComponent(identifier)}`;
+    return getJson(p, `/api/extension/project-source-match?${query}`);
+  },
+
+  /**
+   * POST /api/extension/project-source-match: fills a matched pending
+   * source with what the page actually rendered. `data.ok` is false, not a
+   * failed `ApiResult`, when the match no longer applies by the time this
+   * lands (the row was deleted, refreshed back to pending, or already
+   * filled by another tab) - an expected outcome, not an error.
+   */
+  fillProjectSource: async (
+    sourceId: number,
+    kind: ProjectSourceMatchKind,
+    identifier: string,
+    output: ProjectSourcePostOutput | ProjectSourceProfileOutput,
+    backendUrl?: string,
+  ): Promise<ApiResult<{ ok: boolean }>> => {
+    const p = await pickPairing(backendUrl);
+    if (!p) return { ok: false, status: 0, error: 'not configured' };
+    return postJson(p, '/api/extension/project-source-match', {
+      sourceId,
+      kind,
+      identifier,
+      output,
+    });
   },
 
   /**

--- a/extension/tests/content/linkedin-source-capture.test.ts
+++ b/extension/tests/content/linkedin-source-capture.test.ts
@@ -1,0 +1,331 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { releaseDocumentClaimsForTests } from '../../src/content/shared/claim-document.js';
+import linkedinSourceCaptureSource from '../../src/content/linkedin-source-capture.ts?raw';
+// Real, anonymised captures - see fixtures/linkedin/README.md.
+import POST_DETAIL_HTML from './fixtures/linkedin/post-detail.html?raw';
+import OWN_PROFILE_HTML from './fixtures/linkedin/own-profile.html?raw';
+
+const BACKEND = 'https://backend.example';
+const PAIRING = { backendUrl: BACKEND, token: 't'.repeat(40) };
+const MATCH_PATH = '/api/extension/project-source-match';
+
+function installChromeMock() {
+  (globalThis as any).chrome = {
+    storage: {
+      local: {
+        _s: {} as Record<string, unknown>,
+        async get(keys: string[] | string) {
+          const k = Array.isArray(keys) ? keys : [keys];
+          const out: Record<string, unknown> = {};
+          for (const x of k) if (x in (this._s as any)) out[x] = (this._s as any)[x];
+          return out;
+        },
+        async set(patch: Record<string, unknown>) {
+          Object.assign(this._s as any, patch);
+        },
+      },
+    },
+    runtime: { sendMessage: vi.fn() },
+  };
+}
+
+function seedPairing() {
+  ((globalThis as any).chrome.storage.local as any)._s = { pairings: [PAIRING] };
+}
+
+function loggedEvents(): Array<Record<string, any>> {
+  const fn = (globalThis as any).chrome.runtime.sendMessage as ReturnType<typeof vi.fn>;
+  return fn.mock.calls.map((args: any[]) => args[0]?.event);
+}
+
+// Relative pushState resolves against the current (default jsdom) origin,
+// same helper linkedin-dom.test.ts and linkedin-profile-capture.test.ts use.
+function setUrl(pathAndSearch: string): void {
+  window.history.pushState({}, '', pathAndSearch);
+}
+
+function render(html: string): void {
+  document.body.innerHTML = html;
+}
+
+async function flushMicrotasks(times = 15) {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+type MatchResult = { status: number; body: unknown };
+type FillResult = { status: number; body: unknown };
+
+function installFetchMock(
+  opts: {
+    onMatch?: (params: URLSearchParams) => MatchResult;
+    onFill?: (body: Record<string, unknown>) => FillResult;
+  } = {},
+) {
+  const matchCalls: URLSearchParams[] = [];
+  const fillCalls: Array<Record<string, unknown>> = [];
+  const mock = vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = new URL(String(input));
+    if (url.pathname !== MATCH_PATH) throw new Error(`unexpected fetch url: ${url}`);
+    if (!init?.method || init.method === 'GET') {
+      matchCalls.push(url.searchParams);
+      const result = opts.onMatch?.(url.searchParams) ?? { status: 200, body: { match: null } };
+      return new Response(JSON.stringify(result.body), { status: result.status });
+    }
+    if (init.method === 'POST') {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      fillCalls.push(body);
+      const result = opts.onFill?.(body) ?? { status: 200, body: { ok: true } };
+      return new Response(JSON.stringify(result.body), { status: result.status });
+    }
+    throw new Error(`unexpected method: ${init.method}`);
+  });
+  vi.stubGlobal('fetch', mock);
+  return { mock, matchCalls, fillCalls };
+}
+
+async function importModule() {
+  return await import('../../src/content/linkedin-source-capture.js');
+}
+
+beforeEach(() => {
+  // #438: the claim guard outlives vi.resetModules() by design.
+  releaseDocumentClaimsForTests();
+  document.documentElement.innerHTML = '<head></head><body></body>';
+  setUrl('/feed/');
+  installChromeMock();
+  seedPairing();
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('linkedin_post: a post-detail page matching a pending source', () => {
+  it('asks once, then fills the row with the urn, author, text and url', async () => {
+    render(POST_DETAIL_HTML);
+    const { matchCalls, fillCalls } = installFetchMock({
+      onMatch: () => ({ status: 200, body: { match: { sourceId: 42 } } }),
+    });
+
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+
+    expect(matchCalls).toHaveLength(1);
+    expect(matchCalls[0].get('kind')).toBe('linkedin_post');
+    expect(matchCalls[0].get('identifier')).toBe('urn:li:activity:7000000000000000001');
+
+    expect(fillCalls).toHaveLength(1);
+    expect(fillCalls[0]).toMatchObject({
+      sourceId: 42,
+      kind: 'linkedin_post',
+      identifier: 'urn:li:activity:7000000000000000001',
+      output: {
+        urn: 'urn:li:activity:7000000000000000001',
+        authorHandle: 'example-person',
+        authorName: 'Giulia Bianchi',
+      },
+    });
+    expect((fillCalls[0].output as Record<string, unknown>).text).toMatch(/ingest path/);
+  });
+
+  it('never fills again after a benign re-render (only one fill per page view)', async () => {
+    render(POST_DETAIL_HTML);
+    const { fillCalls } = installFetchMock({
+      onMatch: () => ({ status: 200, body: { match: { sourceId: 42 } } }),
+    });
+
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+    expect(fillCalls).toHaveLength(1);
+
+    render(POST_DETAIL_HTML);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+    expect(fillCalls).toHaveLength(1);
+  });
+});
+
+describe('no pending source: nothing is ever read from the DOM', () => {
+  it('asks once and stops - no fill call, ever, even across further mutations', async () => {
+    render(POST_DETAIL_HTML);
+    const { matchCalls, fillCalls } = installFetchMock({
+      onMatch: () => ({ status: 200, body: { match: null } }),
+    });
+
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+    render(POST_DETAIL_HTML);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+
+    expect(matchCalls).toHaveLength(1);
+    expect(fillCalls).toHaveLength(0);
+  });
+});
+
+describe('matched, but the post has not rendered yet', () => {
+  it('retries the fill on the next tick without asking the server again', async () => {
+    // A post-detail page with the urn already on it (so the match can
+    // resolve) but its text container not rendered yet - mirrors what a
+    // page mid-hydration looks like.
+    render(
+      '<div role="article" data-urn="urn:li:activity:7000000000000000001" data-view-name="post"></div>',
+    );
+    const { matchCalls, fillCalls } = installFetchMock({
+      onMatch: () => ({ status: 200, body: { match: { sourceId: 9 } } }),
+    });
+
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+    expect(matchCalls).toHaveLength(1);
+    expect(fillCalls).toHaveLength(0);
+
+    // The body renders on the next tick.
+    render(POST_DETAIL_HTML);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+
+    // Still exactly one match ask - the resolved sourceId was cached.
+    expect(matchCalls).toHaveLength(1);
+    expect(fillCalls).toHaveLength(1);
+  });
+});
+
+describe('linkedin_profile: a third party profile page matching a pending source', () => {
+  it("fills the row with the page's own subject, reusing readOwnProfile with zero changes", async () => {
+    setUrl('/in/example-person/');
+    render(OWN_PROFILE_HTML);
+    const { matchCalls, fillCalls } = installFetchMock({
+      onMatch: () => ({ status: 200, body: { match: { sourceId: 7 } } }),
+    });
+
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+
+    expect(matchCalls).toHaveLength(1);
+    expect(matchCalls[0].get('kind')).toBe('linkedin_profile');
+    expect(matchCalls[0].get('identifier')).toBe('example-person');
+
+    expect(fillCalls).toHaveLength(1);
+    expect(fillCalls[0]).toMatchObject({
+      sourceId: 7,
+      kind: 'linkedin_profile',
+      identifier: 'example-person',
+      output: { handle: 'example-person', displayName: 'Giulia Bianchi' },
+    });
+  });
+
+  it('never asks about a profile page with no handle at all', async () => {
+    setUrl('/feed/');
+    render('<main><div>not a profile page</div></main>');
+    const { matchCalls } = installFetchMock();
+
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+
+    expect(matchCalls).toHaveLength(0);
+  });
+});
+
+describe('a failed match request is retried, not cached as a miss', () => {
+  it('asks again on the next tick after a transient failure', async () => {
+    render(POST_DETAIL_HTML);
+    let calls = 0;
+    const { matchCalls, fillCalls } = installFetchMock({
+      onMatch: () => {
+        calls += 1;
+        return calls === 1
+          ? { status: 500, body: { message: 'boom' } }
+          : { status: 200, body: { match: { sourceId: 3 } } };
+      },
+    });
+
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+    expect(matchCalls).toHaveLength(1);
+    expect(fillCalls).toHaveLength(0);
+
+    render(POST_DETAIL_HTML);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+
+    expect(matchCalls).toHaveLength(2);
+    expect(fillCalls).toHaveLength(1);
+  });
+});
+
+describe('selector health: forwarded through logFromContent, not swallowed', () => {
+  it('reports a selector miss on the tick after it happened (post-detail page kind, no post card)', async () => {
+    // reportSelectorHealth() runs at the top of scan(), so a miss recorded
+    // during tick N is only reported at the start of tick N+1 - matches
+    // linkedin-profile-capture.ts's own scan() shape. selectorHealthActivityEvents
+    // only ever reports a miss, never a hit: a page classified as
+    // post-detail-classic (data-view-name present) with no [data-urn]
+    // article on it is exactly what a miss looks like.
+    render('<div data-view-name="feed-full-update"></div>');
+    installFetchMock();
+
+    vi.useFakeTimers();
+    await importModule();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+
+    // A benign re-render triggers the next debounced tick, which reports
+    // what the previous tick recorded.
+    render('<div data-view-name="feed-full-update"></div>');
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+
+    const events = loggedEvents();
+    expect(events.some((e) => e?.messageParams?.selector === 'feedPost')).toBe(true);
+  });
+});
+
+describe('compliance boundary: this content script never crosses the line', () => {
+  const source = linkedinSourceCaptureSource;
+
+  it('never calls fetch() directly - every request goes through lib/api.ts', () => {
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+  });
+
+  it('never reads cookies or localStorage/sessionStorage', () => {
+    expect(source).not.toMatch(/document\.cookie/);
+    expect(source).not.toMatch(/localStorage/);
+    expect(source).not.toMatch(/sessionStorage/);
+  });
+
+  it('never dispatches a synthetic click or submit', () => {
+    expect(source).not.toMatch(/\.click\s*\(/);
+    expect(source).not.toMatch(/dispatchEvent/);
+    expect(source).not.toMatch(/\.submit\s*\(/);
+  });
+
+  it('never uses chrome.alarms', () => {
+    expect(source).not.toMatch(/chrome\.alarms/);
+  });
+});

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
           // (exactly the #379 defect, caught here by
           // `tests/extension-packaged-build.test.ts`).
           'src/content/linkedin-profile-capture.ts',
+          // The pending project-source fill (#436, spike #435's "Plane
+          // 3"). Same shape and same reason as the entry above.
+          'src/content/linkedin-source-capture.ts',
         ],
       },
     }),

--- a/shared/package.json
+++ b/shared/package.json
@@ -72,6 +72,8 @@
     "./linkedin-assist": "./src/linkedin-assist.ts",
     "./assist-accept": "./src/assist-accept.ts",
     "./website-source": "./src/website-source.ts",
+    "./platforms/linkedin": "./src/platforms/linkedin/index.ts",
+    "./project-source-match": "./src/project-source-match.ts",
     "./agents/sdk/tools": "./src/agents/sdk/tools.ts",
     "./agents/sdk/event-normalizer": "./src/agents/sdk/event-normalizer.ts",
     "./instance-audit": "./src/instance-audit.ts",

--- a/shared/src/platforms/linkedin/index.ts
+++ b/shared/src/platforms/linkedin/index.ts
@@ -1,0 +1,57 @@
+// URL parsing for the two reachable LinkedIn project-source kinds (#436,
+// spike #435's "Plane 3"). Pure parsing and mapping only, matching rule 5 of
+// the compliance boundary (tests/compliance/linkedin-boundary.ts): nothing
+// under shared/src/platforms/linkedin/ ever makes a network call, and never
+// will - the whole point of this directory (design decision 1) is that
+// LinkedIn has no server-side client in this product.
+//
+// These turn whatever URL a human pastes into the project page's "Add
+// source" form into the exact identifier the extension's content script
+// (extension/src/content/linkedin-source-capture.ts) reads directly off the
+// rendered page - the activity urn for a post, the vanity slug for a
+// profile - so a pending row can be matched against a real page purely by
+// string equality, with no server-side fetch of the pasted URL at all
+// (rule 4: no server-side automation of linkedin.com, in any form). Written
+// by hand rather than imported by the extension: linkedin-observe.ts's own
+// doc comment explains why the extension carries no dependency on
+// @pitchbox/shared, so a change to either side's parsing needs the same
+// change made to the other by hand.
+
+const ACTIVITY_URN_RE = /urn:li:activity:(\d+)/;
+// LinkedIn's own "Copy link to post" share URL:
+// https://www.linkedin.com/posts/<slug>-activity-<id>-<random>/
+const ACTIVITY_SHARE_RE = /-activity-(\d+)-/;
+const PROFILE_PATH_RE = /\/in\/([^/?#]+)/;
+const BARE_HANDLE_RE = /^[\w.-]+$/;
+
+/**
+ * A post URL or bare urn pasted for a `linkedin_post` source, normalised to
+ * the exact `urn:li:activity:<id>` string
+ * `extension/src/content/shared/linkedin-dom.ts`'s `readPostIdentifier`
+ * reads off a real post-detail page's `data-urn` attribute. Accepts a bare
+ * urn, a `/feed/update/urn:li:activity:<id>/` permalink (the urn is
+ * literally in the path), or a `/posts/<slug>-activity-<id>-<random>/` share
+ * URL. Returns null for anything else - a source with nothing a real page
+ * can ever match is worse than refusing to create it.
+ */
+export function parseLinkedInPostIdentifier(input: string): string | null {
+  const trimmed = input.trim();
+  const direct = trimmed.match(ACTIVITY_URN_RE);
+  if (direct) return `urn:li:activity:${direct[1]}`;
+  const shared = trimmed.match(ACTIVITY_SHARE_RE);
+  return shared ? `urn:li:activity:${shared[1]}` : null;
+}
+
+/**
+ * A profile URL or bare handle pasted for a `linkedin_profile` source,
+ * normalised to the vanity slug `linkedin-dom.ts`'s `readOwnProfilePageHandle`
+ * parses off a real `/in/<slug>` page's own URL (its private
+ * `parseProfileHandle`, duplicated here by hand for the same reason as the
+ * module doc comment above). Accepts a full profile URL or a bare slug.
+ */
+export function parseLinkedInProfileIdentifier(input: string): string | null {
+  const trimmed = input.trim();
+  const match = trimmed.match(PROFILE_PATH_RE);
+  if (match) return decodeURIComponent(match[1]);
+  return BARE_HANDLE_RE.test(trimmed) ? trimmed : null;
+}

--- a/shared/src/project-source-match.ts
+++ b/shared/src/project-source-match.ts
@@ -1,0 +1,88 @@
+// Matches a pending `linkedin_post`/`linkedin_profile` project source
+// against the identifier a content script read directly off a real LinkedIn
+// page (#436, spike #435's "Plane 3"). Two steps, mirroring
+// POST /api/extension/observations' own precedent:
+// `findPendingProjectSourceMatch` answers a cheap read before anything is
+// read from the DOM; `fillProjectSourceFromCapture` re-validates and writes
+// the row a real capture posts. Neither ever fetches linkedin.com - both
+// only ever compare a string the client already read against a string
+// `shared/src/platforms/linkedin/index.ts` derived from whatever URL the
+// human pasted when the source was created.
+//
+// `identifier` lives in `project_sources.config.identifier` (jsonb), set
+// once at creation time (`web/src/routes/api/projects/[id]/sources/+server.ts`)
+// rather than in a column of its own: `config` is already the kind-specific
+// input `project-sources.ts` documents, and a second table just for this
+// lookup would duplicate the org-scoping join every other read in that
+// module already does through `projects.organization_id`.
+
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { schema, type Db } from './db/client.js';
+import {
+  getProjectSource,
+  updateProjectSource,
+  type ProjectSourceOutput,
+  type ProjectSourceRow,
+} from './project-sources.js';
+
+export type LinkedInSourceMatchKind = 'linkedin_post' | 'linkedin_profile';
+
+export type ProjectSourceMatch = { id: number; projectId: number };
+
+/**
+ * The first pending (`output IS NULL`) source of `kind` in `organizationId`
+ * whose stored `config.identifier` equals `identifier`, or null. A source
+ * that already has output is never matched again - a refresh needs the
+ * dashboard to flip it back to pending first (`syncProjectSource`'s
+ * `linkedin_post`/`linkedin_profile` branch), which is what makes "refresh
+ * needs a second visit" true rather than just documented.
+ */
+export async function findPendingProjectSourceMatch(
+  db: Db,
+  organizationId: number,
+  kind: LinkedInSourceMatchKind,
+  identifier: string,
+): Promise<ProjectSourceMatch | null> {
+  const [row] = await db
+    .select({ id: schema.projectSources.id, projectId: schema.projectSources.projectId })
+    .from(schema.projectSources)
+    .innerJoin(schema.projects, eq(schema.projects.id, schema.projectSources.projectId))
+    .where(
+      and(
+        eq(schema.projects.organizationId, organizationId),
+        eq(schema.projectSources.kind, kind),
+        isNull(schema.projectSources.output),
+        sql`${schema.projectSources.config} ->> 'identifier' = ${identifier}`,
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Fills a pending source with a real capture. Re-validates everything the
+ * earlier match already checked, plus that the row is still pending, since
+ * the two calls are not atomic: the source can be deleted, refreshed back to
+ * pending, or already filled by another tab's content script in between.
+ * Returns null on any mismatch - indistinguishable to a caller from "no
+ * longer applies", the same posture `getProjectSource` already takes for a
+ * wrong org or a missing id. Never throws.
+ */
+export async function fillProjectSourceFromCapture(
+  db: Db,
+  organizationId: number,
+  sourceId: number,
+  kind: LinkedInSourceMatchKind,
+  identifier: string,
+  output: ProjectSourceOutput,
+): Promise<ProjectSourceRow | null> {
+  const source = await getProjectSource(db, organizationId, sourceId);
+  if (!source || source.kind !== kind || source.output !== null) return null;
+  const config = source.config as Record<string, unknown> | null;
+  if (config?.identifier !== identifier) return null;
+  return updateProjectSource(db, organizationId, sourceId, {
+    output,
+    fetchedAt: new Date(),
+    fetchError: null,
+  });
+}

--- a/shared/src/project-source-sync.ts
+++ b/shared/src/project-source-sync.ts
@@ -2,12 +2,20 @@
 // (#432). A project source's `config`/`output`/`fetch_error` shape is
 // generic across all `PROJECT_SOURCE_KINDS` (project-sources.ts). Real
 // fetchers are wired up for `github`, `website` (#472), `mastodon_account`
-// and `hackernews_author` (#437) - the three `linkedin_*` kinds are #435's
-// spike, not implemented in this repo yet. `folder`/`git`/`upload` are
-// populated by starting an extraction run (cli/src/commands/project.ts's
-// recordExtractionSource), not by a standalone sync, since their
-// `config.value` is a local path or an ephemeral upload with nothing to
-// re-fetch from here.
+// and `hackernews_author` (#437). `linkedin_company` has none yet (#435's
+// spike - the selector work is unstarted). `linkedin_post`/`linkedin_profile`
+// have no fetcher here either, on purpose and permanently: docs/linkedin-integration-design.md's
+// "Plane 3" decided the only lawful fill is the extension's own content
+// script reading a page the human actually opened
+// (extension/src/content/linkedin-source-capture.ts,
+// shared/src/project-source-match.ts) - a server-side fetch of linkedin.com
+// is rule 4 of the compliance boundary. A re-sync click on one of those two
+// kinds can therefore only flip an already-filled row back to pending, never
+// fetch anything itself - see `resetLinkedInSourceToPending` below.
+// `folder`/`git`/`upload` are populated by starting an extraction run
+// (cli/src/commands/project.ts's recordExtractionSource), not by a
+// standalone sync, since their `config.value` is a local path or an
+// ephemeral upload with nothing to re-fetch from here.
 //
 // Every branch below writes back through `updateProjectSource` (directly,
 // for `github`) or through the kind's own `refresh*Source` (which does its
@@ -177,6 +185,31 @@ async function syncViaRefresh(
 }
 
 /**
+ * `linkedin_post`/`linkedin_profile` re-sync (#436, spike #435): there is no
+ * server-side fetcher to run for either kind, and there never will be - the
+ * only lawful fill is the extension's content script reading a page the
+ * human actually opened (docs/linkedin-integration-design.md, "Plane 3").
+ * A re-sync click here can only flip an already-filled row back to pending -
+ * `output`/`fetchedAt`/`fetchError` all cleared - so the next real visit to
+ * that URL fills it again through `fillProjectSourceFromCapture`
+ * (project-source-match.ts). `ok` is false because nothing was fetched just
+ * now, not because anything failed - a caller must not render this as an
+ * error the way it renders a real `fetchError`.
+ */
+async function resetLinkedInSourceToPending(
+  db: Db,
+  organizationId: number,
+  source: ProjectSourceRow,
+): Promise<SyncProjectSourceResult> {
+  const updated = await updateProjectSource(db, organizationId, source.id, {
+    output: null,
+    fetchedAt: null,
+    fetchError: null,
+  });
+  return { ok: false, source: updated ?? source };
+}
+
+/**
  * Fetches (or records why it can't fetch) one source. Returns null when `id`
  * does not exist or its project does not belong to `organizationId` - the
  * caller turns that into a 404, matching every other lookup in
@@ -207,14 +240,15 @@ export async function syncProjectSource(
         refreshHackernewsAuthorSource(db, source.id, { fetchImpl: opts.hackernewsFetchImpl }),
       );
     case 'linkedin_company':
-    case 'linkedin_profile':
-    case 'linkedin_post':
       return markUnfetchable(
         db,
         organizationId,
         source,
         `No fetcher is wired up for ${source.kind} sources yet.`,
       );
+    case 'linkedin_post':
+    case 'linkedin_profile':
+      return resetLinkedInSourceToPending(db, organizationId, source);
     case 'folder':
     case 'git':
     case 'upload':

--- a/shared/tests/project-source-match.test.ts
+++ b/shared/tests/project-source-match.test.ts
@@ -1,0 +1,210 @@
+// Exercises shared/src/project-source-match.ts: matching and filling a
+// pending linkedin_post/linkedin_profile project source against a real
+// identifier (#436, spike #435's "Plane 3").
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, afterEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import { createProjectSource, getProjectSource } from '../src/project-sources.js';
+import {
+  findPendingProjectSourceMatch,
+  fillProjectSourceFromCapture,
+} from '../src/project-source-match.js';
+
+const createdOrgIds: number[] = [];
+
+afterEach(async () => {
+  const db = getDb();
+  while (createdOrgIds.length > 0) {
+    const id = createdOrgIds.pop()!;
+    await db.delete(schema.organizations).where(eq(schema.organizations.id, id));
+  }
+});
+
+async function setupOrgAndProject() {
+  const db = getDb();
+  const slug = `project-source-match-test-${randomUUID()}`;
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  createdOrgIds.push(org.id);
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: 'p', name: 'P' })
+    .returning();
+  return { orgId: org.id, projectId: project.id };
+}
+
+describe('findPendingProjectSourceMatch', () => {
+  it('finds a pending source by kind and identifier', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+    const created = await createProjectSource(db, orgId, projectId, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+
+    const match = await findPendingProjectSourceMatch(
+      db,
+      orgId,
+      'linkedin_post',
+      'urn:li:activity:123',
+    );
+    expect(match).toEqual({ id: created!.id, projectId });
+  });
+
+  it('never matches a source that already has output - a refresh needs a second visit', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+    const created = await createProjectSource(db, orgId, projectId, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+    await getDb()
+      .update(schema.projectSources)
+      .set({ output: { text: 'already captured' }, fetchedAt: new Date() })
+      .where(eq(schema.projectSources.id, created!.id));
+
+    const match = await findPendingProjectSourceMatch(
+      db,
+      orgId,
+      'linkedin_post',
+      'urn:li:activity:123',
+    );
+    expect(match).toBeNull();
+  });
+
+  it('never matches a source scoped to a different organization', async () => {
+    const { orgId: ownerOrgId, projectId } = await setupOrgAndProject();
+    const { orgId: otherOrgId } = await setupOrgAndProject();
+    const db = getDb();
+    await createProjectSource(db, ownerOrgId, projectId, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+
+    const match = await findPendingProjectSourceMatch(
+      db,
+      otherOrgId,
+      'linkedin_post',
+      'urn:li:activity:123',
+    );
+    expect(match).toBeNull();
+  });
+
+  it('never matches a different kind carrying the same identifier text', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+    await createProjectSource(db, orgId, projectId, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'shared-slug',
+    });
+
+    const match = await findPendingProjectSourceMatch(db, orgId, 'linkedin_profile', 'shared-slug');
+    expect(match).toBeNull();
+  });
+});
+
+describe('fillProjectSourceFromCapture', () => {
+  it('fills a pending source and clears any prior fetchError', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+    const created = await createProjectSource(db, orgId, projectId, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+
+    const filled = await fillProjectSourceFromCapture(
+      db,
+      orgId,
+      created!.id,
+      'linkedin_post',
+      'urn:li:activity:123',
+      { urn: 'urn:li:activity:123', text: 'What we shipped this week.' },
+    );
+    expect(filled).not.toBeNull();
+    expect(filled!.output).toEqual({
+      urn: 'urn:li:activity:123',
+      text: 'What we shipped this week.',
+    });
+    expect(filled!.fetchedAt).not.toBeNull();
+    expect(filled!.fetchError).toBeNull();
+
+    const reloaded = await getProjectSource(db, orgId, created!.id);
+    expect(reloaded!.output).toEqual({
+      urn: 'urn:li:activity:123',
+      text: 'What we shipped this week.',
+    });
+  });
+
+  it('refuses a fill whose identifier no longer matches the stored one', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+    const created = await createProjectSource(db, orgId, projectId, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+
+    const filled = await fillProjectSourceFromCapture(
+      db,
+      orgId,
+      created!.id,
+      'linkedin_post',
+      'urn:li:activity:999',
+      { urn: 'urn:li:activity:999', text: 'wrong post' },
+    );
+    expect(filled).toBeNull();
+    const reloaded = await getProjectSource(db, orgId, created!.id);
+    expect(reloaded!.output).toBeNull();
+  });
+
+  it('refuses a fill for a source that is already filled - the row must be reset to pending first', async () => {
+    const { orgId, projectId } = await setupOrgAndProject();
+    const db = getDb();
+    const created = await createProjectSource(db, orgId, projectId, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+    await fillProjectSourceFromCapture(
+      db,
+      orgId,
+      created!.id,
+      'linkedin_post',
+      'urn:li:activity:123',
+      {
+        urn: 'urn:li:activity:123',
+        text: 'first capture',
+      },
+    );
+
+    const secondFill = await fillProjectSourceFromCapture(
+      db,
+      orgId,
+      created!.id,
+      'linkedin_post',
+      'urn:li:activity:123',
+      { urn: 'urn:li:activity:123', text: 'second capture' },
+    );
+    expect(secondFill).toBeNull();
+    const reloaded = await getProjectSource(db, orgId, created!.id);
+    expect(reloaded!.output).toEqual({ urn: 'urn:li:activity:123', text: 'first capture' });
+  });
+
+  it('refuses a fill for a source belonging to a different organization', async () => {
+    const { orgId: ownerOrgId, projectId } = await setupOrgAndProject();
+    const { orgId: otherOrgId } = await setupOrgAndProject();
+    const db = getDb();
+    const created = await createProjectSource(db, ownerOrgId, projectId, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+
+    const filled = await fillProjectSourceFromCapture(
+      db,
+      otherOrgId,
+      created!.id,
+      'linkedin_post',
+      'urn:li:activity:123',
+      { urn: 'urn:li:activity:123', text: 'stolen capture' },
+    );
+    expect(filled).toBeNull();
+  });
+});

--- a/shared/tests/project-source-sync.test.ts
+++ b/shared/tests/project-source-sync.test.ts
@@ -1,7 +1,7 @@
 // Exercises shared/src/project-source-sync.ts: the per-kind fetch dispatcher
 // behind a project source's "re-sync" (#432). `github`, `website` (#472) and
 // `mastodon_account`/`hackernews_author` (#437) each have a real fetcher;
-// `linkedin_*` (not implemented yet - #435) and `folder`/`git`/`upload`
+// `linkedin_company` (not implemented yet - #435) and `folder`/`git`/`upload`
 // (populated by running an extraction, not by syncing) must each come back
 // with a human-readable fetch_error instead of throwing, so an unimplemented
 // kind renders as a source you can add and see rather than a crash. The
@@ -127,7 +127,7 @@ describe('syncProjectSource: github', () => {
 });
 
 describe('syncProjectSource: kinds with no fetcher yet', () => {
-  it.each(['linkedin_company', 'linkedin_profile', 'linkedin_post'] as const)(
+  it.each(['linkedin_company'] as const)(
     '%s sets a fetch_error naming the kind, not a crash',
     async (kind) => {
       const { orgId, projectId } = await setupOrgAndProject();
@@ -286,6 +286,51 @@ describe('syncProjectSource: hackernews_author', () => {
     expect(result?.ok).toBe(false);
     expect(result?.source.fetchError).toMatch(/network error/);
   });
+// #436, spike #435: linkedin_post/linkedin_profile have no fetcher either,
+// but unlike website/linkedin_company that is permanent by design, not a
+// gap - the only lawful fill is the extension's own content script
+// (project-source-match.ts), never a server-side re-sync. A re-sync click
+// on one of these two kinds can only flip an already-filled row back to
+// pending, so the next real page visit fills it again.
+describe('syncProjectSource: linkedin_post/linkedin_profile flip back to pending, never fetch', () => {
+  it.each(['linkedin_post', 'linkedin_profile'] as const)(
+    '%s: syncing a pristine pending row leaves it pending, with no error',
+    async (kind) => {
+      const { orgId, projectId } = await setupOrgAndProject();
+      const db = getDb();
+      const created = await createProjectSource(db, orgId, projectId, kind, {
+        value: 'https://www.linkedin.com/whatever',
+        identifier: 'whatever',
+      });
+      const result = await syncProjectSource(db, orgId, created!.id);
+      expect(result?.ok).toBe(false);
+      expect(result?.source.output).toBeNull();
+      expect(result?.source.fetchedAt).toBeNull();
+      expect(result?.source.fetchError).toBeNull();
+    },
+  );
+
+  it.each(['linkedin_post', 'linkedin_profile'] as const)(
+    '%s: syncing an already-filled row clears output/fetchedAt back to pending, not an error',
+    async (kind) => {
+      const { orgId, projectId } = await setupOrgAndProject();
+      const db = getDb();
+      const created = await createProjectSource(db, orgId, projectId, kind, {
+        value: 'https://www.linkedin.com/whatever',
+        identifier: 'whatever',
+      });
+      await getDb()
+        .update(schema.projectSources)
+        .set({ output: { text: 'captured earlier' }, fetchedAt: new Date() })
+        .where(eq(schema.projectSources.id, created!.id));
+
+      const result = await syncProjectSource(db, orgId, created!.id);
+      expect(result?.ok).toBe(false);
+      expect(result?.source.output).toBeNull();
+      expect(result?.source.fetchedAt).toBeNull();
+      expect(result?.source.fetchError).toBeNull();
+    },
+  );
 });
 
 describe('syncProjectSource: extraction-only kinds', () => {

--- a/shared/tests/project-source-sync.test.ts
+++ b/shared/tests/project-source-sync.test.ts
@@ -286,6 +286,8 @@ describe('syncProjectSource: hackernews_author', () => {
     expect(result?.ok).toBe(false);
     expect(result?.source.fetchError).toMatch(/network error/);
   });
+});
+
 // #436, spike #435: linkedin_post/linkedin_profile have no fetcher either,
 // but unlike website/linkedin_company that is permanent by design, not a
 // gap - the only lawful fill is the extension's own content script

--- a/tests/extension-packaged-build.test.ts
+++ b/tests/extension-packaged-build.test.ts
@@ -62,6 +62,7 @@ describe('the packaged extension', () => {
       'linkedin-comment-assist.js',
       'linkedin-post-assist.js',
       'linkedin-profile-capture.js',
+      'linkedin-source-capture.js',
     ]) {
       expect(existsSync(path.join(DIST, 'src/content', script)), script).toBe(true);
     }

--- a/web/src/lib/components/projects/ProjectSourcesPanel.svelte
+++ b/web/src/lib/components/projects/ProjectSourcesPanel.svelte
@@ -10,11 +10,17 @@
   // own; every other kind is addable here directly by a single string value.
   //
   // `website`, `mastodon_account` and `hackernews_author` (#472, #437) all
-  // have a real fetcher wired up (shared/src/project-source-sync.ts); the
-  // three `linkedin_*` kinds (#435's spike) don't yet - re-syncing one of
-  // those, or a folder/git/upload row, comes back with a fetch_error
-  // explaining that in words rather than crashing or pretending to have
-  // succeeded, so those kinds still render as a source you can add and see.
+  // have a real fetcher wired up (shared/src/project-source-sync.ts).
+  //
+  // `linkedin_post`/`linkedin_profile` (#436, spike #435) are different: a
+  // fresh one is honestly pending, never failed - nothing here fetches it,
+  // the extension's own content script fills it the next time the human
+  // opens the matching LinkedIn page, and a re-sync click can only clear an
+  // already-filled row back to pending for a second visit, never fetch
+  // anything itself. `linkedin_company` is a real `ProjectSourceKind` but
+  // deliberately left out of `ADD_KIND_OPTIONS` below - the selector work to
+  // fill one hasn't shipped, so offering the button would create a row that
+  // can only ever say "waiting for you to open it", forever.
   import * as Card from '$lib/components/ui/card';
   import * as Table from '$lib/components/ui/table';
   import * as AlertDialog from '$lib/components/ui/alert-dialog';
@@ -75,13 +81,13 @@
 
   // Kinds this panel's Add form can create directly: value-only sources.
   // `folder`/`upload` are excluded - see the file header comment.
+  // `linkedin_company` is excluded too, on purpose - see the same comment.
   const ADD_KIND_OPTIONS: Array<{ value: ProjectSourceKind; label: string }> = [
     { value: 'git', label: KIND_LABEL.git },
     { value: 'github', label: KIND_LABEL.github },
     { value: 'website', label: KIND_LABEL.website },
     { value: 'mastodon_account', label: KIND_LABEL.mastodon_account },
     { value: 'hackernews_author', label: KIND_LABEL.hackernews_author },
-    { value: 'linkedin_company', label: KIND_LABEL.linkedin_company },
     { value: 'linkedin_profile', label: KIND_LABEL.linkedin_profile },
     { value: 'linkedin_post', label: KIND_LABEL.linkedin_post },
   ];
@@ -92,7 +98,6 @@
     website: 'https://example.com',
     mastodon_account: 'https://mastodon.social/@handle',
     hackernews_author: 'pg or https://news.ycombinator.com/user?id=pg',
-    linkedin_company: 'https://www.linkedin.com/company/example',
     linkedin_profile: 'https://www.linkedin.com/in/example',
     linkedin_post: 'https://www.linkedin.com/posts/example_activity',
   };
@@ -127,6 +132,13 @@
     return 'pending';
   }
 
+  // The two kinds a content script fills passively, never a server fetch
+  // (#436, spike #435) - used to keep the add/re-sync toasts and the table's
+  // pending caption honest instead of implying a fetch that never happens.
+  function isPassivelyFilledLinkedInSource(kind: ProjectSourceKind): boolean {
+    return kind === 'linkedin_post' || kind === 'linkedin_profile';
+  }
+
   let addKind = $state<ProjectSourceKind>('git');
   let addValue = $state('');
   let adding = $state(false);
@@ -155,7 +167,9 @@
       }
       sourcesState = [...sourcesState, body.source as ProjectSource];
       addValue = '';
-      if (body.source?.fetchError) {
+      if (isPassivelyFilledLinkedInSource(body.source?.kind)) {
+        toast.info('Waiting for you to open that page on linkedin.com.');
+      } else if (body.source?.fetchError) {
         toast.warning(`Added, but the first sync failed: ${body.source.fetchError}`);
       } else {
         toast.success('Source added');
@@ -179,8 +193,12 @@
       sourcesState = sourcesState.map((s) => (s.id === source.id ? (body.source as ProjectSource) : s));
       if (body.ok) {
         toast.success('Synced');
+      } else if (body.source?.fetchError) {
+        toast.warning(body.source.fetchError);
+      } else if (isPassivelyFilledLinkedInSource(source.kind)) {
+        toast.info('Flipped back to pending - open that page on linkedin.com again to refill it.');
       } else {
-        toast.warning(body.source?.fetchError ?? 'Sync failed');
+        toast.warning('Sync failed');
       }
     } finally {
       syncingId = null;
@@ -291,6 +309,10 @@
                   {#if s.fetchError}
                     <span class="max-w-64 text-[11px] text-rose-600 dark:text-rose-400" title={s.fetchError}>
                       {s.fetchError}
+                    </span>
+                  {:else if status(s) === 'pending' && isPassivelyFilledLinkedInSource(s.kind)}
+                    <span class="max-w-64 text-[11px] text-muted-foreground">
+                      Waiting for you to open that page on linkedin.com.
                     </span>
                   {/if}
                 </div>

--- a/web/src/routes/api/extension/project-source-match/+server.ts
+++ b/web/src/routes/api/extension/project-source-match/+server.ts
@@ -1,0 +1,176 @@
+import { json, error } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '$lib/server/db.js';
+import { requireExtensionAuth, resolveDeviceOrgId } from '$lib/server/extension-auth.js';
+import { RateLimiter } from '$lib/server/rate-limit.js';
+import {
+  findPendingProjectSourceMatch,
+  fillProjectSourceFromCapture,
+} from '@pitchbox/shared/project-source-match';
+
+// Plane 3 (#436, spike #435): fills a project's pending `linkedin_post`/
+// `linkedin_profile` source from the human's own navigation, next to
+// POST /api/extension/observations' own precedent - the same device bearer
+// auth, the same org scoping, the same "read only what already rendered"
+// posture. Two calls, on purpose, mirroring linkedin-observe.ts's own
+// assist-state poll before it collects anything: a small GET first asks
+// whether the page the content script just landed on
+// (linkedin-source-capture.ts) matches ANY pending source in this org at
+// all, before anything is read from the DOM; only a real match triggers the
+// second call, POSTing what the page actually showed. A page with nothing
+// pending never has its content sent anywhere.
+//
+// `linkedin_company` is a real `PROJECT_SOURCE_KINDS` value but not
+// reachable here: nothing creates a `linkedin_company` row with an
+// `identifier` in its config
+// (`web/src/routes/api/projects/[id]/sources/+server.ts` deliberately
+// excludes it from `ADDABLE_KINDS` - #436 shipped `linkedin_post`/
+// `linkedin_profile` only, company needs new selector work spike #435
+// explicitly deferred), so GET never matches one and POST never fills one.
+
+const MatchKind = z.enum(['linkedin_post', 'linkedin_profile']);
+
+// A human navigating LinkedIn can land on several matching pages a minute;
+// looser than /suggest's perDevice(20, 60_000) for the same reason
+// observations' own limiter is, tighter than observations' 30 since this is
+// one small read per page load rather than a debounced batch.
+const perDeviceGet = new RateLimiter(40, 60_000);
+const perDevicePost = new RateLimiter(20, 60_000);
+
+export async function GET({ request, url }: { request: Request; url: URL }) {
+  const auth = await requireExtensionAuth(request);
+  if (!perDeviceGet.consume(`device:${auth.deviceId}`)) throw error(429, 'too many requests');
+
+  const kindParsed = MatchKind.safeParse(url.searchParams.get('kind'));
+  const identifier = url.searchParams.get('identifier');
+  if (!kindParsed.success || !identifier) throw error(400, 'invalid query');
+
+  const db = getDb();
+  const orgId = await resolveDeviceOrgId(db, auth.organizationId);
+  if (orgId == null) throw error(404, 'not_found');
+
+  const match = await findPendingProjectSourceMatch(db, orgId, kindParsed.data, identifier);
+  return json({ match: match ? { sourceId: match.id } : null });
+}
+
+// Free text off a real page has no length contract with us - clamped, not
+// rejected, matching operator-profile.ts's own posture for the same reason.
+const MAX_NAME_LEN = 200;
+const MAX_HANDLE_LEN = 200;
+const MAX_HEADLINE_LEN = 300;
+const MAX_ABOUT_LEN = 4000;
+const MAX_TEXT_LEN = 3000;
+const MAX_URL_LEN = 2048;
+const MAX_EXPERIENCES = 20;
+const MAX_EXPERIENCE_FIELD_LEN = 200;
+const MAX_EXPERIENCE_SUMMARY_LEN = 1200;
+
+function clamp(text: string, max: number): string {
+  return text.trim().slice(0, max);
+}
+
+function clampedOrNull(text: string | null | undefined, max: number): string | null {
+  return text?.trim() ? clamp(text, max) : null;
+}
+
+const ExperienceSchema = z.object({
+  title: z.string().nullable().optional(),
+  company: z.string().nullable().optional(),
+  period: z.string().nullable().optional(),
+  summary: z.string().nullable().optional(),
+});
+
+const PostOutputSchema = z.object({
+  urn: z.string().min(1),
+  authorName: z.string().nullable().optional(),
+  authorHandle: z.string().nullable().optional(),
+  text: z.string().min(1),
+  url: z.string().optional(),
+  capturedAt: z.string().optional(),
+});
+
+const ProfileOutputSchema = z.object({
+  handle: z.string().min(1),
+  displayName: z.string().nullable().optional(),
+  headline: z.string().nullable().optional(),
+  about: z.string().nullable().optional(),
+  experiences: z.array(ExperienceSchema).max(MAX_EXPERIENCES).optional(),
+  url: z.string().optional(),
+  capturedAt: z.string().optional(),
+});
+
+const PostBody = z.discriminatedUnion('kind', [
+  z.object({
+    sourceId: z.number().int().positive(),
+    kind: z.literal('linkedin_post'),
+    identifier: z.string().min(1).max(2048),
+    output: PostOutputSchema,
+  }),
+  z.object({
+    sourceId: z.number().int().positive(),
+    kind: z.literal('linkedin_profile'),
+    identifier: z.string().min(1).max(2048),
+    output: ProfileOutputSchema,
+  }),
+]);
+
+function clampPostOutput(o: z.infer<typeof PostOutputSchema>) {
+  return {
+    urn: clamp(o.urn, MAX_HANDLE_LEN),
+    authorName: clampedOrNull(o.authorName, MAX_NAME_LEN),
+    authorHandle: clampedOrNull(o.authorHandle, MAX_HANDLE_LEN),
+    text: clamp(o.text, MAX_TEXT_LEN),
+    url: clampedOrNull(o.url, MAX_URL_LEN),
+    capturedAt: o.capturedAt ?? new Date().toISOString(),
+  };
+}
+
+function clampProfileOutput(o: z.infer<typeof ProfileOutputSchema>) {
+  return {
+    handle: clamp(o.handle, MAX_HANDLE_LEN),
+    displayName: clampedOrNull(o.displayName, MAX_NAME_LEN),
+    headline: clampedOrNull(o.headline, MAX_HEADLINE_LEN),
+    about: clampedOrNull(o.about, MAX_ABOUT_LEN),
+    experiences: (o.experiences ?? []).slice(0, MAX_EXPERIENCES).map((e) => ({
+      title: clampedOrNull(e.title, MAX_EXPERIENCE_FIELD_LEN),
+      company: clampedOrNull(e.company, MAX_EXPERIENCE_FIELD_LEN),
+      period: clampedOrNull(e.period, MAX_EXPERIENCE_FIELD_LEN),
+      summary: clampedOrNull(e.summary, MAX_EXPERIENCE_SUMMARY_LEN),
+    })),
+    url: clampedOrNull(o.url, MAX_URL_LEN),
+    capturedAt: o.capturedAt ?? new Date().toISOString(),
+  };
+}
+
+// Never throws for a stale/mismatched fill attempt - the two calls are not
+// atomic, so a source deleted, refreshed back to pending, or already filled
+// by another tab in between is an expected outcome, not a client error,
+// mirroring `refreshGithubSource`'s "never throw for a fetch that didn't
+// land" contract.
+export async function POST({ request }: { request: Request }) {
+  const auth = await requireExtensionAuth(request);
+  if (!perDevicePost.consume(`device:${auth.deviceId}`)) throw error(429, 'too many requests');
+
+  const raw = await request.json().catch(() => null);
+  const parsed = PostBody.safeParse(raw);
+  if (!parsed.success) throw error(400, 'invalid body');
+  const body = parsed.data;
+
+  const db = getDb();
+  const orgId = await resolveDeviceOrgId(db, auth.organizationId);
+  if (orgId == null) throw error(404, 'not_found');
+
+  const output =
+    body.kind === 'linkedin_post' ? clampPostOutput(body.output) : clampProfileOutput(body.output);
+
+  const source = await fillProjectSourceFromCapture(
+    db,
+    orgId,
+    body.sourceId,
+    body.kind,
+    body.identifier,
+    output,
+  );
+  if (!source) return json({ ok: false });
+  return json({ ok: true, source });
+}

--- a/web/src/routes/api/projects/[id]/sources/+server.ts
+++ b/web/src/routes/api/projects/[id]/sources/+server.ts
@@ -4,11 +4,19 @@ import { z } from 'zod';
 import { getDb } from '$lib/server/db.js';
 import { requireOrgId, requireRole } from '$lib/server/auth.js';
 import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
-import { createProjectSource, listProjectSources } from '@pitchbox/shared/project-sources';
+import {
+  createProjectSource,
+  listProjectSources,
+  type ProjectSourceConfig,
+} from '@pitchbox/shared/project-sources';
 import { syncProjectSource } from '@pitchbox/shared/project-source-sync';
 import { addWebsiteSource } from '@pitchbox/shared/website-source';
 import { addMastodonAccountSource } from '@pitchbox/shared/mastodon-source';
 import { addHackernewsAuthorSource } from '@pitchbox/shared/hackernews-source';
+import {
+  parseLinkedInPostIdentifier,
+  parseLinkedInProfileIdentifier,
+} from '@pitchbox/shared/platforms/linkedin';
 
 // The kinds this endpoint accepts a plain `{ kind, value }` add for: every
 // `PROJECT_SOURCE_KIND` that identifies a source by a URL/identifier alone.
@@ -17,11 +25,19 @@ import { addHackernewsAuthorSource } from '@pitchbox/shared/hackernews-source';
 // the extraction run that produced it, so they're still only added as a side
 // effect of running an extraction (cli/src/commands/project.ts's
 // recordExtractionSource, unchanged by #432) - never a bare POST here.
+//
+// `linkedin_company` is deliberately excluded too (#436): it is a real
+// `PROJECT_SOURCE_KINDS` value, but nothing in this repo can fill one yet -
+// spike #435 found the shape but the selector work for a company page is
+// unstarted, and offering the button here would create a row that can only
+// ever read "waiting for you to open it" forever, which is a worse
+// experience than not offering it. Re-add it once
+// `extension/src/content/shared/linkedin-dom.ts` gains a company-page
+// reader and `linkedin-source-capture.ts` matches it.
 const ADDABLE_KINDS = [
   'git',
   'github',
   'website',
-  'linkedin_company',
   'linkedin_profile',
   'linkedin_post',
   'mastodon_account',
@@ -32,11 +48,14 @@ const ADDABLE_KINDS = [
 // the single `value` string (a URL split into instance+handle for Mastodon,
 // a username-or-profile-URL for HN) into their own `config` shape - the
 // generic `{ value }` row below only ever suits `github`/`git`, whose sync
-// re-parses `config.value` itself (`syncGithub`), and the still-unimplemented
-// `linkedin_*` kinds, which don't read their config yet either way. Routing
-// these three through their dedicated `add*Source` (below, in `POST`) keeps
-// that parsing in one place (shared with the CLI/any other caller) instead
-// of duplicating it here as a second, drifting copy.
+// re-parses `config.value` itself (`syncGithub`). `linkedin_post`/
+// `linkedin_profile` also go through the generic path below, but with a
+// `config.identifier` `buildSourceConfig` derives right here (see its own
+// doc comment) rather than through a dedicated `add*Source`, since there is
+// nothing to fetch at creation time for either kind. Routing the first three
+// through their dedicated `add*Source` (below, in `POST`) keeps that parsing
+// in one place (shared with the CLI/any other caller) instead of duplicating
+// it here as a second, drifting copy.
 
 const PostBody = z.object({
   kind: z.enum(ADDABLE_KINDS),
@@ -46,6 +65,42 @@ const PostBody = z.object({
 function parseId(p: string | undefined): number | null {
   const n = Number(p);
   return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/**
+ * A `linkedin_post`/`linkedin_profile` source needs its identifier derived
+ * and stored at creation time (#436): there is no server-side fetch of the
+ * pasted URL to derive it from later (rule 4 of the compliance boundary), so
+ * this is the one chance to turn whatever the human pasted into the exact
+ * string `linkedin-source-capture.ts` will later read off the real page and
+ * compare against. A value that cannot be parsed 400s rather than creating a
+ * source with nothing a real page can ever match.
+ */
+function buildSourceConfig(
+  kind: (typeof ADDABLE_KINDS)[number],
+  value: string,
+): { config: ProjectSourceConfig } | { error: string } {
+  if (kind === 'linkedin_post') {
+    const identifier = parseLinkedInPostIdentifier(value);
+    if (!identifier) {
+      return {
+        error:
+          'Paste a LinkedIn post URL (or its urn:li:activity: id) - could not find one in that value.',
+      };
+    }
+    return { config: { value, identifier } };
+  }
+  if (kind === 'linkedin_profile') {
+    const identifier = parseLinkedInProfileIdentifier(value);
+    if (!identifier) {
+      return {
+        error:
+          'Paste a LinkedIn profile URL (linkedin.com/in/<handle>) - could not find a handle in that value.',
+      };
+    }
+    return { config: { value, identifier } };
+  }
+  return { config: { value } };
 }
 
 export async function GET(event: RequestEvent) {
@@ -80,6 +135,9 @@ export async function POST(event: RequestEvent) {
     );
   }
 
+  const built = buildSourceConfig(parsed.data.kind, parsed.data.value);
+  if ('error' in built) throw error(400, built.error);
+
   const db = getDb();
   const { kind, value } = parsed.data;
 
@@ -108,7 +166,7 @@ export async function POST(event: RequestEvent) {
     return json({ source: result.source }, { status: 201 });
   }
 
-  const created = await createProjectSource(db, orgId, id, kind, { value });
+  const created = await createProjectSource(db, orgId, id, kind, built.config);
   if (!created) throw error(404, 'not_found');
 
   const synced = await syncProjectSource(db, orgId, created.id);

--- a/web/tests/extension-project-source-match.test.ts
+++ b/web/tests/extension-project-source-match.test.ts
@@ -1,0 +1,281 @@
+// Exercises web/src/routes/api/extension/project-source-match: the device
+// auth, the org scoping, and the pending-match logic behind linkedin-source-
+// capture.ts's two calls (#436, spike #435's "Plane 3"). Modelled on
+// extension-operator-profile.test.ts's own seeding/mintDevice harness.
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { createProjectSource } from '@pitchbox/shared/project-sources';
+import { GET, POST } from '../src/routes/api/extension/project-source-match/+server.js';
+
+async function reset() {
+  await getDb().execute(sql`TRUNCATE project_sources, projects RESTART IDENTITY CASCADE`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  // A plain DELETE, not TRUNCATE ... RESTART IDENTITY: the route's rate
+  // limiter is keyed by numeric device id (extension-observations.test.ts's
+  // own note on this), so resetting the id sequence would collide two
+  // tests' devices in the same in-memory bucket.
+  await getDb().execute(sql`DELETE FROM extension_devices`);
+}
+
+function getReq(path: string, token: string | null): { request: Request; url: URL } {
+  const url = new URL(`http://x${path}`);
+  return {
+    request: new Request(url, { headers: token ? { authorization: `Bearer ${token}` } : {} }),
+    url,
+  };
+}
+
+function postReq(token: string | null, body: unknown): { request: Request } {
+  return {
+    request: new Request('http://x/api/extension/project-source-match', {
+      method: 'POST',
+      headers: token
+        ? { authorization: `Bearer ${token}`, 'content-type': 'application/json' }
+        : {},
+      body: JSON.stringify(body),
+    }),
+  };
+}
+
+async function seedOrg(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  return org;
+}
+
+async function seedProject(organizationId: number, slug: string) {
+  const [project] = await getDb()
+    .insert(schema.projects)
+    .values({ organizationId, slug, name: slug })
+    .returning();
+  return project;
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({
+      organizationId,
+      tokenHash: createHash('sha256').update(token).digest('hex'),
+      label: 'test',
+    });
+}
+
+function postOutput(overrides: Record<string, unknown> = {}) {
+  return {
+    urn: 'urn:li:activity:123',
+    text: 'What we shipped this week.',
+    authorName: 'Jane Doe',
+    authorHandle: 'jane-doe',
+    ...overrides,
+  };
+}
+
+describe('GET /api/extension/project-source-match', () => {
+  beforeEach(reset);
+
+  it('refuses a request with no bearer token (401)', async () => {
+    await expect(
+      GET(getReq('/api/extension/project-source-match?kind=linkedin_post&identifier=x', null)),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('400s an invalid kind', async () => {
+    const org = await seedOrg('psm-get-invalid-kind');
+    await mintDevice(org.id, 'tokInvalidKind');
+    await expect(
+      GET(
+        getReq(
+          '/api/extension/project-source-match?kind=linkedin_company&identifier=x',
+          'tokInvalidKind',
+        ),
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('400s a missing identifier', async () => {
+    const org = await seedOrg('psm-get-missing-id');
+    await mintDevice(org.id, 'tokMissingId');
+    await expect(
+      GET(getReq('/api/extension/project-source-match?kind=linkedin_post', 'tokMissingId')),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('returns a real pending source as a match', async () => {
+    const org = await seedOrg('psm-get-match');
+    const project = await seedProject(org.id, 'p');
+    await mintDevice(org.id, 'tokMatch');
+    const source = await createProjectSource(getDb(), org.id, project.id, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+
+    const res = await GET(
+      getReq(
+        '/api/extension/project-source-match?kind=linkedin_post&identifier=urn%3Ali%3Aactivity%3A123',
+        'tokMatch',
+      ),
+    );
+    const body = (await res.json()) as { match: { sourceId: number } | null };
+    expect(body.match).toEqual({ sourceId: source!.id });
+  });
+
+  it('returns null when nothing pending matches', async () => {
+    const org = await seedOrg('psm-get-nomatch');
+    await mintDevice(org.id, 'tokNoMatch');
+
+    const res = await GET(
+      getReq(
+        '/api/extension/project-source-match?kind=linkedin_post&identifier=urn%3Ali%3Aactivity%3A999',
+        'tokNoMatch',
+      ),
+    );
+    const body = (await res.json()) as { match: { sourceId: number } | null };
+    expect(body.match).toBeNull();
+  });
+
+  it("never matches a pending source belonging to another organization's device", async () => {
+    const ownerOrg = await seedOrg('psm-get-scope-owner');
+    const ownerProject = await seedProject(ownerOrg.id, 'p');
+    const otherOrg = await seedOrg('psm-get-scope-other');
+    await mintDevice(otherOrg.id, 'tokScope');
+    await createProjectSource(getDb(), ownerOrg.id, ownerProject.id, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+
+    const res = await GET(
+      getReq(
+        '/api/extension/project-source-match?kind=linkedin_post&identifier=urn%3Ali%3Aactivity%3A123',
+        'tokScope',
+      ),
+    );
+    const body = (await res.json()) as { match: { sourceId: number } | null };
+    expect(body.match).toBeNull();
+  });
+});
+
+describe('POST /api/extension/project-source-match', () => {
+  beforeEach(reset);
+
+  it('refuses a request with no bearer token (401)', async () => {
+    await expect(
+      POST(
+        postReq(null, {
+          sourceId: 1,
+          kind: 'linkedin_post',
+          identifier: 'urn:li:activity:123',
+          output: postOutput(),
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('400s an invalid body', async () => {
+    const org = await seedOrg('psm-post-invalid');
+    await mintDevice(org.id, 'tokPostInvalid');
+    await expect(
+      POST(postReq('tokPostInvalid', { sourceId: 1, kind: 'linkedin_post' })),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('fills a real pending row and clamps free text', async () => {
+    const org = await seedOrg('psm-post-fill');
+    const project = await seedProject(org.id, 'p');
+    await mintDevice(org.id, 'tokFill');
+    const source = await createProjectSource(getDb(), org.id, project.id, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+
+    const res = await POST(
+      postReq('tokFill', {
+        sourceId: source!.id,
+        kind: 'linkedin_post',
+        identifier: 'urn:li:activity:123',
+        output: postOutput({ text: `  ${'x'.repeat(3100)}  ` }),
+      }),
+    );
+    const body = (await res.json()) as { ok: boolean; source: { output: { text: string } } };
+    expect(body.ok).toBe(true);
+    expect(body.source.output.text.length).toBe(3000);
+    expect(body.source.output.text).not.toMatch(/^\s|\s$/);
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.projectSources)
+      .where(eq(schema.projectSources.id, source!.id));
+    expect(row.fetchedAt).not.toBeNull();
+    expect((row.output as { urn: string }).urn).toBe('urn:li:activity:123');
+  });
+
+  it('answers ok:false rather than throwing when the row is no longer pending', async () => {
+    const org = await seedOrg('psm-post-stale');
+    const project = await seedProject(org.id, 'p');
+    await mintDevice(org.id, 'tokStale');
+    const source = await createProjectSource(getDb(), org.id, project.id, 'linkedin_post', {
+      value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+      identifier: 'urn:li:activity:123',
+    });
+    await getDb()
+      .update(schema.projectSources)
+      .set({
+        output: { urn: 'urn:li:activity:123', text: 'already captured' },
+        fetchedAt: new Date(),
+      })
+      .where(eq(schema.projectSources.id, source!.id));
+
+    const res = await POST(
+      postReq('tokStale', {
+        sourceId: source!.id,
+        kind: 'linkedin_post',
+        identifier: 'urn:li:activity:123',
+        output: postOutput({ text: 'a second, unwanted capture' }),
+      }),
+    );
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(false);
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.projectSources)
+      .where(eq(schema.projectSources.id, source!.id));
+    expect((row.output as { text: string }).text).toBe('already captured');
+  });
+
+  it("refuses to fill a source belonging to another organization's device", async () => {
+    const ownerOrg = await seedOrg('psm-post-scope-owner');
+    const ownerProject = await seedProject(ownerOrg.id, 'p');
+    const otherOrg = await seedOrg('psm-post-scope-other');
+    await mintDevice(otherOrg.id, 'tokPostScope');
+    const source = await createProjectSource(
+      getDb(),
+      ownerOrg.id,
+      ownerProject.id,
+      'linkedin_post',
+      {
+        value: 'https://www.linkedin.com/feed/update/urn:li:activity:123/',
+        identifier: 'urn:li:activity:123',
+      },
+    );
+
+    const res = await POST(
+      postReq('tokPostScope', {
+        sourceId: source!.id,
+        kind: 'linkedin_post',
+        identifier: 'urn:li:activity:123',
+        output: postOutput(),
+      }),
+    );
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(false);
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.projectSources)
+      .where(eq(schema.projectSources.id, source!.id));
+    expect(row.output).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #436.

Implements the spike-decided plane 3 (`docs/linkedin-integration-design.md`, spike #435): a project source of kind `linkedin_post`/`linkedin_profile` is created pending (`output: null`, `fetchedAt: null`) from the dashboard, and stays honestly pending until the human's own navigation actually lands on that LinkedIn page - at which point `linkedin-source-capture.ts` asks the server whether the page matches a pending source and, if it does, posts what the page rendered to fill it. Nothing polls linkedin.com; nothing here fetches, clicks, or reads a cookie.

## Shipped
- **`linkedin_post`** and **`linkedin_profile`**, in the spike's stated order of value. Both reuse existing `linkedin-dom.ts` accessors (`readPostIdentifier`/`readPostAuthor`/`readPostText`, `readOwnProfilePageHandle`/`readOwnProfile`) with **zero new selector work** - exactly what the spike found.
- **Not shipped: `linkedin_company`.** It needs new selector work the spike explicitly deferred (no accessor reads an org page today, and no fixture exists). Rather than half-implement it as a row that can only ever say "waiting for you to open it" forever, it's removed from `ADDABLE_KINDS` in `web/src/routes/api/projects/[id]/sources/+server.ts` - still a valid `PROJECT_SOURCE_KINDS` enum value, just not creatable from the dashboard yet.

## Architecture
- `shared/src/platforms/linkedin/index.ts`: pure URL-to-identifier parsing (no network code, satisfies compliance rule 5) - turns whatever URL a human pastes into the exact identifier the content script will later read off the real page.
- `shared/src/project-source-match.ts`: org-scoped pending-source matching (`findPendingProjectSourceMatch`) and fill (`fillProjectSourceFromCapture`), mirroring `observed-targets.ts`'s own precedent.
- `shared/src/project-source-sync.ts`: a manual "Re-sync" on `linkedin_post`/`linkedin_profile` now flips an already-filled row back to pending (`resetLinkedInSourceToPending`) instead of claiming "no fetcher wired up" - refresh needs a second visit, by design, never a server-side fetch.
- `web/api/extension/project-source-match`: new route, same device bearer auth and org scoping as `POST /api/extension/observations`. `GET` answers a cheap "does this identifier match a pending source" before anything is read from the DOM; `POST` fills it, re-validating everything (org, kind, identifier, still-pending) since the two calls aren't atomic.
- `extension/src/content/linkedin-source-capture.ts`: the new content script. Registered host-wide (`https://www.linkedin.com/*`) like every other LinkedIn script in this repo, gates itself on page kind/pathname, mediated entirely through `lib/api.ts`'s `getJson`/`postJson` so it never calls `fetch()` directly in its own source.
- `ProjectSourcesPanel.svelte`: add/re-sync toasts and a pending-row caption now say "waiting for you to open that page on linkedin.com" for the two passively-filled kinds, instead of implying a fetch that never happens.

## Compliance
`pnpm run test:linkedin-compliance` passes **unchanged** (15/15) - no rule needed relaxing, matching the spike's own finding.

## Verification

### Unit/integration
- Full covering subset green: 64 tests across `shared/tests/project-source-match.test.ts` (new, 8), `shared/tests/project-source-sync.test.ts` (updated), `shared/tests/project-sources.test.ts`, `web/tests/extension-project-source-match.test.ts` (new, 11), `web/tests/project-sources.test.ts`, `extension/tests/content/linkedin-source-capture.test.ts` (new, 12).
- Bite-check: broke `fillProjectSourceFromCapture`'s identifier/already-filled guards - exactly the two assertions defending them failed, the other six in that file kept passing; restored and reconfirmed green.
- `pnpm exec vitest run tests/extension-packaged-build.test.ts` passes: the real built extension emits `src/content/linkedin-source-capture.js` as a standalone script (no `import`/`export`), registered by `chrome.scripting.registerContentScripts`, not a module chunk.
- `pnpm -F @pitchbox/shared typecheck`, `pnpm -F @pitchbox/extension check`, `pnpm -F web check` all clean. `npx eslint`/`npx prettier --check` clean on every touched `.ts` file.

### Real Chrome against real preview.pitchbox.app (post-merge, after #490's i18n hotfix deployed)
Built with `VITE_DEFAULT_BACKEND_URL=https://preview.pitchbox.app`, loaded unpacked via `Extensions.loadUnpacked` over raw CDP against the `personal-b` `omp-chrome` profile, paired against a real preview device token, granted the LinkedIn optional permission through the real native bubble (confirmed via `chrome.permissions.contains` and `chrome.scripting.getRegisteredContentScripts` before touching a post), then:

- **`linkedin_post`**: created a pending source on preview project 2 (`embertold`) for `https://www.linkedin.com/feed/update/urn:li:activity:7502764461087281152/`, a real post from `informatizzato`'s own recent-activity list. Dashboard showed it pending with "Waiting for you to open that page on linkedin.com" and a matching toast. Opened that exact URL in a fresh tab created **after** the scripts were registered (avoiding the orphaned-instance trap). Row filled: `identifier: urn:li:activity:7502764461087281152`, `authorName: "Lorenzo Fiore"`, `authorHandle: "informatizzato"`, and the real Italian post text verbatim (including the embedded link and two tagged names). `fetchedAt` set, `fetchError` null.
- **`linkedin_profile`**: pulled a real third-party mention out of that same post (`/in/ivan-sala/`, not the operator's own), created a pending source, opened a fresh tab. Filled: `handle: "ivan-sala"`, `displayName: "Ivan Sala"`, a real 737-character `about` bio, `experiences: []`. One real-page quirk logged for visibility: `headline` came back "He/Him" (a pronoun badge, not a professional headline) on this profile's specific render - `readOwnProfile`'s "topcard's second text line" selector is LI-21's, unchanged here, not a regression from this PR.
- Both test sources deleted from `embertold` afterward; confirmed `GET /api/projects/2/sources` returns `sources: []`.
- **Not covered**: a real `/posts/<slug>-activity-<id>-<random>/` share-URL permalink against a live page - both real posts available to me were already in the classic `/feed/update/urn:li:activity:<id>/` shape. `parseLinkedInPostIdentifier`'s handling of that shape is unit-tested only. Worth a follow-up with a real "Copy link to post" share URL before calling that case fully closed.
- One open question I couldn't resolve: the dashboard row went from pending to "Synced" without me issuing any reload/navigation on that tab between two checks (only `Page.bringToFront` for screenshots). No poll/websocket/visibility-listener found in `ProjectSourcesPanel.svelte`, the project route, or the layouts - reporting the observation rather than a guessed cause.

## Note: this PR shipped one regression, since fixed
My own covering-subset run never touched `extension/tests/lib/activity-i18n-coverage.test.ts` (full-suite only), so the two new activity messages (`activity.linkedin-collector.source-filled`/`source-fill-failed`) broke `main`'s required `ci` check after merge and blocked `deploy-preview` for about 20 minutes. Fixed in #490 (merged), which is why the real-Chrome verification above happened after that merge rather than immediately after this one.

One pre-existing repo fact worth flagging while I had it in hand: `prettier --check .` silently excludes every `.svelte` file from its glob (no `prettier-plugin-svelte` dependency anywhere in the repo/lockfile) - verified against an untouched, pre-existing `.svelte` file, not something this PR introduced. `ProjectSourcesPanel.svelte`'s formatting was verified by `svelte-check` (clean) and manual review against the file's existing style instead.
