### PR TITLE
feat(web): self-service password change (#506)

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -191,7 +191,12 @@ switch - org-scoped, so it throws `requireRole(event, 'admin')` like
 Retention/Security rather than narrowing like Quota below); the 2026-09-07
 companion decisions added a ninth, `settings/companion` (the operator's
 persona, voice samples and GitHub sources that feed the assistant's prompt -
-same org-scoped `requireRole(event, 'admin')` gate). `/settings`
+same org-scoped `requireRole(event, 'admin')` gate). #506 added a tenth,
+`settings/password` (self-service password change for the signed-in caller -
+gated on `locals.user` existing at all rather than an org role, since a
+password change needs nothing beyond being the account holder; 404s when
+auth is off, since there's no login concept and nothing to change a
+password for). `/settings`
 itself now just redirects (307) to `/settings/status`. The four routes that
 used to be General's tabs each gate their own data set in their own loader,
 the same per-data-set split #237 landed on the old combined page: `status`
@@ -210,8 +215,10 @@ status); only revoking a device (DELETE) and minting a pairing code (POST
 auth is off (no org context to show), and hides the `retention`/`security`/
 `linkedin-assist`/`companion` links from a non-admin since those routes'
 loaders call `requireRole(event, 'admin')` and would 403; `status`/`runners`/
-`extension`/`quota` are always shown because none of their loaders throw,
-they only narrow the payload.
+`extension`/`quota`/`password` are always shown to a signed-in caller because
+none of their loaders throw a role error (`password` still 404s with no
+`locals.user`, i.e. auth off); they only narrow the payload or, for
+`password`, gate on being signed in at all.
 
 **Exempt** (no org role): `auth/*`, `extension/*` (token-auth companion),
 `orgs` POST + `orgs/switch` POST (self-service), `orgs/[slug]/invites/[token]/accept`

--- a/web/src/routes/api/auth/password/+server.ts
+++ b/web/src/routes/api/auth/password/+server.ts
@@ -1,0 +1,111 @@
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { and, eq, ne } from 'drizzle-orm';
+import { getDb, schema } from '../../../../lib/server/db.js';
+import {
+  clearAuthFailures,
+  getLockoutUntil,
+  hashPassword,
+  loadAuthPolicy,
+  recordAuthFailure,
+  verifyPassword,
+} from '@pitchbox/shared/auth';
+
+const COOKIE = 'pitchbox_session';
+
+// Same rule /api/auth/login enforces on `password`: a changed password can
+// never end up weaker than login would have accepted for a fresh sign-in.
+// `currentPassword` only needs to be present - it's checked against the
+// stored hash, not a fresh password policy.
+const Body = z.object({
+  currentPassword: z.string().min(1).max(256),
+  newPassword: z.string().min(8).max(256),
+});
+
+/**
+ * Self-service password change for the signed-in caller. hooks.server.ts
+ * already resolves `locals.user` for this route - only /api/auth/login and
+ * /api/auth/logout are exempt from session resolution (#132) - so the
+ * `!user` check below is defense in depth, same convention as
+ * /api/auth/unlock and /api/auth/failures.
+ */
+export async function POST(event: RequestEvent) {
+  if (process.env.PITCHBOX_AUTH !== 'on') {
+    throw error(404, 'auth_disabled');
+  }
+  const user = event.locals.user;
+  if (!user) throw error(401, 'unauthenticated');
+
+  const raw = await event.request.json().catch(() => null);
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) throw error(400, 'invalid_body');
+
+  const db = getDb();
+  let ip: string;
+  try {
+    ip = event.getClientAddress() || 'unknown';
+  } catch {
+    ip = 'unknown';
+  }
+  // Reuse the exact buckets /api/auth/login writes to. A wrong
+  // current-password guess here is the same credential-guessing login
+  // already throttles, so the two share one lockout window instead of this
+  // endpoint being a second, unthrottled way to brute-force a password.
+  const ipBucket = `ip:${ip}`;
+  const userBucket = `user:${user.username}`;
+  const policy = await loadAuthPolicy(db);
+  const now = new Date();
+  const [ipLock, userLock] = await Promise.all([
+    getLockoutUntil(db, ipBucket, policy, now),
+    getLockoutUntil(db, userBucket, policy, now),
+  ]);
+  const lockedUntil =
+    ipLock && userLock ? (ipLock > userLock ? ipLock : userLock) : (ipLock ?? userLock);
+  if (lockedUntil) {
+    return json(
+      {
+        error: 'rate_limited',
+        retry_after_seconds: Math.max(1, Math.ceil((lockedUntil.getTime() - now.getTime()) / 1000)),
+      },
+      { status: 429 },
+    );
+  }
+
+  const [row] = await db
+    .select({ passwordHash: schema.users.passwordHash })
+    .from(schema.users)
+    .where(eq(schema.users.id, user.id));
+  if (!row) throw error(404, 'not_found');
+
+  const ok = await verifyPassword(parsed.data.currentPassword, row.passwordHash);
+  if (!ok) {
+    await recordAuthFailure(db, ipBucket);
+    await recordAuthFailure(db, userBucket);
+    return json({ error: 'invalid_credentials' }, { status: 401 });
+  }
+
+  // Same counter reset login does on success, so a legitimate change doesn't
+  // leave the caller sitting near the lockout threshold.
+  await Promise.all([clearAuthFailures(db, ipBucket), clearAuthFailures(db, userBucket)]);
+
+  const newHash = await hashPassword(parsed.data.newPassword);
+  await db.update(schema.users).set({ passwordHash: newHash }).where(eq(schema.users.id, user.id));
+
+  // Session decision: revoke every OTHER session for this user; the one
+  // making this request stays alive. A password change is the standard
+  // response to "someone else might know my old password" - if that's true
+  // they may also be holding a live session minted under it, and leaving
+  // sessions alone would mean the change stops nothing for them. The
+  // caller's own session survives so changing your password doesn't also
+  // sign you out of the tab you did it from.
+  const currentSessionId = event.cookies.get(COOKIE);
+  await db
+    .delete(schema.sessions)
+    .where(
+      currentSessionId
+        ? and(eq(schema.sessions.userId, user.id), ne(schema.sessions.id, currentSessionId))
+        : eq(schema.sessions.userId, user.id),
+    );
+
+  return json({ ok: true });
+}

