### PR TITLE
fix(shared,web): the cloud runner enforces a spend budget but not the concurrency cap

### DIFF
--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -46,9 +46,11 @@ export const organizations = pgTable('organizations', {
   // Per-org cloud-runner quota (CLD-P5, docs/cloud-runner-productionization-design.md
   // section 5). Both nullable with no backfill: null means unlimited on that axis.
   // monthlyRunBudgetUsd caps calendar-month run cost (shared/src/org-quota.ts sums
-  // runs.cost_usd for the org); maxConcurrentRuns caps sessions the cloud runner
-  // holds open for the org at once, enforced in-memory on the runner from the
-  // signed JWT quota claim.
+  // runs.cost_usd for the org); maxConcurrentRuns caps how many runs.status='running'
+  // rows the org may hold at once, admitted by
+  // shared/src/org-quota.ts's assertOrgConcurrencyAdmitted (#485 - the old runner
+  // service's in-memory per-org session map disappeared with the service in #420,
+  // and nothing replaced it until this).
   monthlyRunBudgetUsd: numeric('monthly_run_budget_usd', { precision: 10, scale: 2 }),
   maxConcurrentRuns: integer('max_concurrent_runs'),
 });

--- a/shared/src/org-quota.ts
+++ b/shared/src/org-quota.ts
@@ -158,3 +158,105 @@ export async function setOrgQuota(db: Db, orgId: number, fields: OrgQuotaFields)
     .returning({ id: schema.organizations.id });
   return rows.length > 0;
 }
