### PR TITLE
feat(shared,web): forgot password, reset by email

### DIFF
--- a/shared/src/auth.ts
+++ b/shared/src/auth.ts
@@ -1,10 +1,11 @@
-import { randomBytes, scrypt as scryptCb, timingSafeEqual } from 'node:crypto';
+import { createHash, randomBytes, scrypt as scryptCb, timingSafeEqual } from 'node:crypto';
 import { promisify } from 'node:util';
-import { and, desc, eq, gt, sql } from 'drizzle-orm';
+import { and, desc, eq, gt, isNull, sql } from 'drizzle-orm';
 import type { PgDatabase } from 'drizzle-orm/pg-core';
 import {
   appConfig,
   authFailures,
+  passwordResetTokens,
   sessions,
   users,
   organizations,
@@ -47,10 +48,19 @@ export async function loadAuthPolicy(db: Db): Promise<AuthPolicy> {
   };
 }
 
-export async function recordAuthFailure(db: Db, identifier: string): Promise<void> {
-  // Two rows per failed attempt - one keyed by IP, one by username - so the
-  // counter can check either bucket independently.
-  await db.insert(authFailures).values({ identifier, kind: 'login_attempt' });
+export async function recordAuthFailure(
+  db: Db,
+  identifier: string,
+  kind = 'login_attempt',
+): Promise<void> {
+  // One row per attempt against a bucket (IP or the caller's own
+  // identifier) - the counter checks each bucket independently. `kind`
+  // defaults to the original login-attempt label so the two existing call
+  // sites (login, password change) are unaffected; the forgot/reset-
+  // password routes (#509) pass their own kind so an admin reading
+  // listRecentAuthFailures can tell a mail-bomb attempt on the reset flow
+  // apart from a credential-guessing attempt on login.
+  await db.insert(authFailures).values({ identifier, kind });
 }
 
 export async function countAuthFailuresSince(
@@ -349,4 +359,58 @@ export async function findUserByEmail(
     .where(eq(users.email, normalized))
     .limit(1);
   return rows[0] ?? null;
+}
+
+// 20 minutes: inside the 15-30 minute window #509 calls for. Short enough
+// that a link sitting in an inbox for hours is dead by the time anyone but
+// the intended recipient could use it; long enough that fetching mail on a
+// slow connection doesn't race it.
+const RESET_TOKEN_TTL_MS = 20 * 60 * 1000;
+
+/**
+ * Mints a single-use, time-limited password reset token for `userId` and
+ * stores only its hash (`password_reset_tokens.token_hash`). Structurally
+ * this is org_invites' shape - a random token, an expiry, a single-use
+ * marker - but hashed at rest like extension_devices.token_hash
+ * (web/src/lib/server/extension-auth.ts's `hashToken`/`mintDeviceToken`):
+ * org_invites stores its token in the clear, which is fine for a link an
+ * org admin hands out on purpose, but wrong for a credential that proves
+ * control of an arbitrary mailbox. The raw token is returned once here and
+ * is not recoverable from the row afterward.
+ */
+export async function createPasswordResetToken(
+  db: Db,
+  userId: number,
+): Promise<{ token: string; expiresAt: Date }> {
+  const token = randomBytes(24).toString('hex');
+  const expiresAt = new Date(Date.now() + RESET_TOKEN_TTL_MS);
+  await db
+    .insert(passwordResetTokens)
+    .values({ userId, tokenHash: createHash('sha256').update(token).digest('hex'), expiresAt });
+  return { token, expiresAt };
+}
+
+/**
+ * Atomically redeems a reset token: a single UPDATE that only matches a row
+ * still unused and unexpired, in the same statement that marks it used -
+ * the same compare-and-set shape the extension device rotate endpoint uses
+ * (web/src/routes/api/extension/rotate/+server.ts) against a concurrent
+ * second rotate, applied here against a concurrent second redemption of the
+ * same reset link. Returns the owning user id, or null for an unknown,
+ * already-used, or expired token - the caller must answer all three
+ * identically so a probe can't learn which one it hit.
+ */
+export async function consumePasswordResetToken(db: Db, token: string): Promise<number | null> {
+  const [row] = await db
+    .update(passwordResetTokens)
+    .set({ usedAt: new Date() })
+    .where(
+      and(
+        eq(passwordResetTokens.tokenHash, createHash('sha256').update(token).digest('hex')),
+        isNull(passwordResetTokens.usedAt),
+        gt(passwordResetTokens.expiresAt, new Date()),
+      ),
+    )
+    .returning({ userId: passwordResetTokens.userId });
+  return row?.userId ?? null;
 }

--- a/shared/src/db/migrations/0024_password_reset_tokens.sql
+++ b/shared/src/db/migrations/0024_password_reset_tokens.sql
@@ -1,0 +1,26 @@
+-- password_reset_tokens (#509): backs POST /api/auth/password/forgot and
+-- POST /api/auth/password/reset. Only a hash of the token is ever stored,
+-- same convention as extension_devices.token_hash - the raw token exists
+-- only in the emailed link and the requester's browser.
+--
+-- Hand-authored rather than `drizzle-kit generate`, same reason as
+-- 0023_users_email.sql: the committed snapshot chain in migrations/meta/
+-- stops at 0018_snapshot.json, so `generate` tries to re-CREATE TABLE
+-- instance_audit_log and operator_voice_profiles against that stale base
+-- and fails on any database that already has them (see
+-- migrations_archive/README.md). This migration only adds
+-- password_reset_tokens.
+CREATE TABLE "password_reset_tokens" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"token_hash" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"used_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "password_reset_tokens" ADD CONSTRAINT "password_reset_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "password_reset_tokens_token_hash_unique" ON "password_reset_tokens" USING btree ("token_hash");
+--> statement-breakpoint
+CREATE INDEX "password_reset_tokens_user_idx" ON "password_reset_tokens" USING btree ("user_id");

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1788960000010,
       "tag": "0023_users_email",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1788960000011,
+      "tag": "0024_password_reset_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -149,6 +149,33 @@ export const authFailures = pgTable(
   }),
 );
 
