### PR TITLE
feat(shared,web): meter and cap what a tenant can spend on the Gateway

### DIFF
--- a/shared/src/agents/base.ts
+++ b/shared/src/agents/base.ts
@@ -32,6 +32,17 @@ export interface AgentRunOptions {
    * other runners ignore it.
    */
   orgId?: number;
+  /**
+   * Remaining monthly USD Gateway budget for the dispatching run's
+   * organization, snapshotted at dispatch time
+   * (`shared/src/org-quota.ts`'s `getOrgQuotaSnapshot`). Null means
+   * unlimited (no budget configured, or the run has no resolved org). Only
+   * the `cloud` runner (`SdkRunner`) enforces this, aborting mid-stream once
+   * its own accumulated cost would push the org over the line (#419) -
+   * other runners spend nothing against the product's Gateway key and
+   * ignore it.
+   */
+  budgetRemainingUsd?: number | null;
   /** Called with the raw original line for each stdout/stderr chunk - optional, for forensic logging. */
   onRawLine?: (line: string) => void;
   /** Called with one or more normalized ParsedEvents extracted from that line. */

--- a/shared/src/agents/sdk/event-normalizer.ts
+++ b/shared/src/agents/sdk/event-normalizer.ts
@@ -377,14 +377,21 @@ export function normalizeSdkPart(part: unknown, raw: string, seq: number): Parse
 
 /**
  * Already-classified run outcome, decided by the runner from facts only it
- * has: which AbortSignal fired (`cancelled` vs `timeout`), whether an `error`
- * part closed the stream, whether the terminal `finish` part's finishReason
- * came back `tool-calls` with no further step (the step ceiling cut the loop
- * off before the model could act on it - #415's `stopWhen(stepCountIs(n))`),
- * or content-filter/refusal. Mirrors ACP's `AcpStopReasonKind`.
+ * has: which AbortSignal fired (`cancelled` vs `timeout` vs its own
+ * mid-stream budget check, `quota_exceeded`), whether an `error` part closed
+ * the stream, whether the terminal `finish` part's finishReason came back
+ * `tool-calls` with no further step (the step ceiling cut the loop off
+ * before the model could act on it - #415's `stopWhen(stepCountIs(n))`), or
+ * content-filter/refusal. Mirrors ACP's `AcpStopReasonKind`.
  */
 export type SdkStopReasonKind =
-  'end_turn' | 'cancelled' | 'timeout' | 'error' | 'max_turn_requests' | 'refusal';
+  | 'end_turn'
+  | 'cancelled'
+  | 'timeout'
+  | 'error'
+  | 'max_turn_requests'
+  | 'refusal'
+  | 'quota_exceeded';
 
 // Marker text embedded in the closing event's `raw`/`text` so classifyFailure
 // (shared/src/runlog/classify-failure.ts) has something distinctive to match
@@ -395,6 +402,12 @@ const STOP_REASON_TEXT: Partial<Record<SdkStopReasonKind, string>> = {
   error: 'run failed: a provider error ended the run',
   max_turn_requests: 'run stopped: step limit reached before the agent finished',
   refusal: 'run stopped: the model refused to continue',
+  // Contains "quota" on purpose - classifyFailure's QUOTA_PATTERNS matches
+  // that substring and maps it to the `quota_exhausted` failure reason with
+  // no changes needed there (#419: the runner aborts once its own
+  // accumulated cost would push the org over its remaining monthly budget).
+  quota_exceeded:
+    'run stopped: quota exhausted, the organization crossed its monthly Gateway budget mid-run',
 };
 
 /**

--- a/shared/src/agents/sdk/runner.ts
+++ b/shared/src/agents/sdk/runner.ts
@@ -62,6 +62,15 @@ const DEFAULT_STEP_CEILING = 12;
 const MODEL_CATALOGUE_TTL_MS = 5 * 60 * 1000;
 let modelCatalogueCache: { value: GatewayLanguageModelEntry[]; expiresAt: number } | null = null;
 
+// Test-only escape hatch: the cache above is intentionally process-lifetime
+// in production (see the comment on it), but that means every SdkRunner
+// test in the same file/process shares one cache - a plain-catalogue test
+// that runs first would otherwise poison a later test's custom pricing for
+// up to five minutes. Not used by any production code path.
+export function __resetModelCatalogueCacheForTests(): void {
+  modelCatalogueCache = null;
+}
+
 async function loadModelCatalogue(gateway: GatewayProvider): Promise<GatewayLanguageModelEntry[]> {
   const now = Date.now();
   if (modelCatalogueCache && modelCatalogueCache.expiresAt > now) return modelCatalogueCache.value;
@@ -108,11 +117,24 @@ export class SdkRunner implements AgentRunner {
     // the real Gateway). Reading that finish reason as success would record
     // a cancelled or timed-out run as completed, so the outcome comes from
     // this flag, never from whether the loop below threw.
-    let outcome: 'cancel' | 'timeout' | null = null;
+    let outcome: 'cancel' | 'timeout' | 'quota' | null = null;
 
     const cancelFn = () => {
       if (outcome) return; // already terminal - a second cancel is a no-op
       outcome = 'cancel';
+      controller.abort();
+    };
+
+    // A separate closure, exactly like `cancelFn` above, rather than an
+    // inline `outcome = 'quota'` where it's used (inside the loop below):
+    // TypeScript's control-flow narrowing only sees same-scope assignments,
+    // and `cancelFn`/the timeout callback already sit in their own closures
+    // for that reason - an inline assignment in the loop narrowed `outcome`
+    // down to `'quota' | null` for every later read in this function,
+    // making the `stopReasonKind` ternary's `'cancel'`/`'timeout'`
+    // comparisons look like dead code to the type checker.
+    const markQuotaExceeded = () => {
+      outcome = 'quota';
       controller.abort();
     };
 
@@ -168,6 +190,15 @@ export class SdkRunner implements AgentRunner {
 
       const gateway = this.createGatewayFn({ apiKey });
       const model = gateway(modelId);
+
+      // Resolved before the stream starts, not just at the end as before
+      // #419: the mid-stream budget check below needs to price each step's
+      // usage as it accumulates, and `loadModelCatalogue` is cached process-
+      // wide anyway so moving it earlier costs nothing on a warm cache.
+      const catalogueEntries = await loadModelCatalogue(gateway);
+      const pricing: SdkModelPricing | undefined = pricingFromCatalogueEntry(
+        catalogueEntries.find((m) => m.id === modelId),
+      );
 
       // `attachMcp: false` (the in-page suggestion path) gets no tools at
       // all - nothing for it to write, and a tool loop is what a real-time
@@ -268,6 +299,20 @@ export class SdkRunner implements AgentRunner {
               if (part.type === 'finish-step') {
                 stepCount += 1;
                 stepUsage = addSdkUsage(stepUsage, part.usage);
+                // Stop the run the moment its own accumulated cost would
+                // push the org over its remaining monthly Gateway budget
+                // (#419), rather than only discovering it once the run
+                // finishes - `opts.budgetRemainingUsd` is a snapshot taken
+                // by the caller at dispatch time (shared/src/org-quota.ts).
+                // Skipped when pricing is unknown (`costUsd` null): an
+                // un-priced model can't be judged against a budget, so it
+                // runs unmetered rather than aborting on a guess.
+                if (!outcome && opts.budgetRemainingUsd != null) {
+                  const runningCostUsd = buildSdkUsage(stepUsage, { pricing }).costUsd;
+                  if (runningCostUsd != null && runningCostUsd >= opts.budgetRemainingUsd) {
+                    markQuotaExceeded();
+                  }
+                }
               } else if (part.type === 'finish') {
                 finishUsage = part.totalUsage;
                 finishReason = part.finishReason;
@@ -300,13 +345,15 @@ export class SdkRunner implements AgentRunner {
             ? 'cancelled'
             : outcome === 'timeout'
               ? 'timeout'
-              : sawErrorPart || finishReason === 'error'
-                ? 'error'
-                : finishReason === 'content-filter'
-                  ? 'refusal'
-                  : finishReason === 'tool-calls' && stepCount >= this.stepCeiling
-                    ? 'max_turn_requests'
-                    : 'end_turn';
+              : outcome === 'quota'
+                ? 'quota_exceeded'
+                : sawErrorPart || finishReason === 'error'
+                  ? 'error'
+                  : finishReason === 'content-filter'
+                    ? 'refusal'
+                    : finishReason === 'tool-calls' && stepCount >= this.stepCeiling
+                      ? 'max_turn_requests'
+                      : 'end_turn';
 
         // Only a genuine runner-level failure is a non-zero exit: whether
         // the agent actually finished its job (called the playbook's finish
@@ -317,15 +364,15 @@ export class SdkRunner implements AgentRunner {
         const exitCode =
           stopReasonKind === 'cancelled' ||
           stopReasonKind === 'timeout' ||
-          stopReasonKind === 'error'
+          stopReasonKind === 'error' ||
+          stopReasonKind === 'quota_exceeded'
             ? 1
             : 0;
 
+        // `pricing` was already resolved before the stream started (above),
+        // so the final usage is priced with the exact same table the
+        // mid-stream check used - no second catalogue fetch here.
         const usage = finishUsage ?? stepUsage ?? {};
-        const entries = await loadModelCatalogue(gateway);
-        const pricing: SdkModelPricing | undefined = pricingFromCatalogueEntry(
-          entries.find((m) => m.id === modelId),
-        );
         const usageResult = buildSdkUsage(usage, { pricing });
         const tokensUsed = usageResult.inputTokens + usageResult.outputTokens;
 

--- a/shared/tests/agents/sdk/event-normalizer.test.ts
+++ b/shared/tests/agents/sdk/event-normalizer.test.ts
@@ -220,6 +220,7 @@ describe('normalizeStopReason', () => {
       'error',
       'max_turn_requests',
       'refusal',
+      'quota_exceeded',
     ] as const) {
       const [event] = normalizeStopReason(reason, usage, '', 0);
       expect(event.payload).toMatchObject({ type: 'result', success: false });
@@ -274,8 +275,20 @@ describe('classifyFailure integration: SDK-specific reasons', () => {
     expect(classifyFailure(events, 1)).toBe('content_filtered');
   });
 
-  it('the four SDK markers stay distinct from each other', () => {
-    const reasons = ['error', 'cancelled', 'max_turn_requests', 'timeout', 'refusal'] as const;
+  it('classifies a mid-run budget crossing as quota_exhausted (#419)', () => {
+    const events = normalizeStopReason('quota_exceeded', usage, '', 0);
+    expect(classifyFailure(events, 1)).toBe('quota_exhausted');
+  });
+
+  it('the six SDK markers stay distinct from each other', () => {
+    const reasons = [
+      'error',
+      'cancelled',
+      'max_turn_requests',
+      'timeout',
+      'refusal',
+      'quota_exceeded',
+    ] as const;
     const classified = reasons.map((r) => classifyFailure(normalizeStopReason(r, usage, '', 0), 1));
     expect(new Set(classified).size).toBe(reasons.length);
   });

--- a/shared/tests/agents/sdk/runner.test.ts
+++ b/shared/tests/agents/sdk/runner.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import type { streamText } from 'ai';
 import type { createGateway } from '@ai-sdk/gateway';
-import { SdkRunner } from '../../../src/agents/sdk/runner.js';
+import { SdkRunner, __resetModelCatalogueCacheForTests } from '../../../src/agents/sdk/runner.js';
 import type { ParsedEvent } from '../../../src/runlog/types.js';
 import type { PitchboxToolSet } from '../../../src/agents/sdk/tools.js';
 
@@ -54,6 +54,20 @@ function fakeGateway() {
   return vi.fn(() => gateway) as unknown as typeof createGateway;
 }
 
+// A gateway whose catalogue prices exactly one model - the mid-stream
+// budget tests need real per-token rates so `buildSdkUsage`'s computed
+// `costUsd` is non-null and comparable against `budgetRemainingUsd`; the
+// plain `fakeGateway()` above returns an empty catalogue on purpose (every
+// existing test's cost stays null, since pricing isn't their concern).
+function fakeGatewayWithPricing(modelId: string, pricing: { input: string; output: string }) {
+  const getAvailableModels = vi.fn(async () => ({ models: [{ id: modelId, pricing }] }));
+  const gateway = Object.assign(
+    vi.fn((id: string) => ({ modelId: id }) as never),
+    { getAvailableModels },
+  );
+  return vi.fn(() => gateway) as unknown as typeof createGateway;
+}
+
 function tmpLogDir(): string {
   return mkdtempSync(join(tmpdir(), 'sdk-runner-test-'));
 }
@@ -63,6 +77,10 @@ let logDir: string;
 beforeEach(() => {
   logDir = tmpLogDir();
   process.env.AI_GATEWAY_API_KEY = 'test-key';
+  // Otherwise a plain-catalogue test's cached empty model list (5-minute
+  // TTL, process-lifetime by design) leaks into a later test that supplies
+  // its own pricing via a different fake gateway.
+  __resetModelCatalogueCacheForTests();
 });
 
 afterEach(() => {
@@ -344,5 +362,143 @@ describe('SdkRunner', () => {
     expect(res.exitCode).toBe(0);
     const resultEvent = events.find((e) => e.kind === 'result');
     expect(resultEvent?.raw).toMatch(/step limit/);
+  });
+
+  it('aborts mid-stream once its own accumulated cost crosses budgetRemainingUsd, ending as quota-exhausted with the earlier events kept', async () => {
+    const { fn: createToolSetFn } = fakeToolSet();
+    const events: ParsedEvent[] = [];
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGatewayWithPricing('google/gemini-3.1-flash-lite', {
+        input: '0.000002',
+        output: '0.000002',
+      }),
+      createToolSetFn,
+      streamTextFn: fakeStreamText(function (signal) {
+        return (async function* () {
+          // Real content produced before the budget trips - this must
+          // survive the abort, exactly like a real run's already-emitted
+          // events stay in run_events (#419).
+          yield { type: 'text-delta', id: '1', text: 'partial answer' };
+          // 1000 input + 1000 output tokens at $0.000002/token = $0.004,
+          // comfortably over the $0.001 budget below.
+          yield {
+            type: 'finish-step',
+            finishReason: 'tool-calls',
+            usage: { inputTokens: 1000, outputTokens: 1000, inputTokenDetails: {} },
+          };
+          // The real AI SDK ends the stream cleanly on abort rather than
+          // throwing or yielding more (docs/cloud-runner.md #415) - the
+          // runner itself is what calls `controller.abort()` here, once it
+          // sees the finish-step above cross the budget.
+          await waitForAbort(signal);
+        })();
+      }),
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'hi',
+      attachMcp: false,
+      budgetRemainingUsd: 0.001,
+      onParsedEvents: (evs) => {
+        events.push(...evs);
+      },
+    });
+    const res = await handle.result;
+    expect(res.exitCode).toBe(1);
+    expect(res.usage?.costUsd).toBeCloseTo(0.004, 4);
+    const assistantEvent = events.find((e) => e.kind === 'assistant');
+    expect(assistantEvent?.payload).toMatchObject({ type: 'assistant', text: 'partial answer' });
+    const resultEvent = events.find((e) => e.kind === 'result');
+    expect(resultEvent?.payload).toMatchObject({ type: 'result', success: false });
+    expect(resultEvent?.raw).toMatch(/quota exhausted/);
+    expect(resultEvent?.raw).toMatch(/monthly Gateway budget/);
+  });
+
+  it('does not abort a run that stays under its budgetRemainingUsd', async () => {
+    const { fn: createToolSetFn } = fakeToolSet();
+    const events: ParsedEvent[] = [];
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGatewayWithPricing('google/gemini-3.1-flash-lite', {
+        input: '0.000002',
+        output: '0.000002',
+      }),
+      createToolSetFn,
+      streamTextFn: fakeStreamText(() =>
+        gen(
+          // Same $0.004 spend as the tripping test above, but the budget
+          // here is $10 - nowhere near crossed.
+          {
+            type: 'finish-step',
+            finishReason: 'stop',
+            usage: { inputTokens: 1000, outputTokens: 1000, inputTokenDetails: {} },
+          },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            totalUsage: { inputTokens: 1000, outputTokens: 1000 },
+          },
+        ),
+      ),
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'hi',
+      attachMcp: false,
+      budgetRemainingUsd: 10,
+      onParsedEvents: (evs) => {
+        events.push(...evs);
+      },
+    });
+    const res = await handle.result;
+    expect(res.exitCode).toBe(0);
+    const resultEvent = events.find((e) => e.kind === 'result');
+    expect(resultEvent?.payload).toMatchObject({ type: 'result', success: true });
+  });
+
+  it('never aborts on budget when the model has no catalogue pricing, since an unknown cost cannot be judged against it', async () => {
+    const { fn: createToolSetFn } = fakeToolSet();
+    const events: ParsedEvent[] = [];
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      // The plain fakeGateway() below returns an empty catalogue, so
+      // buildSdkUsage's costUsd stays null however many tokens are reported.
+      createGatewayFn: fakeGateway(),
+      createToolSetFn,
+      streamTextFn: fakeStreamText(() =>
+        gen(
+          {
+            type: 'finish-step',
+            finishReason: 'stop',
+            usage: { inputTokens: 1_000_000, outputTokens: 1_000_000, inputTokenDetails: {} },
+          },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            totalUsage: { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+          },
+        ),
+      ),
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'hi',
+      attachMcp: false,
+      // A budget so small it would trip instantly if cost were treated as 0
+      // instead of unknown.
+      budgetRemainingUsd: 0.0000001,
+      onParsedEvents: (evs) => {
+        events.push(...evs);
+      },
+    });
+    const res = await handle.result;
+    expect(res.exitCode).toBe(0);
+    expect(res.usage?.costUsd).toBeNull();
+    const resultEvent = events.find((e) => e.kind === 'result');
+    expect(resultEvent?.payload).toMatchObject({ type: 'result', success: true });
   });
 });

--- a/web/src/lib/server/runner.ts
+++ b/web/src/lib/server/runner.ts
@@ -16,6 +16,7 @@ import {
 } from '@pitchbox/shared/draft-regenerate';
 import { startReplyDrafting } from '@pitchbox/shared/reply-drafter';
 import { getRunOrgId } from '@pitchbox/shared/orgs';
+import { getOrgQuotaSnapshot } from '@pitchbox/shared/org-quota';
 import type { ScenarioSlug } from '@pitchbox/shared/campaigns';
 import { getDb, schema } from './db.js';
 import { and, desc, eq } from 'drizzle-orm';
@@ -129,6 +130,10 @@ async function dispatchRun(
   // run's org never changes mid-flight, so a single lookup avoids repeating
   // the join on every event.
   const orgId = await getRunOrgId(db, run.id);
+  // Snapshotted once, before the runner starts, and handed to it so it can
+  // enforce its own mid-stream abort (#419) without a DB round trip per
+  // step. Only ever set for the `cloud` slug, below.
+  let budgetRemainingUsd: number | null | undefined;
 
   let runner: AgentRunner;
   try {
@@ -147,6 +152,31 @@ async function dispatchRun(
           `managed Pitchbox Cloud runner can dispatch here. Change the runner in project or ` +
           `campaign settings to continue.`,
       );
+    }
+    // The Gateway is the product's money, not the operator's local CLI
+    // subscription (#419) - refuse before the run even starts once this
+    // org's month-to-date spend already meets or exceeds its configured
+    // budget, with a message the caller can show instead of a generic
+    // failure. Only the `cloud` slug (SdkRunner) spends against the
+    // Gateway; every other runner bills nothing to the product and is never
+    // budget-gated. `getOrgQuotaSnapshot` reads the same `runs.cost_usd`
+    // sum the dashboard and the org-quota settings page use
+    // (shared/src/org-quota.ts's `getOrgMonthToDateCostUsd`), so this check
+    // and what an operator sees always agree. The message says "quota" on
+    // purpose: classifyFailedRun folds it into the failed run's own error
+    // text, and classifyFailure's existing QUOTA_PATTERNS then tags this
+    // exact refusal `quota_exhausted` too, the same reason a mid-stream
+    // crossing gets, with no separate classifier branch needed.
+    if (slug === 'cloud' && orgId != null) {
+      const quota = await getOrgQuotaSnapshot(db, orgId);
+      if (quota.remainingUsd != null && quota.remainingUsd <= 0) {
+        throw new Error(
+          `This organization is $${Math.abs(quota.remainingUsd).toFixed(2)} over its monthly ` +
+            `Gateway quota and cannot start another cloud run until next month or until an ` +
+            `operator raises the budget in Settings.`,
+        );
+      }
+      budgetRemainingUsd = quota.remainingUsd;
     }
     // Pre-flight the snapshot. A run whose runner cannot start here fails the
     // same way whatever the reason, but the message has to say so: before #219
@@ -262,9 +292,12 @@ async function dispatchRun(
     },
     cwd: PITCHBOX_ROOT,
     timeoutMs: 15 * 60 * 1000,
-    // Only the cloud runner consumes this (to mint a per-org runner-auth JWT
-    // at dispatch time); already resolved above for the emit() calls.
+    // `orgId` is resolved above for the emit() calls; `budgetRemainingUsd`
+    // (#419) is the snapshot the pre-flight check above just took. Only the
+    // `cloud` runner (SdkRunner) reads the latter, to abort once its own
+    // accumulated cost crosses the line.
     orgId: orgId ?? undefined,
+    budgetRemainingUsd,
 
     onRawLine: () => {
       // Raw lines are already persisted to the runner's log file; no-op here.

--- a/web/tests/gateway-budget-dispatch.test.ts
+++ b/web/tests/gateway-budget-dispatch.test.ts
@@ -1,0 +1,240 @@
+// #419: while the runner used my subscription, an org's spend was bounded by
+// a quota claim minted into a session JWT that the (now-gone) prodbox runner
+// service enforced. The SDK runner spends against the product's own Gateway
+// key instead, so the meter has to live on this side: dispatchRun refuses a
+// 'cloud' run before it starts once the org has no budget left, and passes
+// the remaining budget down so SdkRunner can stop mid-stream too (covered by
+// shared/tests/agents/sdk/runner.test.ts). This file proves the admission
+// check and the cost bookkeeping through the real dispatch path
+// (runCampaign -> dispatchRun), not against org-quota.ts's helpers directly.
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { getOrgMonthToDateCostUsd } from '@pitchbox/shared/org-quota';
+import type {
+  AgentRunHandle,
+  AgentRunOptions,
+  AgentRunner,
+  AgentRunResult,
+} from '@pitchbox/shared/agents';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+import { subscribe } from '../src/lib/server/events.js';
+import { clearDetectionCache } from '@pitchbox/shared/agents/detect';
+
+let capturedOpts: AgentRunOptions | null = null;
+let createCalls = 0;
+let fakeResult: AgentRunResult = { exitCode: 0, logPath: '/dev/null' };
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'cloud',
+    run(opts: AgentRunOptions): AgentRunHandle {
+      createCalls += 1;
+      capturedOpts = opts;
+      return { result: Promise.resolve(fakeResult), cancel: () => {} };
+    },
+  }),
+}));
+
+// Dynamic on purpose - vi.mock above is hoisted, but runner.js has to load
+// after it for createAgentRunner to resolve to the fake gateway runner
+// (same pattern as extension-suggest.test.ts / extension-suggest-voice.test.ts).
+const { runCampaign } = await import('../src/lib/server/runner.js');
+
+async function reset() {
+  const db = getDb();
+  await db.execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  capturedOpts = null;
+  createCalls = 0;
+  fakeResult = { exitCode: 0, logPath: '/dev/null' };
+}
+
+async function platformId(slug: string): Promise<number> {
+  const [platform] = await getDb()
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, slug));
+  if (!platform) throw new Error(`platform "${slug}" is not seeded - did global-setup run?`);
+  return platform.id;
+}
+
+/** A 'cloud'-runner campaign under an org with the given monthly budget. */
+async function seedCloudCampaign(
+  slug: string,
+  monthlyRunBudgetUsd: string | null,
+): Promise<{ orgId: number; campaignId: number }> {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, monthlyRunBudgetUsd })
+    .returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `${slug}-proj`,
+      name: `${slug} p`,
+      defaultAgentRunner: 'cloud',
+    })
+    .returning();
+  const platform = await platformId('reddit');
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({
+      projectId: project.id,
+      platformId: platform,
+      name: 'c',
+      skillSlug: 'reddit-scout',
+      agentRunner: 'cloud',
+    })
+    .returning();
+  return { orgId: org.id, campaignId: campaign.id };
+}
+
+async function runRow(runId: number) {
+  const [row] = await getDb()
+    .select({
+      status: schema.runs.status,
+      error: schema.runs.error,
+      failureReason: schema.runs.failureReason,
+      costUsd: schema.runs.costUsd,
+    })
+    .from(schema.runs)
+    .where(eq(schema.runs.id, runId));
+  return row;
+}
+
+/** dispatchRun's completion write runs off `handle.result`'s own promise
+ * chain, outside runCampaign's own await for a real dispatch - `run:finished`
+ * is emitted right after that write, on the realtime bus every SSE client
+ * already relies on, so subscribing to it is the actual completion signal
+ * rather than a guessed delay. A pre-flight refusal (the org already over
+ * budget) never reaches this: it fails synchronously inside runCampaign's
+ * own await, before dispatchRun even calls the runner. */
+function waitForRunFinished(orgId: number): Promise<void> {
+  return new Promise((resolve) => {
+    const unsubscribe = subscribe(orgId, (evt) => {
+      if (evt.kind !== 'run:finished') return;
+      unsubscribe();
+      resolve();
+    });
+  });
+}
+
+describe('cloud run dispatch is budget-gated (#419)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  const savedRunnerUrl = process.env.PITCHBOX_RUNNER_URL;
+
+  beforeEach(async () => {
+    await reset();
+    // shared/src/agents/detect.ts's cloud probe is still wired to the old
+    // WS-runner's isCloudRunnerEnabled() (PITCHBOX_EDITION + a runner URL) -
+    // stale since #416 repointed the 'cloud' slug at SdkRunner, which needs
+    // neither. Flagged to #420 (owns that file); worked around here so
+    // dispatch reaches the registry-mocked runner instead of being refused
+    // for an unrelated reason before my own budget check is ever exercised.
+    process.env.PITCHBOX_EDITION = 'cloud';
+    process.env.PITCHBOX_RUNNER_URL = 'ws://fake-runner.test';
+    clearDetectionCache();
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+    if (savedRunnerUrl === undefined) delete process.env.PITCHBOX_RUNNER_URL;
+    else process.env.PITCHBOX_RUNNER_URL = savedRunnerUrl;
+    clearDetectionCache();
+  });
+
+  it('refuses to start once the org has no budget left, and tells the caller why - through the real dispatch path', async () => {
+    const { campaignId } = await seedCloudCampaign('gw-over-budget', '0.00');
+
+    const started = Date.now();
+    const { runId } = await runCampaign(campaignId);
+    const run = await runRow(runId);
+
+    // Refused before ever reaching createAgentRunner - not a downstream
+    // failure that happened to also be about budget.
+    expect(createCalls).toBe(0);
+    expect(run?.status).toBe('failed');
+    expect(run?.error).toMatch(/over its monthly.*quota/i);
+    expect(run?.error).toMatch(/\$0\.00/);
+    expect(run?.failureReason).toBe('quota_exhausted');
+    // The bug this guards against is a real dispatch attempt (network,
+    // process spawn) before finding out the org can't afford it; the guard
+    // itself is a DB read plus a synchronous check.
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  it('lets a run start when the org is under budget, and hands the runner its exact remaining budget', async () => {
+    const { orgId, campaignId } = await seedCloudCampaign('gw-under-budget', '10.00');
+
+    const finished = waitForRunFinished(orgId);
+    const { runId } = await runCampaign(campaignId);
+    await finished;
+
+    expect(createCalls).toBe(1);
+    expect(capturedOpts?.budgetRemainingUsd).toBe(10);
+    expect((await runRow(runId))?.status).not.toBe('running');
+  });
+
+  it("persists the SDK runner's own reported cost, and getOrgMonthToDateCostUsd agrees with it exactly", async () => {
+    const { orgId, campaignId } = await seedCloudCampaign('gw-cost-sum', '10.00');
+    fakeResult = {
+      exitCode: 0,
+      logPath: '/dev/null',
+      tokensUsed: 400,
+      usage: {
+        inputTokens: 300,
+        outputTokens: 100,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUsd: 2.5,
+        costReported: true,
+      },
+    };
+
+    const finished = waitForRunFinished(orgId);
+    const { runId } = await runCampaign(campaignId);
+    await finished;
+
+    const run = await runRow(runId);
+    expect(Number(run?.costUsd)).toBeCloseTo(2.5, 4);
+    // Not the same call as the write above: this re-reads via the exact
+    // helper the dashboard and the org-quota settings page call, proving the
+    // two never diverge rather than just re-asserting the row we just wrote.
+    const monthToDate = await getOrgMonthToDateCostUsd(getDb(), orgId);
+    expect(monthToDate).toBeCloseTo(2.5, 4);
+  });
+
+  it('a second run is refused once the first pushed the org over budget', async () => {
+    const { orgId, campaignId } = await seedCloudCampaign('gw-second-run', '2.00');
+    fakeResult = {
+      exitCode: 0,
+      logPath: '/dev/null',
+      usage: {
+        inputTokens: 100,
+        outputTokens: 100,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUsd: 3, // over the $2.00 budget by itself
+        costReported: true,
+      },
+    };
+    const firstFinished = waitForRunFinished(orgId);
+    await runCampaign(campaignId);
+    await firstFinished;
+    expect(createCalls).toBe(1);
+
+    const second = await runCampaign(campaignId);
+    const secondRun = await runRow(second.runId);
+    expect(createCalls).toBe(1); // still 1 - the second dispatch never reached it
+    expect(secondRun?.status).toBe('failed');
+    expect(secondRun?.failureReason).toBe('quota_exhausted');
+
+    const monthToDate = await getOrgMonthToDateCostUsd(getDb(), orgId);
+    expect(monthToDate).toBeCloseTo(3, 4);
+  });
+});


### PR DESCRIPTION
Closes #419

While the runner used my subscription, an org's spend was bounded by a quota claim minted into a session JWT that the (now-gone) prodbox runner service enforced. The SDK runner spends against the product's own Gateway key, so the meter has to live on this side.

## Change

- `web/src/lib/server/runner.ts`'s `dispatchRun` refuses a `cloud` run before it starts once the org's month-to-date spend meets or exceeds its configured budget, with a message the caller can show. The message folds into the failed run's own error text; `classifyFailure`'s existing `QUOTA_PATTERNS` map it to `quota_exhausted` with no classifier changes needed.
- `shared/src/agents/base.ts`'s `AgentRunOptions` gains `budgetRemainingUsd`, the snapshot `dispatchRun` takes at dispatch time via the existing `org-quota.ts` helpers (`getOrgQuotaSnapshot`).
- `shared/src/agents/sdk/runner.ts` (`SdkRunner`) resolves Gateway catalogue pricing before the stream starts (was only resolved after), and checks its own accumulated cost against `budgetRemainingUsd` after every `finish-step`, aborting mid-stream the instant it would cross the line - a new `outcome='quota'` alongside the existing `cancel`/`timeout`. Already-emitted events stay in `run_events` since they're persisted as they stream, before the abort.
- `shared/src/agents/sdk/event-normalizer.ts`'s `SdkStopReasonKind` gains `quota_exceeded`, with a marker text containing "quota" so `classify-failure.ts`'s existing pattern maps it to `quota_exhausted`.

## Storage decision

No migration. A per-run cost already exists on `runs.cost_usd`, and `org-quota.ts`'s `getOrgMonthToDateCostUsd`/`getOrgQuotaSnapshot` already compute the org's month-to-date spend correctly from it. Both the pre-flight admission check and the mid-stream check reuse that single existing function rather than adding a rollup column or table - a second cached total would just be another place for the number to drift from the dashboard and the org-quota settings page, which already read the same helper. I'm not using the reserved idx 22 migration slot.

## Real Gateway verification

Drove a real campaign run through the actual dispatch path (`runCampaign` -> `dispatchRun` -> the real `SdkRunner`, no mocks) against the live Gateway, with the org's budget set to $0.01 (`organizations.monthly_run_budget_usd` is `numeric(10,2)`, so that's the smallest non-zero value) and an oversized first-step prompt to force real spend past it quickly:

