### PR TITLE
feat(shared,deploy): outbound email transport, with a null default

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -46,6 +46,28 @@ PUBLIC_WEB_ORIGIN=https://app.pitchbox.app
 PITCHBOX_OWNER_USERNAME=
 PITCHBOX_OWNER_PASSWORD=
 
+# --- outbound email (#508) --------------------------------------------------
+# With nothing set below, the null transport is used: nothing throws, and a
+# send just logs what it would have sent. Password reset (#509) and invite
+# email (#510) both need a real transport configured to actually leave the
+# box. MAIL_PROVIDER selects one explicitly ('resend' or 'smtp'); selecting
+# one without its required credential(s) below still falls back to the null
+# transport rather than failing at send time.
+# MAIL_PROVIDER=resend
+# Sender address for every outbound email, "Name <addr>" or a bare address.
+# Optional: defaults to "Pitchbox <no-reply@pitchbox.app>".
+MAIL_FROM=
+# resend: already in use on canonry-landing, the boring default real
+# transport. Get a key at https://resend.com/api-keys.
+RESEND_API_KEY=
+# smtp: self-host escape hatch when you'd rather point at your own mail
+# server or a provider-neutral SMTP relay than use Resend.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=
+SMTP_PASS=
+
 # --- web exposure ----------------------------------------------------------
 WEB_PORT=5180
 # Host address the web port is published on. 127.0.0.1 (behind a proxy) or 0.0.0.0.

--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,27 @@ WEB_PORT=5180
 # still saves a model id typed by hand, and every job falls back to its coded
 # default.
 # AI_GATEWAY_API_KEY=
+
+# Outbound email (#508). With nothing set below, the null transport is used:
+# nothing throws, and a send just logs what it would have sent - fine for a
+# self-host that never needed a reset/invite email to leave the box.
+# MAIL_PROVIDER selects a real transport explicitly ('resend' or 'smtp');
+# selecting one without its required credential(s) below still falls back to
+# the null transport rather than failing at send time.
+# MAIL_PROVIDER=resend
+
+# Sender address for every outbound email, "Name <addr>" or a bare address.
+# Optional: defaults to "Pitchbox <no-reply@pitchbox.app>".
+# MAIL_FROM=
+
+# --- resend (MAIL_PROVIDER=resend) ------------------------------------------
+# Already in use on canonry-landing, so it's the boring default real
+# transport. Get a key at https://resend.com/api-keys.
+# RESEND_API_KEY=
+
+# --- smtp (MAIL_PROVIDER=smtp) - self-host escape hatch ---------------------
+# SMTP_HOST=
+# SMTP_PORT=587
+# SMTP_SECURE=false
+# SMTP_USER=
+# SMTP_PASS=

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      nodemailer:
+        specifier: ^10.0.1
+        version: 10.0.1
       pg:
         specifier: ^8.23.0
         version: 8.23.0
@@ -237,6 +240,9 @@ importers:
       puppeteer-extra-plugin-stealth:
         specifier: ^2.11.2
         version: 2.11.2(playwright-extra@4.3.6(playwright-core@1.62.1)(playwright@1.62.1))
+      resend:
+        specifier: ^6.26.0
+        version: 6.26.0
       zod:
         specifier: ^4.5.4
         version: 4.5.4
@@ -244,6 +250,9 @@ importers:
       '@types/html-to-text':
         specifier: ^9.0.4
         version: 9.0.4
+      '@types/nodemailer':
+        specifier: ^8.0.1
+        version: 8.0.1
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -1454,6 +1463,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1670,6 +1682,9 @@ packages:
 
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+
+  '@types/nodemailer@8.0.1':
+    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
 
   '@types/parse5@6.0.3':
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
@@ -2604,6 +2619,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.6:
     resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
@@ -3351,6 +3369,10 @@ packages:
   node-html-parser@7.1.0:
     resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
 
