### PR TITLE
feat(web): send an invite by email instead of copying a link by hand

### DIFF
--- a/web/src/routes/api/orgs/[slug]/invites/+server.ts
+++ b/web/src/routes/api/orgs/[slug]/invites/+server.ts
@@ -2,13 +2,41 @@ import { json } from '@sveltejs/kit';
 import { z } from 'zod';
 import { getDb } from '$lib/server/db.js';
 import { createInvite, findOrgBySlug, isOrgAdmin } from '@pitchbox/shared/orgs';
+import { createMailTransport } from '@pitchbox/shared/mail/registry';
+import { loadMailEnv } from '@pitchbox/shared/mail/env';
+import { renderPlainTextMail } from '@pitchbox/shared/mail/template';
 
 const Body = z.object({
   email: z.email().optional(),
   role: z.enum(['owner', 'admin', 'member']).default('member'),
 });
 
-export async function POST(event) {
+/**
+ * Builds the invite email body. The link is built from `origin` - the
+ * caller's own `event.url.origin`, which adapter-node resolves from the
+ * ORIGIN env var (see `web/src/lib/trusted-origins.js`) rather than a
+ * hardcoded host, so a deployment on any domain gets a link that works.
+ */
+function inviteMail(args: {
+  to: string;
+  orgName: string;
+  role: string;
+  origin: string;
+  token: string;
+  expiresAt: Date;
+}) {
+  const url = `${args.origin}/invite/${args.token}`;
+  const rendered = renderPlainTextMail(
+    `You're invited to join ${args.orgName} on Pitchbox`,
+    `You've been invited to join ${args.orgName} on Pitchbox as ${args.role}.\n\n` +
+      `Accept the invite: ${url}\n\n` +
+      `This invite expires on ${args.expiresAt.toDateString()}. If you weren't ` +
+      `expecting this, you can ignore this email.`,
+  );
+  return { to: args.to, subject: rendered.subject, text: rendered.text, html: rendered.html };
+}
+
+export async function POST(event: import('@sveltejs/kit').RequestEvent) {
   const user = event.locals.user;
   if (!user) return json({ error: 'unauthenticated' }, { status: 401 });
   const slug = event.params.slug as string;
@@ -32,5 +60,27 @@ export async function POST(event) {
     createdByUserId: user.id,
   });
   const url = `${event.url.origin}/invite/${invite.token}`;
-  return json({ token: invite.token, url, expiresAt: invite.expiresAt }, { status: 201 });
+  // The link stays the fallback regardless of a mail attempt (#510): a
+  // self-host with nothing configured selects the null transport, which
+  // logs and drops rather than delivering anywhere, so `emailSent` tells
+  // the UI whether a real transport actually took it.
+  let emailSent = false;
+  if (parsed.data.email) {
+    const transport = createMailTransport(loadMailEnv());
+    await transport.send(
+      inviteMail({
+        to: parsed.data.email,
+        orgName: org.name,
+        role: parsed.data.role,
+        origin: event.url.origin,
+        token: invite.token,
+        expiresAt: invite.expiresAt,
+      }),
+    );
+    emailSent = transport.name !== 'null';
+  }
+  return json(
+    { token: invite.token, url, expiresAt: invite.expiresAt, emailSent },
+    { status: 201 },
+  );
 }

--- a/web/src/routes/settings/organization/+page.svelte
+++ b/web/src/routes/settings/organization/+page.svelte
@@ -104,12 +104,18 @@
   // Invite dialog.
   let inviteOpen = $state(false);
   let inviteRole = $state<(typeof ROLES)[number]>('member');
+  let inviteEmail = $state('');
   let generating = $state(false);
   let generatedUrl = $state('');
+  let generatedEmail = $state('');
+  let generatedEmailSent = $state(false);
 
   function openInvite() {
     inviteRole = 'member';
+    inviteEmail = '';
     generatedUrl = '';
+    generatedEmail = '';
+    generatedEmailSent = false;
     inviteOpen = true;
   }
 
@@ -117,21 +123,31 @@
     if (!data.org || generating) return;
     generating = true;
     try {
+      const email = inviteEmail.trim();
       const res = await fetch(`/api/orgs/${data.org.slug}/invites`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ role: inviteRole }),
+        body: JSON.stringify({ role: inviteRole, ...(email ? { email } : {}) }),
       });
-      const body = (await res.json().catch(() => ({}))) as { url?: string; error?: string };
+      const body = (await res.json().catch(() => ({}))) as {
+        url?: string;
+        emailSent?: boolean;
+        error?: string;
+      };
       if (!res.ok) {
         toast.error(
           body?.error === 'not_found'
             ? 'Only owners and admins can invite people'
-            : 'Could not create the invite',
+            : body?.error === 'invalid_body'
+              ? 'Enter a valid email address'
+              : 'Could not create the invite',
         );
         return;
       }
       generatedUrl = body.url ?? '';