+export const passwordResetTokens = pgTable(
+  'password_reset_tokens',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    // Hashed at rest, same convention as extension_devices.token_hash
+    // (shared/src/db/schema.ts, extensionDevices below): the raw token is
+    // only ever in the emailed link, never written to the database, so a
+    // read of this table (backup, replica, compromised credential) cannot
+    // be turned into an account takeover.
+    tokenHash: text('token_hash').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    // Single use: null until the token is redeemed, set exactly once by the
+    // same atomic UPDATE that checks it's still null (shared/src/auth.ts's
+    // consumePasswordResetToken) - a second redemption attempt matches zero
+    // rows instead of racing a separate delete.
+    usedAt: timestamp('used_at', { withTimezone: true }),
+  },
+  (t) => ({
+    tokenHashUnique: uniqueIndex('password_reset_tokens_token_hash_unique').on(t.tokenHash),
+    byUser: index('password_reset_tokens_user_idx').on(t.userId),
+  }),
+);
+
 export const playbooks = pgTable('playbooks', {
   id: serial('id').primaryKey(),
   slug: text('slug').notNull().unique(),

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -120,6 +120,17 @@ function isExemptPath(pathname: string): boolean {
     pathname.startsWith('/api/auth/login') ||
     pathname.startsWith('/api/auth/logout') ||
     pathname.startsWith('/api/auth/register') ||
+    // Forgot/reset password (#509): a locked-out visitor has no session by
+    // definition, so the request page (`/reset`), the confirm page
+    // (`/reset/<token>`), and both API endpoints all need to be reachable
+    // session-less. Exact prefixes, same as the entries above - not a
+    // blanket `/api/auth/password`, which would also exempt the signed-in
+    // self-service change at POST /api/auth/password
+    // (web/src/routes/api/auth/password/+server.ts) that must stay behind
+    // session resolution.
+    pathname.startsWith('/reset') ||
+    pathname.startsWith('/api/auth/password/forgot') ||
+    pathname.startsWith('/api/auth/password/reset') ||
     pathname.startsWith('/_app/') ||
     pathname.startsWith('/favicon')
   );

--- a/web/src/routes/api/auth/password/forgot/+server.ts
+++ b/web/src/routes/api/auth/password/forgot/+server.ts
@@ -1,0 +1,91 @@
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '../../../../../lib/server/db.js';
+import {
+  createPasswordResetToken,
+  findUserByEmail,
+  getLockoutUntil,
+  loadAuthPolicy,
+  normalizeEmail,
+  recordAuthFailure,
+} from '@pitchbox/shared/auth';
+import { createMailTransport } from '@pitchbox/shared/mail/registry';
+import { loadMailEnv } from '@pitchbox/shared/mail/env';
+import { renderPlainTextMail } from '@pitchbox/shared/mail/template';
+
+const Body = z.object({
+  email: z.string().trim().pipe(z.email()),
+});
+
+/**
+ * Requests a password reset link for `email` (#509). Always answers 200
+ * with the same body whether or not the address belongs to an account -
+ * distinguishing the two turns this endpoint into a way to test which
+ * addresses have a Pitchbox account, which is exactly what
+ * `findUserByEmail` returning null must never surface to the caller.
+ *
+ * Rate-limited by IP and by the submitted address through the same
+ * auth_failures table login uses, so repeatedly requesting a reset for
+ * someone else's real address can't be used to mail-bomb their inbox.
+ */
+export async function POST(event: RequestEvent) {
+  if (process.env.PITCHBOX_AUTH !== 'on') {
+    throw error(404, 'auth_disabled');
+  }
+  const raw = await event.request.json().catch(() => null);
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) throw error(400, 'invalid_body');
+  const email = normalizeEmail(parsed.data.email);
+  if (!email) throw error(400, 'invalid_body');
+
+  const db = getDb();
+  let ip: string;
+  try {
+    ip = event.getClientAddress() || 'unknown';
+  } catch {
+    ip = 'unknown';
+  }
+  const ipBucket = `reset:ip:${ip}`;
+  const addressBucket = `reset:email:${email}`;
+  const policy = await loadAuthPolicy(db);
+  const now = new Date();
+  const [ipLock, addressLock] = await Promise.all([
+    getLockoutUntil(db, ipBucket, policy, now),
+    getLockoutUntil(db, addressBucket, policy, now),
+  ]);
+  const lockedUntil =
+    ipLock && addressLock ? (ipLock > addressLock ? ipLock : addressLock) : (ipLock ?? addressLock);
+  if (lockedUntil) {
+    return json(
+      {
+        error: 'rate_limited',
+        retry_after_seconds: Math.max(1, Math.ceil((lockedUntil.getTime() - now.getTime()) / 1000)),
+      },
+      { status: 429 },
+    );
+  }
+
+  // Counts this request against both buckets regardless of what happens
+  // next - an unknown address still costs the caller one of their attempts,
+  // otherwise probing addresses that don't exist would be unthrottled.
+  await Promise.all([
+    recordAuthFailure(db, ipBucket, 'password_reset_request'),
+    recordAuthFailure(db, addressBucket, 'password_reset_request'),
+  ]);
+
+  const user = await findUserByEmail(db, email);
+  if (user) {
+    const { token } = await createPasswordResetToken(db, user.id);
+    const resetUrl = `${event.url.origin}/reset/${token}`;
+    const rendered = renderPlainTextMail(
+      'Reset your Pitchbox password',
+      `Someone asked to reset the password on this Pitchbox account.\n\n` +
+        `Open this link within 20 minutes to choose a new one:\n${resetUrl}\n\n` +
+        `If this wasn't you, ignore this message - your password stays the same.`,
+    );
+    const transport = createMailTransport(loadMailEnv());
+    await transport.send({ to: email, ...rendered });
+  }
+
+  return json({ ok: true });
+}

--- a/web/src/routes/api/auth/password/reset/+server.ts
+++ b/web/src/routes/api/auth/password/reset/+server.ts
@@ -1,0 +1,105 @@
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../../../../../lib/server/db.js';
+import {
+  clearAuthFailures,
+  consumePasswordResetToken,
+  createSession,
+  getLockoutUntil,
+  hashPassword,
+  loadAuthPolicy,
+  recordAuthFailure,
+} from '@pitchbox/shared/auth';
+
+const COOKIE = 'pitchbox_session';
+
+const Body = z.object({
+  token: z.string().min(1),
+  newPassword: z.string().min(8).max(256),
+});
+
+/**
+ * Completes a password reset (#509): redeems the single-use token minted by
+ * POST /api/auth/password/forgot, sets the new password, and - unlike the
+ * self-service change at POST /api/auth/password, which keeps the caller's
+ * own session alive - drops every session for the account, including any
+ * the caller might already be holding. Whoever reset the password may be
+ * recovering from a compromise; nothing from before this request should
+ * still be trusted. The caller ends up signed in through a session minted
+ * fresh by this request, not one that survived from before it.
+ */
+export async function POST(event: RequestEvent) {
+  if (process.env.PITCHBOX_AUTH !== 'on') {
+    throw error(404, 'auth_disabled');
+  }
+  const raw = await event.request.json().catch(() => null);
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) throw error(400, 'invalid_body');
+
+  const db = getDb();
+  let ip: string;
+  try {
+    ip = event.getClientAddress() || 'unknown';
+  } catch {
+    ip = 'unknown';
+  }
+  const ipBucket = `reset:ip:${ip}`;
+  const policy = await loadAuthPolicy(db);
+  const now = new Date();
+  const ipLock = await getLockoutUntil(db, ipBucket, policy, now);
+  if (ipLock) {
+    return json(
+      {
+        error: 'rate_limited',
+        retry_after_seconds: Math.max(1, Math.ceil((ipLock.getTime() - now.getTime()) / 1000)),
+      },
+      { status: 429 },
+    );
+  }
+
+  // Unknown, already-used, and expired all answer identically - same
+  // reasoning as the forgot endpoint not distinguishing a known address
+  // from an unknown one.
+  const userId = await consumePasswordResetToken(db, parsed.data.token);
+  if (!userId) {
+    await recordAuthFailure(db, ipBucket, 'password_reset_confirm');
+    return json({ error: 'invalid_or_expired_token' }, { status: 400 });
+  }
+
+  const [user] = await db
+    .select({ username: schema.users.username, email: schema.users.email })
+    .from(schema.users)
+    .where(eq(schema.users.id, userId));
+  if (!user) {
+    return json({ error: 'invalid_or_expired_token' }, { status: 400 });
+  }
+
+  const newHash = await hashPassword(parsed.data.newPassword);
+  await db.update(schema.users).set({ passwordHash: newHash }).where(eq(schema.users.id, userId));
+
+  // Every session gone, not just "every other one" - there is no session
+  // making this request to spare, and any that survived from before a
+  // possible compromise should not either.
+  await db.delete(schema.sessions).where(eq(schema.sessions.userId, userId));
+
+  // Whoever just proved control of the mailbox shouldn't still be locked
+  // out by whatever failed login attempts sent them to this flow in the
+  // first place (#509). Clears the login bucket, this reset flow's own
+  // per-address bucket, and the IP bucket that gated this very request.
+  await Promise.all([
+    clearAuthFailures(db, `user:${user.username}`),
+    clearAuthFailures(db, ipBucket),
+    ...(user.email ? [clearAuthFailures(db, `reset:email:${user.email}`)] : []),
+  ]);
+
+  const session = await createSession(db, userId);
+  event.cookies.set(COOKIE, session.id, {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    expires: session.expiresAt,
+  });
+  return json({ ok: true });
+}

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -74,14 +74,17 @@
 				<Button onclick={submit} disabled={busy || !username || password.length < 8}>
 					{data.firstUser ? 'Create' : 'Sign in'}
 				</Button>