+  nodemailer@10.0.1:
+    resolution: {integrity: sha512-c+gU9cL9HLDax3vjxL88kW+6NOgdtEUWaZ+AUtxdJR6LLhf0kGdCLExof7yiKW7zdO9EfXCSIgmhGyFmUM0mYQ==}
+    engines: {node: '>=20.0.0'}
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -3502,6 +3524,9 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  postal-mime@2.7.5:
+    resolution: {integrity: sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==}
+
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3642,6 +3667,15 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  resend@6.26.0:
+    resolution: {integrity: sha512-vkrULozV5nGF8o7tyun/t0+qFgtPpn+cyRhVqeorhOsPUNDiSc/9p/pn8AprdHqJpYaTvftpnQgWurW++FkCdw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -3823,6 +3857,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -5234,6 +5271,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.17.0)':
@@ -5441,6 +5480,10 @@ snapshots:
   '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/nodemailer@8.0.1':
+    dependencies:
+      '@types/node': 26.1.0
 
   '@types/parse5@6.0.3': {}
 
@@ -6351,6 +6394,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.6: {}
 
   fdir@6.5.0(picomatch@4.0.4):
@@ -7250,6 +7295,8 @@ snapshots:
       css-select: 5.2.2
       he: 1.2.0
 
+  nodemailer@10.0.1: {}
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -7381,6 +7428,8 @@ snapshots:
       playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  postal-mime@2.7.5: {}
 
   postcss@8.5.26:
     dependencies:
@@ -7526,6 +7575,11 @@ snapshots:
       unified: 10.1.2
 
   require-from-string@2.0.2: {}
+
+  resend@6.26.0:
+    dependencies:
+      postal-mime: 2.7.5
+      standardwebhooks: 1.0.0
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -7804,6 +7858,11 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -77,7 +77,11 @@
     "./instance-audit": "./src/instance-audit.ts",
     "./mastodon-source": "./src/mastodon-source.ts",
     "./hackernews-source": "./src/hackernews-source.ts",
-    "./project-description-refresh": "./src/project-description-refresh.ts"
+    "./project-description-refresh": "./src/project-description-refresh.ts",
+    "./mail": "./src/mail/base.ts",
+    "./mail/registry": "./src/mail/registry.ts",
+    "./mail/template": "./src/mail/template.ts",
+    "./mail/env": "./src/mail/env.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",
@@ -94,14 +98,17 @@
     "drizzle-orm": "^0.45.2",
     "html-to-text": "^9.0.5",
     "jose": "^6.2.3",
+    "nodemailer": "^10.0.1",
     "pg": "^8.23.0",
     "playwright": "^1.62.1",
     "playwright-extra": "^4.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
