### PR TITLE
fix(web,daemon,shared): resolve the MCP tool set in a deployed build

### DIFF
--- a/daemon/package.json
+++ b/daemon/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@pitchbox/cli": "workspace:*",
     "@pitchbox/shared": "workspace:*",
     "cron-parser": "^5.10.0",
     "dotenv": "^17.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
 
   daemon:
     dependencies:
+      '@pitchbox/cli':
+        specifier: workspace:*
+        version: link:../cli
       '@pitchbox/shared':
         specifier: workspace:*
         version: link:../shared
@@ -257,6 +260,9 @@ importers:
       '@lucide/svelte':
         specifier: ^1.23.0
         version: 1.23.0(svelte@5.57.0(@typescript-eslint/types@8.62.1))
+      '@pitchbox/cli':
+        specifier: workspace:*
+        version: link:../cli
       '@pitchbox/daemon':
         specifier: workspace:*
         version: link:../daemon

--- a/shared/src/agents/sdk/tools.ts
+++ b/shared/src/agents/sdk/tools.ts
@@ -39,16 +39,28 @@ async function importToolSetModule(): Promise<ToolSetModule> {
     // via cli's exports map when present, tsx/vitest fallback below.
     return (await import('@pitchbox/cli/mcp/tool-set')) as ToolSetModule;
   } catch (primaryErr) {
-    try {
-      const spec = ['..', '..', '..', '..', 'cli', 'src', 'mcp', 'tool-set.js'].join('/');
-      // Intentionally dynamic (tsx/vitest-only fallback); tell Vite not to try to analyze it.
-      return (await import(/* @vite-ignore */ spec)) as ToolSetModule;
-    } catch {
-      // The path fallback only applies to the unbundled tsx/vitest case; in
-      // a bundled build it never resolves. Surface the primary error - it's
-      // the real cause.
-      throw primaryErr;
+    // Two fallbacks, both for an unbundled run: the relative source path
+    // (tsx and vitest, where nothing is bundled and the specifier above may
+    // not resolve), and the same file under `PITCHBOX_ROOT`, which is what
+    // works from a bundled server whose chunk sits under `web/build/`.
+    // #491: the deployed cloud edition had neither, because the specifier
+    // cannot resolve from a workspace that does not declare `cli`, and every
+    // campaign run failed with "Cannot find package '@pitchbox/cli'".
+    const candidates = [
+      ['..', '..', '..', '..', 'cli', 'src', 'mcp', 'tool-set.js'].join('/'),
+      ...(process.env.PITCHBOX_ROOT
+        ? [`${process.env.PITCHBOX_ROOT}/cli/src/mcp/tool-set.ts`]
+        : []),
+    ];
+    for (const spec of candidates) {
+      try {
+        // Intentionally dynamic; tell Vite not to try to analyze it.
+        return (await import(/* @vite-ignore */ spec)) as ToolSetModule;
+      } catch {
+        // Try the next candidate. The primary error is the one worth raising.
+      }
     }
+    throw primaryErr;
   }
 }
 

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@bytemd/plugin-gfm": "^1.22.0",
     "@lucide/svelte": "^1.23.0",
+    "@pitchbox/cli": "workspace:*",
     "@pitchbox/daemon": "workspace:*",
     "@pitchbox/shared": "workspace:*",
     "@tailwindcss/vite": "^4.3.2",

