### PR TITLE
fix(extension): add missing i18n entries for the two new source-fill activity keys

### DIFF
--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -169,6 +169,11 @@ export const en = {
     'LinkedIn observations sent - {inserted} new, {duplicates} duplicate, {dropped} dropped.',
   'activity.linkedin-collector.batch-failed': 'LinkedIn observation batch failed: {reason}',
   'activity.linkedin-collector.stopped': 'LinkedIn observation collector stopped: {reason}',
+  // Pending project-source fill (#436, spike #435's "Plane 3"): a
+  // linkedin_post/linkedin_profile source filled from the page the human
+  // actually opened.
+  'activity.linkedin-collector.source-filled': 'Filled a pending {kind} project source.',
+  'activity.linkedin-collector.source-fill-failed': 'LinkedIn project source fill failed: {reason}',
   // Passive operator-profile/voice-sample capture (Persona, decision 3): the
   // handle/headline/experience read off a profile page the human opened, and
   // recent posts read the same way as voice samples.

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -164,6 +164,9 @@ export const it = {
   'activity.linkedin-collector.batch-failed':
     'Invio del batch di osservazioni LinkedIn fallito: {reason}',
   'activity.linkedin-collector.stopped': 'Collettore di osservazioni LinkedIn fermato: {reason}',
+  'activity.linkedin-collector.source-filled': 'Fonte progetto {kind} in sospeso compilata.',
+  'activity.linkedin-collector.source-fill-failed':
+    'Compilazione della fonte progetto LinkedIn fallita: {reason}',
   'activity.linkedin-collector.profile-captured': 'Profilo LinkedIn acquisito.',
   'activity.linkedin-collector.profile-refused':
     "Acquisizione profilo LinkedIn saltata: questa pagina non corrisponde all'operatore registrato.",


### PR DESCRIPTION
My #488 (LinkedIn post/profile project sources) added two new content-script activity log messages - `activity.linkedin-collector.source-filled` and `activity.linkedin-collector.source-fill-failed` - but never added their `dict-en.ts`/`dict-it.ts` entries. `extension/tests/lib/activity-i18n-coverage.test.ts` only runs in the full suite (`Tests (Postgres)`, which moved to `push: main` only), so my own covering-subset run never touched it, and it broke `main`'s required `ci` check after #488 merged, blocking the preview deploy.

Fix: added both entries, matching the existing linkedin-collector group's style. `extension/tests/lib/activity-i18n-coverage.test.ts` now passes (4/4). `npx eslint`/`npx prettier --check` clean, `pnpm -F @pitchbox/extension check` clean.