--- a/web/src/routes/settings/+layout.svelte
+++ b/web/src/routes/settings/+layout.svelte
@@ -7,6 +7,7 @@
     Bot,
     Puzzle,
     Gauge,
+    KeyRound,
     Building2,
     Archive,
     ShieldCheck,
@@ -17,11 +18,14 @@
 
   let { data, children }: { data: LayoutData; children: Snippet } = $props();
 
-  // Flat rail of nine (#254 shipped seven; LI-19/#316 added LinkedIn assist;
-  // 2026-09-07's companion decisions added Companion). Status/Agent
-  // runners/Browser extension/Quota never 403 - each loader gates its own
-  // data set (member sees an "Admin access required" card instead of a
-  // thrown error) - so they're always shown, same as General used to be.
+  // Flat rail of ten (#254 shipped seven; LI-19/#316 added LinkedIn assist;
+  // 2026-09-07's companion decisions added Companion; #506 added Password).
+  // Status/Agent runners/Browser extension/Quota never 403 - each loader
+  // gates its own data set (member sees an "Admin access required" card
+  // instead of a thrown error) - so they're always shown, same as General
+  // used to be. Password is self-service (gated on being signed in at all,
+  // not an org role - docs/permissions.md) rather than org-scoped, so it
+  // uses `data.signedIn` instead of `data.isAdmin`/`data.authOn`.
   // Organization needs an org context (auth on); Retention, Security,
   // LinkedIn assist and Companion loaders call requireRole(event, 'admin')
   // and do throw, so those stay role-filtered here too. The server loaders
@@ -32,6 +36,7 @@
       { href: '/settings/runners', label: 'Agent runners', icon: Bot, show: true },
       { href: '/settings/extension', label: 'Browser extension', icon: Puzzle, show: true },
       { href: '/settings/quota', label: 'Quota', icon: Gauge, show: true },
