### PR TITLE
feat(cli): create and recover an account from the command line

### DIFF
--- a/cli/src/commands/seed-owner.ts
+++ b/cli/src/commands/seed-owner.ts
@@ -12,12 +12,12 @@ export type SeedOwnerResult =
 // Mirrors the `Body` schema in web/src/routes/api/auth/login/+server.ts, so a
 // seeded owner always satisfies the same rules the login route enforces.
 // Keep these in sync if either changes.
-const OwnerUsername = z
+export const OwnerUsername = z
   .string()
   .min(1)
   .max(64)
   .regex(/^[a-zA-Z0-9_.-]+$/);
-const OwnerPassword = z.string().min(8).max(256);
+export const OwnerPassword = z.string().min(8).max(256);
 
 // Core logic, extracted from the commander action so it can be reused by both
 // the `pitchbox` CLI and (if ever needed) the Pitchbox MCP server. Meant to

--- a/cli/src/commands/user.ts
+++ b/cli/src/commands/user.ts
@@ -1,0 +1,193 @@
+import { Command } from 'commander';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import {
+  createUser,
+  findUserByUsername,
+  hashPassword,
+  clearAuthFailures,
+} from '@pitchbox/shared/auth';
+import { OwnerUsername, OwnerPassword } from './seed-owner.js';
+import { readSecret } from '../lib/password.js';
+import { ok, fail } from '../lib/output.js';
+
+const PASSWORD_ENV = 'PITCHBOX_CLI_PASSWORD';
+const PASSWORD_HELP =
+  `Reads the password from ${PASSWORD_ENV}, or from stdin when it is piped ` +
+  '(not a TTY), or prompts interactively with echo suppressed otherwise. ' +
+  'Never pass a password as a command-line argument - it lands in shell ' +
+  'history and is visible to every other process on the box via `ps`.';
+
+export type UserCreateResult =
+  | { created: true; userId: number; username: string; isInstanceAdmin: boolean }
+  | { created: false; reason: 'user_exists'; message: string }
+  | { created: false; reason: 'invalid_username' | 'invalid_password'; message: string };
+
+// Same createUser() path seed:owner and the first-login bootstrap use, so
+// hashing and the default-org owner membership never diverge between the
+// three. Unlike seed:owner (which only ever runs on an empty users table),
+// this can run against a deployment that already has users - createUser
+// tolerates that: it only creates the `default` org if missing, and the
+// membership insert is `onConflictDoNothing`, so a second account just joins
+// the org that's already there.
+export async function createUserCli(args: {
+  username: string;
+  password: string;
+  admin: boolean;
+}): Promise<UserCreateResult> {
+  const usernameCheck = OwnerUsername.safeParse(args.username);
+  if (!usernameCheck.success) {
+    const message =
+      'Invalid username: must be 1-64 characters, letters/digits/"_"/"."/"-" only.';
+    return { created: false, reason: 'invalid_username', message };
+  }
+  const passwordCheck = OwnerPassword.safeParse(args.password);
+  if (!passwordCheck.success) {
+    const message = 'Invalid password: must be 8-256 characters.';
+    return { created: false, reason: 'invalid_password', message };
+  }
+
+  const db = getDb();
+  const existing = await findUserByUsername(db, args.username);
+  if (existing) {
+    return {
+      created: false,
+      reason: 'user_exists',
+      message: `A user named "${args.username}" already exists. Use user:reset-password to recover it instead.`,
+    };
+  }
+
+  const userId = await createUser(db, {
+    username: args.username,
+    password: args.password,
+    isInstanceAdmin: args.admin,
+  });
+  return { created: true, userId, username: args.username, isInstanceAdmin: args.admin };
+}
+
+export type UserResetPasswordResult =
+  | { reset: true; userId: number; username: string; sessionsRevoked: number }
+  | { reset: false; reason: 'user_not_found'; message: string }
+  | { reset: false; reason: 'invalid_password'; message: string };
+
+// Same recovery a self-service password change performs (web/src/routes/api/
+// auth/password/+server.ts): rehash, drop every session for the account (an
+// operator resetting a password from the shell has no "this tab" session to
+// spare the way the self-service route does), and clear the login-throttle
+// bucket the login route keyed on this username, so the freshly-set password
+// isn't immediately rejected as still-locked-out.
+export async function resetPasswordCli(args: {
+  username: string;
+  password: string;
+}): Promise<UserResetPasswordResult> {
+  const passwordCheck = OwnerPassword.safeParse(args.password);
+  if (!passwordCheck.success) {
+    return {
+      reset: false,
+      reason: 'invalid_password',
+      message: 'Invalid password: must be 8-256 characters.',
+    };
+  }
+
+  const db = getDb();
+  const user = await findUserByUsername(db, args.username);
+  if (!user) {
+    return {
+      reset: false,
+      reason: 'user_not_found',
+      message: `No user named "${args.username}". Use user:create to add it instead.`,
+    };
+  }
+
+  const passwordHash = await hashPassword(args.password);
+  await db.update(schema.users).set({ passwordHash }).where(eq(schema.users.id, user.id));
+  const revoked = await db
+    .delete(schema.sessions)
+    .where(eq(schema.sessions.userId, user.id))
+    .returning({ id: schema.sessions.id });
+  await clearAuthFailures(db, `user:${args.username}`);
+
+  return { reset: true, userId: user.id, username: args.username, sessionsRevoked: revoked.length };
+}
+
+export type UserListRow = {
+  id: number;
+  username: string;
+  email: string | null;
+  isInstanceAdmin: boolean;
+  organizations: { slug: string; role: string }[];
+};
+
+// Backs `pitchbox user:list`: the fastest way to answer "who can get into
+// this deployment" from a shell, without a database client.
+export async function listUsersCli(): Promise<UserListRow[]> {
+  const db = getDb();
+  const rows = await db
+    .select({
+      id: schema.users.id,
+      username: schema.users.username,
+      email: schema.users.email,
+      isInstanceAdmin: schema.users.isInstanceAdmin,
+      orgSlug: schema.organizations.slug,
+      role: schema.memberships.role,
+    })
+    .from(schema.users)
+    .leftJoin(schema.memberships, eq(schema.memberships.userId, schema.users.id))
+    .leftJoin(schema.organizations, eq(schema.organizations.id, schema.memberships.organizationId))
+    .orderBy(schema.users.username);
+
+  const byId = new Map<number, UserListRow>();
+  for (const row of rows) {
+    let user = byId.get(row.id);
+    if (!user) {
+      user = {
+        id: row.id,
+        username: row.username,
+        email: row.email,
+        isInstanceAdmin: row.isInstanceAdmin,
+        organizations: [],
+      };
+      byId.set(row.id, user);
+    }
+    if (row.orgSlug && row.role) {
+      user.organizations.push({ slug: row.orgSlug, role: row.role });
+    }
+  }
+  return [...byId.values()];
+}
+
+export function registerUserCommands(program: Command) {
+  program
+    .command('user:create <username>')
+    .description(
+      `Create an account (and default-org owner membership). ${PASSWORD_HELP} Pass --admin to also grant instance-admin - a separate, explicit flag rather than something a fresh account gets for free.`,
+    )
+    .option('--admin', 'grant instance-admin on creation', false)
+    .action(async (username: string, opts: { admin: boolean }) => {
+      const password = await readSecret(PASSWORD_ENV, `Password for ${username}: `);
+      const result = await createUserCli({ username, password, admin: opts.admin });
+      if (!result.created) fail(result.reason, result);
+      ok(result);
+    });
+
+  program
+    .command('user:reset-password <username>')
+    .description(
+      `Set a new password for an existing account, revoking every one of its sessions and clearing its login-throttle bucket. ${PASSWORD_HELP}`,
+    )
+    .action(async (username: string) => {
+      const password = await readSecret(PASSWORD_ENV, `New password for ${username}: `);
+      const result = await resetPasswordCli({ username, password });
+      if (!result.reset) fail(result.reason, result);
+      ok(result);
+    });
+
+  program
+    .command('user:list')
+    .description(
+      'List every account: id, username, email, instance-admin flag, and org membership/role.',
+    )
+    .action(async () => {
+      ok(await listUsersCli());
+    });
+}

