### PR TITLE
chore: release 0.11.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch, to carry #502 to prod: since v0.11.0 landed, every `/api/*` mutation from a browser on the apex has been refused with a 403, which is where every existing bookmark still points. Also carries #500, which stops the app host serving marketing metadata to a crawler that cannot get past the login.