+      generatedEmail = email;
+      generatedEmailSent = body.emailSent ?? false;
+      if (generatedEmailSent) toast.success(`Invite sent to ${email}`);
       await invalidateAll();
     } catch {
       toast.error('Could not create the invite');
@@ -685,7 +701,7 @@
     <Dialog.Header>
       <Dialog.Title>Invite a member</Dialog.Title>
       <Dialog.Description>
-        Pick a role, then share the generated link. It expires in 7 days.
+        Pick a role and, if you have it, an email address. It expires in 7 days.
       </Dialog.Description>
     </Dialog.Header>
     <div class="flex flex-col gap-4 py-2">
@@ -709,6 +725,19 @@
         <p class="text-xs text-muted-foreground">{ROLE_HINT[inviteRole]}</p>
       </div>
 
+      <div class="flex flex-col gap-2">
+        <span class="text-sm font-medium">Email (optional)</span>
+        <Input
+          type="email"
+          placeholder="person@example.com"
+          bind:value={inviteEmail}
+          disabled={!!generatedUrl}
+        />
+        <p class="text-xs text-muted-foreground">
+          If mail isn't set up on this deployment, you'll still get a link to share by hand.
+        </p>
+      </div>
+
       {#if generatedUrl}
         <div class="flex flex-col gap-2">
           <span class="text-sm font-medium">Invite link</span>
@@ -719,7 +748,14 @@
             </Button>
           </div>
           <p class="text-xs text-muted-foreground">
-            Anyone with this link can join as <span class="capitalize">{inviteRole}</span>.
+            {#if generatedEmail && generatedEmailSent}
+              Sent to {generatedEmail}. If it doesn't arrive, share this link instead.
+            {:else if generatedEmail && !generatedEmailSent}
+              Mail isn't configured on this deployment, so share this link with {generatedEmail}
+              yourself.
+            {:else}
+              Anyone with this link can join as <span class="capitalize">{inviteRole}</span>.
+            {/if}
           </p>
         </div>
       {/if}
@@ -730,7 +766,9 @@
         <Button onclick={() => (inviteOpen = false)}>Done</Button>
       {:else}
         <Button variant="ghost" onclick={() => (inviteOpen = false)}>Cancel</Button>
-        <Button onclick={generateInvite} loading={generating}>Generate link</Button>
+        <Button onclick={generateInvite} loading={generating}>
+          {inviteEmail.trim() ? 'Send invite' : 'Generate link'}
+        </Button>
       {/if}
     </Dialog.Footer>
   </Dialog.Content>

--- a/web/tests/org-invite-mail.test.ts
+++ b/web/tests/org-invite-mail.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { sql } from 'drizzle-orm';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type { MailMessage, MailTransport } from '@pitchbox/shared/mail';
+
+/**
+ * #510: creating an invite with an address sends it through
+ * `@pitchbox/shared/mail` rather than requiring the address be copied by
+ * hand. `createMailTransport` is faked here (mirrors `createAgentRunner`
+ * being faked in extension-suggest-voice.test.ts) so a test can assert on
+ * exactly what would have been sent, without depending on the null
+ * transport's console logging.
+ */
+
+const { sent, transportState } = vi.hoisted(() => {
+  const sent: MailMessage[] = [];
+  const transportState = { name: 'smtp' };
+  return { sent, transportState };
+});
+
+vi.mock('@pitchbox/shared/mail/registry', () => ({
+  createMailTransport: (): MailTransport => ({
+    get name() {
+      return transportState.name;
+    },
+    async send(message: MailMessage) {
+      sent.push(message);
+    },
+  }),
+}));
+
+// Dynamic on purpose: `vi.mock` above is hoisted, but the route module has to
+// load after it for `createMailTransport` to resolve to the fake - a static
+// import here would race the hoisted mock (same pattern as
+// extension-suggest-voice.test.ts).
+const { POST } = await import('../src/routes/api/orgs/[slug]/invites/+server.js');
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`DELETE FROM org_invites`);
+  await db.execute(sql`DELETE FROM memberships`);
+  await db.execute(sql`DELETE FROM users`);
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  sent.length = 0;
+  transportState.name = 'smtp';
+}
+
+async function seed(username: string, slug: string, orgName: string, role: string) {
+  const db = getDb();
+  const [u] = await db.insert(schema.users).values({ username, passwordHash: 'x' }).returning();
+  const [o] = await db.insert(schema.organizations).values({ slug, name: orgName }).returning();
+  await db.insert(schema.memberships).values({ organizationId: o.id, userId: u.id, role });
+  return { userId: u.id, orgId: o.id, slug };
+}
+
+function ev(
+  userId: number,
+  slug: string,
+  body: unknown,
+  origin = 'https://app.pitchbox.app',
+): RequestEvent {
+  return {
+    locals: { user: { id: userId, username: 'x' } },
+    params: { slug },
+    request: new Request(`${origin}/api/orgs/${slug}/invites`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    url: new URL(`${origin}/api/orgs/${slug}/invites`),
+  } as unknown as RequestEvent;
+}
+
+describe('POST /api/orgs/[slug]/invites - email delivery (#510)', () => {
+  beforeEach(reset);
+
+  it('sends exactly one message, to the invited address, carrying the link/org/role', async () => {
+    const a = await seed('owner1', 'inv-a', 'Acme Inc', 'owner');
+    const res = await POST(ev(a.userId, 'inv-a', { email: 'friend@example.com', role: 'admin' }));
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { url: string; emailSent: boolean };
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toBe('friend@example.com');
+    expect(sent[0].text).toContain(body.url);
+    expect(sent[0].text).toContain('Acme Inc');
+    expect(sent[0].text).toContain('admin');
+    expect(body.emailSent).toBe(true);
+  });
+
+  it('sends nothing and still returns the link when no address is given', async () => {
+    const a = await seed('owner2', 'inv-b', 'Beta Co', 'owner');
+    const res = await POST(ev(a.userId, 'inv-b', { role: 'member' }));
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { url: string; emailSent: boolean };
+
+    expect(sent).toHaveLength(0);
+    expect(body.url).toMatch(/^https:\/\/app\.pitchbox\.app\/invite\//);
+    expect(body.emailSent).toBe(false);
+  });
+
+  it('builds the link in the message from the request origin, not a hardcoded host', async () => {
+    const a = await seed('owner3', 'inv-c', 'Gamma LLC', 'owner');
+    const res = await POST(
+      ev(
+        a.userId,
+        'inv-c',
+        { email: 'x@example.com', role: 'member' },
+        'https://preview.pitchbox.app',
+      ),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { url: string };
+
+    expect(body.url.startsWith('https://preview.pitchbox.app/invite/')).toBe(true);
+    expect(sent[0].text).toContain('https://preview.pitchbox.app/invite/');
+    expect(sent[0].text).not.toContain('app.pitchbox.app');
+  });
+
+  it('reports emailSent false when the deployment has no real transport configured', async () => {
+    transportState.name = 'null';
+    const a = await seed('owner4', 'inv-d', 'Delta', 'owner');
+    const res = await POST(ev(a.userId, 'inv-d', { email: 'x@example.com', role: 'member' }));
+    const body = (await res.json()) as { emailSent: boolean };
+
+    // The null transport still "sends" (logs and drops) - it is attempted,
+    // it just doesn't reach anyone, which is what emailSent tells the UI.
+    expect(sent).toHaveLength(1);
+    expect(body.emailSent).toBe(false);
+  });
+
+  it('rejects a member (not admin/owner) with 404 and sends nothing', async () => {
+    const m = await seed('member1', 'inv-e', 'Epsilon', 'member');
+    const res = await POST(ev(m.userId, 'inv-e', { email: 'x@example.com', role: 'member' }));
+    expect(res.status).toBe(404);
+    expect(sent).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #510

Creating an org invite with an address now sends it through `@pitchbox/shared/mail` instead of requiring the link be copied and shared through some other channel. The copyable link stays the fallback: with nothing configured the null transport is selected, `emailSent` comes back `false`, and the dialog says mail isn't configured so the link has to be shared by hand.

## Changes
- `POST /api/orgs/[slug]/invites` (`web/src/routes/api/orgs/[slug]/invites/+server.ts`): when `email` is given, builds a plain-text invite mail (`renderPlainTextMail`) naming the org and role, with the invite link built from `event.url.origin` (the same origin adapter-node resolves from `ORIGIN`/`PUBLIC_WEB_ORIGIN`, per `web/src/lib/trusted-origins.js` - never a hardcoded host), and sends it via `createMailTransport(loadMailEnv())`. Response now includes `emailSent` (true only when a non-null transport actually took it).
- `web/src/routes/settings/organization/+page.svelte`: invite dialog collects an optional email, sends it, and shows "sent to X" / "mail isn't configured, share this link" / the original "anyone with this link can join" copy depending on whether an address was given and whether it was actually emailed. The copy-link fallback is unchanged.

## Non-goals (per this wave's split)
- `POST /api/auth/register` and `/register` (#505/Signup505) - untouched.
- The password reset flow (#509/Signup509) - untouched.
- No resend action or pending-invite address display - out of scope for this issue's acceptance as assigned.

## Tests
Added `web/tests/org-invite-mail.test.ts`, faking `createMailTransport` (same `vi.mock` + dynamic-import pattern already used for `createAgentRunner` in `extension-suggest-voice.test.ts`):
- creating an invite with an address sends exactly one message, to that address, whose text contains the absolute invite URL, the org name, and the role
- creating an invite without an address sends nothing and still returns the link
- the URL in the message is built from the request's origin, not a hardcoded host (asserted against a non-default origin)
- `emailSent` is `false` when the resolved transport is the null one
- a member (not admin/owner) is rejected with 404 and nothing is sent

Every assertion above was broken one at a time (wrong org name, always-send, hardcoded origin, always-true `emailSent`, removed the admin gate) and confirmed to fail before restoring, run locally against `pitchbox_test_w510`.

`pnpm -F web check` is clean (0 errors). Had to add an explicit `event: import('@sveltejs/kit').RequestEvent` annotation to the route's `POST` (matching the sibling `[token]/+server.ts` route's existing convention): without it, calling the handler from a test produced a type error that didn't exist when the file wasn't imported anywhere with a typed `RequestEvent`.