-				{#if !data.firstUser}
-					<p class="text-center text-xs text-muted-foreground">
-						Need an account? <a
-							href={`/register?next=${encodeURIComponent($page.url.searchParams.get('next') || '/')}`}
-							class="underline">Create one</a
-						>
-					</p>
-				{/if}
+			{#if !data.firstUser}
+				<p class="text-center text-xs text-muted-foreground">
+					Need an account? <a
+						href={`/register?next=${encodeURIComponent($page.url.searchParams.get('next') || '/')}`}
+						class="underline">Create one</a
+					>
+				</p>
+				<p class="text-center text-xs text-muted-foreground">
+					<a href="/reset" class="underline">Forgot your password?</a>
+				</p>
+			{/if}
 			</Card.Content>
 		{/if}
 	</Card.Root>

--- a/web/src/routes/reset/+layout@.svelte
+++ b/web/src/routes/reset/+layout@.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import '../../app.css';
+	import { ModeWatcher } from 'mode-watcher';
+	let { children } = $props();
+</script>
+
+<!--
+  Reset-password pages bypass the dashboard chrome, same as /login and
+  /register (web/src/routes/login/+layout@.svelte, web/src/routes/register/
+  +layout@.svelte) - one convention for every session-less auth page.
+-->
+<ModeWatcher defaultMode="dark" />
+
+<div class="min-h-screen bg-background text-foreground">
+	{@render children()}
+</div>

--- a/web/src/routes/reset/+page.server.ts
+++ b/web/src/routes/reset/+page.server.ts
@@ -1,0 +1,5 @@
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+  return { authOn: process.env.PITCHBOX_AUTH === 'on' };
+};

--- a/web/src/routes/reset/+page.svelte
+++ b/web/src/routes/reset/+page.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import * as Card from '$lib/components/ui/card';
+	import { toast } from 'svelte-sonner';
+	import Seo from '$lib/components/Seo.svelte';
+	import { TONE_TEXT_CLASS } from '$lib/config/status-badges';
+
+	let { data }: { data: { authOn: boolean } } = $props();
+
+	let email = $state('');
+	let busy = $state(false);
+	let sent = $state(false);
+
+	async function submit() {
+		if (busy || !email) return;
+		busy = true;
+		try {
+			const res = await fetch('/api/auth/password/forgot', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ email }),
+			});
+			if (res.status === 429) {
+				const body = (await res.json()) as { retry_after_seconds?: number };
+				toast.error('Too many attempts', {
+					description: body.retry_after_seconds
+						? `Try again in ${body.retry_after_seconds}s`
+						: undefined,
+				});
+				return;
+			}
+			if (!res.ok) {
+				toast.error('Could not send reset link');
+				return;
+			}
+			// #509: the response is identical whether or not the address has an
+			// account, so the confirmation below never varies with `res` beyond
+			// the ok/429/error branches above - a different message here would
+			// itself leak which case ran.
+			sent = true;
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+<Seo
+	title={data.authOn ? 'Reset your password' : 'Authentication disabled'}
+	description="Request a password reset link"
+/>
+
+<div class="min-h-screen flex items-center justify-center bg-background p-6">
+	<Card.Root class="w-full max-w-sm">
+		{#if !data.authOn}
+			<Card.Header>
+				<Card.Title>Authentication is disabled</Card.Title>
+				<p class="text-xs {TONE_TEXT_CLASS.amber}">
+					This instance runs with PITCHBOX_AUTH off, so there is no account to reset a
+					password for. Set PITCHBOX_AUTH=on in your environment to enable this.
+				</p>
+			</Card.Header>
+			<Card.Content>
+				<Button href="/" variant="outline" class="w-full">Go to Pitchbox</Button>
+			</Card.Content>
+		{:else if sent}
+			<Card.Header>
+				<Card.Title>Check your email</Card.Title>
+				<Card.Description>
+					If that address has a Pitchbox account, a reset link is on its way. It expires in
+					20 minutes.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content>
+				<Button href="/login" variant="outline" class="w-full">Back to sign in</Button>
+			</Card.Content>
+		{:else}
+			<Card.Header>
+				<Card.Title>Reset your password</Card.Title>
+				<Card.Description>
+					Enter the email on your account and we'll send you a link to choose a new
+					password.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content class="flex flex-col gap-3">
+				<label class="flex flex-col gap-1 text-xs">
+					Email
+					<Input type="email" bind:value={email} autocomplete="email" />
+				</label>
+				<Button onclick={submit} disabled={busy || !email}>
+					{busy ? 'Sending…' : 'Send reset link'}
+				</Button>
+				<p class="text-center text-xs text-muted-foreground">
+					<a href="/login" class="underline">Back to sign in</a>
+				</p>
+			</Card.Content>
+		{/if}
+	</Card.Root>
+</div>

--- a/web/src/routes/reset/[token]/+page.server.ts
+++ b/web/src/routes/reset/[token]/+page.server.ts
@@ -1,0 +1,13 @@
+import type { PageServerLoad } from './$types';
+
+// The token itself is never validated here - only the confirm endpoint
+// (POST /api/auth/password/reset) checks it, and only after a submit. A
+// `load` that previewed validity would let a GET distinguish a live link
+// from a dead one before anyone submits anything, which is the same
+// account-enumeration shape #509 rules out on the request side.
+export const load: PageServerLoad = async (event) => {
+  return {
+    authOn: process.env.PITCHBOX_AUTH === 'on',
+    token: event.params.token,
+  };
+};

--- a/web/src/routes/reset/[token]/+page.svelte
+++ b/web/src/routes/reset/[token]/+page.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import * as Card from '$lib/components/ui/card';
+	import { toast } from 'svelte-sonner';
+	import Seo from '$lib/components/Seo.svelte';
+	import { TONE_TEXT_CLASS } from '$lib/config/status-badges';
+
+	let { data }: { data: { authOn: boolean; token: string } } = $props();
+
+	let newPassword = $state('');
+	let confirmPassword = $state('');
+	let busy = $state(false);
+
+	const canSubmit = $derived(
+		!busy && newPassword.length >= 8 && newPassword === confirmPassword,
+	);
+
+	async function submit() {
+		if (!canSubmit) return;
+		busy = true;
+		try {
+			const res = await fetch('/api/auth/password/reset', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ token: data.token, newPassword }),
+			});
+			if (res.ok) {
+				toast.success('Password reset', {
+					description: 'Every other session on your account was signed out.',
+				});
+				await goto('/', { invalidateAll: true });
+				return;
+			}
+			if (res.status === 429) {
+				const body = (await res.json()) as { retry_after_seconds?: number };
+				toast.error('Too many attempts', {
+					description: body.retry_after_seconds
+						? `Try again in ${body.retry_after_seconds}s`
+						: undefined,
+				});
+				return;
+			}
+			toast.error('This link is no longer valid', {
+				description: 'It may have expired or already been used - request a new one.',
+			});
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+<Seo
+	title={data.authOn ? 'Choose a new password' : 'Authentication disabled'}
+	description="Choose a new Pitchbox password"
+/>
+
+<div class="min-h-screen flex items-center justify-center bg-background p-6">
+	<Card.Root class="w-full max-w-sm">
+		{#if !data.authOn}
+			<Card.Header>
+				<Card.Title>Authentication is disabled</Card.Title>
+				<p class="text-xs {TONE_TEXT_CLASS.amber}">
+					This instance runs with PITCHBOX_AUTH off, so there is no account to reset a
+					password for. Set PITCHBOX_AUTH=on in your environment to enable this.
+				</p>
+			</Card.Header>
+			<Card.Content>
+				<Button href="/" variant="outline" class="w-full">Go to Pitchbox</Button>
+			</Card.Content>
+		{:else}
+			<Card.Header>
+				<Card.Title>Choose a new password</Card.Title>
+				<Card.Description>
+					At least 8 characters. This signs you in and signs out every other session on
+					this account.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content class="flex flex-col gap-3">
+				<label class="flex flex-col gap-1 text-xs">
+					New password
+					<Input
+						type="password"
+						bind:value={newPassword}
+						disabled={busy}
+						autocomplete="new-password"
+					/>
+				</label>
+				<label class="flex flex-col gap-1 text-xs">
+					Confirm new password
+					<Input
+						type="password"
+						bind:value={confirmPassword}
+						disabled={busy}
+						autocomplete="new-password"
+					/>
+				</label>
+				<Button onclick={submit} disabled={!canSubmit}>
+					{busy ? 'Resetting…' : 'Reset password'}
+				</Button>
+			</Card.Content>
+		{/if}
+	</Card.Root>
+</div>

--- a/web/tests/password-reset.test.ts
+++ b/web/tests/password-reset.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, beforeEach, afterAll, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { sql, eq } from 'drizzle-orm';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { createSession, hashPassword } from '@pitchbox/shared/auth';
+import { POST as forgotPassword } from '../src/routes/api/auth/password/forgot/+server.js';
+import { POST as resetPassword } from '../src/routes/api/auth/password/reset/+server.js';
+import { POST as login } from '../src/routes/api/auth/login/+server.js';
+import { type CookieJar, makeCookies, runThroughHandle } from './helpers/handle-harness.js';
+
+const USERNAME = 'debra';
+const EMAIL = 'debra@example.com';
+const PASSWORD = 'correct-horse-battery';
+const WRONG = 'wrong-password-9999';
+const NEW_PASSWORD = 'brand-new-battery-1';
+
+// Captured at import time so afterAll can restore it and this file doesn't
+// leak PITCHBOX_AUTH into other test files sharing this worker.
+const originalAuth = process.env.PITCHBOX_AUTH;
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`TRUNCATE password_reset_tokens RESTART IDENTITY CASCADE`);
+  await db.execute(sql`TRUNCATE auth_failures RESTART IDENTITY CASCADE`);
+  await db.execute(sql`DELETE FROM sessions`);
+  await db.execute(sql`DELETE FROM memberships`);
+  await db.execute(sql`DELETE FROM users`);
+  await db.execute(sql`DELETE FROM app_config WHERE key = 'auth_policy'`);
+}
+
+async function seedUser(): Promise<{ userId: number }> {
+  const db = getDb();
+  const hash = await hashPassword(PASSWORD);
+  const [row] = await db
+    .insert(schema.users)
+    .values({ username: USERNAME, passwordHash: hash, email: EMAIL })
+    .returning();
+  let [org] = await db.select().from(schema.organizations).where(sql`slug = 'default'`);
+  if (!org) {
+    [org] = await db
+      .insert(schema.organizations)
+      .values({ slug: 'default', name: 'Default' })
+      .returning();
+  }
+  await db
+    .insert(schema.memberships)
+    .values({ organizationId: org.id, userId: row.id, role: 'owner' })
+    .onConflictDoNothing();
+  return { userId: row.id };
+}
+
+function forgotRequest(email: string) {
+  return new Request('http://localhost/api/auth/password/forgot', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email }),
+  });
+}
+
+function resetRequestBody(token: string, newPassword: string) {
+  return new Request('http://localhost/api/auth/password/reset', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ token, newPassword }),
+  });
+}
+
+// Drives the real forgot-password route through the real handle(), and
+// captures the reset link from the null transport's console.log - the same
+// thing a person reading process logs on a self-host with nothing
+// configured would see, and the only place the raw token exists once this
+// call returns (shared/src/auth.ts never returns it a second time).
+async function requestReset(
+  email: string,
+  ip = '10.9.0.1',
+): Promise<{ res: Response; token: string | null; logged: string }> {
+  const jar: CookieJar = { store: new Map() };
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  let res: Response;
+  let logged: string;
+  try {
+    res = await runThroughHandle(
+      forgotRequest(email),
+      jar,
+      // runThroughHandle's routeHandler is `(event: unknown) => Promise<Response>`
+      // since it forwards whatever locals the real hook populated; the real
+      // route declares the narrower RequestEvent the hook actually builds.
+      (event) => forgotPassword(event as unknown as RequestEvent),
+      ip,
+    );
+    logged = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+  } finally {
+    logSpy.mockRestore();
+  }
+  const match = logged.match(/\/reset\/([0-9a-f]+)/);
+  return { res, token: match?.[1] ?? null, logged };
+}
+
+async function confirmReset(
+  token: string,
+  newPassword: string,
+  ip = '10.9.1.1',
+): Promise<{ res: Response; jar: CookieJar }> {
+  const jar: CookieJar = { store: new Map() };
+  const res = await runThroughHandle(
+    resetRequestBody(token, newPassword),
+    jar,
+    (event) => resetPassword(event as unknown as RequestEvent),
+    ip,
+  );
+  return { res, jar };
+}
+
+async function attemptLogin(username: string, password: string, ip: string) {
+  const jar: CookieJar = { store: new Map() };
+  const event = {
+    request: new Request('http://localhost/api/auth/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    }),
+    cookies: makeCookies(jar),
+    getClientAddress: () => ip,
+  };
+  // Minimal RequestEvent stand-in: login() only reads request/cookies/
+  // getClientAddress, same shape password-change.test.ts's attemptLogin uses.
+  return login(event as unknown as RequestEvent);
+}
+
+describe('forgot/reset password', () => {
+  beforeEach(async () => {
+    process.env.PITCHBOX_AUTH = 'on';
+    await reset();
+  });
+
+  it('a session-less GET reaches /reset/<token> through the real handle(), not a login redirect', async () => {
+    const jar: CookieJar = { store: new Map() };
+    const dummyPage = async () => new Response('reset page', { status: 200 });
+    const res = await runThroughHandle(
+      new Request('http://localhost/reset/some-token', { method: 'GET' }),
+      jar,
+      dummyPage,
+      '10.9.0.9',
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('reset page');
+  });
+
+  it('answers a known and an unknown address identically, and only mails the known one', async () => {
+    await seedUser();
+    const known = await requestReset(EMAIL, '10.9.1.10');
+    const unknown = await requestReset('nobody@example.com', '10.9.1.11');
+
+    expect(known.res.status).toBe(unknown.res.status);
+    expect(await known.res.json()).toEqual(await unknown.res.json());
+    expect(known.logged).toContain('would send');
+    expect(unknown.logged).toBe('');
+  });
+
+  it('stores only a hash of the token, never the token itself', async () => {
+    const { userId } = await seedUser();
+    const { token } = await requestReset(EMAIL, '10.9.2.10');
+    expect(token).toBeTruthy();
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.passwordResetTokens)
+      .where(eq(schema.passwordResetTokens.userId, userId));
+    expect(row.tokenHash).not.toBe(token);
+    expect(row.tokenHash).toBe(createHash('sha256').update(token!).digest('hex'));
+  });
+
+  it('a token works exactly once - a second redemption is rejected', async () => {
+    await seedUser();
+    const { token } = await requestReset(EMAIL, '10.9.3.10');
+
+    const first = await confirmReset(token!, NEW_PASSWORD, '10.9.3.11');
+    expect(first.res.status).toBe(200);
+
+    const second = await confirmReset(token!, 'yet-another-password-2', '10.9.3.12');
+    expect(second.res.status).toBe(400);
+    expect(await second.res.json()).toEqual({ error: 'invalid_or_expired_token' });
+  });
+
+  it('an expired token is refused', async () => {
+    await seedUser();
+    const { token } = await requestReset(EMAIL, '10.9.4.10');
+    const tokenHash = createHash('sha256').update(token!).digest('hex');
+    await getDb()
+      .update(schema.passwordResetTokens)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(schema.passwordResetTokens.tokenHash, tokenHash));
+
+    const { res } = await confirmReset(token!, NEW_PASSWORD, '10.9.4.11');
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_or_expired_token' });
+  });
+
+  it('a completed reset retires the old password, admits the new one, and revokes every existing session', async () => {
+    const { userId } = await seedUser();
+    const priorSession = await createSession(getDb(), userId);
+    const { token } = await requestReset(EMAIL, '10.9.5.10');
+
+    const { res, jar } = await confirmReset(token!, NEW_PASSWORD, '10.9.5.11');
+    expect(res.status).toBe(200);
+
+    const remaining = await getDb()
+      .select({ id: schema.sessions.id })
+      .from(schema.sessions)
+      .where(eq(schema.sessions.userId, userId));
+    // The prior session is gone; the only session left is the fresh one the
+    // reset itself minted, matching the cookie the response set. Checked
+    // before the login attempts below, since a successful login mints its
+    // own session and would otherwise show up in this count too.
+    expect(remaining.map((r) => r.id)).not.toContain(priorSession.id);
+    const mintedSessionId = jar.store.get('pitchbox_session')?.value;
+    expect(remaining.map((r) => r.id)).toEqual([mintedSessionId]);
+
+    const oldLogin = await attemptLogin(USERNAME, PASSWORD, '10.9.5.12');
+    expect(oldLogin.status).toBe(401);
+    const newLogin = await attemptLogin(USERNAME, NEW_PASSWORD, '10.9.5.13');
+    expect(newLogin.status).toBe(200);
+  });
+
+  it('clears the account login lockout on a completed reset, without touching an unrelated IP bucket', async () => {
+    await seedUser();
+    // Five wrong-password guesses against the account, each from a
+    // different IP - only the per-user bucket crosses the threshold, no
+    // single IP bucket does.
+    for (let i = 0; i < 5; i++) {
+      const r = await attemptLogin(USERNAME, WRONG, `10.9.6.${i}`);
+      expect(r.status).toBe(401);
+    }
+    const stillLocked = await attemptLogin(USERNAME, PASSWORD, '10.9.6.90');
+    expect(stillLocked.status).toBe(429);
+
+    const { token } = await requestReset(EMAIL, '10.9.7.10');
+    const { res } = await confirmReset(token!, NEW_PASSWORD, '10.9.7.11');
+    expect(res.status).toBe(200);
+
+    const afterReset = await attemptLogin(USERNAME, NEW_PASSWORD, '10.9.6.91');
+    expect(afterReset.status).toBe(200);
+  });
+
+  it('rate limits repeated reset requests for the same address', async () => {
+    await seedUser();
+    for (let i = 0; i < 5; i++) {
+      const { res } = await requestReset(EMAIL, `10.9.8.${i}`);
+      expect(res.status).toBe(200);
+    }
+    const { res } = await requestReset(EMAIL, '10.9.8.90');
+    expect(res.status).toBe(429);
+  });
+});
+
+afterAll(async () => {
+  if (originalAuth === undefined) delete process.env.PITCHBOX_AUTH;
+  else process.env.PITCHBOX_AUTH = originalAuth;
+});