+      { href: '/settings/password', label: 'Password', icon: KeyRound, show: data.signedIn },
       {
         href: '/settings/linkedin-assist',
         label: 'LinkedIn assist',

--- a/web/src/routes/settings/password/+page.server.ts
+++ b/web/src/routes/settings/password/+page.server.ts
@@ -1,0 +1,16 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+/**
+ * Self-service password change. Gated on having a signed-in user rather than
+ * an org role (docs/permissions.md) - a password change needs nothing beyond
+ * being the account holder. hooks.server.ts already requires a valid session
+ * for this route when auth is on (#132's exempt list only covers /login and
+ * /api/auth/{login,logout}), so `locals.user` missing here means auth is
+ * off - there's no login concept and nothing to change a password for, so
+ * 404 rather than a misleading empty form.
+ */
+export const load: PageServerLoad = async (event) => {
+  if (!event.locals.user) throw error(404, 'not_found');
+  return { username: event.locals.user.username };
+};

--- a/web/src/routes/settings/password/+page.svelte
+++ b/web/src/routes/settings/password/+page.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import Seo from '$lib/components/Seo.svelte';
+	import PageContainer from '$lib/components/PageContainer.svelte';
+	import { toast } from 'svelte-sonner';
+
+	type PageData = { username: string };
+	let { data }: { data: PageData } = $props();
+
+	let currentPassword = $state('');
+	let newPassword = $state('');
+	let confirmPassword = $state('');
+	let busy = $state(false);
+
+	const canSubmit = $derived(
+		!busy &&
+			currentPassword.length > 0 &&
+			newPassword.length >= 8 &&
+			newPassword === confirmPassword,
+	);
+
+	async function submit() {
+		if (!canSubmit) return;
+		busy = true;
+		try {
+			const res = await fetch('/api/auth/password', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ currentPassword, newPassword }),
+			});
+			if (res.ok) {
+				toast.success('Password changed', {
+					description: 'Every other session on your account was signed out.',
+				});
+				currentPassword = '';
+				newPassword = '';
+				confirmPassword = '';
+				return;
+			}
+			if (res.status === 401) {
+				toast.error('Current password is incorrect');
+				return;
+			}
+			if (res.status === 429) {
+				const body = (await res.json()) as { retry_after_seconds?: number };
+				toast.error('Too many attempts', {
+					description: body.retry_after_seconds
+						? `Try again in ${body.retry_after_seconds}s`
+						: undefined,
+				});
+				return;
+			}
+			toast.error('Could not change password', { description: await res.text() });
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+<PageContainer size="default">
+<Seo title="Settings - Password" description="Change your account password." />
+
+<PageHeader title="Password" description={`Change the password for ${data.username}.`} />
+
+<div class="mt-4 grid gap-4">
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>Change password</Card.Title>
+			<Card.Description>
+				Requires your current password. The new one needs at least 8 characters, same as
+				sign-in. Changing it signs out every other session on your account - this one stays
+				signed in.
+			</Card.Description>
+		</Card.Header>
+		<Card.Content class="flex max-w-sm flex-col gap-3">
+			<label class="flex flex-col gap-1 text-xs">
+				Current password
+				<Input
+					type="password"
+					bind:value={currentPassword}
+					disabled={busy}
+					autocomplete="current-password"
+				/>
+			</label>
+			<label class="flex flex-col gap-1 text-xs">
+				New password
+				<Input
+					type="password"
+					bind:value={newPassword}
+					disabled={busy}
+					autocomplete="new-password"
+				/>
+			</label>
+			<label class="flex flex-col gap-1 text-xs">
+				Confirm new password
+				<Input
+					type="password"
+					bind:value={confirmPassword}
+					disabled={busy}
+					autocomplete="new-password"
+				/>
+			</label>
+			<Button onclick={submit} disabled={!canSubmit}>Change password</Button>
+		</Card.Content>
+	</Card.Root>
+</div>
+</PageContainer>

