### PR TITLE
fix(web): trust the same origins in both cross-site checks

### DIFF
--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm';
 import { loadSession } from '@pitchbox/shared/auth';
 import { loadActiveOrganization } from '@pitchbox/shared/orgs';
 import { extensionCorsHeaders } from '$lib/server/extension-cors.js';
+import { trustedOriginSet } from '$lib/trusted-origins.js';
 
 /**
  * One-shot cleanup on server boot.
@@ -120,12 +121,22 @@ function isExemptPath(pathname: string): boolean {
   );
 }
 
+const TRUSTED_ORIGIN_SET = trustedOriginSet();
+
 /**
  * Reject cross-origin mutations to /api/* (except extension routes which
  * have their own bearer-token auth and explicit allowed origins). Same-origin
  * dashboard fetches pass through unchanged. This is the lightweight CSRF
  * defence - we don't need a per-request token because every state-changing
  * route is fetch-only (no plain HTML forms).
+ *
+ * `event.url` is built from adapter-node's ORIGIN, not from the request's
+ * Host header, so "same origin" here means "the origin this deployment says
+ * it serves" and every other host answered by the same server looks
+ * cross-site. That is why the same allowlist SvelteKit's own form check gets
+ * (`csrf.trustedOrigins`) has to apply here too: without it, moving ORIGIN
+ * to app.pitchbox.app turned every mutation from a browser still on the
+ * apex into a 403 nothing explained (#501).
  */
 function blocksCrossOriginMutation(event: { request: Request; url: URL }): boolean {
   if (!event.url.pathname.startsWith('/api/')) return false;
@@ -139,7 +150,8 @@ function blocksCrossOriginMutation(event: { request: Request; url: URL }): boole
   } catch {
     return true;
   }