--- a/web/tests/mcp-tool-set-resolution.test.ts
+++ b/web/tests/mcp-tool-set-resolution.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { createPitchboxToolSet } from '@pitchbox/shared/agents/sdk/tools';
+
+// #491: the SDK runner loads the Pitchbox MCP tool set from `cli` through a
+// lazy `import('@pitchbox/cli/mcp/tool-set')`, because `shared` stays the leaf
+// workspace and does not declare a dependency on `cli`. That specifier can
+// only resolve from a workspace that *does* declare it, and until this test
+// existed nothing did: every local run resolved through the source-path
+// fallback, which a bundled build never reaches. The deployed cloud edition
+// therefore failed every campaign run with "Cannot find package
+// '@pitchbox/cli'", measured on preview at run 25.
+//
+// This asserts the property the deployment needs: the process that dispatches
+// a run can resolve the tool set by package specifier, not only by walking up
+// the umbrella's directories.
+
+const webRoot = fileURLToPath(new URL('..', import.meta.url));
+const requireFromWeb = createRequire(new URL('../package.json', import.meta.url));
+
+describe('Pitchbox MCP tool set resolution (#491)', () => {
+  it('resolves by package specifier from the web workspace, not only by source path', () => {
+    // `require.resolve` walks the same node_modules chain the bundled server
+    // does at runtime, which is exactly what the source-path fallback hides.
+    expect(() => requireFromWeb.resolve('@pitchbox/cli/mcp/tool-set')).not.toThrow();
+  });
+
+  it('is a declared dependency of every workspace that dispatches a run', () => {
+    // The web server and the daemon both call `dispatchRun`, and a run
+    // dispatched from either has to reach the tool set. A dependency that
+    // exists only in one of them fails in production on whichever process
+    // happens to pick up the campaign.
+    for (const workspace of ['web', 'daemon']) {
+      const pkg: unknown = JSON.parse(
+        readFileSync(new URL(`../../${workspace}/package.json`, import.meta.url), 'utf8'),
+      );
+      const deps =
+        pkg && typeof pkg === 'object' && 'dependencies' in pkg ? pkg.dependencies : undefined;
+      const has =
+        deps && typeof deps === 'object' && '@pitchbox/cli' in deps
+          ? deps['@pitchbox/cli']
+          : undefined;
+      expect(has, `${workspace} must declare @pitchbox/cli`).toBe('workspace:*');
+    }
+  });
+
+  it('hands back the real tool set through the loader the runner uses', async () => {
+    // Not a resolution check: the loader's own error message is reassuring
+    // even when it is wrapping a failure, so drive it and look at the tools.
+    const set = await createPitchboxToolSet({});
+    try {
+      expect(Object.keys(set.tools).length).toBeGreaterThan(20);
+      expect(Object.keys(set.tools)).toContain('drafts_create');
+    } finally {
+      await set.close();
+    }
+    expect(webRoot).toContain('web');
+  });
+});


### PR DESCRIPTION
Closes #491. Under epic #396, and it is what makes that epic's closing condition actually reachable.

I triggered a real campaign run on preview right after the cutover merged, and it failed in under a minute:

```
Error: Pitchbox MCP tool set not available - expected cli/src/mcp/tool-set.ts in this checkout.
Cannot find package '@pitchbox/cli' imported from
/app/web/build/server/chunks/chunks/registry.js-BJNvpp-N.js
```

The interesting half is why every local check passed. `shared/src/agents/sdk/tools.ts` reaches the tool set by package specifier on purpose, so `shared` stays the leaf workspace nobody depends back on (#470). But no workspace declared `@pitchbox/cli` either: `web/node_modules/@pitchbox/` holds only `shared` and `daemon`, which is what `web/package.json` asks for. Locally the relative source-path fallback covers the gap, because under tsx and vitest nothing is bundled and the path walks up the umbrella. In the image the server is a bundled adapter-node build whose chunk lives under `web/build/server/chunks/`, so that path lands nowhere and the specifier is the only route left.

Two changes. `web` and `daemon` both declare `@pitchbox/cli`, since both dispatch runs and declaring it in one would fail on whichever process picks up the campaign. And the fallback gains a `PITCHBOX_ROOT`-anchored candidate, which is the path that does work from a bundled build, so the loader has a real second chance rather than a decorative one.

On the test, and on which part of it bites. `web/tests/mcp-tool-set-resolution.test.ts` resolves the specifier through `createRequire` the way the runtime does, asserts both dispatching workspaces declare the dependency, and drives the loader to check it really hands back the 26 tools rather than a reassuring error message. Proven by removing the dependency from both `package.json` files and deleting the links: the declaration assertion fails. The `require.resolve` one keeps passing, because pnpm's root store can satisfy the specifier locally even when the image cannot, and I am leaving it in with that noted rather than pretending it is the guard.

The real proof is the deployment, so: I merge this, preview redeploys, and I trigger a campaign run and report the run row, its events and its cost on #491. If that run does not complete, this PR did not fix it and I will say so there.