- Run ended `status: failed`, `failure_reason: quota_exhausted`.
- `runs.cost_usd = 0.0106` against `google/gemini-3.1-flash-lite` (42,442 input / 15 output tokens, real Gateway pricing $0.00000025/$0.0000015 per token).
- 3 pre-abort events (`tool-call` [`run_start`], `tool-result`, `result`) are in `run_events` for that run - the events it produced were kept.
- `getOrgMonthToDateCostUsd` for that org returned `0.0106`, exactly matching `runs.cost_usd` - the dashboard number and the sum of the runs agree.

Also verified the pre-flight refusal through `runCampaign` with a $0.00 budget: refused before `createAgentRunner` was ever called, run marked `failed`/`quota_exhausted` with a readable error, in under 2 seconds.

## Tests

- `shared/tests/agents/sdk/runner.test.ts`: 3 new tests (mid-stream abort with real cost math, stays under budget, unpriced model never trips). Each proven to bite: disabling the budget check hangs/times out the abort test (real streamed-abort fixture waits on a signal that never fires); restored, passes.
- `shared/tests/agents/sdk/event-normalizer.test.ts`: extended `normalizeStopReason`/`classifyFailure` coverage for `quota_exceeded`. Proven to bite: stripping "quota" from the marker text flips the classification assertion to `unknown`; restored, passes.
- `web/tests/gateway-budget-dispatch.test.ts` (new): 4 tests through the real dispatch path (`runCampaign`, registry mocked only at the runner boundary) - refusal, admission + `budgetRemainingUsd` wiring, cost persistence agreeing with `getOrgMonthToDateCostUsd`, and a second run refused once the first exhausted the budget. Proven to bite: disabling the pre-flight check flips 3 of the 4 assertions (the cost-persistence test correctly stays green, since it doesn't depend on that check); restored, passes.

`pnpm exec vitest run` on all touched/new files, `npx eslint`, `npx prettier --check`, and `shared`/`web` `tsc --noEmit` (pre-existing, unrelated errors only in `web`'s generated-types-dependent files) all pass. `pnpm run test:linkedin-compliance` unaffected (15/15 passing).

## Non-goals honored

- Did not touch the old ACP/WS cloud runner cleanup (#420) or `docs/cloud-runner.md` (#421).
- Coordinated with `Cutover420` over `org-quota.ts`'s `RunnerJwtQuota` type (they're moving it into `org-quota.ts` itself as part of #420; I don't touch that type).
- Found and reported to `Cutover420` a stale `shared/src/agents/detect.ts` gate (`isCloudRunnerEnabled()`/`PITCHBOX_RUNNER_URL`) that blocks any 'cloud' dispatch without those legacy env vars even though `SdkRunner` doesn't need them - already fixed in their open PR #487 (not yet merged into this worktree). My web tests set `PITCHBOX_EDITION`/`PITCHBOX_RUNNER_URL` to fake values as a temporary workaround, noted inline as dead weight once #420 lands.

## Known gap (out of scope)

`organizations.max_concurrent_runs` (`concurrencyCap`, also part of the quota snapshot) is unenforced now that the runner service's in-memory per-org session map is gone with the cutover. This issue's scope is the USD budget only; concurrency enforcement would be a separate follow-up.