--- a/cli/src/commands/user.ts
+++ b/cli/src/commands/user.ts
@@ -37,8 +37,7 @@ export async function createUserCli(args: {
 }): Promise<UserCreateResult> {
   const usernameCheck = OwnerUsername.safeParse(args.username);
   if (!usernameCheck.success) {
-    const message =
-      'Invalid username: must be 1-64 characters, letters/digits/"_"/"."/"-" only.';
+    const message = 'Invalid username: must be 1-64 characters, letters/digits/"_"/"."/"-" only.';
     return { created: false, reason: 'invalid_username', message };
   }
   const passwordCheck = OwnerPassword.safeParse(args.password);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,6 +18,7 @@ async function main() {
   const { registerProjectCommands } = await import('./commands/project.js');
   const { registerSkillCommands } = await import('./commands/skill.js');
   const { registerSeedCommands } = await import('./commands/seed-owner.js');
+  const { registerUserCommands } = await import('./commands/user.js');
   registerRunCommands(program);
   registerDraftCommands(program);
   registerRedditCommands(program);
@@ -28,6 +29,7 @@ async function main() {
   registerProjectCommands(program);
   registerSkillCommands(program);
   registerSeedCommands(program);
+  registerUserCommands(program);
   await program.parseAsync(process.argv);
 }
 

--- a/cli/src/lib/password.ts
+++ b/cli/src/lib/password.ts
@@ -1,0 +1,72 @@
+// A password must never arrive as a command-line argument: argv lands in
+// shell history and is visible to every other process on the box via `ps`.
+// This is the one place `user:create` and `user:reset-password` read a
+// secret from, in priority order:
+//
+//   1. the named environment variable (the deploy-pipeline / scripted case,
+//      same convention as `PITCHBOX_OWNER_PASSWORD` in seed-owner.ts)
+//   2. stdin, when it is not a TTY (piped input - `echo "$PW" | pitchbox ...`)
+//   3. an interactive, echo-suppressed prompt, when stdin *is* a TTY
+//
+// Callers must say which applies in their own `--help` text (see user.ts).
+export async function readSecret(envVar: string, promptLabel: string): Promise<string> {
+  const fromEnv = process.env[envVar];
+  if (fromEnv) return fromEnv;
+  if (!process.stdin.isTTY) {
+    return await readStdin();
+  }
+  return await promptMasked(promptLabel);
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8').trim();
+}
+
+// cli/tsconfig.json targets ES2022 (no lib.es2024), so `Promise.withResolvers`
+// isn't available here - the executor form is the one that typechecks.
+function promptMasked(label: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const stdin = process.stdin;
+    const wasRaw = stdin.isRaw;
+    process.stdout.write(label);
+    let input = '';
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
+
+    const cleanup = () => {
+      stdin.removeListener('data', onData);
+      stdin.setRawMode(wasRaw);
+      stdin.pause();
+    };
+    const onData = (raw: string) => {
+      const char = raw.toString();
+      switch (char) {
+        case '\n':
+        case '\r':
+        case '\u0004': // Ctrl-D
+          cleanup();
+          process.stdout.write('\n');
+          resolve(input);
+          break;
+        case '\u0003': // Ctrl-C
+          cleanup();
+          process.stdout.write('\n');
+          reject(new Error('aborted'));
+          break;
+        case '\u007f': // backspace
+        case '\b':
+          input = input.slice(0, -1);
+          break;
+        default:
+          input += char;
+          break;
+      }
+    };
+    stdin.on('data', onData);
+  });
+}