+    "resend": "^6.26.0",
     "zod": "^4.5.4"
   },
   "devDependencies": {
     "@types/html-to-text": "^9.0.4",
+    "@types/nodemailer": "^8.0.1",
     "@types/pg": "^8.20.0",
     "drizzle-kit": "^0.31.10",
     "tsx": "^4.23.13"

--- a/shared/src/mail/base.ts
+++ b/shared/src/mail/base.ts
@@ -1,0 +1,54 @@
+/**
+ * Platform-agnostic interface for sending a single outbound email. Shaped
+ * like the other pluggable boundaries in this repo (`AgentRunner`,
+ * `ReplyReader`): one interface, a null implementation that is always safe
+ * to run, and a config-driven selection (`./registry.ts`) between it and a
+ * real transport.
+ *
+ * This module is deliberately just the transport. It sends whatever
+ * `MailMessage` it is given; deciding what a password reset or an invite
+ * email says is #509's and #510's job, not this one's.
+ */
+export type MailMessage = {
+  /** Recipient address. */
+  to: string;
+  /**
+   * Sender address, `"Name <addr>"` or bare `addr`. Optional: a transport
+   * falls back to its own configured default (`MAIL_FROM`) when omitted.
+   */
+  from?: string;
+  subject: string;
+  /** Plain-text body. Always present - see `./template.ts`. */
+  text: string;
+  /** HTML alternative. Always present - see `./template.ts`. */
+  html: string;
+};
+
+export interface MailTransport {
+  /** Transport identifier, for logging - "null", "resend", or "smtp". */
+  readonly name: string;
+  /**
+   * Send `message`. A real transport may throw on failure (network error,
+   * provider rejection); it does not swallow one. Nothing today retries or
+   * queues a failed send - that lands with whichever of #509/#510 first
+   * wires this into a user-facing flow.
+   */
+  send(message: MailMessage): Promise<void>;
+}
+
+/**
+ * Null implementation: logs what it would have sent and drops it. This is
+ * the default transport - a self-host with nothing configured keeps
+ * working, and a reset/invite request that nobody will ever see still shows
+ * up somewhere a person debugging it can find it (the process log), rather
+ * than throwing or silently doing nothing.
+ */
+export class NullMailTransport implements MailTransport {
+  readonly name = 'null';
+
+  async send(message: MailMessage): Promise<void> {
+    console.log(
+      `[mail] null transport - would send "${message.subject}" to ${message.to}:\n${message.text}`,
+    );
+  }
+}

--- a/shared/src/mail/env.ts
+++ b/shared/src/mail/env.ts
@@ -1,0 +1,76 @@
+/**
+ * Reads the deployment's mail configuration straight from the environment,
+ * the same way `AI_GATEWAY_API_KEY` works for the cloud runner
+ * (`shared/src/agents/sdk/runner.ts`): a deployment-level secret read once
+ * from `process.env`, never persisted to the database or exposed on a
+ * Settings page. `app_config` (`runner_configs`, `quota_defaults`,
+ * `notification_webhooks`) is for operator-editable, non-secret settings a
+ * deploy can change without a restart - a provider API key or an SMTP
+ * password is not that, so it stays in `.env` alongside `ENCRYPTION_KEY`
+ * and `PITCHBOX_INTERNAL_TOKEN`.
+ *
+ * `MAIL_PROVIDER` selects the transport explicitly (`resend` | `smtp`);
+ * unset, unrecognized, or missing the provider's required credential all
+ * fall back to `null` - see `./registry.ts` for why a half-configured
+ * provider must not become a transport that only fails once it tries to
+ * send.
+ */
+export type MailEnv =
+  | { provider: 'null' }
+  | { provider: 'resend'; apiKey: string; from: string }
+  | {
+      provider: 'smtp';
+      host: string;
+      port: number;
+      secure: boolean;
+      user?: string;
+      pass?: string;
+      from: string;
+    };
+
+const DEFAULT_FROM = 'Pitchbox <no-reply@pitchbox.app>';
+const DEFAULT_SMTP_PORT = 587;
+
+export function loadMailEnv(env: Record<string, string | undefined> = process.env): MailEnv {
+  const from = env.MAIL_FROM?.trim() || DEFAULT_FROM;
+  const provider = env.MAIL_PROVIDER?.trim().toLowerCase();
+
+  if (provider === 'resend') {
+    const apiKey = env.RESEND_API_KEY?.trim();
+    if (!apiKey) {
+      console.warn(
+        '[mail] MAIL_PROVIDER=resend but RESEND_API_KEY is not set - falling back to the null transport',
+      );
+      return { provider: 'null' };
+    }
+    return { provider: 'resend', apiKey, from };
+  }
+
+  if (provider === 'smtp') {
+    const host = env.SMTP_HOST?.trim();
+    if (!host) {
+      console.warn(
+        '[mail] MAIL_PROVIDER=smtp but SMTP_HOST is not set - falling back to the null transport',
+      );
+      return { provider: 'null' };
+    }
+    const port = env.SMTP_PORT ? Number(env.SMTP_PORT) : DEFAULT_SMTP_PORT;
+    if (!Number.isFinite(port)) {
+      console.warn(
+        `[mail] MAIL_PROVIDER=smtp but SMTP_PORT ("${env.SMTP_PORT}") is not a number - falling back to the null transport`,
+      );
+      return { provider: 'null' };
+    }
+    return {
+      provider: 'smtp',
+      host,
+      port,
+      secure: env.SMTP_SECURE === 'true',
+      user: env.SMTP_USER?.trim() || undefined,
+      pass: env.SMTP_PASS?.trim() || undefined,
+      from,
+    };
+  }
+
+  return { provider: 'null' };
+}

--- a/shared/src/mail/registry.ts
+++ b/shared/src/mail/registry.ts
@@ -1,0 +1,25 @@
+import { NullMailTransport, type MailTransport } from './base.js';
+import type { MailEnv } from './env.js';
+import { ResendMailTransport } from './resend.js';
+import { SmtpMailTransport } from './smtp.js';
+
+/**
+ * Selects a `MailTransport` from an already-loaded `MailEnv`. Mirrors
+ * `createAgentRunner` (`../agents/registry.ts`): one switch over the
+ * resolved config, never a re-check of `process.env` here - `loadMailEnv`
+ * already turned a missing credential into `{ provider: 'null' }`, so this
+ * function can never construct a half-configured real transport.
+ */
+export function createMailTransport(cfg: MailEnv): MailTransport {
+  switch (cfg.provider) {
+    case 'resend':
+      return new ResendMailTransport(cfg.apiKey, cfg.from);
+    case 'smtp':
+      return new SmtpMailTransport(
+        { host: cfg.host, port: cfg.port, secure: cfg.secure, user: cfg.user, pass: cfg.pass },
+        cfg.from,
+      );
+    case 'null':
+      return new NullMailTransport();
+  }
+}

--- a/shared/src/mail/resend.ts
+++ b/shared/src/mail/resend.ts
@@ -1,0 +1,31 @@
+import { Resend } from 'resend';
+import type { MailMessage, MailTransport } from './base.js';
+
+/**
+ * Real transport backed by Resend (https://resend.com). Already in use on
+ * canonry-landing, so it is the boring choice here rather than a new
+ * provider to learn.
+ */
+export class ResendMailTransport implements MailTransport {
+  readonly name = 'resend';
+  private readonly client: Resend;
+  private readonly defaultFrom: string;
+
+  constructor(apiKey: string, defaultFrom: string) {
+    this.client = new Resend(apiKey);
+    this.defaultFrom = defaultFrom;
+  }
+
+  async send(message: MailMessage): Promise<void> {
+    const { error } = await this.client.emails.send({
+      from: message.from ?? this.defaultFrom,
+      to: message.to,
+      subject: message.subject,
+      text: message.text,
+      html: message.html,
+    });
+    if (error) {
+      throw new Error(`resend send to ${message.to} failed: ${error.name} - ${error.message}`);
+    }
+  }
+}

--- a/shared/src/mail/smtp.ts
+++ b/shared/src/mail/smtp.ts
@@ -1,0 +1,41 @@
+import * as nodemailer from 'nodemailer';
+import type { MailMessage, MailTransport } from './base.js';
+
+export type SmtpOptions = {
+  host: string;
+  port: number;
+  secure: boolean;
+  user?: string;
+  pass?: string;
+};
+
+/**
+ * Real transport speaking SMTP directly (via nodemailer) - the self-host
+ * escape hatch for a deploy that has its own mail server or a
+ * provider-neutral SMTP relay instead of a Resend account.
+ */
+export class SmtpMailTransport implements MailTransport {
+  readonly name = 'smtp';
+  private readonly transporter: nodemailer.Transporter;
+  private readonly defaultFrom: string;
+
+  constructor(opts: SmtpOptions, defaultFrom: string) {
+    this.transporter = nodemailer.createTransport({
+      host: opts.host,
+      port: opts.port,
+      secure: opts.secure,
+      auth: opts.user && opts.pass ? { user: opts.user, pass: opts.pass } : undefined,
+    });
+    this.defaultFrom = defaultFrom;
+  }
+
+  async send(message: MailMessage): Promise<void> {
+    await this.transporter.sendMail({
+      from: message.from ?? this.defaultFrom,
+      to: message.to,
+      subject: message.subject,
+      text: message.text,
+      html: message.html,
+    });
+  }
+}

--- a/shared/src/mail/template.ts
+++ b/shared/src/mail/template.ts
@@ -1,0 +1,37 @@
+/**
+ * Turns a subject and a plain-text body into a `RenderedMail` carrying both
+ * a text part and an HTML alternative. Every template (#509's password
+ * reset, #510's invite) is authored as plain text only and rendered through
+ * this - a reset mail that lands in spam because it had no text part, or
+ * had an HTML part someone forgot to keep in sync with the text, is a
+ * broken feature, not a cosmetic gap. Deriving the HTML mechanically from
+ * the one authored text is what keeps that impossible rather than merely
+ * discouraged.
+ */
+export type RenderedMail = {
+  subject: string;
+  text: string;
+  html: string;
+};
+
+export function renderPlainTextMail(subject: string, text: string): RenderedMail {
+  const trimmedSubject = subject.trim();
+  const trimmedText = text.trim();
+  if (!trimmedSubject) throw new Error('renderPlainTextMail: subject must not be empty');
+  if (!trimmedText) throw new Error('renderPlainTextMail: text must not be empty');
+  return { subject: trimmedSubject, text: trimmedText, html: textToHtml(trimmedText) };
+}
+
+function textToHtml(text: string): string {
+  const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const paragraphs = escaped
+    .split(/\n{2,}/)
+    .map((p) => `<p>${p.replace(/\n/g, '<br>')}</p>`)
+    .join('\n');
+  return (
+    '<!doctype html><html><body style="font-family: -apple-system, BlinkMacSystemFont, ' +
+    'sans-serif; line-height: 1.5; color: #111;">\n' +
+    paragraphs +
+    '\n</body></html>'
+  );
+}

--- a/shared/tests/mail/base.test.ts
+++ b/shared/tests/mail/base.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { NullMailTransport } from '../../src/mail/base.js';
+import { renderPlainTextMail } from '../../src/mail/template.js';
+
+describe('NullMailTransport', () => {
+  it('reports its name as "null"', () => {
+    expect(new NullMailTransport().name).toBe('null');
+  });
+
+  it('resolves without throwing when sending', async () => {
+    const transport = new NullMailTransport();
+    const rendered = renderPlainTextMail('Reset your password', 'Click the link to reset.');
+
+    await expect(transport.send({ to: 'user@example.com', ...rendered })).resolves.toBeUndefined();
+  });
+
+  it('logs the subject, recipient and text body it would have sent', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const transport = new NullMailTransport();
+      const rendered = renderPlainTextMail('Reset your password', 'Click the link to reset.');
+
+      await transport.send({ to: 'user@example.com', ...rendered });
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const logged = logSpy.mock.calls[0]?.[0] as string;
+      expect(logged).toContain('user@example.com');
+      expect(logged).toContain('Reset your password');
+      expect(logged).toContain('Click the link to reset.');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/shared/tests/mail/env.test.ts
+++ b/shared/tests/mail/env.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadMailEnv } from '../../src/mail/env.js';
+
+describe('loadMailEnv', () => {
+  it('selects the null transport when nothing is configured', () => {
+    expect(loadMailEnv({})).toEqual({ provider: 'null' });
+  });
+
+  it('selects resend when MAIL_PROVIDER=resend and RESEND_API_KEY is set', () => {
+    const cfg = loadMailEnv({ MAIL_PROVIDER: 'resend', RESEND_API_KEY: 're_abc123' });
+    expect(cfg).toEqual({
+      provider: 'resend',
+      apiKey: 're_abc123',
+      from: 'Pitchbox <no-reply@pitchbox.app>',
+    });
+  });
+
+  it('falls back to null when MAIL_PROVIDER=resend but RESEND_API_KEY is missing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(loadMailEnv({ MAIL_PROVIDER: 'resend' })).toEqual({ provider: 'null' });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('falls back to null when MAIL_PROVIDER=resend but RESEND_API_KEY is blank', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(loadMailEnv({ MAIL_PROVIDER: 'resend', RESEND_API_KEY: '   ' })).toEqual({
+      provider: 'null',
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('selects smtp when MAIL_PROVIDER=smtp and SMTP_HOST is set', () => {
+    const cfg = loadMailEnv({
+      MAIL_PROVIDER: 'smtp',
+      SMTP_HOST: 'smtp.example.com',
+      SMTP_PORT: '2525',
+      SMTP_SECURE: 'true',
+      SMTP_USER: 'bot',
+      SMTP_PASS: 'secret',
+    });
+    expect(cfg).toEqual({
+      provider: 'smtp',
+      host: 'smtp.example.com',
+      port: 2525,
+      secure: true,
+      user: 'bot',
+      pass: 'secret',
+      from: 'Pitchbox <no-reply@pitchbox.app>',
+    });
+  });
+
+  it('defaults the smtp port to 587 when SMTP_PORT is unset', () => {
+    const cfg = loadMailEnv({ MAIL_PROVIDER: 'smtp', SMTP_HOST: 'smtp.example.com' });
+    expect(cfg).toMatchObject({ provider: 'smtp', port: 587, secure: false });
+  });
+
+  it('falls back to null when MAIL_PROVIDER=smtp but SMTP_HOST is missing', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(loadMailEnv({ MAIL_PROVIDER: 'smtp' })).toEqual({ provider: 'null' });
+    vi.restoreAllMocks();
+  });
+
+  it('falls back to null when MAIL_PROVIDER=smtp but SMTP_PORT is not a number', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(
+      loadMailEnv({ MAIL_PROVIDER: 'smtp', SMTP_HOST: 'smtp.example.com', SMTP_PORT: 'nope' }),
+    ).toEqual({ provider: 'null' });
+    vi.restoreAllMocks();
+  });
+
+  it('falls back to null for an unrecognized MAIL_PROVIDER value', () => {
+    expect(loadMailEnv({ MAIL_PROVIDER: 'sendgrid', RESEND_API_KEY: 're_abc123' })).toEqual({
+      provider: 'null',
+    });
+  });
+
+  it('honors a custom MAIL_FROM', () => {
+    const cfg = loadMailEnv({
+      MAIL_PROVIDER: 'resend',
+      RESEND_API_KEY: 're_abc123',
+      MAIL_FROM: 'Pitchbox Support <support@pitchbox.app>',
+    });
+    expect(cfg).toMatchObject({ from: 'Pitchbox Support <support@pitchbox.app>' });
+  });
+});

--- a/shared/tests/mail/registry.test.ts
+++ b/shared/tests/mail/registry.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createMailTransport } from '../../src/mail/registry.js';
+import { loadMailEnv } from '../../src/mail/env.js';
+import { NullMailTransport } from '../../src/mail/base.js';
+import { ResendMailTransport } from '../../src/mail/resend.js';
+import { SmtpMailTransport } from '../../src/mail/smtp.js';
+
+describe('createMailTransport', () => {
+  it('selects the null transport when nothing is configured', () => {
+    const transport = createMailTransport(loadMailEnv({}));
+    expect(transport).toBeInstanceOf(NullMailTransport);
+  });
+
+  it('selects the resend transport when resend is fully configured', () => {
+    const transport = createMailTransport(
+      loadMailEnv({ MAIL_PROVIDER: 'resend', RESEND_API_KEY: 're_abc123' }),
+    );
+    expect(transport).toBeInstanceOf(ResendMailTransport);
+  });
+
+  it('selects the smtp transport when smtp is fully configured', () => {
+    const transport = createMailTransport(
+      loadMailEnv({ MAIL_PROVIDER: 'smtp', SMTP_HOST: 'smtp.example.com' }),
+    );
+    expect(transport).toBeInstanceOf(SmtpMailTransport);
+  });
+
+  // The acceptance case this whole module exists to satisfy: a deploy that
+  // opts into a real provider but forgets (or has not yet set) its
+  // credential must not get a transport that only discovers the problem on
+  // its first real send attempt (an opaque provider auth error at draft
+  // time, in front of whoever is testing a reset flow). loadMailEnv already
+  // downgrades that to `{ provider: 'null' }` before createMailTransport
+  // ever runs its switch, so there is no code path here that can construct
+  // a ResendMailTransport/SmtpMailTransport with a missing credential.
+  it('falls back to the null transport, not a half-configured real one, when a selected provider is missing its credential', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const resendMissingKey = createMailTransport(loadMailEnv({ MAIL_PROVIDER: 'resend' }));
+      expect(resendMissingKey).toBeInstanceOf(NullMailTransport);
+
+      const smtpMissingHost = createMailTransport(loadMailEnv({ MAIL_PROVIDER: 'smtp' }));
+      expect(smtpMissingHost).toBeInstanceOf(NullMailTransport);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+});

--- a/shared/tests/mail/template.test.ts
+++ b/shared/tests/mail/template.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { renderPlainTextMail } from '../../src/mail/template.js';
+
+describe('renderPlainTextMail', () => {
+  it('carries both a text part and an HTML part, and the text part is not empty', () => {
+    const rendered = renderPlainTextMail(
+      'Reset your password',
+      'Click the link below to reset your password.\n\nIf you did not request this, ignore this email.',
+    );
+
+    expect(rendered.text.length).toBeGreaterThan(0);
+    expect(rendered.html.length).toBeGreaterThan(0);
+    expect(rendered.text).toBe(
+      'Click the link below to reset your password.\n\nIf you did not request this, ignore this email.',
+    );
+    expect(rendered.html).toContain('Click the link below to reset your password.');
+    expect(rendered.html).toContain('<html');
+  });
+
+  it('preserves the subject verbatim (trimmed)', () => {
+    const rendered = renderPlainTextMail('  Reset your password  ', 'body');
+    expect(rendered.subject).toBe('Reset your password');
+  });
+
+  it('escapes HTML-significant characters from the text in the HTML part', () => {
+    const rendered = renderPlainTextMail('Subject', 'Use <script>alert(1)</script> & enjoy');
+    expect(rendered.html).not.toContain('<script>alert(1)</script>');
+    expect(rendered.html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(rendered.html).toContain('&amp;');
+    // The text part is untouched - callers get the literal text back.
+    expect(rendered.text).toBe('Use <script>alert(1)</script> & enjoy');
+  });
+
+  it('rejects an empty text body rather than silently producing a text-less mail', () => {
+    expect(() => renderPlainTextMail('Subject', '')).toThrow(/text must not be empty/);
+    expect(() => renderPlainTextMail('Subject', '   ')).toThrow(/text must not be empty/);
+  });
+
+  it('rejects an empty subject', () => {
+    expect(() => renderPlainTextMail('', 'body')).toThrow(/subject must not be empty/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -114,6 +114,15 @@ export default defineConfig({
       DATABASE_URL: testDatabaseUrl(),
       PITCHBOX_TEST_MODE: '1',
       AI_GATEWAY_API_KEY: '',
+      // Same reasoning as AI_GATEWAY_API_KEY above, for #508's mail
+      // transport: a real RESEND_API_KEY/SMTP_* sitting in a developer's
+      // .env must not let a test that calls loadMailEnv()/createMailTransport()
+      // with the default process.env construct a real transport and attempt
+      // a live send. Tests exercising the real transports pass their own
+      // fake env object explicitly instead of relying on process.env.
+      MAIL_PROVIDER: '',
+      RESEND_API_KEY: '',
+      SMTP_HOST: '',
     },
   },
 });


### PR DESCRIPTION
Closes #508.

## What this adds

A pluggable outbound email transport shaped like the other boundaries in this repo (`AgentRunner`, `ReplyReader`): one interface, a null implementation that logs what it would have sent and drops it, two real transports, and config-driven selection between them.

- `shared/src/mail/base.ts`: `MailTransport` interface, `MailMessage`, `NullMailTransport`.
- `shared/src/mail/template.ts`: `renderPlainTextMail(subject, text)` derives the HTML alternative mechanically from a plain-text body, so a template (written once, as plain text) can never end up with a missing text part or an HTML part that drifted from it.
- `shared/src/mail/env.ts`: `loadMailEnv()` reads `MAIL_PROVIDER` / `RESEND_API_KEY` / `SMTP_*` straight from `process.env` - the same deployment-secret pattern as `AI_GATEWAY_API_KEY`, not `app_config`/`runner_configs`, which are for operator-editable non-secret settings (quota defaults, webhook URLs, model pins) rather than provider credentials. A provider selected without its required credential falls back to the null transport instead of constructing a half-configured real one.
- `shared/src/mail/resend.ts`, `shared/src/mail/smtp.ts`: the two real transports. Resend (already in use on canonry-landing) is the default real transport; SMTP via nodemailer is the self-host escape hatch.
- `shared/src/mail/registry.ts`: `createMailTransport(cfg)`, the selection switch, mirroring `createAgentRunner`.
- New env keys documented in `.env.example` and `.env.docker.example`.
- Exported through `shared/package.json`'s `exports` map (`./mail`, `./mail/registry`, `./mail/template`, `./mail/env`) rather than deep imports.
- `vitest.config.ts` blanks `MAIL_PROVIDER`/`RESEND_API_KEY`/`SMTP_HOST` for every test run, same reasoning as the existing `AI_GATEWAY_API_KEY` blank: a real credential sitting in a developer's `.env` must not let a test construct a real transport by accident.

## Non-goals (per the issue and #509/#510)

Nothing here is wired into a user-facing flow. Password reset (#509) and invite email (#510) are separate issues and separate PRs; this only builds the transport they will both use.

**I have not verified a real send.** That needs a real `RESEND_API_KEY` (or SMTP credential) and a real address to send to, both of which are Lorenzo's step, not something I can do here. I've left this as the one remaining acceptance item, both here and as a comment on #508.

## Tests

`shared/tests/mail/{base,env,registry,template}.test.ts`, 22 tests, all against the pure config/rendering/logging boundary (no live provider call):

- `base.test.ts`: `NullMailTransport.send()` resolves without throwing and logs the recipient, subject and text body. I broke this by replacing the logging body with a no-op; `logs the subject, recipient and text body it would have sent` failed (`expected "log" to be called 1 times, but got 0 times`). Restored, green again.
- `env.test.ts` / `registry.test.ts`: selection is by configuration, and a provider selected without its credential falls back to null rather than a half-configured real sender. I broke this by removing `loadMailEnv`'s missing-`RESEND_API_KEY` guard (returning `{ provider: 'resend', apiKey: '' }` instead of falling back); three tests failed, including `registry.test.ts`'s end-to-end one, which failed with the exact real-world symptom this guards against - the Resend SDK throwing `Missing API key. Pass it to the constructor` inside `createMailTransport`. Restored, green again.
- `template.test.ts`: the rendered message carries both a text and an HTML part, and the text part is not empty. I broke this by hardcoding `text: ''` in `renderPlainTextMail`; 4 of 5 tests failed, including the one asserting `text.length > 0`. Restored, green again.

Scoped verification run for this change: `pnpm exec vitest run shared/tests/mail/` (22 passed), `npx eslint shared/src/mail/*.ts shared/tests/mail/*.ts` (clean), `npx prettier --check` on the same files (clean), `pnpm -F @pitchbox/shared typecheck` (clean). Full `pnpm test` also ran (as `preflight`, on push) and passed in 380s.
