### PR TITLE
chore: release 0.11.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.10.16",
+  "version": "0.11.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.10.16",
+  "version": "0.11.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.10.16",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.10.16",
+  "version": "0.11.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.10.16",
+  "version": "0.11.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.10.16",
+  "version": "0.11.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
A minor rather than a patch, because what changed under it is the runner: the ACP runner service is deleted and the model loop runs in-process on the AI SDK through the Gateway (#396), which is a different architecture and not a bug fix on the old one.

What this release carries, briefly: the voice work (#394), the cloud runner and its metering and concurrency caps (#416, #417, #418, #419, #485), the instance admin area (#395), the LinkedIn page-as-project-source plane (#398 in part), the host move to `app.pitchbox.app` in code (#424), the migration guard that catches a silently skipped migration (#493), and the MCP tool set resolution that made the cloud edition unable to run in a deployed build (#491).

Prod is still on v0.10.16, seven days old, so this tag is what carries all of it there. Prod holds zero projects, campaigns and drafts, so the migration chain applies to an empty database.

I will push the tag once CI is green on the merge commit, not alongside it.