### PR TITLE
fix(shared): re-issue the silently skipped migration, and detect the next one

### DIFF
--- a/shared/src/db/migrate.ts
+++ b/shared/src/db/migrate.ts
@@ -4,16 +4,53 @@ import { resolve } from 'node:path';
 config({ path: resolve(import.meta.dirname, '../../..', '.env') });
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import { sql } from 'drizzle-orm';
 import pg from 'pg';
+import {
+  findMissingMigrations,
+  readJournalMigrations,
+  readSupersededMigrations,
+} from './migration-audit.js';
+
+const migrationsFolder = new URL('./migrations', import.meta.url).pathname;
 
 async function main() {
   const url = process.env.DATABASE_URL;
   if (!url) throw new Error('DATABASE_URL is not set');
   const pool = new pg.Pool({ connectionString: url, max: 1 });
   const db = drizzle(pool);
-  await migrate(db, { migrationsFolder: new URL('./migrations', import.meta.url).pathname });
+  await migrate(db, { migrationsFolder });
+
+  // Verify rather than trust: drizzle says "migrations applied" even when its
+  // own ordering rule made it skip one (#493, see migration-audit.ts).
+  const journal = readJournalMigrations(migrationsFolder);
+  const applied = await db.execute<{ hash: string }>(
+    sql`select hash from drizzle.__drizzle_migrations`,
+  );
+  const missing = findMissingMigrations({
+    journal,
+    appliedHashes: new Set(applied.rows.map((r) => r.hash)),
+    superseded: readSupersededMigrations(migrationsFolder),
+  });
   await pool.end();
-  console.log('migrations applied');
+
+  if (missing.length > 0) {
+    const newest = Math.max(...journal.map((m) => m.when));
+    console.error(
+      `ERROR: ${missing.length} migration(s) in the journal were never applied to this database:`,
+    );
+    for (const m of missing) console.error(`  - ${m.tag} (idx ${m.idx}, when ${m.when})`);
+    console.error(
+      'Drizzle skips a migration whose journal `when` is not greater than the newest one\n' +
+        `already applied (newest in this journal: ${newest}). Re-issue the skipped migration as a\n` +
+        'new file with a higher `when`, written so it is safe against a database that already has\n' +
+        'the object (IF NOT EXISTS), and record it in migrations/meta/_superseded.json. Never edit\n' +
+        'the skipped file in place: an applied migration and its recorded hash have to keep agreeing.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`migrations applied (${journal.length} in journal, all present)`);
 }
 
 main().catch((e) => {

--- a/shared/src/db/migration-audit.ts
+++ b/shared/src/db/migration-audit.ts
@@ -1,0 +1,86 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+// Drizzle applies a migration only when its journal `when` is greater than the
+// newest `when` already recorded in the database, and prints "migrations
+// applied" either way. A migration authored on one branch and merged after a
+// branch carrying a higher `when` is therefore skipped in silence. That is not
+// hypothetical: `0016_operator_voice_profile` (when 1788960000003) merged after
+// two migrations carrying 1788960000004 and 1788960000005, so the preview
+// deployment never created `operator_voice_profiles`, `migrate` reported
+// success, and the first request that read the table 500'd hours later (#493).
+//
+// Only a database with history can detect this, so the check runs at migrate
+// time in every environment rather than as a test over the repo.
+
+export interface JournalMigration {
+  idx: number;
+  when: number;
+  tag: string;
+  /** sha256 of the SQL file's raw bytes: how the migrator records it. */
+  hash: string;
+}
+
+/** Reads the journal and hashes each migration the way drizzle does. */
+export function readJournalMigrations(migrationsFolder: string): JournalMigration[] {
+  const journal: unknown = JSON.parse(
+    readFileSync(`${migrationsFolder}/meta/_journal.json`, 'utf8'),
+  );
+  const entries =
+    journal && typeof journal === 'object' && 'entries' in journal ? journal.entries : [];
+  const out: JournalMigration[] = [];
+  for (const raw of Array.isArray(entries) ? entries : []) {
+    if (!raw || typeof raw !== 'object') continue;
+    const tag = 'tag' in raw && typeof raw.tag === 'string' ? raw.tag : null;
+    if (!tag) continue;
+    const body = readFileSync(`${migrationsFolder}/${tag}.sql`, 'utf8');
+    out.push({
+      idx: 'idx' in raw && typeof raw.idx === 'number' ? raw.idx : -1,
+      when: 'when' in raw && typeof raw.when === 'number' ? raw.when : -1,
+      tag,
+      hash: createHash('sha256').update(body).digest('hex'),
+    });
+  }
+  return out;
+}
+
+/**
+ * Skipped-migration tag to the tag of the migration that re-issues it. A
+ * database that ran the replacement has a repaired history rather than a hole,
+ * so the skipped one is acceptable there and only there.
+ */
+export function readSupersededMigrations(migrationsFolder: string): Map<string, string> {
+  const raw: unknown = JSON.parse(
+    readFileSync(`${migrationsFolder}/meta/_superseded.json`, 'utf8'),
+  );
+  const out = new Map<string, string>();
+  if (!raw || typeof raw !== 'object') return out;
+  for (const [tag, replacement] of Object.entries(raw)) {
+    // `_comment` and any future note key.
+    if (tag.startsWith('_')) continue;
+    if (typeof replacement === 'string') out.set(tag, replacement);
+  }
+  return out;
+}
+
+/**
+ * Which journal migrations this database never applied, ignoring one that a
+ * later migration already re-issued here. Sorted by journal order so the
+ * report reads like the history it is describing.
+ */
+export function findMissingMigrations(args: {
+  journal: JournalMigration[];
+  appliedHashes: ReadonlySet<string>;
+  superseded: ReadonlyMap<string, string>;
+}): JournalMigration[] {
+  const appliedTags = new Set(
+    args.journal.filter((m) => args.appliedHashes.has(m.hash)).map((m) => m.tag),
+  );
+  return args.journal
+    .filter((m) => !args.appliedHashes.has(m.hash))
+    .filter((m) => {
+      const replacement = args.superseded.get(m.tag);
+      return !replacement || !appliedTags.has(replacement);
+    })
+    .sort((a, b) => a.idx - b.idx);
+}

--- a/shared/src/db/migrations/0021_operator_voice_profiles_repair.sql
+++ b/shared/src/db/migrations/0021_operator_voice_profiles_repair.sql
@@ -1,0 +1,37 @@
+-- Re-issue of 0016_operator_voice_profile, which drizzle silently skipped on
+-- every database that had already applied 0017 or 0018 (#493). 0016 was
+-- authored on a branch with `when` 1788960000003 and merged after two branches
+-- carrying 1788960000004 and 1788960000005, so the migrator never ran it and
+-- still reported success. The preview deployment therefore had no
+-- `operator_voice_profiles` table, and the first suggestion that read it
+-- failed with a 500.
+--
+-- Written to be safe against a database that already has the table (a fresh
+-- one, where 0016 did run), so both histories converge here. 0016 stays in the
+-- journal untouched: editing an applied migration in place is how a schema
+-- and its history stop agreeing.
+CREATE TABLE IF NOT EXISTS "operator_voice_profiles" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"organization_id" integer NOT NULL,
+	"summary" text DEFAULT '' NOT NULL,
+	"traits" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"openings" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"closings" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"common_words" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"words_per_sentence" integer DEFAULT 0 NOT NULL,
+	"item_count" integer DEFAULT 0 NOT NULL,
+	"word_count" integer DEFAULT 0 NOT NULL,
+	"evidence" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"source" text DEFAULT 'derived' NOT NULL,
+	"derived_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "operator_voice_profiles" ADD CONSTRAINT "operator_voice_profiles_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+	WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "operator_voice_profiles_org_unique" ON "operator_voice_profiles" USING btree ("organization_id");

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1788960000007,
       "tag": "0020_instance_audit",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1788960000008,
+      "tag": "0021_operator_voice_profiles_repair",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/migrations/meta/_superseded.json
+++ b/shared/src/db/migrations/meta/_superseded.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "A migration drizzle skipped on some databases and a later migration that re-issues it. The migrate script treats the skipped one as acceptable on a database where the replacement is applied, and still fails when neither is. Keys are the skipped tag, values the tag that repairs it. See #493.",
+  "0016_operator_voice_profile": "0021_operator_voice_profiles_repair"
+}

--- a/shared/tests/migration-audit.test.ts
+++ b/shared/tests/migration-audit.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findMissingMigrations,
+  readJournalMigrations,
+  readSupersededMigrations,
+  type JournalMigration,
+} from '../src/db/migration-audit.js';
+
+const migrationsFolder = new URL('../src/db/migrations', import.meta.url).pathname;
+
+// #493: drizzle skips a migration whose journal `when` is not greater than the
+// newest already applied, and reports success anyway. The preview deployment
+// lost `operator_voice_profiles` that way. These tests defend the audit that
+// makes `migrate` fail loudly instead.
+
+function entry(idx: number, tag: string, hash: string): JournalMigration {
+  return { idx, when: 1788960000000 + idx, tag, hash };
+}
+
+describe('migration audit (#493)', () => {
+  it('hashes the real journal the way the migrator records it', () => {
+    const journal = readJournalMigrations(migrationsFolder);
+    expect(journal.length).toBeGreaterThan(20);
+    // The hash a real deployment recorded for 0020_instance_audit, read off
+    // preview's own drizzle.__drizzle_migrations table. If the hashing ever
+    // stops matching, every audit below is comparing nothing to nothing.
+    const instanceAudit = journal.find((m) => m.tag === '0020_instance_audit');
+    expect(instanceAudit?.hash).toBe(
+      '037ed71ab0e4803ad63a649fdeee70050cfc761ed67fa35f058bf42c3f146891',
+    );
+  });
+
+  it('reports a migration this database never applied', () => {
+    const journal = [entry(1, 'a', 'hash-a'), entry(2, 'b', 'hash-b')];
+    const missing = findMissingMigrations({
+      journal,
+      appliedHashes: new Set(['hash-a']),
+      superseded: new Map(),
+    });
+    expect(missing.map((m) => m.tag)).toEqual(['b']);
+  });
+
+  it('says nothing when every journal migration is applied', () => {
+    const journal = [entry(1, 'a', 'hash-a'), entry(2, 'b', 'hash-b')];
+    expect(
+      findMissingMigrations({
+        journal,
+        appliedHashes: new Set(['hash-a', 'hash-b']),
+        superseded: new Map(),
+      }),
+    ).toEqual([]);
+  });
+
+  it('accepts a skipped migration on a database that ran its replacement', () => {
+    // The repaired history: 0016 never ran here, 0021 re-issued it and did.
+    const journal = [
+      entry(16, 'skipped', 'hash-16'),
+      entry(17, 'other', 'hash-17'),
+      entry(21, 'repair', 'hash-21'),
+    ];
+    const missing = findMissingMigrations({
+      journal,
+      appliedHashes: new Set(['hash-17', 'hash-21']),
+      superseded: new Map([['skipped', 'repair']]),
+    });
+    expect(missing).toEqual([]);
+  });
+
+  it('still reports the skipped migration when the replacement is missing too', () => {
+    const journal = [entry(16, 'skipped', 'hash-16'), entry(21, 'repair', 'hash-21')];
+    const missing = findMissingMigrations({
+      journal,
+      appliedHashes: new Set<string>(),
+      superseded: new Map([['skipped', 'repair']]),
+    });
+    expect(missing.map((m) => m.tag)).toEqual(['skipped', 'repair']);
+  });
+
+  it('reads the superseded map and ignores its note keys', () => {
+    const superseded = readSupersededMigrations(migrationsFolder);
+    expect(superseded.get('0016_operator_voice_profile')).toBe(
+      '0021_operator_voice_profiles_repair',
+    );
+    expect([...superseded.keys()].some((k) => k.startsWith('_'))).toBe(false);
+  });
+
+  it('names a real repair for every entry in the superseded map', () => {
+    // A replacement that is not itself in the journal would silence a real
+    // hole forever, which is the one way this mechanism could hurt.
+    const journal = readJournalMigrations(migrationsFolder);
+    const tags = new Set(journal.map((m) => m.tag));
+    for (const [skipped, replacement] of readSupersededMigrations(migrationsFolder)) {
+      expect(tags.has(skipped), `${skipped} must exist in the journal`).toBe(true);
+      expect(tags.has(replacement), `${replacement} must exist in the journal`).toBe(true);
+      const skippedWhen = journal.find((m) => m.tag === skipped)?.when ?? 0;
+      const replacementWhen = journal.find((m) => m.tag === replacement)?.when ?? 0;
+      expect(replacementWhen).toBeGreaterThan(skippedWhen);
+    }
+  });
+});


### PR DESCRIPTION
Closes #493. Under epic #396.

A panel suggestion on preview returned a 500 and the log named a failed query against `operator_voice_profiles`. That table does not exist there, although `migrate` has reported success on every deploy since #468.

Drizzle applies a migration only when its journal `when` is greater than the newest already recorded, and says "migrations applied" either way. `0016_operator_voice_profile` carries `when: 1788960000003` and merged after #408 (004) and #431 (005), so on preview it was skipped in silence. `AGENTS.md` documents this trap and I walked into it anyway, because I handed out the slots and gave 16 to the branch that merged last.

**Two halves, and the second is the one worth reviewing.** `0021_operator_voice_profiles_repair` re-issues the table with `IF NOT EXISTS` so a database where 0016 did run converges rather than failing, and 0016 stays in the journal untouched, because editing an applied migration in place is how a schema and its recorded hash stop agreeing. Then `migrate` stops trusting itself: it hashes every journal entry the way the migrator does (sha256 of the file's raw bytes, verified against the hash preview actually recorded for `0020_instance_audit`), compares that to `drizzle.__drizzle_migrations`, and exits non-zero naming what was skipped and what to do about it. Only a database with history can detect this, which is why the check runs at migrate time in every environment rather than as a test over the repo.

`migrations/meta/_superseded.json` records that 0021 repairs 0016, so a repaired database is green while a genuinely missing pair still fails. One of the tests asserts that every entry in that map names migrations which really exist and that the replacement's `when` is higher, because a bogus entry there would silence a real hole forever.

Reproduced before fixing, on a scratch database: migrate from a journal without 0016, then migrate again with it, and you get 19 migrations, no table, and a success message. With this change the second run fails and names 0016. `findMissingMigrations` is extracted so that logic is unit-testable; bypassing its supersede branch fails exactly the two tests that defend it.

Two consequences to state plainly. Prod has the same hole and the next deploy carrying 0021 repairs it. And the habit that caused this has to change: assigning `when` values in advance across parallel branches is only safe if they merge in that order, which the author does not control.