### PR TITLE
chore: release 0.11.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch, to carry the `qs` override from #518 into the deployed image. It is the only one of the nine Dependabot alerts that was in code running in production, arriving through express under the MCP SDK, and a patched dependency that never gets deployed is not a fix.