--- a/web/tests/password-reset.test.ts
+++ b/web/tests/password-reset.test.ts
@@ -36,7 +36,10 @@ async function seedUser(): Promise<{ userId: number }> {
     .insert(schema.users)
     .values({ username: USERNAME, passwordHash: hash, email: EMAIL })
     .returning();
-  let [org] = await db.select().from(schema.organizations).where(sql`slug = 'default'`);
+  let [org] = await db
+    .select()
+    .from(schema.organizations)
+    .where(sql`slug = 'default'`);
   if (!org) {
     [org] = await db
       .insert(schema.organizations)


### PR DESCRIPTION
Closes #509

## What
- `password_reset_tokens` table: hashed at rest (sha256), single use, 20-minute TTL. Structurally the same shape as `org_invites` (random token, expiry, single-use marker), but hashed like `extension_devices.token_hash` rather than stored in the clear like `org_invites.token` - a reset token proves control of an arbitrary mailbox, an invite token doesn't need that bar.
- `POST /api/auth/password/forgot`: answers `{ ok: true }` / 200 whether or not the address has an account. Rate limited per IP and per submitted address through the existing `auth_failures`/`loadAuthPolicy` machinery (same mechanism login uses), so it can't be used to mail-bomb someone.
- `POST /api/auth/password/reset`: redeems the token via a single atomic `UPDATE ... WHERE token_hash = $1 AND used_at IS NULL AND expires_at > now() RETURNING user_id` (same CAS shape the extension device rotate endpoint uses), sets the new password, deletes **every** session for the account (not just "every other one" like the self-service change at `/settings/password` - there's no session making this request to spare), clears the account's login lockout bucket, and signs the caller in with a freshly minted session.
- `/reset` (request a link) and `/reset/<token>` (set the new password) pages, same bypass-the-dashboard-chrome convention as `/login` and `/register`. Added a "Forgot your password?" link on `/login`.
- `web/src/hooks.server.ts`: added `/reset`, `/api/auth/password/forgot`, `/api/auth/password/reset` as exact-prefix exempt paths (not a blanket `/api/auth/password`, which would also exempt the signed-in self-service change route).

## Migration
Hand-authored per the batch convention (`pnpm run migrate:generate` is broken repo-wide, #527). Verified on a database dropped and recreated from scratch:

```
migrations applied (24 in journal, all present)
```

## Token shape
24 random bytes, hex-encoded (same as `org_invites`' token). Only `sha256(token).hex` is ever written to the database (`password_reset_tokens.token_hash`); the raw token exists only in the emailed link and is never returned or logged again after the request that mints it.

## Tests (`web/tests/password-reset.test.ts`, 8 tests)
Each assertion below was proven to bite: broken, watched fail, restored, confirmed green.
- **Enumeration**: a known and an unknown address get the identical status/body; only the known one produces a mail-transport log line. *Broke by short-circuiting the route to 404 an unknown address - test caught the status mismatch.*
- **Single use**: a second redemption of the same token is rejected. *Broke by dropping the `usedAt IS NULL` predicate from the redeem query - test caught the second call still succeeding.*
- **Expiry**: an expired token is refused. *Broke by dropping the `expiresAt > now()` predicate - test caught it.*
- **Hash at rest**: the stored `tokenHash` is never the raw token. *Broke by inserting the raw token instead of its hash - test caught the equality.*
- **Session/password**: a completed reset retires the old password, admits the new one, and leaves only the freshly minted session. *Broke the session delete and separately the password update - each broke its own assertion.*
- **Lockout clearing**: a completed reset clears the account's own login lockout without touching an unrelated IP bucket. *Broke by removing the `user:<username>` clear call - test caught the still-429 login.*
- **Rate limiting**: 6 reset requests for the same address from different IPs get a 429 on the 6th. *Broke by removing the `recordAuthFailure` calls - test caught the still-200.*
- **Real handle()**: a session-less GET to `/reset/<token>` reaches the page through the actual `hooks.server.ts` `handle()`, not a hand-injected locals object. *Broke by dropping `/reset` from `isExemptPath` - test caught the 302 redirect to `/login` (this is also the bug I hit live testing the page in a browser before writing the test).*

Also ran the neighboring auth suites (password-change, register, auth-hardening, internal-dispatch-auth x2, shared mail tests, shared auth unit tests) against the same worktree database - 52 + 15 tests, all green, no regressions.

## Manual verification
Ran the dev server on this worktree's `WEB_PORT` against its own database and drove the full flow with curl plus a headless browser: `/reset` and `/reset/<token>` render correctly in the dashboard's dark theme, the login page shows the new "Forgot your password?" link, a real forgot request logs the reset link via the null transport, the confirm endpoint accepts it once and rejects the replay, and the DB ends up with the token marked used, the password hash changed, and exactly one session (the new one).