+
+/**
+ * Admit-or-refuse a single already-inserted `runs` row against
+ * `organizations.max_concurrent_runs` (#485). The old runner service
+ * enforced this from an in-memory per-org session map that disappeared
+ * with the service itself (#420); nothing replaced it, so an org could
+ * start as many simultaneous cloud runs as it could trigger.
+ *
+ * Every dispatch path (`web/src/lib/server/runner.ts`) inserts its `runs`
+ * row with `status: 'running'` before calling `dispatchRun`, so by the time
+ * this runs the caller's own row already counts itself - a plain
+ * `count > cap` after the fact would only ever refuse, never decide which
+ * of two racing dispatches gets the free slot, and a plain count taken
+ * *before* either insert is visible to the other is exactly the TOCTOU gap
+ * #485 reported (both readers see themselves as first). Both are closed by
+ * `pg_advisory_xact_lock` keyed on the org, the same primitive
+ * `withCampaignLock` (shared/src/scheduler/dispatch-lock.ts) already uses
+ * for the sibling per-campaign race: it forces every concurrent admission
+ * decision for one org through a single line, so whichever one runs the
+ * ranking query below always sees a fully-committed, stable view. Once
+ * inside the lock, every currently `running` row for the org is ranked by
+ * `id` (insertion order) and this run is admitted iff its own rank is
+ * within the cap - so of N runs racing for the org's free slots, exactly
+ * as many as the cap allows win, not "however many happened to look small"
+ * and not "all of them, because nobody's insert was visible to anybody
+ * else's read yet".
+ *
+ * A plain partial UNIQUE index (`runs_one_running_per_campaign`'s own
+ * mechanism) does not generalise here: it can express "at most one", not
+ * "at most `max_concurrent_runs`", and `max_concurrent_runs` is an
+ * operator-configured integer, not always 1. A separately maintained
+ * counter column plus an atomic `UPDATE ... RETURNING` would generalise,
+ * but only if every place a run leaves `running` (success, failure,
+ * cancellation, and dispatchRun's own early-failure branch) reliably
+ * decrements it - miss one and a slot leaks forever. Ranking the live
+ * `status = 'running'` rows needs no separate column and no decrement to
+ * remember: the moment something flips a row away from `running`, the very
+ * next admission check already sees the freed slot.
+ *
+ * Throws with a message that never contains "quota" or "rate limit" - the
+ * budget refusal in `dispatchRun` does, and `classifyFailure`
+ * (shared/src/runlog/classify-failure.ts) has to tell the two apart as
+ * `concurrency_exhausted` vs `quota_exhausted` rather than folding both
+ * into one label an operator can't act on without reading the run's raw
+ * error.
+ */
+export async function assertOrgConcurrencyAdmitted(
+  db: Db,
+  orgId: number,
+  runId: number,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    const [org] = await tx
+      .select({ maxConcurrentRuns: schema.organizations.maxConcurrentRuns })
+      .from(schema.organizations)
+      .where(eq(schema.organizations.id, orgId))
+      .limit(1);
+    const cap = org?.maxConcurrentRuns ?? null;
+    if (cap == null) return; // unlimited - nothing to admit against.
+
+    // Transaction-scoped: blocks any other admission decision for this org
+    // until this one commits or rolls back, and releases automatically
+    // either way - no separate cleanup path to forget.
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${`org-concurrency:${orgId}`}, 0))`,
+    );
+
+    const orgProjects = await tx
+      .select({ id: schema.projects.id })
+      .from(schema.projects)
+      .where(eq(schema.projects.organizationId, orgId));
+    const projectIds = orgProjects.map((p) => p.id);
+    // No projects means no runs to rank against, including this one -
+    // unreachable in practice (this run's own row implies a project) but
+    // never treat "found nothing" as "refuse".
+    if (projectIds.length === 0) return;
+
+    const running = await tx
+      .select({ id: schema.runs.id })
+      .from(schema.runs)
+      .leftJoin(schema.campaigns, eq(schema.campaigns.id, schema.runs.campaignId))
+      .where(
+        and(
+          or(
+            inArray(schema.runs.projectId, projectIds),
+            inArray(schema.campaigns.projectId, projectIds),
+          ),
+          eq(schema.runs.status, 'running'),
+        ),
+      )
+      .orderBy(schema.runs.id);
+
+    const rank = running.findIndex((r) => r.id === runId) + 1; // 0 -> "not found"
+    if (rank > 0 && rank <= cap) return; // admitted - within the cap.
+
+    throw new Error(
+      `This organization already has ${cap} cloud run${cap === 1 ? '' : 's'} in progress, its ` +
+        `configured concurrency limit, and cannot start another until one finishes or an ` +
+        `operator raises the limit in Settings.`,
+    );
+  });
+}

--- a/shared/src/runlog/classify-failure.ts
+++ b/shared/src/runlog/classify-failure.ts
@@ -12,6 +12,7 @@ export type RunFailureReason =
   | 'runner_missing'
   | 'auth_expired'
   | 'quota_exhausted'
+  | 'concurrency_exhausted'
   | 'playbook_error'
   | 'playbook_incomplete'
   | 'network'
@@ -27,6 +28,7 @@ export const RUN_FAILURE_REASONS: readonly RunFailureReason[] = [
   'runner_missing',
   'auth_expired',
   'quota_exhausted',
+  'concurrency_exhausted',
   'playbook_error',
   'playbook_incomplete',
   'network',
@@ -76,6 +78,14 @@ const QUOTA_PATTERNS = [
   'rate limit', // distinct from runlog "rate-limit" kind: this catches text mentions
   'rate-limit',
 ];
+
+// #485: the org's concurrency cap (organizations.max_concurrent_runs) is a
+// different failure than the budget above - "you already have N runs going"
+// has a different fix (wait or raise the cap) than "you are out of money
+// this month" (wait for next month or raise the budget) - so the refusal
+// text in assertOrgConcurrencyAdmitted (shared/src/org-quota.ts) deliberately
+// never says "quota" or "rate limit" and needs its own pattern here.
+const CONCURRENCY_PATTERNS = ['concurrency limit'];
 
 const NETWORK_PATTERNS = [
   'econnrefused',
@@ -137,6 +147,7 @@ export function classifyFailure(events: ParsedEvent[], exitCode: number | null):
   if (SDK_TIMEOUT_PATTERNS.some((p) => haystack.includes(p))) return 'agent_timeout';
   if (AUTH_PATTERNS.some((p) => haystack.includes(p))) return 'auth_expired';
   if (QUOTA_PATTERNS.some((p) => haystack.includes(p))) return 'quota_exhausted';
+  if (CONCURRENCY_PATTERNS.some((p) => haystack.includes(p))) return 'concurrency_exhausted';
   if (NETWORK_PATTERNS.some((p) => haystack.includes(p))) return 'network';
   if (PROVIDER_ERROR_PATTERNS.some((p) => haystack.includes(p))) return 'provider_error';
   if (CONTENT_FILTERED_PATTERNS.some((p) => haystack.includes(p))) return 'content_filtered';

--- a/shared/tests/org-quota.test.ts
+++ b/shared/tests/org-quota.test.ts
@@ -9,8 +9,9 @@
 import { randomUUID } from 'node:crypto';
 import { describe, it, expect, afterEach } from 'vitest';
 import { eq } from 'drizzle-orm';
-import { getDb, schema } from '../src/db/client.js';
+import { getDb, getPool, schema } from '../src/db/client.js';
 import {
+  assertOrgConcurrencyAdmitted,
   getOrgMonthToDateCostUsd,
   getOrgQuotaFields,
   getOrgQuotaSnapshot,
@@ -66,6 +67,18 @@ async function makeRun(opts: { projectId: number; costUsd: string | null; starte
     costUsd: opts.costUsd,
     startedAt: opts.startedAt,
   });
+}
+
+/** A `running` run under a bare project, for the concurrency-admission
+ * tests below - `assertOrgConcurrencyAdmitted` ranks exactly this status,
+ * unlike `makeRun` above which seeds `success` rows for the cost sum. */
+async function makeRunningRun(projectId: number): Promise<number> {
+  const db = getDb();
+  const [run] = await db
+    .insert(schema.runs)
+    .values({ kind: 'project_extraction', projectId, trigger: 'manual', status: 'running' })
+    .returning({ id: schema.runs.id });
+  return run.id;
 }
 
 /** A second project in the same org, so a campaign can be anchored to a
@@ -343,5 +356,126 @@ describe('setOrgQuota', () => {
   it('returns false for an org id that does not exist', async () => {
     const ok = await setOrgQuota(getDb(), -1, { monthlyRunBudgetUsd: 1, maxConcurrentRuns: 1 });
     expect(ok).toBe(false);
+  });
+});
+
+// #485: organizations.max_concurrent_runs went unenforced once the old
+// runner service's in-memory per-org session map disappeared with it
+// (#420). assertOrgConcurrencyAdmitted is the replacement - see its own
+// doc comment in ../src/org-quota.ts for why it ranks live `running` rows
+// under an org-scoped pg_advisory_xact_lock rather than a maintained
+// counter or a plain count-then-decide read.
+describe('assertOrgConcurrencyAdmitted', () => {
+  it('admits a run when the org is under its concurrency cap', async () => {
+    const { orgId, projectId } = await setupOrg({ maxConcurrentRuns: 2 });
+    await makeRunningRun(projectId); // one other run already occupying a slot
+    const runId = await makeRunningRun(projectId);
+
+    await expect(assertOrgConcurrencyAdmitted(getDb(), orgId, runId)).resolves.toBeUndefined();
+  });
+
+  it('refuses once the org is already at its concurrency cap, with a message that never says quota', async () => {
+    const { orgId, projectId } = await setupOrg({ maxConcurrentRuns: 1 });
+    await makeRunningRun(projectId); // fills the org's only slot
+    const runId = await makeRunningRun(projectId);
+
+    await expect(assertOrgConcurrencyAdmitted(getDb(), orgId, runId)).rejects.toThrow(
+      /concurrency limit/i,
+    );
+    await expect(assertOrgConcurrencyAdmitted(getDb(), orgId, runId)).rejects.not.toThrow(
+      /quota|rate.limit/i,
+    );
+  });
+
+  it('is unlimited when max_concurrent_runs is null, however many runs are already going', async () => {
+    const { orgId, projectId } = await setupOrg({ maxConcurrentRuns: null });
+    await makeRunningRun(projectId);
+    await makeRunningRun(projectId);
+    await makeRunningRun(projectId);
+    const runId = await makeRunningRun(projectId);
+
+    await expect(assertOrgConcurrencyAdmitted(getDb(), orgId, runId)).resolves.toBeUndefined();
+  });
+
+  it('refuses a run id that never occupied a slot, once the org is already at its cap', async () => {
+    const { orgId, projectId } = await setupOrg({ maxConcurrentRuns: 1 });
+    await makeRunningRun(projectId);
+
+    await expect(assertOrgConcurrencyAdmitted(getDb(), orgId, -1)).rejects.toThrow(
+      /concurrency limit/i,
+    );
+  });
+
+  // Ranking correctness under real concurrent execution: fire N already-
+  // `running` rows' admission checks as genuinely concurrent promises
+  // (Promise.allSettled, not two sequential awaits) and confirm exactly
+  // `cap` of them are admitted - and deterministically the `cap` with the
+  // LOWEST run id (insertion order), never an arbitrary subset. The N
+  // inserts above are themselves fired concurrently too, so array index
+  // does not track assigned id order - sort by the actual id Postgres
+  // handed back before asserting who won.
+  async function raceChecks(orgId: number, runIds: number[]) {
+    const outcomes = await Promise.allSettled(
+      runIds.map((id) => assertOrgConcurrencyAdmitted(getDb(), orgId, id)),
+    );
+    return runIds.map((id, i) => ({ id, status: outcomes[i].status })).sort((a, b) => a.id - b.id);
+  }
+
+  it('concurrently checking N running rows against cap 1 admits exactly the oldest one', async () => {
+    const { orgId, projectId } = await setupOrg({ maxConcurrentRuns: 1 });
+    const runIds = await Promise.all([1, 2, 3].map(() => makeRunningRun(projectId)));
+
+    const ranked = await raceChecks(orgId, runIds);
+
+    expect(ranked.map((r) => r.status)).toEqual(['fulfilled', 'rejected', 'rejected']);
+  });
+
+  it('concurrently checking N running rows against cap 2 admits exactly the 2 oldest', async () => {
+    const { orgId, projectId } = await setupOrg({ maxConcurrentRuns: 2 });
+    const runIds = await Promise.all([1, 2, 3, 4].map(() => makeRunningRun(projectId)));
+
+    const ranked = await raceChecks(orgId, runIds);
+
+    expect(ranked.map((r) => r.status)).toEqual(['fulfilled', 'fulfilled', 'rejected', 'rejected']);
+  });
+
+  // The actual TOCTOU bug (#485): two dispatches deciding "may this org
+  // start a run" at the same time, each reading a snapshot that does not
+  // yet include the other. A timing race against a real (fast, local)
+  // Postgres is not reliable proof by itself - both round trips can land
+  // microseconds apart and never overlap. This instead CONTROLS the
+  // overlap: a raw client takes the exact `pg_advisory_xact_lock` key
+  // `assertOrgConcurrencyAdmitted` takes internally and holds it open, then
+  // a genuinely concurrent call into the real function is proven to block
+  // behind it rather than racing past on a plain read - and to proceed the
+  // instant the lock is released. A count-then-decide implementation with
+  // no locking at all would resolve immediately regardless of the held
+  // lock, so this fails exactly the way #485's original bug would.
+  it('a concurrent admission decision for the same org is serialized by a real Postgres lock, not an optimistic read (#485)', async () => {
+    const { orgId, projectId } = await setupOrg({ maxConcurrentRuns: 5 });
+    const runId = await makeRunningRun(projectId);
+
+    const holder = await getPool().connect();
+    try {
+      await holder.query('BEGIN');
+      await holder.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [
+        `org-concurrency:${orgId}`,
+      ]);
+
+      let settled = false;
+      const checkPromise = assertOrgConcurrencyAdmitted(getDb(), orgId, runId).finally(() => {
+        settled = true;
+      });
+
+      // Give the check every chance to run if it were not actually blocked.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      expect(settled).toBe(false);
+
+      await holder.query('COMMIT'); // releases the advisory lock
+      await expect(checkPromise).resolves.toBeUndefined();
+      expect(settled).toBe(true);
+    } finally {
+      holder.release();
+    }
   });
 });

--- a/shared/tests/runlog/classify-failure.test.ts
+++ b/shared/tests/runlog/classify-failure.test.ts
@@ -32,6 +32,21 @@ describe('classifyFailure', () => {
     expect(classifyFailure([ev('hit Reddit rate limit, backing off')], 1)).toBe('quota_exhausted');
   });
 
+  it('detects concurrency_exhausted on the org concurrency refusal text, distinctly from quota_exhausted (#485)', () => {
+    expect(
+      classifyFailure(
+        [
+          ev(
+            'This organization already has 2 cloud runs in progress, its configured ' +
+              'concurrency limit, and cannot start another until one finishes or an operator ' +
+              'raises the limit in Settings.',
+          ),
+        ],
+        1,
+      ),
+    ).toBe('concurrency_exhausted');
+  });
+
   it('detects network failures on common Node error codes', () => {
     expect(classifyFailure([ev('fetch failed: ECONNREFUSED 127.0.0.1:5180')], 1)).toBe('network');
     expect(classifyFailure([ev('getaddrinfo ENOTFOUND api.example.com')], 1)).toBe('network');

--- a/web/src/lib/server/runner.ts
+++ b/web/src/lib/server/runner.ts
@@ -16,7 +16,7 @@ import {
 } from '@pitchbox/shared/draft-regenerate';
 import { startReplyDrafting } from '@pitchbox/shared/reply-drafter';
 import { getRunOrgId } from '@pitchbox/shared/orgs';
-import { getOrgQuotaSnapshot } from '@pitchbox/shared/org-quota';
+import { getOrgQuotaSnapshot, assertOrgConcurrencyAdmitted } from '@pitchbox/shared/org-quota';
 import type { ScenarioSlug } from '@pitchbox/shared/campaigns';
 import { getDb, schema } from './db.js';
 import { and, desc, eq } from 'drizzle-orm';
@@ -177,6 +177,13 @@ async function dispatchRun(
         );
       }
       budgetRemainingUsd = quota.remainingUsd;
+      // Separate from the budget check above on purpose (#485): "you're out
+      // of money this month" and "you already have N runs going" are
+      // different problems with different fixes, so assertOrgConcurrencyAdmitted
+      // throws its own differently-worded refusal rather than sharing this
+      // one's text. It races safely against any other concurrent dispatch
+      // for this org - see its own doc comment (shared/src/org-quota.ts).
+      await assertOrgConcurrencyAdmitted(db, orgId, run.id);
     }
     // Pre-flight the snapshot. A run whose runner cannot start here fails the
     // same way whatever the reason, but the message has to say so: before #219

--- a/web/tests/gateway-concurrency-dispatch.test.ts
+++ b/web/tests/gateway-concurrency-dispatch.test.ts
@@ -1,0 +1,248 @@
+// #485: organizations.max_concurrent_runs went unenforced once the old
+// runner service's in-memory per-org session map disappeared with it
+// (#420) - an org could start as many simultaneous cloud runs as it could
+// trigger, each spending real money against the product's own Gateway key.
+// dispatchRun now refuses a 'cloud' run before it starts once the org is
+// already at its concurrency cap, via shared/src/org-quota.ts's
+// assertOrgConcurrencyAdmitted. This file proves that admission check
+// through the real dispatch path (runCampaign -> dispatchRun), not against
+// org-quota.ts's helper directly, and proves the race is actually closed
+// with genuinely concurrent dispatches against one real database - see
+// gateway-budget-dispatch.test.ts (#419) for the budget-side sibling this
+// mirrors, and shared/tests/org-quota.test.ts for a lower-level, more
+// exhaustive proof of the locking mechanism itself.
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type {
+  AgentRunHandle,
+  AgentRunOptions,
+  AgentRunner,
+  AgentRunResult,
+} from '@pitchbox/shared/agents';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+import { subscribe } from '../src/lib/server/events.js';
+import { clearDetectionCache } from '@pitchbox/shared/agents/detect';
+
+let capturedOpts: AgentRunOptions[] = [];
+let createCalls = 0;
+let fakeResult: AgentRunResult = { exitCode: 0, logPath: '/dev/null' };
+// Set by a test to make the NEXT dispatched run's underlying "agent" hang
+// forever (never resolve), so that run stays 'running' for the rest of the
+// test - the concurrency-boundary tests need a slot genuinely occupied,
+// not a DB row hand-inserted as 'running' behind the real dispatch path's
+// back. `Promise.withResolvers()` gives a promise with no scheduled
+// settlement rather than a `new Promise` executor that never calls its
+// callback.
+let pendingHold: Promise<AgentRunResult> | null = null;
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'cloud',
+    run(opts: AgentRunOptions): AgentRunHandle {
+      createCalls += 1;
+      capturedOpts.push(opts);
+      return { result: pendingHold ?? Promise.resolve(fakeResult), cancel: () => {} };
+    },
+  }),
+}));
+
+// Dynamic on purpose - vi.mock above is hoisted, but runner.js has to load
+// after it for createAgentRunner to resolve to the fake gateway runner
+// (same pattern as gateway-budget-dispatch.test.ts).
+const { runCampaign } = await import('../src/lib/server/runner.js');
+
+async function reset() {
+  const db = getDb();
+  await db.execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  capturedOpts = [];
+  createCalls = 0;
+  fakeResult = { exitCode: 0, logPath: '/dev/null' };
+  pendingHold = null;
+}
+
+async function platformId(slug: string): Promise<number> {
+  const [platform] = await getDb()
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, slug));
+  if (!platform) throw new Error(`platform "${slug}" is not seeded - did global-setup run?`);
+  return platform.id;
+}
+
+/** An org with the given `max_concurrent_runs`, one project, and `count`
+ * separate 'cloud'-runner campaigns under it (separate campaigns so a race
+ * between them never collides with `runs_one_running_per_campaign` - the
+ * cap under test here is the org-level one, not the per-campaign one). */
+async function seedCloudOrg(
+  slug: string,
+  maxConcurrentRuns: number | null,
+  count: number,
+): Promise<{ orgId: number; campaignIds: number[] }> {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, maxConcurrentRuns })
+    .returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `${slug}-proj`,
+      name: `${slug} p`,
+      defaultAgentRunner: 'cloud',
+    })
+    .returning();
+  const platform = await platformId('reddit');
+  const campaignIds: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const [campaign] = await db
+      .insert(schema.campaigns)
+      .values({
+        projectId: project.id,
+        platformId: platform,
+        name: `c${i}`,
+        skillSlug: 'reddit-scout',
+        agentRunner: 'cloud',
+      })
+      .returning();
+    campaignIds.push(campaign.id);
+  }
+  return { orgId: org.id, campaignIds };
+}
+
+async function runRow(runId: number) {
+  const [row] = await getDb()
+    .select({
+      status: schema.runs.status,
+      error: schema.runs.error,
+      failureReason: schema.runs.failureReason,
+    })
+    .from(schema.runs)
+    .where(eq(schema.runs.id, runId));
+  return row;
+}
+
+/** dispatchRun's completion write runs off `handle.result`'s own promise
+ * chain, outside runCampaign's own await for a real dispatch (see
+ * gateway-budget-dispatch.test.ts) - `run:finished` on the realtime bus is
+ * the actual completion signal. */
+function waitForRunFinished(orgId: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const unsubscribe = subscribe(orgId, (evt) => {
+    if (evt.kind !== 'run:finished') return;
+    unsubscribe();
+    resolve();
+  });
+  return promise;
+}
+
+describe('cloud run dispatch is concurrency-capped (#485)', () => {
+  const savedGatewayKey = process.env.AI_GATEWAY_API_KEY;
+
+  beforeEach(async () => {
+    await reset();
+    // shared/src/agents/detect.ts's cloud probe gates purely on
+    // AI_GATEWAY_API_KEY being configured - vitest.config.ts blanks it for
+    // every test so a developer's real key never leaks into a test run.
+    process.env.AI_GATEWAY_API_KEY = 'test-key';
+    clearDetectionCache();
+  });
+  afterEach(() => {
+    if (savedGatewayKey === undefined) delete process.env.AI_GATEWAY_API_KEY;
+    else process.env.AI_GATEWAY_API_KEY = savedGatewayKey;
+    clearDetectionCache();
+  });
+
+  it('refuses to start once the org is already at its concurrency cap, and tells the caller why - through the real dispatch path', async () => {
+    const { campaignIds } = await seedCloudOrg('conc-at-cap', 1, 2);
+
+    // Occupy the org's only slot with a genuinely dispatched run whose
+    // underlying agent never finishes, so it stays 'running' for the rest
+    // of the test. runCampaign itself still resolves as soon as the run is
+    // dispatched (its own completion write runs off the handle's promise
+    // chain, not this await), so no sleep is needed to "let it land".
+    pendingHold = Promise.withResolvers<AgentRunResult>().promise;
+    await runCampaign(campaignIds[0]);
+    expect(createCalls).toBe(1);
+    pendingHold = null;
+
+    const started = Date.now();
+    const { runId } = await runCampaign(campaignIds[1]);
+    const run = await runRow(runId);
+
+    // Refused before ever reaching createAgentRunner for the second
+    // campaign - not a downstream failure that happened to also be about
+    // concurrency.
+    expect(createCalls).toBe(1);
+    expect(run?.status).toBe('failed');
+    expect(run?.error).toMatch(/concurrency limit/i);
+    expect(run?.error).not.toMatch(/quota|rate.limit/i);
+    expect(run?.failureReason).toBe('concurrency_exhausted');
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  it('lets a run start once the org is under its concurrency cap', async () => {
+    const { orgId, campaignIds } = await seedCloudOrg('conc-under-cap', 2, 1);
+
+    const finished = waitForRunFinished(orgId);
+    const { runId } = await runCampaign(campaignIds[0]);
+    await finished;
+
+    expect(createCalls).toBe(1);
+    expect((await runRow(runId))?.status).not.toBe('running');
+  });
+
+  it('is never capped when max_concurrent_runs is unset (unlimited)', async () => {
+    const { orgId, campaignIds } = await seedCloudOrg('conc-unlimited', null, 3);
+
+    const results = await Promise.all(campaignIds.map((id) => runCampaign(id)));
+    await Promise.all(results.map(() => waitForRunFinished(orgId)));
+
+    expect(createCalls).toBe(3);
+    for (const { runId } of results) {
+      expect((await runRow(runId))?.status).not.toBe('running');
+    }
+  });
+
+  // The actual bug (#485): a count-then-insert race between two dispatches
+  // for the same org. Fired as genuinely concurrent promises against one
+  // real Postgres (runCampaign -> dispatchRun for two DIFFERENT campaigns
+  // under the same org, so runs_one_running_per_campaign's own per-campaign
+  // uniqueness can't be what's blocking the second one), not two sequential
+  // awaits - a sequential pair would trivially pass even with no admission
+  // check at all.
+  it('two dispatches racing at the concurrency boundary cannot both win', async () => {
+    const { campaignIds } = await seedCloudOrg('conc-race', 1, 2);
+
+    const [first, second] = await Promise.all([
+      runCampaign(campaignIds[0]),
+      runCampaign(campaignIds[1]),
+    ]);
+    const [firstRun, secondRun] = await Promise.all([runRow(first.runId), runRow(second.runId)]);
+
+    // Exactly one reached the runner (createCalls); the other was refused
+    // at the concurrency pre-flight before ever spawning one. Distinguish
+    // "admitted" from "refused" by `failureReason`, not by the winner's own
+    // eventual status - the mocked agent's run can still fail afterward for
+    // reasons that have nothing to do with #485 (e.g. the run-completion
+    // contract in web/src/lib/server/runner.ts, unrelated to this check),
+    // and asserting a bare 'success' here would make this test depend on
+    // that unrelated contract too. Both racers being admitted (both
+    // createCalls, neither carrying `concurrency_exhausted`) is exactly the
+    // bug #485 reported.
+    expect(createCalls).toBe(1);
+    const refused = [firstRun, secondRun].filter(
+      (r) => r?.failureReason === 'concurrency_exhausted',
+    );
+    const admitted = [firstRun, secondRun].filter(
+      (r) => r?.failureReason !== 'concurrency_exhausted',
+    );
+    expect(refused).toHaveLength(1);
+    expect(admitted).toHaveLength(1);
+    expect(refused[0]?.error).toMatch(/concurrency limit/i);
+  });
+});


### PR DESCRIPTION
Closes #485

## What was broken

`organizations.max_concurrent_runs` went unenforced once the old runner service's in-memory per-org session map disappeared with it in #420. #419 wired the USD budget check into `dispatchRun`'s pre-flight, but nothing replaced the concurrency half: an org could start as many simultaneous cloud runs as it could trigger, each spending real money against the product's own Gateway key.

## What changed

`dispatchRun`'s pre-flight (`web/src/lib/server/runner.ts`) now calls a new `assertOrgConcurrencyAdmitted` (`shared/src/org-quota.ts`) right next to the existing budget check - the same place that already answers "may this org start a run".

It refuses with its own wording ("concurrency limit", never "quota" or "rate limit"), and `classifyFailure` now tells the two apart as `concurrency_exhausted` vs `quota_exhausted`. Those are different problems with different fixes - raising a budget does nothing for a concurrency refusal and vice versa - so an operator needs the distinction rather than one shared label.

## The race, and what I chose over what

Every dispatch path inserts its `runs` row as `status: 'running'` *before* `dispatchRun`'s pre-flight ever runs, so a plain count-then-decide read has the exact TOCTOU gap the issue described: two concurrent admission checks can each read a snapshot that doesn't yet include the other and both admit themselves.

I closed it with a transaction-scoped `pg_advisory_xact_lock` keyed on the org - the same primitive `withCampaignLock` (`shared/src/scheduler/dispatch-lock.ts`) already uses for the sibling per-campaign race. Inside the lock, every currently `running` row for the org is ranked by `id` (insertion order), and the run under check is admitted iff its own rank is within the cap.

I verified the previous agent's proposed mechanisms against the real schema and passed on both:

- **A partial unique index** (`runs_one_running_per_campaign`'s own mechanism) doesn't generalise here: it can express "at most one", not "at most `max_concurrent_runs`", and the cap is an operator-configured integer, not always 1.
- **A maintained counter column plus an atomic `UPDATE ... RETURNING`** would also close the race, but only if every place a run leaves `running` (success, failure, cancellation, and `dispatchRun`'s own early-failure branch) reliably decrements it - miss one and a slot leaks forever. Ranking the live `status = 'running'` rows needs no separate column and no decrement to remember: the moment something flips a row away from `running`, the very next admission check already sees the freed slot.
- **A full `SERIALIZABLE` transaction** (the other option the issue named) would also work, but means retry-on-`40001` logic and a broader isolation-level change for one org-scoped invariant, versus a lock scoped exactly to the critical section that needs serializing.

No migration - nothing here needed a schema change, so I didn't author the pre-allocated `0022_org_concurrency` (per #493, a migration whose `when` doesn't beat the newest applied gets skipped in silence, so I only write one I actually need).

## How I raced it

- `shared/tests/org-quota.test.ts` (`assertOrgConcurrencyAdmitted`): a deterministic test that takes the *exact* `pg_advisory_xact_lock` key externally via a raw client, holds it open, and proves a concurrent call into the real function blocks behind it (not an optimistic read) and proceeds the instant the lock releases - a timing race against a fast local Postgres isn't reliable proof by itself, so this controls the overlap instead of hoping for a lucky window. Also: `Promise.allSettled` over N pre-seeded `running` rows proving exactly `cap` are admitted (the `cap` lowest ids, sorted after the race since concurrent inserts don't preserve array-index-to-id order either).
- `web/tests/gateway-concurrency-dispatch.test.ts`: the same property through the real dispatch path - `Promise.all([runCampaign(a), runCampaign(b)])` for two different campaigns under one org at cap 1, proving `createCalls` (the mocked runner) is hit exactly once and exactly one run carries `concurrency_exhausted`.

Every new assertion was proven to bite: broke the rank comparison, the null-cap early return, the message wording, and the lock itself (one at a time), watched the exact matching assertions fail, restored, confirmed green again.

## Verification

- `pnpm exec vitest run shared/tests/org-quota.test.ts shared/tests/runlog/classify-failure.test.ts web/tests/gateway-concurrency-dispatch.test.ts web/tests/gateway-budget-dispatch.test.ts` - 45 passed, including the pre-existing budget suite (no regression).
- `pnpm -F @pitchbox/shared typecheck`, `pnpm -F web check` - clean.
- `npx eslint` / `npx prettier --check` on every changed file - clean.

Not merging - report and wait.