--- a/web/tests/password-change.test.ts
+++ b/web/tests/password-change.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, beforeEach, afterAll } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { hashPassword, createSession } from '@pitchbox/shared/auth';
+import { POST as changePassword } from '../src/routes/api/auth/password/+server.js';
+import { POST as login } from '../src/routes/api/auth/login/+server.js';
+import { type CookieJar, makeCookies, runThroughHandle } from './helpers/handle-harness.js';
+
+const USERNAME = 'carol';
+const PASSWORD = 'correct-horse-battery';
+const WRONG = 'wrong-password-9999';
+const NEW_PASSWORD = 'new-correct-battery-1';
+
+// Captured at import time so afterAll can restore it and this file doesn't
+// leak PITCHBOX_AUTH into other test files sharing this worker.
+const originalAuth = process.env.PITCHBOX_AUTH;
+
+async function reset() {
+  await getDb().execute(sql`TRUNCATE auth_failures RESTART IDENTITY CASCADE`);
+  await getDb().execute(sql`DELETE FROM sessions`);
+  await getDb().execute(sql`DELETE FROM memberships`);
+  await getDb().execute(sql`DELETE FROM users`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'auth_policy'`);
+}
+
+async function seedUser(): Promise<{ userId: number; passwordHash: string }> {
+  const hash = await hashPassword(PASSWORD);
+  const [row] = await getDb()
+    .insert(schema.users)
+    .values({ username: USERNAME, passwordHash: hash })
+    .returning();
+  let [org] = await getDb()
+    .select()
+    .from(schema.organizations)
+    .where(sql`slug = 'default'`);
+  if (!org) {
+    [org] = await getDb()
+      .insert(schema.organizations)
+      .values({ slug: 'default', name: 'Default' })
+      .returning();
+  }
+  await getDb()
+    .insert(schema.memberships)
+    .values({ organizationId: org.id, userId: row.id, role: 'owner' })
+    .onConflictDoNothing();
+  return { userId: row.id, passwordHash: row.passwordHash };
+}
+
+function changeRequest(body: unknown) {
+  return new Request('http://localhost/api/auth/password', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function attemptLogin(username: string, password: string, ip: string) {
+  const jar: CookieJar = { store: new Map() };
+  return login({
+    request: new Request('http://localhost/api/auth/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    }),
+    cookies: makeCookies(jar) as any,
+    getClientAddress: () => ip,
+  } as any);
+}
+
+describe('self-service password change', () => {
+  beforeEach(async () => {
+    process.env.PITCHBOX_AUTH = 'on';
+    await reset();
+  });
+
+  it('refuses a wrong current password and leaves the stored hash unchanged', async () => {
+    const { userId, passwordHash } = await seedUser();
+    const session = await createSession(getDb(), userId);
+    const jar: CookieJar = { store: new Map([['pitchbox_session', { value: session.id }]]) };
+
+    const res = await runThroughHandle(
+      changeRequest({ currentPassword: WRONG, newPassword: NEW_PASSWORD }),
+      jar,
+      changePassword as any,
+      '10.5.0.1',
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'invalid_credentials' });
+
+    const [row] = await getDb().select().from(schema.users).where(eq(schema.users.id, userId));
+    expect(row.passwordHash).toBe(passwordHash);
+  });
+
+  it('a correct change retires the old password and admits the new one, through the real login handler', async () => {
+    const { userId } = await seedUser();
+    const session = await createSession(getDb(), userId);
+    const jar: CookieJar = { store: new Map([['pitchbox_session', { value: session.id }]]) };
+
+    const res = await runThroughHandle(
+      changeRequest({ currentPassword: PASSWORD, newPassword: NEW_PASSWORD }),
+      jar,
+      changePassword as any,
+      '10.5.0.2',
+    );
+    expect(res.status).toBe(200);
+
+    const oldLogin = await attemptLogin(USERNAME, PASSWORD, '10.5.0.3');
+    expect(oldLogin.status).toBe(401);
+
+    const newLogin = await attemptLogin(USERNAME, NEW_PASSWORD, '10.5.0.4');
+    expect(newLogin.status).toBe(200);
+  });
+
+  it('revokes every other session but keeps the one that made the change', async () => {
+    const { userId } = await seedUser();
+    const currentSession = await createSession(getDb(), userId);
+    const otherSession = await createSession(getDb(), userId);
+    const jar: CookieJar = {
+      store: new Map([['pitchbox_session', { value: currentSession.id }]]),
+    };
+
+    const res = await runThroughHandle(
+      changeRequest({ currentPassword: PASSWORD, newPassword: NEW_PASSWORD }),
+      jar,
+      changePassword as any,
+      '10.5.0.5',
+    );
+    expect(res.status).toBe(200);
+
+    const remaining = await getDb()
+      .select({ id: schema.sessions.id })
+      .from(schema.sessions)
+      .where(eq(schema.sessions.userId, userId));
+    expect(remaining.map((r) => r.id)).toEqual([currentSession.id]);
+
+    const otherStillThere = await getDb()
+      .select()
+      .from(schema.sessions)
+      .where(eq(schema.sessions.id, otherSession.id));
+    expect(otherStillThere.length).toBe(0);
+  });
+
+  it('shares the login lockout bucket: 5 wrong current-password guesses lock out login too', async () => {
+    const { userId } = await seedUser();
+    const session = await createSession(getDb(), userId);
+    const jar: CookieJar = { store: new Map([['pitchbox_session', { value: session.id }]]) };
+
+    for (let i = 0; i < 5; i++) {
+      const r = await runThroughHandle(
+        changeRequest({ currentPassword: WRONG, newPassword: NEW_PASSWORD }),
+        jar,
+        changePassword as any,
+        '10.5.0.6',
+      );
+      expect(r.status).toBe(401);
+    }
+
+    const loginRes = await attemptLogin(USERNAME, PASSWORD, '10.5.0.6');
+    expect(loginRes.status).toBe(429);
+  });
+});
+
+afterAll(async () => {
+  if (originalAuth === undefined) delete process.env.PITCHBOX_AUTH;
+  else process.env.PITCHBOX_AUTH = originalAuth;
+});


### PR DESCRIPTION
Adds `/settings/password`: a signed-in user can change their own password by proving the current one.

Details:
- New password follows the same zod rule `/api/auth/login` enforces (8-256 chars). Current password just has to be present, checked against the stored hash.
- Wrong current-password guesses share login's own rate-limit buckets (`ip:<ip>`, `user:<username>`) rather than opening a second, unthrottled way to brute-force a password.
- On a successful change, every other session for that user is revoked. The session that made the request stays alive, so the change doesn't also sign the caller out of the tab they did it from. Reasoning is in a code comment on the route.
- The page is a new flat settings route (`settings/password`), not folded into the existing admin-only `settings/security` (failed-login list and lockouts, unrelated to this). Its loader gates on `locals.user` existing at all rather than an org role, since this is self-service, not org-scoped - documented in `docs/permissions.md`. 404s when auth is off (no login concept).
- No `shared/src/auth.ts` changes: I only call its existing exports (`hashPassword`, `verifyPassword`, the rate-limit helpers) and query `schema.users`/`schema.sessions` directly, since `auth.ts` is owned by Accounts504 this wave.

Testing: `web/tests/password-change.test.ts`, through the real route handlers via `handle-harness.ts` (not by calling helpers directly):
- wrong current password refused, stored hash unchanged
- correct change retires the old password and admits the new one, proven through the real login handler
- every other session revoked, the session that made the change survives
- wrong current-password guesses share login's lockout bucket (5 guesses lock out login too)

Every assertion above was verified to bite: I broke the corresponding line (skipped verification, skipped the hash write, deleted every session instead of every-other, and split the rate-limit bucket), watched the matching test fail, then restored it and confirmed green again.

Verification:
- `pnpm exec vitest run web/tests/password-change.test.ts web/tests/auth-hardening.test.ts` - 15/15 passing
- `pnpm -F web check` - clean
- `npx eslint` / `npx prettier --check` on every changed file - clean
- Visual: `uishot` against a live dev server at light/dark, mobile/tablet/desktop, `--axe` - no new violations (the two pre-existing ones on `.border-border/60` contrast and the `.sr-only` notifications region also show up on `/settings/status`, which this PR doesn't touch)
- `preflight` passed before push

Closes #506