### PR TITLE
feat(shared,web): users.email plus a register route so an invite can finally be accepted

### DIFF
--- a/cli/src/commands/seed-owner.ts
+++ b/cli/src/commands/seed-owner.ts
@@ -64,7 +64,7 @@ export async function seedOwner(): Promise<SeedOwnerResult> {
   // one bootstrap owner - not a self-created-org admin - and instance-wide
   // config (default runner, quota defaults, webhook config) must be gated on
   // that distinction.
-  const userId = await createUser(db, username, password, { isInstanceAdmin: true });
+  const userId = await createUser(db, { username, password, isInstanceAdmin: true });
   return { created: true, userId, username };
 }
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -19,6 +19,35 @@ On a brand-new install the `users` table is empty and the initial owner account 
 
 For any internet-facing deployment, claim the owner account (or seed it from deploy credentials) before the URL is reachable, so the initial account is never left unclaimed by an operator. Run `pitchbox seed:owner` right after migrations in the deploy pipeline: it reads `PITCHBOX_OWNER_USERNAME` and `PITCHBOX_OWNER_PASSWORD` from the environment and creates the owner (plus its default-org owner membership) through the same `createUser()` path the login bootstrap uses. It is a no-op (logs and exits 0) if a user already exists or either env var is unset, so it's safe to run on every deploy.
 
