### PR TITLE
app.pitchbox.app asks not to be indexed instead of serving marketing metadata (#426)

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -6,15 +6,12 @@
     <meta name="text-scale" content="scale" />
     <title>Pitchbox</title>
     <meta name="description" content="Self-hosted outreach automation - draft, review, send." />
+    <meta name="robots" content="noindex, nofollow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="alternate icon" type="image/png" href="/favicon-32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#0a0a0a" />
-    <meta property="og:title" content="Pitchbox" />
-    <meta property="og:description" content="Self-hosted, human-in-the-loop outreach agent." />
-    <meta property="og:image" content="/og-image.png" />
-    <meta name="twitter:card" content="summary_large_image" />
     <!-- Beacon read by the Pitchbox browser extension's auto-pair content
          script. Presence + value identify this origin as a Pitchbox dashboard
          worth probing via GET /api/extension/auto-pair. -->

--- a/web/src/lib/components/Seo.svelte
+++ b/web/src/lib/components/Seo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	/**
 	 * Page-level <head> metadata. Every route should render exactly one <Seo />
-	 * at the top of its template so title/description/OG tags stay consistent.
+	 * at the top of its template so title/description stay consistent.
 	 */
 	let {
 		title,
@@ -10,7 +10,7 @@
 	}: {
 		/** Page title - rendered as `<title>` and joined with the app name. */
 		title: string;
-		/** One-sentence description for <meta name="description"> and OG. */
+		/** One-sentence description for <meta name="description">. */
 		description: string;
 		/**
 		 * Self-hosted outreach dashboards are not for public crawlers; default to
@@ -26,13 +26,6 @@
 <svelte:head>
 	<title>{fullTitle}</title>
 	<meta name="description" content={description} />
-	<meta property="og:title" content={fullTitle} />
-	<meta property="og:description" content={description} />
-	<meta property="og:site_name" content={APP_NAME} />
-	<meta property="og:type" content="website" />
-	<meta name="twitter:card" content="summary" />
-	<meta name="twitter:title" content={fullTitle} />
-	<meta name="twitter:description" content={description} />
 	{#if noindex}
 		<meta name="robots" content="noindex, nofollow" />
 	{/if}

--- a/web/static/robots.txt
+++ b/web/static/robots.txt
@@ -1,3 +1,4 @@
-# allow crawling everything by default
+# app.pitchbox.app serves the logged-in Pitchbox dashboard, not a public
+# marketing site - nothing here is meant to be indexed.
 User-agent: *
-Disallow:
+Disallow: /

--- a/web/tests/app-host-noindex.test.ts
+++ b/web/tests/app-host-noindex.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Static-analysis guard for issue #426 (app half): app.pitchbox.app serves
+// the logged-in Pitchbox dashboard behind a login wall a crawler can never
+// get past, while the apex will carry a separate marketing landing. The app
+// host should ask not to be indexed at all rather than advertise marketing
+// preview metadata that made sense only while the apex served the app.
+
+function readSource(relativePath: string): string {
+  return readFileSync(fileURLToPath(new URL(`../${relativePath}`, import.meta.url)), 'utf8');
+}
+
+describe('app host asks not to be indexed (#426)', () => {
+  it('robots.txt disallows crawling the whole app host', () => {
+    const robots = readSource('static/robots.txt');
+    const lines = robots
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'));
+    expect(lines).toContain('User-agent: *');
+    expect(lines).toContain('Disallow: /');
+  });
+
+  it('app.html carries a blanket noindex directive', () => {
+    const appHtml = readSource('src/app.html');
+    expect(appHtml).toMatch(/<meta\s+name="robots"\s+content="noindex,\s*nofollow"\s*\/>/);
+  });
+
+  it('app.html no longer advertises apex marketing OG/Twitter previews', () => {
+    const appHtml = readSource('src/app.html');
+    expect(appHtml).not.toMatch(/property="og:/);
+    expect(appHtml).not.toMatch(/name="twitter:/);
+  });
+
+  it('the per-page Seo component no longer emits OG/Twitter preview tags', () => {
+    // A logged-in app has no link previews to earn: a crawler or an
+    // unfurling bot can never authenticate past the login wall to fetch the
+    // page these tags describe, so they were dead weight kept only from the
+    // days the apex served the app directly.
+    const seo = readSource('src/lib/components/Seo.svelte');
+    expect(seo).not.toMatch(/property="og:/);
+    expect(seo).not.toMatch(/name="twitter:/);
+  });
+});


### PR DESCRIPTION
## What

app.pitchbox.app is now a live host of its own (DNS + Caddy vhost, TLS issued) serving the Pitchbox app, while the apex `pitchbox.app` will soon serve a marketing landing from a separate repo that does not exist yet. This is the app half of #426 only, since it is independent of that landing repo.

The app host is behind a login wall a crawler can never get past, so it should ask not to be indexed at all rather than serve marketing metadata that only made sense while the apex served the app directly.

## Changes

- `web/static/robots.txt`: disallow crawling of the whole app host (`Disallow: /`) instead of allowing everything.
- `web/src/app.html`: added `<meta name="robots" content="noindex, nofollow" />` and removed the static `og:title`, `og:description`, `og:image`, and `twitter:card` tags. Kept charset, viewport, `text-scale`, title, description, theme-color, icons, manifest, and the extension auto-pair beacon comment/meta - all genuinely functional, none of them marketing.
- `web/src/lib/components/Seo.svelte`: removed the per-page `og:title`, `og:description`, `og:site_name`, `og:type`, `twitter:card`, `twitter:title`, and `twitter:description` tags this component emitted on every route. Kept `<title>`, `<meta name="description">`, and the conditional `noindex`/`nofollow` `<meta name="robots">` (every route already renders `<Seo>` with the default `noindex=true`, and no route opts out).

### Why the OG/Twitter tags go, not just get gated

A logged-in app has no link previews to earn: an unfurling bot (Slack, Discord, iMessage) can never authenticate past `/login` to actually fetch the page these tags describe, so they were dead weight kept only from when the apex served the app directly. Removing them here, rather than leaving them conditionally rendered, matches that they no longer describe anything reachable.

`<title>` and `<meta name="description">` stay because they are genuinely functional (browser tab title, bookmarks) independent of any crawler or previewer.

I also grepped the rest of `web/src` and `web/static` for `og:`, `twitter:`, and `robots` - the only other hits were the per-route `<Seo>` call sites themselves, which already pass through the component's default `noindex=true` and needed no changes.

## Non-goals (explicitly out of scope)

The landing half of #426 - per-page metadata, OG images, and a sitemap on the not-yet-existing landing repo for the apex `pitchbox.app` - is out of scope here and stays open on the issue.

## Testing

Added `web/tests/app-host-noindex.test.ts`, a static-analysis guard asserting `robots.txt` disallows crawling, `app.html` carries the noindex directive, and neither `app.html` nor `Seo.svelte` emit `og:`/`twitter:` tags anymore.

- Proved it bites: `git checkout <pre-fix-commit> -- web/src/app.html web/static/robots.txt web/src/lib/components/Seo.svelte`, reran the test - all 4 assertions failed against the old source. Restored the fix, reran - green again.
- `pnpm -F web check`: 0 errors, 0 warnings.
- `npx eslint`/`npx prettier --check` on the changed `.ts`/`.html` files: clean (`.svelte` and `.txt` files aren't prettier-parseable in this repo's existing config, confirmed pre-existing by checking an untouched `.svelte` file - not a regression here).

Not merging; opening for review per the assignment.