--- a/cli/tests/commands/user.test.ts
+++ b/cli/tests/commands/user.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, beforeEach, afterAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import { getDb, getPool, schema } from '@pitchbox/shared/db';
+import { verifyPassword } from '@pitchbox/shared/auth';
+import { sql, eq } from 'drizzle-orm';
+
+function cli(args: string, env?: Record<string, string>): string {
+  return execSync(`pnpm -s -F @pitchbox/cli dev ${args}`, {
+    encoding: 'utf8',
+    cwd: process.cwd(),
+    env: { ...process.env, ...env },
+  });
+}
+
+// Same shape as seed-owner.test.ts's helper: captures both stdout (success)
+// and stderr (fail() writes there and exits 1), since a duplicate-username
+// or not-found run is expected to fail rather than throw.
+function cliResult(args: string, env?: Record<string, string>) {
+  try {
+    const out = execSync(`pnpm -s -F @pitchbox/cli dev ${args}`, {
+      encoding: 'utf8',
+      cwd: process.cwd(),
+      env: { ...process.env, ...env },
+    });
+    return JSON.parse(out.trim().split('\n').at(-1)!);
+  } catch (err) {
+    const stdout = String((err as { stdout?: unknown }).stdout ?? '');
+    const stderr = String((err as { stderr?: unknown }).stderr ?? '');
+    const combined = (stdout + stderr).trim().split('\n').filter(Boolean);
+    return JSON.parse(combined.at(-1)!);
+  }
+}
+
+function lastJson(out: string) {
+  return JSON.parse(out.trim().split('\n').at(-1)!);
+}
+
+async function reset() {
+  // Same convention as seed-owner.test.ts: never truncate `organizations`
+  // (would drop the `default` org other test files in this suite share).
+  await getDb().execute(sql`TRUNCATE users, sessions, memberships, auth_failures RESTART IDENTITY CASCADE`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+describe('pitchbox user:create', () => {
+  beforeEach(reset);
+
+  it('creates an account with a usable password hash, joining the default org', async () => {
+    const res = cliResult('user:create alice', { PITCHBOX_CLI_PASSWORD: 'correct horse battery' });
+    expect(res.ok).toBe(true);
+    expect(res.data.created).toBe(true);
+    expect(res.data.username).toBe('alice');
+    expect(res.data.isInstanceAdmin).toBe(false);
+
+    const db = getDb();
+    const [user] = await db.select().from(schema.users).where(eq(schema.users.username, 'alice'));
+    expect(user).toBeDefined();
+    expect(await verifyPassword('correct horse battery', user.passwordHash)).toBe(true);
+    // Not the actual password, hashed differently every time (random salt).
+    expect(user.passwordHash).not.toBe('correct horse battery');
+
+    const [membership] = await db
+      .select({ role: schema.memberships.role, orgSlug: schema.organizations.slug })
+      .from(schema.memberships)
+      .innerJoin(schema.organizations, eq(schema.organizations.id, schema.memberships.organizationId))
+      .where(eq(schema.memberships.userId, user.id));
+    expect(membership.role).toBe('owner');
+    expect(membership.orgSlug).toBe('default');
+  });
+
+  it('grants instance-admin only when --admin is passed explicitly', async () => {
+    const res = cliResult('user:create bob --admin', { PITCHBOX_CLI_PASSWORD: 'correct horse battery' });
+    expect(res.ok).toBe(true);
+    expect(res.data.isInstanceAdmin).toBe(true);
+
+    const db = getDb();
+    const [user] = await db.select().from(schema.users).where(eq(schema.users.username, 'bob'));
+    expect(user.isInstanceAdmin).toBe(true);
+  });
+
+  it('fails with an actionable message on a second run against an existing username, rather than a stack trace', async () => {
+    cli('user:create carol', { PITCHBOX_CLI_PASSWORD: 'correct horse battery' });
+    const res = cliResult('user:create carol', { PITCHBOX_CLI_PASSWORD: 'another password entirely' });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('user_exists');
+    expect(res.details.message).toMatch(/already exists/);
+    expect(res.details.message).not.toMatch(/at Object|node_modules|\.ts:\d+/);
+
+    // The original account is untouched - a rejected create must not have
+    // silently reset the existing password.
+    const db = getDb();
+    const [user] = await db.select().from(schema.users).where(eq(schema.users.username, 'carol'));
+    expect(await verifyPassword('correct horse battery', user.passwordHash)).toBe(true);
+  });
+
+  it('never echoes the password anywhere in stdout or stderr', async () => {
+    const secret = 'never-print-this-secret-42';
+    const out = execSync(`pnpm -s -F @pitchbox/cli dev user:create dave`, {
+      encoding: 'utf8',
+      cwd: process.cwd(),
+      env: { ...process.env, PITCHBOX_CLI_PASSWORD: secret },
+    });
+    expect(out).not.toContain(secret);
+  });
+});
+
+describe('pitchbox user:reset-password', () => {
+  beforeEach(reset);
+
+  it('sets a usable new password, revokes existing sessions, and clears the login-throttle bucket', async () => {
+    cli('user:create erin', { PITCHBOX_CLI_PASSWORD: 'original password here' });
+    const db = getDb();
+    const [user] = await db.select().from(schema.users).where(eq(schema.users.username, 'erin'));
+
+    const expiresAt = new Date(Date.now() + 60_000);
+    await db.insert(schema.sessions).values({ id: 'sess-erin-1', userId: user.id, expiresAt });
+    await db.insert(schema.sessions).values({ id: 'sess-erin-2', userId: user.id, expiresAt });
+    await db.insert(schema.authFailures).values({ identifier: `user:erin`, kind: 'login' });
+
+    const res = cliResult('user:reset-password erin', { PITCHBOX_CLI_PASSWORD: 'brand new password' });
+    expect(res.ok).toBe(true);
+    expect(res.data.reset).toBe(true);
+    expect(res.data.sessionsRevoked).toBe(2);
+
+    const [updated] = await db.select().from(schema.users).where(eq(schema.users.id, user.id));
+    expect(await verifyPassword('brand new password', updated.passwordHash)).toBe(true);
+    expect(await verifyPassword('original password here', updated.passwordHash)).toBe(false);
+
+    const remainingSessions = await db
+      .select()
+      .from(schema.sessions)
+      .where(eq(schema.sessions.userId, user.id));
+    expect(remainingSessions).toHaveLength(0);
+
+    const remainingFailures = await db
+      .select()
+      .from(schema.authFailures)
+      .where(eq(schema.authFailures.identifier, 'user:erin'));
+    expect(remainingFailures).toHaveLength(0);
+  });
+
+  it('fails with an actionable message against a username that does not exist, rather than a stack trace', async () => {
+    const res = cliResult('user:reset-password ghost', { PITCHBOX_CLI_PASSWORD: 'brand new password' });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('user_not_found');
+    expect(res.details.message).toMatch(/No user named/);
+    expect(res.details.message).not.toMatch(/at Object|node_modules|\.ts:\d+/);
+  });
+
+  it('never echoes the password anywhere in stdout or stderr', async () => {
+    cli('user:create frank', { PITCHBOX_CLI_PASSWORD: 'first password here' });
+    const secret = 'never-print-this-either-99';
+    const out = execSync(`pnpm -s -F @pitchbox/cli dev user:reset-password frank`, {
+      encoding: 'utf8',
+      cwd: process.cwd(),
+      env: { ...process.env, PITCHBOX_CLI_PASSWORD: secret },
+    });
+    expect(out).not.toContain(secret);
+  });
+});
+
+describe('pitchbox user:list', () => {
+  beforeEach(reset);
+
+  it('prints id, username, email, instance-admin flag, and org membership for every account', async () => {
+    cli('user:create grace --admin', { PITCHBOX_CLI_PASSWORD: 'password one here' });
+    cli('user:create henry', { PITCHBOX_CLI_PASSWORD: 'password two here' });
+
+    const out = cli('user:list');
+    const res = lastJson(out);
+    expect(res.ok).toBe(true);
+    expect(res.data).toHaveLength(2);
+
+    const grace = res.data.find((u: { username: string }) => u.username === 'grace');
+    expect(grace.isInstanceAdmin).toBe(true);
+    expect(grace.organizations).toEqual([{ slug: 'default', role: 'owner' }]);
+    expect(grace.email).toBeNull();
+
+    const henry = res.data.find((u: { username: string }) => u.username === 'henry');
+    expect(henry.isInstanceAdmin).toBe(false);
+    expect(henry.organizations).toEqual([{ slug: 'default', role: 'owner' }]);
+  });
+});
+
+afterAll(async () => {
+  await getPool().end();
+});

--- a/cli/tests/commands/user.test.ts
+++ b/cli/tests/commands/user.test.ts
@@ -38,7 +38,9 @@ function lastJson(out: string) {
 async function reset() {
   // Same convention as seed-owner.test.ts: never truncate `organizations`
   // (would drop the `default` org other test files in this suite share).
-  await getDb().execute(sql`TRUNCATE users, sessions, memberships, auth_failures RESTART IDENTITY CASCADE`);
+  await getDb().execute(
+    sql`TRUNCATE users, sessions, memberships, auth_failures RESTART IDENTITY CASCADE`,
+  );
   await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
 }
 
@@ -62,14 +64,19 @@ describe('pitchbox user:create', () => {
     const [membership] = await db
       .select({ role: schema.memberships.role, orgSlug: schema.organizations.slug })
       .from(schema.memberships)
-      .innerJoin(schema.organizations, eq(schema.organizations.id, schema.memberships.organizationId))
+      .innerJoin(
+        schema.organizations,
+        eq(schema.organizations.id, schema.memberships.organizationId),
+      )
       .where(eq(schema.memberships.userId, user.id));
     expect(membership.role).toBe('owner');
     expect(membership.orgSlug).toBe('default');
   });
 
   it('grants instance-admin only when --admin is passed explicitly', async () => {
-    const res = cliResult('user:create bob --admin', { PITCHBOX_CLI_PASSWORD: 'correct horse battery' });
+    const res = cliResult('user:create bob --admin', {
+      PITCHBOX_CLI_PASSWORD: 'correct horse battery',
+    });
     expect(res.ok).toBe(true);
     expect(res.data.isInstanceAdmin).toBe(true);
 
@@ -80,7 +87,9 @@ describe('pitchbox user:create', () => {
 
   it('fails with an actionable message on a second run against an existing username, rather than a stack trace', async () => {
     cli('user:create carol', { PITCHBOX_CLI_PASSWORD: 'correct horse battery' });
-    const res = cliResult('user:create carol', { PITCHBOX_CLI_PASSWORD: 'another password entirely' });
+    const res = cliResult('user:create carol', {
+      PITCHBOX_CLI_PASSWORD: 'another password entirely',
+    });
     expect(res.ok).toBe(false);
     expect(res.error).toBe('user_exists');
     expect(res.details.message).toMatch(/already exists/);
@@ -117,7 +126,9 @@ describe('pitchbox user:reset-password', () => {
     await db.insert(schema.sessions).values({ id: 'sess-erin-2', userId: user.id, expiresAt });
     await db.insert(schema.authFailures).values({ identifier: `user:erin`, kind: 'login' });
 
-    const res = cliResult('user:reset-password erin', { PITCHBOX_CLI_PASSWORD: 'brand new password' });
+    const res = cliResult('user:reset-password erin', {
+      PITCHBOX_CLI_PASSWORD: 'brand new password',
+    });
     expect(res.ok).toBe(true);
     expect(res.data.reset).toBe(true);
     expect(res.data.sessionsRevoked).toBe(2);
@@ -140,7 +151,9 @@ describe('pitchbox user:reset-password', () => {
   });
 
   it('fails with an actionable message against a username that does not exist, rather than a stack trace', async () => {
-    const res = cliResult('user:reset-password ghost', { PITCHBOX_CLI_PASSWORD: 'brand new password' });
+    const res = cliResult('user:reset-password ghost', {
+      PITCHBOX_CLI_PASSWORD: 'brand new password',
+    });
     expect(res.ok).toBe(false);
     expect(res.error).toBe('user_not_found');
     expect(res.details.message).toMatch(/No user named/);

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -76,6 +76,10 @@ Override by inserting/updating that row directly - the login route reads it on e
 
 `/settings/security` lists the last 50 entries in `auth_failures` and exposes an **Unlock account** action that clears the `user:<username>` bucket via `POST /api/auth/unlock`. The IP bucket is not cleared by default - pass `{ "ip": "..." }` to clear that too.
 
+## Account recovery from the shell
+
+A self-host that never configures email still needs a way in when a password is lost, and no console. `pitchbox user:create <username> [--admin]`, `pitchbox user:reset-password <username>`, and `pitchbox user:list` (see `docs/cli.md`) cover it: create an account, set a password, and grant instance-admin are each an explicit action, not one magic command that does all three. `user:create` and `user:reset-password` never accept a password as an argument - `PITCHBOX_CLI_PASSWORD`, piped stdin, or an echo-suppressed prompt only - and `user:reset-password` deletes that user's sessions and clears their `auth_failures` bucket, the same recovery `/settings/password` performs on itself.
+
 ## Organizations and memberships
 
 The schema already carries `organizations` + `memberships`. On a fresh install a single `default` org is seeded, and the first user is auto-joined as `owner`. The data model is the same across editions - a single-org self-host is just a multi-tenant cloud install with one tenant.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,3 +29,17 @@ pitchbox drafts:regenerate <id> [--hint "..."]
 ```
 
 Regeneration runs as an agent job dispatched by the web app. The dashboard's `POST /api/drafts/[id]/regenerate` (and the Inbox **Regenerate** action) launch a `draft_regeneration` run that rewrites the draft body honoring the reviewer hint, records the hint into `draft_regeneration_hints`, appends a `regenerated` draft_event that snapshots the previous body (so the change is undoable), and re-scores the draft. The CLI command is a thin pointer to that web flow.
+
+## `pitchbox user:create <username> [--admin]`
+
+Creates an account (and default-org owner membership, same `createUser()` path `seed:owner` and first-login bootstrap use) - the way an operator with shell access gets in without writing a `password_hash` into Postgres by hand. Fails with `user_exists` and an actionable message, not a stack trace, on a username that already exists. `--admin` grants instance-admin at creation; it is a separate, explicit flag rather than something a fresh account gets for free.
+
+The password is never a command-line argument - it lands in shell history and is visible to every other process on the box via `ps`. It's read, in order: from `PITCHBOX_CLI_PASSWORD`, or from stdin when piped (`echo "$PW" | pitchbox user:create alice`), or from an interactive echo-suppressed prompt otherwise.
+
+## `pitchbox user:reset-password <username>`
+
+Sets a new password for an existing account: rehashes, revokes every one of that account's sessions, and clears its `auth_failures` login-throttle bucket - same as the self-service `/settings/password` flow, minus the "keep my own tab signed in" exception (there is no signed-in tab from a shell). Fails with `user_not_found` and an actionable message on an unknown username. Reads the password the same way `user:create` does - see above.
+
+## `pitchbox user:list`
+
+Read-only. Prints every account's id, username, email, instance-admin flag, and org membership/role - the fastest way to answer "who can get into this deployment" without a database client.


### PR DESCRIPTION
Adds `pitchbox user:create`, `pitchbox user:reset-password` and `pitchbox user:list` next to `seed:owner`, so an operator with shell access never needs to write a `password_hash` into Postgres by hand.

- `user:create <username> [--admin]`: creates an account through the same `createUser()` path `seed:owner` and the first-login bootstrap use, so hashing and the default-org owner membership never diverge between the three. `--admin` is a separate, explicit flag - a fresh account never gets instance-admin for free.
- `user:reset-password <username>`: rehashes, revokes every session for that account, and clears its `auth_failures` login-throttle bucket, same as the self-service `/settings/password` flow.
- `user:list`: prints id, username, email, instance-admin flag, and org membership/role for every account.

The password is never a command-line argument. `readSecret` (`cli/src/lib/password.ts`) reads it, in order, from `PITCHBOX_CLI_PASSWORD`, from stdin when piped, or from an echo-suppressed interactive prompt - `--help` on both commands says which. Both commands fail with a plain, actionable message and exit 1 on a duplicate or unknown username, never a raw stack trace.

Documented in `docs/cli.md` and `docs/auth.md`.

Closes #511