+## Registration
+
+`POST /api/auth/register` (#504) creates an account for anyone, since the
+decision of 2026-09-09 opened sign-up: `username`, `password` and `email`
+(required, unique on a normalized - trimmed, lowercased - value, #507), plus
+an optional `token` when the visitor arrived via `/invite/<token>`. It never
+goes through `createUser()`: that helper always joins the single-tenant
+`default` org as owner, which would make every stranger who registers an
+owner of it. Instead, in one transaction:
+
+- **With a valid token**: the account is created and `acceptInvite` joins the
+  inviting org with the invited role - never `default`, no org of its own.
+- **With no token**: the account gets its own single-owner organization
+  (`createOrganization`, slug derived from the username and collision-
+  suffixed). #513 owns the real policy here (slug source, quota, role
+  nuance); this is a narrow stand-in so open sign-up isn't accidentally
+  invite-only.
+
+An invalid, expired, revoked or already-consumed token refuses the whole
+registration (no account is created). A duplicate username or email returns
+`409 { "error": "username_taken" | "email_taken" }`. Rate-limited by IP
+through the same `auth_failures` table and policy as login. Login itself
+stays username-only rather than accepting either username or email -
+password recovery (a separate future child of #503) identifies people by
+address through its own route instead.
+
+`/invite/<token>` sends a visitor with no session to `/register?next=...`
+(not `/login`): an invite is an account nobody has yet.
+
 ## Sessions
 
 `createSession()` mints a 32-byte hex token, stores it in the `sessions` table with a 30-day expiry, and sets it as an httpOnly cookie. `loadSession()` joins `sessions × users` and only returns non-expired rows. Logging out deletes the row and clears the cookie.

--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -52,7 +52,12 @@ Each returns `false` for cross-tenant access; the route then returns 404.
    The invite is valid for **7 days** and is single-use (the row is marked `accepted_at` once consumed).
 
 2. **Invitee visits `/invite/<token>`**
-   - Not logged in? Redirected to `/login?next=/invite/<token>`.
+   - Not logged in? Redirected to `/register?next=/invite/<token>` (#504) -
+     an invite is an account nobody has yet, not a login form. `/register`
+     prefills the email field when the invite carried one and offers a
+     "Sign in instead" link back to `/login` for someone who already has an
+     account. Registering with the invite's token accepts it in the same
+     transaction that creates the account.
    - Logged in? The page server calls `acceptInvite`, creates a membership, and redirects to `/`.
 
 3. **Programmatic accept**
@@ -70,6 +75,7 @@ Each returns `false` for cross-tenant access; the route then returns 404.
 ## Database
 
 ```
+users                 id, username (unique), password_hash, email (nullable, unique), is_instance_admin
 organizations         id, slug (unique), name
 memberships           id, organization_id, user_id, role, created_at  (unique org+user)
 org_invites           id, organization_id, token (unique), email, role,

--- a/shared/src/auth.ts
+++ b/shared/src/auth.ts
@@ -201,26 +201,59 @@ export async function countUsers(
   return rows.length;
 }
 
-export async function createUser(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  db: PgDatabase<any, any, any>,
-  username: string,
-  password: string,
-  opts: { isInstanceAdmin?: boolean } = {},
+/** Trims and lowercases an email so every write and lookup compares the same normalized form. Empty/absent collapses to null. */
+export function normalizeEmail(email: string | null | undefined): string | null {
+  if (!email) return null;
+  const trimmed = email.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+/**
+ * Inserts a user row only - no org membership, no default-org bootstrap.
+ * `createUser` below is for the two paths (first login, `seed:owner`) that
+ * always want the `default` org as owner; `POST /api/auth/register` (#504)
+ * must not go through that path (createUser would make every invited or
+ * self-registered person an owner of the single-tenant `default` org - see
+ * #503's write-up of that trap), so it composes this with `acceptInvite` or
+ * `createOrganization` itself, inside its own transaction.
+ */
+export async function createUserRecord(
+  db: Db,
+  args: { username: string; password: string; email?: string | null },
 ): Promise<number> {
-  const passwordHash = await hashPassword(password);
-  const [row] = await db.insert(users).values({ username, passwordHash }).returning();
+  const passwordHash = await hashPassword(args.password);
+  const [row] = await db
+    .insert(users)
+    .values({ username: args.username, passwordHash, email: normalizeEmail(args.email) })
+    .returning();
+  return row.id;
+}
+
+export async function createUser(
+  db: Db,
+  args: {
+    username: string;
+    password: string;
+    email?: string | null;
+    isInstanceAdmin?: boolean;
+  },
+): Promise<number> {
+  const userId = await createUserRecord(db, {
+    username: args.username,
+    password: args.password,
+    email: args.email,
+  });
   // The only place that writes `is_instance_admin` true is setInstanceAdmin
   // below (#413): routing the bootstrap grant through it too means there is
   // exactly one function to audit or extend, not a second insert-time path
   // that can quietly drift from the promote path.
-  if (opts.isInstanceAdmin) {
-    await setInstanceAdmin(db, row.id, true);
+  if (args.isInstanceAdmin) {
+    await setInstanceAdmin(db, userId, true);
   }
   // First user implicitly joins the default org as owner. If the default org
   // doesn't exist yet (fresh install without seed:core), create it inline.
   let [org] = await db.select().from(organizations).where(eq(organizations.slug, 'default'));
-  const orgName = defaultOrgName(username);
+  const orgName = defaultOrgName(args.username);
   if (!org) {
     [org] = await db.insert(organizations).values({ slug: 'default', name: orgName }).returning();
   } else if (org.name === 'Default' || org.name === 'My Organization') {
@@ -235,9 +268,9 @@ export async function createUser(
   await ensurePersonalProject(db, org.id);
   await db
     .insert(memberships)
-    .values({ organizationId: org.id, userId: row.id, role: 'owner' })
+    .values({ organizationId: org.id, userId, role: 'owner' })
     .onConflictDoNothing();
-  return row.id;
+  return userId;
 }
 
 /**
@@ -300,6 +333,20 @@ export async function findUserByUsername(
     .select({ id: users.id, passwordHash: users.passwordHash })
     .from(users)
     .where(eq(users.username, username))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function findUserByEmail(
+  db: Db,
+  email: string,
+): Promise<{ id: number; passwordHash: string } | null> {
+  const normalized = normalizeEmail(email);
+  if (!normalized) return null;
+  const rows = await db
+    .select({ id: users.id, passwordHash: users.passwordHash })
+    .from(users)
+    .where(eq(users.email, normalized))
     .limit(1);
   return rows[0] ?? null;
 }

--- a/shared/src/db/migrations/0023_users_email.sql
+++ b/shared/src/db/migrations/0023_users_email.sql
@@ -1,0 +1,15 @@
+-- users.email (#507): nullable so accounts predating it (first-run bootstrap,
+-- `pitchbox seed:owner`) keep working with no backfill story. Required at
+-- `POST /api/auth/register` (#504) instead, at the application layer.
+--
+-- Hand-authored rather than `drizzle-kit generate`: the committed snapshot
+-- chain in migrations/meta/ stops at 0018_snapshot.json (0019-0022 landed
+-- without a snapshot ever being committed for them, the same drift that
+-- forced the 2026-07-13 baseline squash - see migrations_archive/README.md).
+-- Running `generate` against that stale base tries to re-CREATE TABLE
+-- instance_audit_log and operator_voice_profiles, which would fail outright
+-- on any database that already has them. Reconciling that chain is a
+-- separate, repo-wide fix; this migration only touches `users`.
+ALTER TABLE "users" ADD COLUMN "email" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "users_email_unique" ON "users" USING btree ("email");

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1788960000009,
       "tag": "0022_description_refresh_run_kind",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1788960000010,
+      "tag": "0023_users_email",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -27,16 +27,35 @@ export const platforms = pgTable('platforms', {
   enabled: boolean('enabled').notNull().default(true),
 });
 
-export const users = pgTable('users', {
-  id: serial('id').primaryKey(),
-  username: text('username').notNull().unique(),
-  passwordHash: text('password_hash').notNull(),
-  // Instance-wide admin, distinct from per-org 'admin' role. Gates global
-  // config that spans every tenant (default runner, quota defaults, webhook
-  // config) - a self-created org owner must NOT get this for free.
-  isInstanceAdmin: boolean('is_instance_admin').notNull().default(false),
-  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-});
+export const users = pgTable(
+  'users',
+  {
+    id: serial('id').primaryKey(),
+    username: text('username').notNull().unique(),
+    passwordHash: text('password_hash').notNull(),
+    // Instance-wide admin, distinct from per-org 'admin' role. Gates global
+    // config that spans every tenant (default runner, quota defaults, webhook
+    // config) - a self-created org owner must NOT get this for free.
+    isInstanceAdmin: boolean('is_instance_admin').notNull().default(false),
+    // Nullable: accounts created before #507 (first-run bootstrap,
+    // `pitchbox seed:owner`) have none, and nothing in the app requires one
+    // for those to keep working. Required at `POST /api/auth/register`
+    // (#504) since open sign-up (#505) makes the address the only thing
+    // tying a self-registered account to a person, and later the way back in
+    // after a lost password. Always written already normalized (trimmed,
+    // lowercased, see `normalizeEmail` in `shared/src/auth.ts`), so the
+    // unique index below is a plain column constraint rather than an
+    // expression index, and two logins differing only in case collide.
+    email: text('email'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    // Postgres treats each NULL as distinct in a unique index, so accounts
+    // with no email never collide with each other - only two non-null,
+    // already-normalized addresses do.
+    emailUnique: uniqueIndex('users_email_unique').on(t.email),
+  }),
+);
 
 export const organizations = pgTable('organizations', {
   id: serial('id').primaryKey(),

--- a/shared/src/orgs.ts
+++ b/shared/src/orgs.ts
@@ -18,6 +18,8 @@ type Db = PgDatabase<any, any, any>;
 
 export type OrgRole = 'owner' | 'admin' | 'member';
 
+export type OrgInvite = typeof orgInvites.$inferSelect;
+
 const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 /**
@@ -200,6 +202,7 @@ export async function listOrgMembers(db: Db, orgId: number) {
     .select({
       userId: memberships.userId,
       username: users.username,
+      email: users.email,
       role: memberships.role,
       createdAt: memberships.createdAt,
     })
@@ -283,7 +286,7 @@ export async function createInvite(
   return { id: row.id, token, expiresAt };
 }
 
-export async function findValidInvite(db: Db, token: string) {
+export async function findValidInvite(db: Db, token: string): Promise<OrgInvite | null> {
   const now = new Date();
   const [row] = await db
     .select()
@@ -373,6 +376,32 @@ export async function createOrganization(
   // means a brand new org is never waiting on a migration to have one.
   await ensurePersonalProject(db, org.id);
   return { id: org.id, slug: org.slug, role: 'owner' };
+}
+
+/**
+ * Derives an available organization slug from a username, for the register
+ * route's no-invite path (open sign-up, #505). #513 owns the real policy
+ * here - where the slug should really come from (username vs. email local
+ * part), the new org's name and quota, and what a later-invited owner of
+ * their own org keeps - this is a narrow, unopinionated stand-in so open
+ * sign-up is not accidentally invite-only in the meantime. Collision-
+ * suffixed with a numeric counter against `organizations.slug`'s unique
+ * constraint.
+ */
+export async function uniqueOrgSlugFromUsername(db: Db, username: string): Promise<string> {
+  const base =
+    username
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 54) || 'org';
+  let candidate = base;
+  let suffix = 2;
+  while (await findOrgBySlug(db, candidate)) {
+    candidate = `${base}-${suffix}`;
+    suffix += 1;
+  }
+  return candidate;
 }
 
 /** The role of a user in an org, or null if they are not a member. */

--- a/shared/tests/auth.test.ts
+++ b/shared/tests/auth.test.ts
@@ -7,7 +7,10 @@ import {
   hashPassword,
   verifyPassword,
   createUser,
+  createUserRecord,
   findUserByUsername,
+  findUserByEmail,
+  normalizeEmail,
   createSession,
   loadSession,
   deleteSession,
@@ -39,7 +42,7 @@ describe('shared/auth', () => {
   });
 
   it('createUser bootstraps the default org membership', async () => {
-    const id = await createUser(getDb(), 'alice', 'a-very-long-password');
+    const id = await createUser(getDb(), { username: 'alice', password: 'a-very-long-password' });
     expect(typeof id).toBe('number');
 
     const org = await loadOrganizationForUser(getDb(), id);
@@ -55,7 +58,7 @@ describe('shared/auth', () => {
   // created inline, and it must not have to wait for a migration to get its
   // `personal` project (shared/src/personal-project.ts, decision 2026-09-07).
   it('createUser creates the personal project for a freshly-created default org', async () => {
-    const id = await createUser(getDb(), 'frank', 'a-very-long-password');
+    const id = await createUser(getDb(), { username: 'frank', password: 'a-very-long-password' });
     const org = await loadOrganizationForUser(getDb(), id);
     expect(org).not.toBeNull();
 
@@ -67,11 +70,16 @@ describe('shared/auth', () => {
   });
 
   it('createUser defaults isInstanceAdmin to false, and honours the opt-in (#137)', async () => {
-    const memberId = await createUser(getDb(), 'dave', 'a-very-long-password');
+    const memberId = await createUser(getDb(), {
+      username: 'dave',
+      password: 'a-very-long-password',
+    });
     const [memberRow] = await getDb().select().from(users).where(eq(users.id, memberId));
     expect(memberRow.isInstanceAdmin).toBe(false);
 
-    const ownerId = await createUser(getDb(), 'erin', 'a-very-long-password', {
+    const ownerId = await createUser(getDb(), {
+      username: 'erin',
+      password: 'a-very-long-password',
       isInstanceAdmin: true,
     });
     const [ownerRow] = await getDb().select().from(users).where(eq(users.id, ownerId));
@@ -82,8 +90,77 @@ describe('shared/auth', () => {
     expect(await findUserByUsername(getDb(), 'nope')).toBeNull();
   });
 
+  it('normalizeEmail trims and lowercases, and collapses empty/absent to null', () => {
+    expect(normalizeEmail('  Alice@Example.COM  ')).toBe('alice@example.com');
+    expect(normalizeEmail('')).toBeNull();
+    expect(normalizeEmail('   ')).toBeNull();
+    expect(normalizeEmail(null)).toBeNull();
+    expect(normalizeEmail(undefined)).toBeNull();
+  });
+
+  it('createUser stores email already normalized, and leaves it null when omitted (#507)', async () => {
+    const withEmail = await createUser(getDb(), {
+      username: 'greta',
+      password: 'a-very-long-password',
+      email: '  Greta@Example.COM  ',
+    });
+    const [row] = await getDb().select().from(users).where(eq(users.id, withEmail));
+    expect(row.email).toBe('greta@example.com');
+
+    const withoutEmail = await createUser(getDb(), {
+      username: 'harry',
+      password: 'a-very-long-password',
+    });
+    const [row2] = await getDb().select().from(users).where(eq(users.id, withoutEmail));
+    expect(row2.email).toBeNull();
+  });
+
+  it('findUserByEmail matches case- and whitespace-insensitively, and returns null when missing (#507)', async () => {
+    const id = await createUser(getDb(), {
+      username: 'ivy',
+      password: 'a-very-long-password',
+      email: 'ivy@example.com',
+    });
+    const found = await findUserByEmail(getDb(), '  IVY@Example.com ');
+    expect(found?.id).toBe(id);
+    expect(await findUserByEmail(getDb(), 'nobody@example.com')).toBeNull();
+  });
+
+  // A duplicate address that differs only in case or surrounding whitespace
+  // must still collide, since both createUser and the register route always
+  // normalize before writing - this is the DB-level backstop for that
+  // invariant, independent of any application-level pre-check.
+  it('the users.email unique index rejects a second account with the same normalized address (#507)', async () => {
+    await createUser(getDb(), {
+      username: 'jack',
+      password: 'a-very-long-password',
+      email: 'jack@example.com',
+    });
+    await expect(
+      createUser(getDb(), {
+        username: 'jackalt',
+        password: 'a-very-long-password',
+        email: '  Jack@Example.com  ',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('createUserRecord inserts a user row with no org membership, unlike createUser (#504)', async () => {
+    const id = await createUserRecord(getDb(), {
+      username: 'kim',
+      password: 'a-very-long-password',
+      email: 'kim@example.com',
+    });
+    expect(await loadOrganizationForUser(getDb(), id)).toBeNull();
+    const [row] = await getDb().select().from(users).where(eq(users.id, id));
+    expect(row.email).toBe('kim@example.com');
+  });
+
   it('setInstanceAdmin flips the flag on and off (#413)', async () => {
-    const userId = await createUser(getDb(), 'frank', 'a-very-long-password');
+    const userId = await createUser(getDb(), {
+      username: 'frank',
+      password: 'a-very-long-password',
+    });
     const [before] = await getDb().select().from(users).where(eq(users.id, userId));
     expect(before.isInstanceAdmin).toBe(false);
 
@@ -97,8 +174,12 @@ describe('shared/auth', () => {
   });
 
   it('listUsers reports every user with their instance-admin flag, ordered by username (#413)', async () => {
-    await createUser(getDb(), 'zack', 'a-very-long-password');
-    await createUser(getDb(), 'amy', 'a-very-long-password', { isInstanceAdmin: true });
+    await createUser(getDb(), { username: 'zack', password: 'a-very-long-password' });
+    await createUser(getDb(), {
+      username: 'amy',
+      password: 'a-very-long-password',
+      isInstanceAdmin: true,
+    });
     const rows = await listUsers(getDb());
     expect(rows.map((r) => r.username)).toEqual(['amy', 'zack']);
     expect(rows.find((r) => r.username === 'amy')?.isInstanceAdmin).toBe(true);
@@ -112,7 +193,7 @@ describe('shared/auth', () => {
   // time `isInstanceAdmin:` assignment fails this test instead of silently
   // drifting from `setInstanceAdmin`.
   it('sessions can be created, loaded, and deleted', async () => {
-    const userId = await createUser(getDb(), 'bob', 'a-very-long-password');
+    const userId = await createUser(getDb(), { username: 'bob', password: 'a-very-long-password' });
     const sess = await createSession(getDb(), userId);
     expect(sess.id).toMatch(/^[0-9a-f]{64}$/);
 
@@ -125,7 +206,10 @@ describe('shared/auth', () => {
   });
 
   it('expired sessions are not returned by loadSession', async () => {
-    const userId = await createUser(getDb(), 'carol', 'a-very-long-password');
+    const userId = await createUser(getDb(), {
+      username: 'carol',
+      password: 'a-very-long-password',
+    });
     const sess = await createSession(getDb(), userId);
     // Force-expire the row.
     await getDb().execute(

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -109,13 +109,17 @@ function isExemptPath(pathname: string): boolean {
   return (
     pathname.startsWith('/api/extension/') ||
     pathname.startsWith('/login') ||
-    // Only login/logout are exempt - a signed-in-or-not caller has to be
-    // able to reach them. `/api/auth/unlock` and `/api/auth/failures` are
+    // A visitor with no session has to be able to reach both halves of
+    // sign-up too (#504): /register itself, and /invite/<token>'s own
+    // redirect there for someone with no account yet. `/api/auth/unlock`
+    // and `/api/auth/failures` stay OUT of this list on purpose - they are
     // admin-only management endpoints and must go through the same
     // session + org/role resolution as every other /api/* route below, or
     // `requireRole` in those handlers has nothing to gate on (#132).
+    pathname.startsWith('/register') ||
     pathname.startsWith('/api/auth/login') ||
     pathname.startsWith('/api/auth/logout') ||
+    pathname.startsWith('/api/auth/register') ||
     pathname.startsWith('/_app/') ||
     pathname.startsWith('/favicon')
   );
@@ -185,7 +189,11 @@ export const handle = async ({ event, resolve }) => {
             headers: { 'content-type': 'application/json' },
           });
         }
-        return new Response(null, { status: 302, headers: { location: `/login?next=${next}` } });
+        // An invite link is an account nobody has yet (#504) - send a
+        // session-less visitor to create one, not to a login form for a
+        // user that doesn't exist. Every other route still goes to /login.
+        const base = event.url.pathname.startsWith('/invite/') ? '/register' : '/login';
+        return new Response(null, { status: 302, headers: { location: `${base}?next=${next}` } });
       }
       // Verified internal dispatch to /api/run (see INTERNAL_TOKEN above):
       // fall through with no locals.user / locals.org, same as the

--- a/web/src/routes/api/auth/login/+server.ts
+++ b/web/src/routes/api/auth/login/+server.ts
@@ -67,13 +67,25 @@ export async function POST(event: RequestEvent) {
     );
   }
 
+  // Decision (#507, 2026-09-09): login stays username-only rather than
+  // accepting either a username or an email. Password recovery (a separate
+  // future child of #503) identifies people by address through its own
+  // route, not by widening what this form's single identifier field means -
+  // the two flows don't need to share an input shape. Accepting both here
+  // would also touch the bootstrap branch just below, which writes the
+  // submitted value straight into `users.username`: an email-shaped string
+  // would either have to be rejected there anyway or silently become a
+  // username, neither of which is the small change it looks like from this
+  // form alone. `register` below reuses this exact zod shape unchanged.
   let userId: number;
   const total = await countUsers(db);
   if (total === 0) {
     // First user becomes the owner - and the instance admin - on first login
     // attempt (#137: instance-admin gates instance-wide config and must not
     // be handed to every self-created-org owner, only this bootstrap one).
-    userId = await createUser(db, parsed.data.username, parsed.data.password, {
+    userId = await createUser(db, {
+      username: parsed.data.username,
+      password: parsed.data.password,
       isInstanceAdmin: true,
     });
   } else {

--- a/web/src/routes/api/auth/register/+server.ts
+++ b/web/src/routes/api/auth/register/+server.ts
@@ -1,0 +1,197 @@
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '../../../../lib/server/db.js';
+import {
+  clearAuthFailures,
+  createSession,
+  createUserRecord,
+  deleteSession,
+  findUserByEmail,
+  findUserByUsername,
+  getLockoutUntil,
+  loadAuthPolicy,
+  normalizeEmail,
+  recordAuthFailure,
+} from '@pitchbox/shared/auth';
+import {
+  acceptInvite,
+  createOrganization,
+  defaultOrgName,
+  findValidInvite,
+  uniqueOrgSlugFromUsername,
+  type OrgInvite,
+} from '@pitchbox/shared/orgs';
+
+// Same identifier/password shape as POST /api/auth/login (web/src/routes/api/
+// auth/login/+server.ts) - one convention for both routes, per #504. Email is
+// the one addition: required at registration (#507), since open sign-up
+// (#505) makes it the only thing tying a self-registered account to a
+// person, validated with the same z.email() the invites API already uses -
+// trimmed first, so a pasted address with stray surrounding whitespace still
+// passes format validation instead of failing before normalizeEmail() below
+// ever gets a chance to clean it up.
+const Body = z.object({
+  username: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(/^[a-zA-Z0-9_.-]+$/),
+  password: z.string().min(8).max(256),
+  email: z.string().trim().pipe(z.email()),
+  // Present when the visitor arrived via /invite/<token>. Always
+  // re-validated server-side against org_invites (findValidInvite) rather
+  // than trusted from the client - see the transaction below.
+  token: z.string().min(1).optional(),
+});
+
+const COOKIE = 'pitchbox_session';
+
+// Thrown to unwind the transaction when the invite token stops being valid
+// between the pre-check and the transactional accept (revoked, expired, or
+// consumed by a concurrent request) - the account must never exist without
+// the membership it was created for.
+class InviteRaceError extends Error {}
+
+function isUniqueViolation(e: unknown, constraintSubstring: string): boolean {
+  const err = e as Error & {
+    code?: string;
+    cause?: Error & { code?: string; constraint?: string };
+  };
+  const code = err.code ?? err.cause?.code;
+  const constraint = err.cause?.constraint ?? '';
+  const msg = String(err.message ?? '');
+  const causeMsg = String(err.cause?.message ?? '');
+  return (
+    code === '23505' &&
+    (constraint.includes(constraintSubstring) ||
+      msg.includes(constraintSubstring) ||
+      causeMsg.includes(constraintSubstring))
+  );
+}
+
+export async function POST(event: RequestEvent) {
+  const { request, cookies } = event;
+  if (process.env.PITCHBOX_AUTH !== 'on') {
+    throw error(404, 'auth_disabled');
+  }
+  const raw = await request.json().catch(() => null);
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) throw error(400, 'invalid_body');
+  const db = getDb();
+
+  let ip: string;
+  try {
+    ip = event.getClientAddress() || 'unknown';
+  } catch {
+    ip = 'unknown';
+  }
+
+  // Rate-limited by IP through the same auth_failures table and policy the
+  // login route uses (loadAuthPolicy/getLockoutUntil/recordAuthFailure). No
+  // per-identity bucket like login's `user:<username>`: every registration
+  // attempt names a brand-new identity by definition, so bucketing by IP is
+  // the one that actually slows down a spam/enumeration run.
+  const ipBucket = `register:ip:${ip}`;
+  const policy = await loadAuthPolicy(db);
+  const now = new Date();
+  const ipLock = await getLockoutUntil(db, ipBucket, policy, now);
+  if (ipLock) {
+    return json(
+      {
+        error: 'rate_limited',
+        retry_after_seconds: Math.max(1, Math.ceil((ipLock.getTime() - now.getTime()) / 1000)),
+      },
+      { status: 429 },
+    );
+  }
+
+  const email = normalizeEmail(parsed.data.email);
+  if (!email) throw error(400, 'invalid_body');
+
+  // Friendly pre-checks so a client gets a shape it can act on
+  // (`username_taken` / `email_taken`) rather than a generic 500. The unique
+  // indexes (`users_username_key`, `users_email_unique`) are still the real
+  // guard against a concurrent registration racing this check - caught below.
+  if (await findUserByUsername(db, parsed.data.username)) {
+    await recordAuthFailure(db, ipBucket);
+    return json({ error: 'username_taken' }, { status: 409 });
+  }
+  if (await findUserByEmail(db, email)) {
+    await recordAuthFailure(db, ipBucket);
+    return json({ error: 'email_taken' }, { status: 409 });
+  }
+
+  let invite: OrgInvite | null = null;
+  if (parsed.data.token) {
+    invite = await findValidInvite(db, parsed.data.token);
+    if (!invite) {
+      await recordAuthFailure(db, ipBucket);
+      return json({ error: 'invalid_or_expired_invite' }, { status: 400 });
+    }
+  }
+
+  let userId: number;
+  try {
+    userId = await db.transaction(async (tx) => {
+      // createUserRecord, not createUser: createUser unconditionally joins
+      // the `default` org as owner, which would make every invited or
+      // self-registered stranger an owner of the single-tenant self-host org
+      // (#503's write-up of that trap). The account never exists without a
+      // membership - both branches below add one in the same transaction.
+      const id = await createUserRecord(tx, {
+        username: parsed.data.username,
+        password: parsed.data.password,
+        email,
+      });
+      if (invite) {
+        const accepted = await acceptInvite(tx, invite.token, id);
+        if (!accepted) throw new InviteRaceError();
+      } else {
+        // #513 owns the real self-registration org policy (slug source,
+        // quota, role nuance, what an invited-later user keeps). This is a
+        // narrow, unopinionated stand-in so open sign-up (#505) is not
+        // accidentally invite-only in the meantime: every stranger gets
+        // their own single-owner org through the existing createOrganization
+        // primitive, never `default`.
+        const slug = await uniqueOrgSlugFromUsername(tx, parsed.data.username);
+        await createOrganization(tx, {
+          slug,
+          name: defaultOrgName(parsed.data.username),
+          ownerUserId: id,
+        });
+      }
+      return id;
+    });
+  } catch (e) {
+    if (e instanceof InviteRaceError) {
+      await recordAuthFailure(db, ipBucket);
+      return json({ error: 'invalid_or_expired_invite' }, { status: 400 });
+    }
+    if (isUniqueViolation(e, 'users_username_key')) {
+      await recordAuthFailure(db, ipBucket);
+      return json({ error: 'username_taken' }, { status: 409 });
+    }
+    if (isUniqueViolation(e, 'users_email_unique')) {
+      await recordAuthFailure(db, ipBucket);
+      return json({ error: 'email_taken' }, { status: 409 });
+    }
+    throw e;
+  }
+
+  // Session rotation + cookie, identical to POST /api/auth/login.
+  const prevCookie = cookies.get(COOKIE);
+  if (prevCookie) {
+    await deleteSession(db, prevCookie);
+  }
+  await clearAuthFailures(db, ipBucket);
+
+  const session = await createSession(db, userId);
+  cookies.set(COOKIE, session.id, {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    expires: session.expiresAt,
+  });
+  return json({ ok: true });
+}

--- a/web/src/routes/invite/[token]/+page.server.ts
+++ b/web/src/routes/invite/[token]/+page.server.ts
@@ -18,7 +18,7 @@ export const load: PageServerLoad = async (event) => {
   }
   if (!event.locals.user) {
     const next = encodeURIComponent(event.url.pathname);
-    throw redirect(302, `/login?next=${next}`);
+    throw redirect(302, `/register?next=${next}`);
   }
   const [org] = await db
     .select({ name: schema.organizations.name })
@@ -43,7 +43,7 @@ export const actions: Actions = {
     const db = getDb();
     if (!event.locals.user) {
       const next = encodeURIComponent(event.url.pathname);
-      throw redirect(302, `/login?next=${next}`);
+      throw redirect(302, `/register?next=${next}`);
     }
     const accepted = await acceptInvite(db, token, event.locals.user.id);
     if (!accepted) {

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -74,6 +74,14 @@
 				<Button onclick={submit} disabled={busy || !username || password.length < 8}>
 					{data.firstUser ? 'Create' : 'Sign in'}
 				</Button>
+				{#if !data.firstUser}
+					<p class="text-center text-xs text-muted-foreground">
+						Need an account? <a
+							href={`/register?next=${encodeURIComponent($page.url.searchParams.get('next') || '/')}`}
+							class="underline">Create one</a
+						>
+					</p>
+				{/if}
 			</Card.Content>
 		{/if}
 	</Card.Root>

--- a/web/src/routes/register/+layout@.svelte
+++ b/web/src/routes/register/+layout@.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import '../../app.css';
+	import { ModeWatcher } from 'mode-watcher';
+	let { children } = $props();
+</script>
+
+<!--
+  Register page bypasses the dashboard chrome, same as /login
+  (web/src/routes/login/+layout@.svelte) - one convention for both.
+-->
+<ModeWatcher defaultMode="dark" />
+
+<div class="min-h-screen bg-background text-foreground">
+	{@render children()}
+</div>

--- a/web/src/routes/register/+page.server.ts
+++ b/web/src/routes/register/+page.server.ts
@@ -1,0 +1,42 @@
+import { redirect } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '$lib/server/db.js';
+import { findValidInvite } from '@pitchbox/shared/orgs';
+import type { PageServerLoad } from './$types';
+
+// `/invite/<token>` redirects an unauthenticated visitor here with
+// `?next=/invite/<token>` (web/src/routes/invite/[token]/+page.server.ts).
+// Only that exact shape is trusted for an invite prefill/context lookup -
+// anything else in `next` is just where the register form sends the browser
+// after a successful POST.
+const INVITE_NEXT = /^\/invite\/([^/?#]+)$/;
+
+export const load: PageServerLoad = async (event) => {
+  const authOn = process.env.PITCHBOX_AUTH === 'on';
+  const rawNext = event.url.searchParams.get('next');
+  const next = rawNext && rawNext.startsWith('/') ? rawNext : null;
+
+  // Already signed in: nothing to register, go wherever `next` pointed (or
+  // home). Mirrors the login page having no reason to show a form to a
+  // caller who already has a session.
+  if (event.locals.user) {
+    throw redirect(302, next ?? '/');
+  }
+
+  let invite: { token: string; email: string | null; orgName: string | null } | null = null;
+  const inviteMatch = authOn && next ? next.match(INVITE_NEXT) : null;
+  if (inviteMatch) {
+    const token = inviteMatch[1];
+    const db = getDb();
+    const found = await findValidInvite(db, token);
+    if (found) {
+      const [org] = await db
+        .select({ name: schema.organizations.name })
+        .from(schema.organizations)
+        .where(eq(schema.organizations.id, found.organizationId));
+      invite = { token, email: found.email, orgName: org?.name ?? null };
+    }
+  }
+
+  return { authOn, next, invite };
+};

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import * as Card from '$lib/components/ui/card';
+	import { toast } from 'svelte-sonner';
+	import Seo from '$lib/components/Seo.svelte';
+	import { TONE_TEXT_CLASS } from '$lib/config/status-badges';
+
+	type PageData = {
+		authOn: boolean;
+		next: string | null;
+		invite: { token: string; email: string | null; orgName: string | null } | null;
+	};
+	let { data }: { data: PageData } = $props();
+
+	let username = $state('');
+	// svelte-ignore state_referenced_locally
+	let email = $state(data.invite?.email ?? '');
+	let password = $state('');
+	let busy = $state(false);
+
+	function signInHref(): string {
+		return data.next ? `/login?next=${encodeURIComponent(data.next)}` : '/login';
+	}
+
+	async function submit() {
+		if (busy) return;
+		busy = true;
+		try {
+			const res = await fetch('/api/auth/register', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					username,
+					email,
+					password,
+					token: data.invite?.token,
+				}),
+			});
+			if (!res.ok) {
+				const body = (await res.json().catch(() => ({}))) as { error?: string };
+				const message =
+					body.error === 'username_taken'
+						? 'That username is already taken'
+						: body.error === 'email_taken'
+							? 'That email is already registered'
+							: body.error === 'invalid_or_expired_invite'
+								? 'This invite is no longer valid'
+								: body.error === 'rate_limited'
+									? 'Too many attempts, try again shortly'
+									: 'Could not create account';
+				toast.error(message);
+				return;
+			}
+			await goto(data.next ?? '/', { invalidateAll: true });
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+<Seo
+	title={data.authOn ? 'Create an account' : 'Authentication disabled'}
+	description="Create a Pitchbox account"
+/>
+
+<div class="min-h-screen flex items-center justify-center bg-background p-6">
+	<Card.Root class="w-full max-w-sm">
+		{#if !data.authOn}
+			<Card.Header>
+				<Card.Title>Authentication is disabled</Card.Title>
+				<p class="text-xs {TONE_TEXT_CLASS.amber}">
+					This instance runs with PITCHBOX_AUTH off, so there is no account to create. Set
+					PITCHBOX_AUTH=on in your environment to enable registration.
+				</p>
+			</Card.Header>
+			<Card.Content>
+				<Button href="/" variant="outline" class="w-full">Go to Pitchbox</Button>
+			</Card.Content>
+		{:else}
+			<Card.Header>
+				<Card.Title>Create an account</Card.Title>
+				{#if data.invite}
+					<p class="text-xs text-muted-foreground">
+						You have been invited to join
+						<span class="font-medium text-foreground">{data.invite.orgName ?? 'an organization'}</span
+						>. Create an account to accept.
+					</p>
+				{/if}
+			</Card.Header>
+			<Card.Content class="flex flex-col gap-3">
+				<label class="flex flex-col gap-1 text-xs">
+					Username
+					<Input bind:value={username} autocomplete="username" />
+				</label>
+				<label class="flex flex-col gap-1 text-xs">
+					Email
+					<Input type="email" bind:value={email} autocomplete="email" />
+				</label>
+				<label class="flex flex-col gap-1 text-xs">
+					Password
+					<Input type="password" bind:value={password} autocomplete="new-password" />
+				</label>
+				<Button
+					onclick={submit}
+					disabled={busy || !username || !email || password.length < 8}
+				>
+					{busy ? 'Creating…' : 'Create account'}
+				</Button>
+				<p class="text-center text-xs text-muted-foreground">
+					Already have an account? <a href={signInHref()} class="underline">Sign in</a>
+				</p>
+			</Card.Content>
+		{/if}
+	</Card.Root>
+</div>

--- a/web/src/routes/settings/organization/+page.server.ts
+++ b/web/src/routes/settings/organization/+page.server.ts
@@ -69,6 +69,7 @@ export const load: PageServerLoad = async (event) => {
     members: members.map((m) => ({
       userId: m.userId,
       username: m.username,
+      email: m.email,
       role: m.role,
       joinedAt: m.createdAt.toISOString(),
     })),

--- a/web/src/routes/settings/organization/+page.svelte
+++ b/web/src/routes/settings/organization/+page.svelte
@@ -15,7 +15,13 @@
   import RemoveMemberDialog from '$lib/components/settings/RemoveMemberDialog.svelte';
   import LeaveOrgDialog from '$lib/components/settings/LeaveOrgDialog.svelte';
 
-  type Member = { userId: number; username: string; role: string; joinedAt: string };
+  type Member = {
+    userId: number;
+    username: string;
+    email: string | null;
+    role: string;
+    joinedAt: string;
+  };
   type Invite = {
     token: string;
     role: string;
@@ -533,10 +539,15 @@
             >
               {initials(m.username)}
             </span>
-            <span class="flex-1 truncate text-sm font-medium">
-              {m.username}
-              {#if m.userId === data.currentUserId}
-                <span class="font-normal text-muted-foreground">(you)</span>
+            <span class="min-w-0 flex-1">
+              <span class="block truncate text-sm font-medium">
+                {m.username}
+                {#if m.userId === data.currentUserId}
+                  <span class="font-normal text-muted-foreground">(you)</span>
+                {/if}
+              </span>
+              {#if m.email}
+                <span class="block truncate text-xs text-muted-foreground">{m.email}</span>
               {/if}
             </span>
             <span

--- a/web/tests/register.test.ts
+++ b/web/tests/register.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, beforeEach, afterAll } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { createInvite, findOrgBySlug, listUserOrganizations } from '@pitchbox/shared/orgs';
+import { POST as register } from '../src/routes/api/auth/register/+server.js';
+import { load as inviteLoad } from '../src/routes/invite/[token]/+page.server.js';
+import { type CookieJar, makeCookies, runThroughHandle } from './helpers/handle-harness.js';
+
+const originalAuth = process.env.PITCHBOX_AUTH;
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`TRUNCATE auth_failures RESTART IDENTITY CASCADE`);
+  await db.execute(sql`DELETE FROM org_invites`);
+  await db.execute(sql`DELETE FROM sessions`);
+  await db.execute(sql`DELETE FROM memberships`);
+  await db.execute(sql`DELETE FROM users`);
+  // Keep `default`: seed:core creates it once for the whole suite and other
+  // test files running later in this sequential run rely on it existing.
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function seedOrgAdmin(orgSlug: string) {
+  const db = getDb();
+  const [admin] = await db
+    .insert(schema.users)
+    .values({ username: `admin-${orgSlug}`, passwordHash: 'x' })
+    .returning();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug: orgSlug, name: orgSlug })
+    .returning();
+  await db
+    .insert(schema.memberships)
+    .values({ organizationId: org.id, userId: admin.id, role: 'owner' });
+  return { adminId: admin.id, orgId: org.id };
+}
+
+function makeEvent(body: unknown, jar: CookieJar, ip = '10.1.0.1'): RequestEvent {
+  const request = new Request('http://localhost/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return {
+    request,
+    cookies: makeCookies(jar),
+    getClientAddress: () => ip,
+  } as unknown as RequestEvent;
+}
+
+async function callRegister(body: unknown, jar: CookieJar, ip = '10.1.0.1'): Promise<Response> {
+  return await register(makeEvent(body, jar, ip));
+}
+
+describe('POST /api/auth/register', () => {
+  beforeEach(async () => {
+    process.env.PITCHBOX_AUTH = 'on';
+    await reset();
+  });
+
+  // Acceptance: the whole point of #504 - an invited person could not
+  // reach an account at all before this route existed.
+  it('an invited person registers, is signed in, and ends up with the invited membership and no default membership', async () => {
+    const { adminId, orgId } = await seedOrgAdmin('acme');
+    const invite = await createInvite(getDb(), {
+      organizationId: orgId,
+      role: 'admin',
+      createdByUserId: adminId,
+    });
+
+    const jar: CookieJar = { store: new Map() };
+    const res = await callRegister(
+      {
+        username: 'invitee1',
+        email: 'invitee1@example.com',
+        password: 'a-very-long-password',
+        token: invite.token,
+      },
+      jar,
+    );
+    expect(res.status).toBe(200);
+    expect(jar.store.get('pitchbox_session')).toBeTruthy();
+
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, 'invitee1'));
+    expect(user.email).toBe('invitee1@example.com');
+
+    const orgs = await listUserOrganizations(getDb(), user.id);
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0].slug).toBe('acme');
+    expect(orgs[0].role).toBe('admin');
+
+    const [invRow] = await getDb()
+      .select()
+      .from(schema.orgInvites)
+      .where(eq(schema.orgInvites.token, invite.token));
+    expect(invRow.acceptedAt).not.toBeNull();
+  });
+
+  it('a second use of an already-consumed invite token is refused and creates no account', async () => {
+    const { adminId, orgId } = await seedOrgAdmin('reused');
+    const invite = await createInvite(getDb(), { organizationId: orgId, createdByUserId: adminId });
+
+    const jar1: CookieJar = { store: new Map() };
+    const first = await callRegister(
+      {
+        username: 'first-in',
+        email: 'first@example.com',
+        password: 'a-very-long-password',
+        token: invite.token,
+      },
+      jar1,
+    );
+    expect(first.status).toBe(200);
+
+    const jar2: CookieJar = { store: new Map() };
+    const second = await callRegister(
+      {
+        username: 'second-in',
+        email: 'second@example.com',
+        password: 'a-very-long-password',
+        token: invite.token,
+      },
+      jar2,
+    );
+    expect(second.status).toBe(400);
+    const body = await second.json();
+    expect(body.error).toBe('invalid_or_expired_invite');
+
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, 'second-in'));
+    expect(user).toBeUndefined();
+  });
+
+  it('an expired invite token refuses registration and creates no account', async () => {
+    const { adminId, orgId } = await seedOrgAdmin('expired-org');
+    const invite = await createInvite(getDb(), { organizationId: orgId, createdByUserId: adminId });
+    await getDb().execute(
+      sql`UPDATE org_invites SET expires_at = now() - interval '1 day' WHERE token = ${invite.token}`,
+    );
+
+    const jar: CookieJar = { store: new Map() };
+    const res = await callRegister(
+      {
+        username: 'toolate',
+        email: 'toolate@example.com',
+        password: 'a-very-long-password',
+        token: invite.token,
+      },
+      jar,
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_or_expired_invite');
+    expect(jar.store.get('pitchbox_session')).toBeUndefined();
+
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, 'toolate'));
+    expect(user).toBeUndefined();
+  });
+
+  it('a stranger with no invite registers into their own new organization, not default', async () => {
+    const jar: CookieJar = { store: new Map() };
+    const res = await callRegister(
+      { username: 'solo-founder', email: 'solo@example.com', password: 'a-very-long-password' },
+      jar,
+    );
+    expect(res.status).toBe(200);
+
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, 'solo-founder'));
+    const orgs = await listUserOrganizations(getDb(), user.id);
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0].slug).not.toBe('default');
+    expect(orgs[0].role).toBe('owner');
+  });
+
+  it('two strangers whose usernames collide on the derived slug get distinct organizations', async () => {
+    const jar1: CookieJar = { store: new Map() };
+    await callRegister(
+      { username: 'sameish', email: 'sameish1@example.com', password: 'a-very-long-password' },
+      jar1,
+    );
+    const jar2: CookieJar = { store: new Map() };
+    await callRegister(
+      { username: 'sameish-2', email: 'sameish2@example.com', password: 'a-very-long-password' },
+      jar2,
+    );
+    // Both derive the same slug base ("sameish") after stripping non-slug
+    // characters, so the second must be collision-suffixed rather than fail.
+    expect(await findOrgBySlug(getDb(), 'sameish')).not.toBeNull();
+    expect(await findOrgBySlug(getDb(), 'sameish-2')).not.toBeNull();
+  });
+
+  it('refuses a duplicate email that differs only in case and surrounding whitespace', async () => {
+    const jar1: CookieJar = { store: new Map() };
+    const first = await callRegister(
+      { username: 'dupemail1', email: 'Case@Example.com', password: 'a-very-long-password' },
+      jar1,
+    );
+    expect(first.status).toBe(200);
+
+    const jar2: CookieJar = { store: new Map() };
+    const second = await callRegister(
+      { username: 'dupemail2', email: '  case@EXAMPLE.com  ', password: 'a-very-long-password' },
+      jar2,
+    );
+    expect(second.status).toBe(409);
+    expect((await second.json()).error).toBe('email_taken');
+
+    const rows = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, 'dupemail2'));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('refuses a duplicate username', async () => {
+    const jar1: CookieJar = { store: new Map() };
+    const first = await callRegister(
+      { username: 'dupeuser', email: 'dupeuser1@example.com', password: 'a-very-long-password' },
+      jar1,
+    );
+    expect(first.status).toBe(200);
+
+    const jar2: CookieJar = { store: new Map() };
+    const second = await callRegister(
+      { username: 'dupeuser', email: 'dupeuser2@example.com', password: 'a-very-long-password' },
+      jar2,
+    );
+    expect(second.status).toBe(409);
+    expect((await second.json()).error).toBe('username_taken');
+
+    const rows = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.email, 'dupeuser2@example.com'));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('rejects a body missing the required email with 400', async () => {
+    const jar: CookieJar = { store: new Map() };
+    await expect(
+      callRegister({ username: 'noemail', password: 'a-very-long-password' }, jar),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe('/invite/<token> sends a session-less visitor to /register, not /login (#504)', () => {
+  beforeEach(async () => {
+    process.env.PITCHBOX_AUTH = 'on';
+    await reset();
+  });
+
+  it('the real hooks.server.ts handle() redirects an unauthenticated GET to /register?next=...', async () => {
+    const jar: CookieJar = { store: new Map() };
+    const req = new Request('http://localhost/invite/some-token', {
+      headers: { accept: 'text/html' },
+    });
+    const res = await runThroughHandle(req, jar, async () => new Response('unreachable'));
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('/register?next=%2Finvite%2Fsome-token');
+  });
+
+  it("the invite page's own load() redirects an unauthenticated visitor to /register as a defense-in-depth fallback", async () => {
+    const { adminId, orgId } = await seedOrgAdmin('fallback-org');
+    const invite = await createInvite(getDb(), { organizationId: orgId, createdByUserId: adminId });
+    const event = {
+      params: { token: invite.token },
+      url: new URL(`http://x/invite/${invite.token}`),
+      locals: {},
+    } as unknown as Parameters<typeof inviteLoad>[0];
+    await expect(inviteLoad(event)).rejects.toMatchObject({
+      status: 302,
+      location: `/register?next=%2Finvite%2F${invite.token}`,
+    });
+  });
+});
+
+afterAll(async () => {
+  if (originalAuth === undefined) delete process.env.PITCHBOX_AUTH;
+  else process.env.PITCHBOX_AUTH = originalAuth;
+});