-  return originUrl.host !== event.url.host;
+  if (originUrl.host === event.url.host) return false;
+  return !TRUSTED_ORIGIN_SET.has(originUrl.origin);
 }
 
 export const handle = async ({ event, resolve }) => {

--- a/web/src/lib/trusted-origins.js
+++ b/web/src/lib/trusted-origins.js
@@ -1,0 +1,46 @@
+// The one list of origins this deployment answers a mutation from, shared by
+// the two checks that need it: SvelteKit's own cross-site form check
+// (`csrf.trustedOrigins` in svelte.config.js) and the hook that guards
+// /api/* mutations (`blocksCrossOriginMutation` in hooks.server.ts).
+//
+// They have to agree, and until #501 they did not. adapter-node builds
+// `event.url` from the ORIGIN env var rather than from the request's Host
+// header, so once ORIGIN moved to app.pitchbox.app the hook's
+// `origin.host !== url.host` comparison started rejecting every browser
+// still on the apex - a 403 `cross_origin_blocked` on every mutation, while
+// `csrf.trustedOrigins` had already been given both hosts for exactly that
+// reason. Reproduced against the deployed prod build on 2026-09-09.
+//
+// This is a plain .js module on purpose: svelte.config.js is loaded by Node
+// before any TypeScript exists, and it cannot import from the app's TS
+// sources. Keeping the list here rather than in svelte.config.js also keeps
+// the runtime hook from importing @sveltejs/adapter-node, which is a
+// devDependency and absent from the deployed image.
+//
+// Transitional: drop `pitchbox.app` and `www.pitchbox.app` once the apex has
+// served the landing page, not this app, for a full release (#422, #424).
+export const TRUSTED_ORIGINS = [
+  'https://app.pitchbox.app',
+  'https://pitchbox.app',
+  'https://www.pitchbox.app',
+];
+
+/**
+ * The origins a mutation's `Origin` header may carry, on top of whatever
+ * origin the request itself resolved to. Compared in full rather than by
+ * host, so `http://pitchbox.app` is not trusted because the https one is.
+ *
+ * @returns {Set<string>} normalized origins (scheme, host, port)
+ */
+export function trustedOriginSet() {
+  const origins = new Set();
+  for (const origin of TRUSTED_ORIGINS) {
+    try {
+      origins.add(new URL(origin).origin);
+    } catch {
+      // A malformed entry is a typo in the list above, not a runtime input:
+      // skip it rather than failing every request on this deployment.
+    }
+  }
+  return origins;
+}

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -8,14 +8,12 @@ import adapter from '@sveltejs/adapter-node';
 // a stale ORIGIN as the cause. The two manual cutover steps - flipping
 // Caddy/DNS to app.pitchbox.app and updating the deployed ORIGIN to match -
 // cannot be made atomic, so trustedOrigins covers the gap regardless of
-// which one lands first. Transitional: drop `pitchbox.app` and
-// `www.pitchbox.app` once the apex has served the landing page, not this
-// app, for a full release.
-const TRUSTED_ORIGINS = [
-  'https://app.pitchbox.app',
-  'https://pitchbox.app',
-  'https://www.pitchbox.app',
-];
+// which one lands first.
+//
+// The list itself lives in src/lib/trusted-origins.js because the hook that
+// guards /api/* mutations needs the same one and disagreed with this one
+// until #501.
+import { TRUSTED_ORIGINS } from './src/lib/trusted-origins.js';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {

--- a/web/tests/cross-origin-mutation.test.ts
+++ b/web/tests/cross-origin-mutation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { runThroughHandle, type CookieJar } from './helpers/handle-harness.js';
+
+/**
+ * #501: the hook that guards /api/* mutations compared the request's Origin
+ * against `event.url.host`, and adapter-node builds `event.url` from the
+ * ORIGIN env var rather than from the request's Host header. So once ORIGIN
+ * moved to app.pitchbox.app (#424), a browser still on the apex - which the
+ * same server was still answering - got a 403 `cross_origin_blocked` on
+ * every mutation, while SvelteKit's own form check had already been given
+ * both hosts in `csrf.trustedOrigins` for exactly that reason.
+ *
+ * Reproduced against the deployed prod build before the fix: a POST to
+ * https://pitchbox.app/api/auth/login with `Origin: https://pitchbox.app`
+ * answered 403 `cross_origin_blocked`, and the same POST with
+ * `Origin: https://app.pitchbox.app` got through to the route (400
+ * invalid_body). These tests are that shape: `event.url` on the app host,
+ * the Origin header on the other one.
+ */
+
+function jar(): CookieJar {
+  return { store: new Map() };
+}
+
+async function mutate(origin: string | null): Promise<Response> {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (origin) headers.origin = origin;
+  const request = new Request('https://app.pitchbox.app/api/auth/login', {
+    method: 'POST',
+    headers,
+    body: '{}',
+  });
+  // The route handler is a stand-in on purpose: what is under test is
+  // whether the hook lets the request reach a handler at all.
+  return runThroughHandle(request, jar(), async () => new Response('reached', { status: 200 }));
+}
+
+describe('cross-origin mutation guard (#501)', () => {
+  it('lets the apex through while it is still a host of this deployment', async () => {
+    for (const origin of ['https://pitchbox.app', 'https://www.pitchbox.app']) {
+      const res = await mutate(origin);
+      expect({ origin, status: res.status }).toEqual({ origin, status: 200 });
+    }
+  });
+
+  it('lets the deployment its own origin through', async () => {
+    expect((await mutate('https://app.pitchbox.app')).status).toBe(200);
+  });
+
+  it('still blocks an origin this deployment does not serve', async () => {
+    for (const origin of [
+      'https://evil.example',
+      'http://pitchbox.app',
+      'https://pitchbox.app.evil.example',
+    ]) {
+      const res = await mutate(origin);
+      expect({ origin, status: res.status }).toEqual({ origin, status: 403 });
+      expect(await res.json()).toEqual({ error: 'cross_origin_blocked' });
+    }
+  });
+
+  it('still allows a request with no Origin header at all, as before', async () => {
+    // A server-to-server caller sends none; the guard has never treated its
+    // absence as cross-site, and this test exists so that stays deliberate.
+    expect((await mutate(null)).status).toBe(200);
+  });
+});


### PR DESCRIPTION
Closes #501, and it is a defect the host move created about twenty minutes after prod carried it, found by curling the deployed environment rather than by a local test.

What was happening on prod: `POST https://pitchbox.app/api/auth/login` with `Origin: https://pitchbox.app` answered `403 {"error":"cross_origin_blocked"}`, while the same request with `Origin: https://app.pitchbox.app` reached the route. Every mutation from a browser on the apex was refused, and the apex is still where every existing bookmark points.

The cause is that `blocksCrossOriginMutation` compared the `Origin` header against `event.url.host`, and adapter-node builds `event.url` from `ORIGIN` and not from the request's `Host`. So once `ORIGIN` moved, every other host the same server answers looked cross-site. #496 predicted this failure for SvelteKit's own form check and covered it with `csrf.trustedOrigins`; what it could not know is that there is a second, app-level check with its own implicit allowlist of exactly one origin. Two checks, two lists, one of them told about the transition.

The list is now in `web/src/lib/trusted-origins.js` and both read it. Plain JS on purpose: `svelte.config.js` is loaded by Node before any TypeScript exists, and keeping the list out of `svelte.config.js` also stops the runtime hook importing `@sveltejs/adapter-node`, which is a devDependency and not in the deployed image. The guard now compares a full origin instead of a host, so `http://pitchbox.app` is not trusted for free because the https one is.

## Tests

`web/tests/cross-origin-mutation.test.ts` drives real requests through the real `handle()` hook with the harness the repo already has, in exactly the shape prod produced: `event.url` on the app host, the `Origin` header on the other one.

Proven to bite, three ways:

- restored the old `return originUrl.host !== event.url.host` - `lets the apex through while it is still a host of this deployment` failed
- made the shared module collect hosts instead of origins - the same test failed
- added `http://pitchbox.app` to the trusted list - `still blocks an origin this deployment does not serve` failed on that exact entry

Each time restored and confirmed 4 passing. `web/tests/csrf-trusted-origins.test.ts` still passes unchanged, since `svelte.config.js` re-exports the list. `pnpm -F web check` clean (0 errors, 0 warnings), eslint and prettier clean on every changed file.

I will tag a patch release after this merges: prod is refusing apex mutations until it carries this.