### PR DESCRIPTION
Closes #507
Closes #504

## #507: users.email

`users.email`: nullable, unique on the normalized (trimmed, lowercased) value, validated with the same `z.email()` check `POST /api/orgs/[slug]/invites` already uses. `createUser` now takes an object arg `{ username, password, email?, isInstanceAdmin? }`; `createUserRecord` is the new lower-level insert (row only, no org membership) that the register route composes instead. Shown in the org member list, under the username.

**Login decision, recorded on #507 and as a comment at the decision site in the login route:** login stays username-only rather than accepting either a username or an email. Password recovery (a separate future epic child) identifies people by address through its own route, not by widening what the login form's identifier field means. Accepting both there would also touch the first-login bootstrap branch, which writes the submitted value straight into `users.username` - not the small change it looks like from the form alone.

### Migration

Hand-authored (`0023_users_email.sql`), not `drizzle-kit generate`: the committed snapshot chain in `shared/src/db/migrations/meta/` stops at `0018_snapshot.json`, so `generate` tries to re-`CREATE TABLE` two tables that already exist on every real database. Filed as **#527**, left untouched here on Main's instruction. Journal `when` (`1788960000010`) pushed past the highest existing value (`1788960000009`) per the AGENTS.md trap.

Verified on a database dropped and recreated from scratch:

```
$ docker exec pitchbox-postgres psql -U pitchbox -d pitchbox -c "DROP DATABASE IF EXISTS pitchbox_test_w504;" -c "CREATE DATABASE pitchbox_test_w504 OWNER pitchbox;"
DROP DATABASE
CREATE DATABASE

$ DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5434/pitchbox_test_w504 pnpm run migrate
migrations applied (23 in journal, all present)
```

And the column checked directly rather than trusting that output:

```
$ docker exec pitchbox-postgres psql -U pitchbox -d pitchbox_test_w504 -c "\d users"
...
 email             | text                     |           |          |
Indexes:
    "users_email_unique" UNIQUE, btree (email)
```

## #504: register route + invite reachability

`POST /api/auth/register` + `/register` page, same shape as `/api/auth/login`: same username/password zod rules, same session creation + cookie rotation, same `auth_failures`-backed rate limiting (bucketed by IP under `register:ip:*`, since every registration attempt names a brand-new identity). Email required.

Never goes through `createUser()` (it unconditionally joins `default` as owner - see #503's write-up of that trap). Instead, in one DB transaction: `createUserRecord` inserts the row, then either `acceptInvite` (token path - the account never exists without the membership it was created for) or `createOrganization` with a collision-suffixed slug (no-token path). The no-token org-creation is a **narrow, explicitly-marked stand-in for #513**, which owns the real policy (slug source, quota, role nuance for a later-invited owner of their own org) - not improvised here, per #504's own instruction. Left undone on purpose: everything #513 lists as its own job (proper slug-source decision, quota, personal-project removal per #523).

`/invite/<token>` now sends a session-less visitor to `/register?next=...` instead of `/login` (both the `hooks.server.ts` hook-level redirect and the page's own defense-in-depth check). `/register` prefills the email from `org_invites.email` when the invite carried one, and offers a "Sign in instead" link back to `/login` (which now offers "Create one" back to `/register`), both preserving `next`.

### Tests (`web/tests/register.test.ts`, `shared/tests/auth.test.ts`)

- Invited person: `/invite/<token>` → register → signed-in account with the invited role in the inviting org, no `default` membership, invite marked accepted. This is the acceptance criterion for #504.
- Second use of a consumed token, and an expired token: both refused, no account created.
- Duplicate email differing only in case/whitespace → `409 email_taken`, no row created.
- Duplicate username → `409 username_taken`, no row created.
- No-token registration lands in the registrant's own org (not `default`); two colliding usernames get distinct slugs.
- `hooks.server.ts`'s real `handle()` redirects an unauthenticated `/invite/<token>` GET to `/register?next=...`.
- `shared/tests/auth.test.ts`: `normalizeEmail`, `createUser` storing/normalizing email, `findUserByEmail`, the `users_email_unique` index rejecting a case/whitespace duplicate, `createUserRecord` leaving no org membership (contrast with `createUser`).

Every new assertion was proven to bite (break the code under it, watch the exact test fail, restore, confirm green):
- `normalizeEmail`'s `.toLowerCase()` removed → 4 tests failed (the unit test itself, stored-email, `findUserByEmail`, the unique-index-collision test).
- `createUserRecord` temporarily made to join `default` like `createUser` does → the "no org membership" assertion failed as expected.

### Checks run (scoped, not the full matrix)

```
pnpm exec vitest run web/tests/register.test.ts web/tests/invite-accept-csrf.test.ts web/tests/org-invite.test.ts web/tests/auth-hardening.test.ts shared/tests/auth.test.ts cli/tests/commands/seed-owner.test.ts
# 46 passed

pnpm -F web check        # 0 errors, 0 warnings
pnpm -F @pitchbox/shared typecheck   # clean
pnpm -F cli typecheck                # clean
npx eslint <changed .ts files>       # 0 errors
npx prettier --check <changed .ts files>  # clean (changed .svelte files aren't covered by prettier in this repo - no svelte plugin installed; svelte-check above is their gate)
```

`docs/auth.md` and `docs/orgs.md` updated (registration section, invite-flow redirect target, `users` row in the schema table).

Filed #527 for the broken migration snapshot chain (`migrate:generate` unusable), flagged to Main before proceeding, and left `meta/*_snapshot.json` untouched as instructed.