### PR TITLE
feat(web,shared): registration policy - invite-only by default (#505)

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -97,7 +97,10 @@ POST, `settings/webhooks` PUT, `settings/model-functions` POST,
 `webhooks/deliveries/[id]/retry` POST (also tenant-guarded: the delivery
 must belong to the caller's org before the instance-admin gate runs),
 `settings/retention` form action (saving only - viewing the page, and the
-GET routes above, stay `requireRole(event, 'admin')`).
+GET routes above, stay `requireRole(event, 'admin')`), `settings/admin/registration`
+GET + POST (#505's registration policy switch - open/invite/off - surfaced on
+`settings/admin` itself rather than a route of its own, since it is a single
+value with no per-data-set split to justify one).
 
 ### Instance-wide audit trail (#414)
 
@@ -113,13 +116,14 @@ each route recording it differently - and it redacts `before`/`after` itself
 (any JSON field whose name looks like a credential, and any `*url` field,
 which a webhook target can carry one inside), so a caller does not have to
 remember to. Wired into default-runner, runner-config, quota, webhooks,
-retention, model-functions, and the account-promotion action
-(`web/src/routes/api/settings/admin/promote/+server.ts`, #413) - every
-`requireInstanceAdmin`-gated write above records itself under key
+retention, model-functions, registration-policy, and the account-promotion
+action (`web/src/routes/api/settings/admin/promote/+server.ts`, #413) -
+every `requireInstanceAdmin`-gated write above records itself under key
 `default_runner`, `runner_config:<slug>`, `quota_defaults`,
-`notification_webhooks`, `retention`, `model_function:<fn>`, or
-`user_promotion`. Rendered at `settings/admin/audit` (gated the same way as
-every other page in the area below), most recent first.
+`notification_webhooks`, `retention`, `model_function:<fn>`,
+`registration_policy`, or `user_promotion`. Rendered at `settings/admin/audit`
+(gated the same way as every other page in the area below), most recent
+first.
 
 The redaction is a name-based heuristic, not a guarantee: it catches a
 field named `key`/`token`/`secret`/`password`/`credential` (any case, any

--- a/shared/package.json
+++ b/shared/package.json
@@ -81,7 +81,8 @@
     "./mail": "./src/mail/base.ts",
     "./mail/registry": "./src/mail/registry.ts",
     "./mail/template": "./src/mail/template.ts",
-    "./mail/env": "./src/mail/env.ts"
+    "./mail/env": "./src/mail/env.ts",
+    "./registration-policy": "./src/registration-policy.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -626,7 +626,8 @@ export const appConfig = pgTable('app_config', {
 // has none of). `key` names the app_config row (or app_config-shaped
 // concern) that changed - 'default_runner', 'quota_defaults',
 // 'runner_config:<slug>', 'notification_webhooks', 'retention',
-// 'model_function:<fn>', 'user_promotion' - `before`/`after` hold the value
+// 'model_function:<fn>', 'registration_policy', 'user_promotion' - `before`/
+// `after` hold the value
 // on each side of the write, run through `redactInstanceAuditValue`
 // (shared/src/instance-audit.ts) before they ever reach this table so a
 // credential-shaped field is never stored raw. `recordInstanceAudit` is the

--- a/shared/src/registration-policy.ts
+++ b/shared/src/registration-policy.ts
@@ -1,0 +1,47 @@
+// Registration policy (#505): whether POST /api/auth/register accepts a
+// registration at all, and if so, whether it needs a valid invite token.
+// Three states, same convention as retention/quota/default-runner - a
+// single instance-wide `app_config` row, read at request time so opening or
+// closing a deployment needs no redeploy:
+//
+//   - 'open':   anyone can register, with or without an invite token.
+//   - 'invite': a registration must carry a valid invite token.
+//   - 'off':    no registration at all - accounts come from `seed:owner` or
+//               the CLI.
+//
+// The code default is 'invite': a self-host operator turning
+// `PITCHBOX_AUTH=on` is usually a single person making the app reachable,
+// and a public registration form is the last thing they want by default. A
+// deployment that wants open sign-up (the cloud edition) sets this
+// explicitly through the instance-admin area - never the code default.
+
+import { eq } from 'drizzle-orm';
+import { schema, type Db } from './db/client.js';
+
+export type RegistrationPolicy = 'open' | 'invite' | 'off';
+
+export const DEFAULT_REGISTRATION_POLICY: RegistrationPolicy = 'invite';
+
+const APP_CONFIG_KEY = 'registration_policy';
+
+export async function loadRegistrationPolicy(db: Db): Promise<RegistrationPolicy> {
+  const [row] = await db
+    .select({ value: schema.appConfig.value })
+    .from(schema.appConfig)
+    .where(eq(schema.appConfig.key, APP_CONFIG_KEY))
+    .limit(1);
+  const raw = (row?.value as { policy?: unknown } | undefined)?.policy;
+  return raw === 'open' || raw === 'invite' || raw === 'off' ? raw : DEFAULT_REGISTRATION_POLICY;
+}
+
+export async function saveRegistrationPolicy(
+  db: Db,
+  policy: RegistrationPolicy,
+): Promise<RegistrationPolicy> {
+  const value = { policy };
+  await db
+    .insert(schema.appConfig)
+    .values({ key: APP_CONFIG_KEY, value })
+    .onConflictDoUpdate({ target: schema.appConfig.key, set: { value } });
+  return policy;
+}

--- a/web/src/routes/api/auth/register/+server.ts
+++ b/web/src/routes/api/auth/register/+server.ts
@@ -21,6 +21,7 @@ import {
   uniqueOrgSlugFromUsername,
   type OrgInvite,
 } from '@pitchbox/shared/orgs';
+import { loadRegistrationPolicy } from '@pitchbox/shared/registration-policy';
 
 // Same identifier/password shape as POST /api/auth/login (web/src/routes/api/
 // auth/login/+server.ts) - one convention for both routes, per #504. Email is
@@ -102,6 +103,35 @@ export async function POST(event: RequestEvent) {
         retry_after_seconds: Math.max(1, Math.ceil((ipLock.getTime() - now.getTime()) / 1000)),
       },
       { status: 429 },
+    );
+  }
+
+  // #505: the instance-wide switch, read fresh on every call so an operator
+  // opening or closing registration from settings/admin takes effect
+  // immediately, no redeploy. Checked before any other work so a probe
+  // against a closed/invite-only deployment never reaches the uniqueness
+  // checks below. Own error codes (not `invalid_credentials` or a bare 403)
+  // so the page can explain what happened rather than show a generic
+  // failure.
+  const regPolicy = await loadRegistrationPolicy(db);
+  if (regPolicy === 'off') {
+    await recordAuthFailure(db, ipBucket);
+    return json(
+      {
+        error: 'registration_closed',
+        message: 'Registration is disabled on this deployment. Ask its operator for an account.',
+      },
+      { status: 403 },
+    );
+  }
+  if (regPolicy === 'invite' && !parsed.data.token) {
+    await recordAuthFailure(db, ipBucket);
+    return json(
+      {
+        error: 'invite_required',
+        message: 'This deployment is invite-only. Ask an organization owner for an invite link.',
+      },
+      { status: 403 },
     );
   }
 

--- a/web/src/routes/api/settings/admin/registration/+server.ts
+++ b/web/src/routes/api/settings/admin/registration/+server.ts
@@ -1,0 +1,39 @@
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '$lib/server/db.js';
+import { requireInstanceAdmin } from '$lib/server/auth.js';
+import {
+  loadRegistrationPolicy,
+  saveRegistrationPolicy,
+} from '@pitchbox/shared/registration-policy';
+import { recordInstanceAudit } from '@pitchbox/shared/instance-audit';
+
+const Body = z.object({ policy: z.enum(['open', 'invite', 'off']) });
+
+// The registration policy switch (#505): instance-wide, like default-runner/
+// quota/retention/webhooks/model-functions, so it needs the stricter
+// `requireInstanceAdmin` rather than the per-org 'admin' role - a
+// self-created-org admin must never be able to open sign-up for the whole
+// deployment.
+export async function GET(event: RequestEvent) {
+  await requireInstanceAdmin(event);
+  return json({ policy: await loadRegistrationPolicy(getDb()) });
+}
+
+export async function POST(event: RequestEvent) {
+  await requireInstanceAdmin(event);
+  const raw = await event.request.json().catch(() => null);
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) throw error(400, 'invalid_body');
+
+  const db = getDb();
+  const before = await loadRegistrationPolicy(db);
+  const after = await saveRegistrationPolicy(db, parsed.data.policy);
+  await recordInstanceAudit(db, {
+    key: 'registration_policy',
+    actor: event.locals.user ?? null,
+    before: { policy: before },
+    after: { policy: after },
+  });
+  return json({ ok: true, policy: after });
+}

--- a/web/src/routes/register/+page.server.ts
+++ b/web/src/routes/register/+page.server.ts
@@ -2,6 +2,11 @@ import { redirect } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 import { getDb, schema } from '$lib/server/db.js';
 import { findValidInvite } from '@pitchbox/shared/orgs';
+import {
+  loadRegistrationPolicy,
+  DEFAULT_REGISTRATION_POLICY,
+  type RegistrationPolicy,
+} from '@pitchbox/shared/registration-policy';
 import type { PageServerLoad } from './$types';
 
 // `/invite/<token>` redirects an unauthenticated visitor here with
@@ -24,19 +29,29 @@ export const load: PageServerLoad = async (event) => {
   }
 
   let invite: { token: string; email: string | null; orgName: string | null } | null = null;
-  const inviteMatch = authOn && next ? next.match(INVITE_NEXT) : null;
-  if (inviteMatch) {
-    const token = inviteMatch[1];
+  let policy: RegistrationPolicy = DEFAULT_REGISTRATION_POLICY;
+  if (authOn) {
     const db = getDb();
-    const found = await findValidInvite(db, token);
-    if (found) {
-      const [org] = await db
-        .select({ name: schema.organizations.name })
-        .from(schema.organizations)
-        .where(eq(schema.organizations.id, found.organizationId));
-      invite = { token, email: found.email, orgName: org?.name ?? null };
+    policy = await loadRegistrationPolicy(db);
+    const inviteMatch = next ? next.match(INVITE_NEXT) : null;
+    if (inviteMatch) {
+      const token = inviteMatch[1];
+      const found = await findValidInvite(db, token);
+      if (found) {
+        const [org] = await db
+          .select({ name: schema.organizations.name })
+          .from(schema.organizations)
+          .where(eq(schema.organizations.id, found.organizationId));
+        invite = { token, email: found.email, orgName: org?.name ?? null };
+      }
     }
   }
 
-  return { authOn, next, invite };
+  // #505: the same three-state policy the route enforces server-side, read
+  // here so the page never offers a form that POST /api/auth/register would
+  // only refuse - a hidden/disabled form is presentation, not the gate, but
+  // showing one that cannot possibly succeed is worse than showing nothing.
+  const canRegister = policy === 'open' || (policy === 'invite' && invite !== null);
+
+  return { authOn, next, invite, policy, canRegister };
 };

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -11,6 +11,8 @@
 		authOn: boolean;
 		next: string | null;
 		invite: { token: string; email: string | null; orgName: string | null } | null;
+		policy: 'open' | 'invite' | 'off';
+		canRegister: boolean;
 	};
 	let { data }: { data: PageData } = $props();
 
@@ -39,7 +41,10 @@
 				}),
 			});
 			if (!res.ok) {
-				const body = (await res.json().catch(() => ({}))) as { error?: string };
+				const body = (await res.json().catch(() => ({}))) as {
+					error?: string;
+					message?: string;
+				};
 				const message =
 					body.error === 'username_taken'
 						? 'That username is already taken'
@@ -49,7 +54,10 @@
 								? 'This invite is no longer valid'
 								: body.error === 'rate_limited'
 									? 'Too many attempts, try again shortly'
-									: 'Could not create account';
+									: (body.error === 'registration_closed' || body.error === 'invite_required') &&
+										  body.message
+										? body.message
+										: 'Could not create account';
 				toast.error(message);
 				return;
 			}
@@ -77,6 +85,20 @@
 			</Card.Header>
 			<Card.Content>
 				<Button href="/" variant="outline" class="w-full">Go to Pitchbox</Button>
+			</Card.Content>
+		{:else if !data.canRegister}
+			<Card.Header>
+				<Card.Title>
+					{data.policy === 'off' ? 'Registration is disabled' : 'This deployment is invite-only'}
+				</Card.Title>
+				<p class="text-xs {TONE_TEXT_CLASS.amber}">
+					{data.policy === 'off'
+						? 'Registration is disabled on this deployment. Ask its operator for an account.'
+						: 'This deployment is invite-only. Ask an organization owner for an invite link to create an account.'}
+				</p>
+			</Card.Header>
+			<Card.Content>
+				<Button href={signInHref()} variant="outline" class="w-full">Sign in instead</Button>
 			</Card.Content>
 		{:else}
 			<Card.Header>

--- a/web/src/routes/settings/admin/+page.server.ts
+++ b/web/src/routes/settings/admin/+page.server.ts
@@ -1,12 +1,19 @@
 import type { PageServerLoad } from './$types';
 import { getDb } from '$lib/server/db.js';
 import { listUsers } from '@pitchbox/shared/auth';
+import { loadRegistrationPolicy } from '@pitchbox/shared/registration-policy';
 
 // Lists every user with their instance-admin flag so a promotion (#413) is
-// visible from the UI rather than the database. The gate for this whole
+// visible from the UI rather than the database, and the current
+// registration policy (#505) so the switch on this page reflects the
+// stored value rather than a client-side guess. The gate for this whole
 // subtree already ran in +layout.server.ts (requireInstanceAdmin), so this
 // loader only needs to fetch the data.
 export const load: PageServerLoad = async () => {
-  const users = await listUsers(getDb());
-  return { users };
+  const db = getDb();
+  const [users, registrationPolicy] = await Promise.all([
+    listUsers(db),
+    loadRegistrationPolicy(db),
+  ]);
+  return { users, registrationPolicy };
 };

--- a/web/src/routes/settings/admin/+page.svelte
+++ b/web/src/routes/settings/admin/+page.svelte
@@ -4,6 +4,7 @@
   import * as Table from '$lib/components/ui/table';
   import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
+  import { SelectField } from '$lib/components/ui/select-field';
   import { Info, Bot, Gauge, Archive, Webhook, ScrollText } from '@lucide/svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
   import PageContainer from '$lib/components/PageContainer.svelte';
@@ -12,7 +13,8 @@
   import { invalidateAll } from '$app/navigation';
 
   type AdminUser = { id: number; username: string; isInstanceAdmin: boolean };
-  type PageData = { authOn: boolean; users: AdminUser[] };
+  type RegistrationPolicy = 'open' | 'invite' | 'off';
+  type PageData = { authOn: boolean; users: AdminUser[]; registrationPolicy: RegistrationPolicy };
   let { data }: { data: PageData } = $props();
 
   let promoting = $state<number | null>(null);
@@ -35,6 +37,39 @@
       toast.error('Could not promote that user');
     } finally {
       promoting = null;
+    }
+  }
+
+  const REGISTRATION_POLICY_OPTIONS: { value: RegistrationPolicy; label: string }[] = [
+    { value: 'open', label: 'Open - anyone can register' },
+    { value: 'invite', label: 'Invite-only - a valid invite token is required' },
+    { value: 'off', label: 'Off - no registration at all' },
+  ];
+  // svelte-ignore state_referenced_locally
+  let registrationPolicy = $state<RegistrationPolicy>(data.registrationPolicy);
+  let savingRegistrationPolicy = $state(false);
+
+  async function saveRegistrationPolicy(next: RegistrationPolicy) {
+    const previous = registrationPolicy;
+    registrationPolicy = next;
+    savingRegistrationPolicy = true;
+    try {
+      const res = await fetch('/api/settings/admin/registration', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ policy: next }),
+      });
+      if (!res.ok) {
+        registrationPolicy = previous;
+        toast.error('Could not save the registration policy');
+        return;
+      }
+      toast.success('Registration policy saved');
+    } catch {
+      registrationPolicy = previous;
+      toast.error('Could not save the registration policy');
+    } finally {
+      savingRegistrationPolicy = false;
     }
   }
 
@@ -115,6 +150,26 @@
       </a>
     {/each}
   </div>
+
+  <Card.Root class="mt-8 max-w-3xl">
+    <Card.Header>
+      <Card.Title>Registration policy</Card.Title>
+      <Card.Description>
+        Whether POST /api/auth/register accepts a new account, and whether it needs a valid
+        invite token. Read fresh on every request, so a change here takes effect without a
+        redeploy. Code default is invite-only.
+      </Card.Description>
+    </Card.Header>
+    <Card.Content class="flex flex-col gap-2 sm:max-w-sm">
+      <SelectField
+        value={registrationPolicy}
+        onValueChange={(v) => saveRegistrationPolicy(v as RegistrationPolicy)}
+        options={REGISTRATION_POLICY_OPTIONS}
+        disabled={savingRegistrationPolicy}
+        fullWidth
+      />
+    </Card.Content>
+  </Card.Root>
 
   <Card.Root class="mt-8 max-w-3xl">
     <Card.Header>

--- a/web/tests/register.test.ts
+++ b/web/tests/register.test.ts
@@ -3,6 +3,7 @@ import { sql, eq } from 'drizzle-orm';
 import type { RequestEvent } from '@sveltejs/kit';
 import { getDb, schema } from '@pitchbox/shared/db';
 import { createInvite, findOrgBySlug, listUserOrganizations } from '@pitchbox/shared/orgs';
+import { saveRegistrationPolicy } from '@pitchbox/shared/registration-policy';
 import { POST as register } from '../src/routes/api/auth/register/+server.js';
 import { load as inviteLoad } from '../src/routes/invite/[token]/+page.server.js';
 import { type CookieJar, makeCookies, runThroughHandle } from './helpers/handle-harness.js';
@@ -19,6 +20,12 @@ async function reset() {
   // Keep `default`: seed:core creates it once for the whole suite and other
   // test files running later in this sequential run rely on it existing.
   await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  // This file's tests below predate #505 and exercise what a token-less
+  // registration does once it is allowed (own org, dedup, rate limiting),
+  // not the policy gate itself - that gate has its own tests in
+  // registration-policy.test.ts. Set 'open' explicitly so they keep
+  // covering that rather than tripping the invite-only default.
+  await saveRegistrationPolicy(db, 'open');
 }
 
 async function seedOrgAdmin(orgSlug: string) {

--- a/web/tests/registration-policy.test.ts
+++ b/web/tests/registration-policy.test.ts
@@ -1,0 +1,222 @@
+// #505: the registration policy switch. `POST /api/auth/register`'s own
+// behavior (self-org creation, dedup, invite acceptance) already has
+// coverage in register.test.ts, seeded to the 'open' policy so it keeps
+// exercising that rather than this gate. This file is the gate itself: the
+// three `app_config.registration_policy` states, the code default with no
+// config row at all, and the instance-admin-only write side.
+import { describe, expect, it, beforeEach, afterAll } from 'vitest';
+import { sql } from 'drizzle-orm';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { createInvite } from '@pitchbox/shared/orgs';
+import { hashPassword } from '@pitchbox/shared/auth';
+import {
+  loadRegistrationPolicy,
+  saveRegistrationPolicy,
+} from '@pitchbox/shared/registration-policy';
+import { POST as register } from '../src/routes/api/auth/register/+server.js';
+import {
+  GET as adminGet,
+  POST as adminPost,
+} from '../src/routes/api/settings/admin/registration/+server.js';
+import { type CookieJar, makeCookies } from './helpers/handle-harness.js';
+
+const originalAuth = process.env.PITCHBOX_AUTH;
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`TRUNCATE auth_failures RESTART IDENTITY CASCADE`);
+  await db.execute(sql`DELETE FROM org_invites`);
+  await db.execute(sql`DELETE FROM sessions`);
+  await db.execute(sql`DELETE FROM memberships`);
+  await db.execute(sql`DELETE FROM users`);
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  // No row at all, not even an explicit 'invite' - this is what a fresh
+  // install actually has, and loadRegistrationPolicy must fall back to the
+  // 'invite' code default rather than erroring or defaulting open.
+  await db.execute(sql`DELETE FROM app_config WHERE key = 'registration_policy'`);
+  await db.execute(sql`DELETE FROM instance_audit_log`);
+}
+
+async function seedOrgOwner(orgSlug: string) {
+  const db = getDb();
+  const [owner] = await db
+    .insert(schema.users)
+    .values({ username: `owner-${orgSlug}`, passwordHash: 'x' })
+    .returning();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug: orgSlug, name: orgSlug })
+    .returning();
+  await db
+    .insert(schema.memberships)
+    .values({ organizationId: org.id, userId: owner.id, role: 'owner' });
+  return { ownerId: owner.id, orgId: org.id };
+}
+
+function registerEvent(body: unknown, jar: CookieJar): RequestEvent {
+  const request = new Request('http://localhost/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return {
+    request,
+    cookies: makeCookies(jar),
+    getClientAddress: () => '10.2.0.1',
+  } as unknown as RequestEvent;
+}
+
+async function callRegister(body: unknown): Promise<Response> {
+  return await register(registerEvent(body, { store: new Map() }));
+}
+
+// requireInstanceAdmin only ever looks at event.locals.user and re-queries
+// users.is_instance_admin - it does not consult locals.org, so a synthetic
+// event with just `locals.user` exercises the real gate, same convention as
+// retention-role.test.ts.
+async function userWith(username: string, isInstanceAdmin: boolean): Promise<{ id: number }> {
+  const hash = await hashPassword('correct-horse-battery');
+  const [user] = await getDb()
+    .insert(schema.users)
+    .values({ username, passwordHash: hash, isInstanceAdmin })
+    .returning({ id: schema.users.id });
+  return user;
+}
+
+function adminEvent(user: { id: number } | undefined, body?: unknown): RequestEvent {
+  return {
+    locals: user ? { user } : {},
+    request: new Request('http://localhost/api/settings/admin/registration', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }),
+  } as unknown as RequestEvent;
+}
+
+describe('registration policy (#505)', () => {
+  beforeEach(async () => {
+    process.env.PITCHBOX_AUTH = 'on';
+    await reset();
+  });
+
+  // The assertion that matters most: with no configuration at all, a
+  // token-less registration is refused, and refused with its own error code
+  // (not invalid_credentials, not a bare 403) so the page can explain why.
+  it('with no configuration at all, a token-less registration is refused - the default is closed', async () => {
+    expect(await loadRegistrationPolicy(getDb())).toBe('invite');
+
+    const res = await callRegister({
+      username: 'nobody',
+      email: 'nobody@example.com',
+      password: 'a-very-long-password',
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe('invite_required');
+    expect(typeof body.message).toBe('string');
+    expect(body.message.length).toBeGreaterThan(0);
+
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(sql`username = 'nobody'`);
+    expect(user).toBeUndefined();
+  });
+
+  it('a valid invite token still registers under the closed default', async () => {
+    const { ownerId, orgId } = await seedOrgOwner('closed-invite');
+    const invite = await createInvite(getDb(), { organizationId: orgId, createdByUserId: ownerId });
+
+    const res = await callRegister({
+      username: 'invited-under-closed',
+      email: 'invited-under-closed@example.com',
+      password: 'a-very-long-password',
+      token: invite.token,
+    });
+    expect(res.status).toBe(200);
+
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(sql`username = 'invited-under-closed'`);
+    expect(user).toBeDefined();
+  });
+
+  it("'off' refuses registration outright, with or without a token", async () => {
+    const { ownerId, orgId } = await seedOrgOwner('off-org');
+    const invite = await createInvite(getDb(), { organizationId: orgId, createdByUserId: ownerId });
+    await saveRegistrationPolicy(getDb(), 'off');
+
+    const withoutToken = await callRegister({
+      username: 'off-stranger',
+      email: 'off-stranger@example.com',
+      password: 'a-very-long-password',
+    });
+    expect(withoutToken.status).toBe(403);
+    expect((await withoutToken.json()).error).toBe('registration_closed');
+
+    const withToken = await callRegister({
+      username: 'off-invited',
+      email: 'off-invited@example.com',
+      password: 'a-very-long-password',
+      token: invite.token,
+    });
+    expect(withToken.status).toBe(403);
+    expect((await withToken.json()).error).toBe('registration_closed');
+
+    const rows = await getDb()
+      .select()
+      .from(schema.users)
+      .where(sql`username in ('off-stranger', 'off-invited')`);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('an instance admin can open registration, and a token-less registration then succeeds', async () => {
+    const admin = await userWith('reg-policy-iadmin', true);
+    const res = await adminPost(adminEvent(admin, { policy: 'open' }));
+    expect(res.status).toBe(200);
+    expect(await loadRegistrationPolicy(getDb())).toBe('open');
+
+    const registered = await callRegister({
+      username: 'opened-up',
+      email: 'opened-up@example.com',
+      password: 'a-very-long-password',
+    });
+    expect(registered.status).toBe(200);
+
+    // Recorded on the instance-wide audit trail, not silently.
+    const [auditRow] = await getDb()
+      .select()
+      .from(schema.instanceAuditLog)
+      .where(sql`key = 'registration_policy'`);
+    expect(auditRow).toBeDefined();
+  });
+
+  it('a member cannot flip the switch', async () => {
+    const member = await userWith('reg-policy-member', false);
+    await expect(adminPost(adminEvent(member, { policy: 'open' }))).rejects.toMatchObject({
+      status: 403,
+    });
+    expect(await loadRegistrationPolicy(getDb())).toBe('invite');
+  });
+
+  it('an org owner who is not the instance admin cannot flip the switch', async () => {
+    const { ownerId } = await seedOrgOwner('owner-cannot-flip');
+    await expect(adminPost(adminEvent({ id: ownerId }, { policy: 'open' }))).rejects.toMatchObject({
+      status: 403,
+    });
+    expect(await loadRegistrationPolicy(getDb())).toBe('invite');
+  });
+
+  it('the GET side is instance-admin gated too', async () => {
+    const member = await userWith('reg-policy-get-member', false);
+    await expect(adminGet(adminEvent(member))).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+afterAll(async () => {
+  if (originalAuth === undefined) delete process.env.PITCHBOX_AUTH;
+  else process.env.PITCHBOX_AUTH = originalAuth;
+});


### PR DESCRIPTION
Closes #505.

Adds the three-state registration policy: `open`, `invite` (code default), `off`. Stored in `app_config` under `registration_policy`, same convention as `retention`/`quota_defaults`/`default_runner`, read fresh on every request so an operator can flip it without a redeploy.

`POST /api/auth/register` enforces it server-side before any other work: `off` refuses everything with `registration_closed`, `invite` refuses a token-less attempt with `invite_required`, both as their own JSON error code plus an actionable `message` rather than a bare 403 or `invalid_credentials`. A valid invite token still registers under the closed default regardless of policy.

The `/register` page reads the same policy through its own loader and never renders a form that cannot succeed: closed or invite-only-without-a-valid-invite shows an explanation and a link to sign in instead, rather than a form that would only be refused on submit.

The switch itself lives in the instance-admin area (`settings/admin`), gated by `requireInstanceAdmin` like every other instance-wide config write in that family, with its own audit trail entry under key `registration_policy`.

Tests added in `web/tests/registration-policy.test.ts`:
- default (no config row at all) refuses a token-less registration - the most important assertion, proven to bite by flipping the code default to `open` and watching it fail
- a valid invite token still registers under the closed default
- `off` refuses both a token-less and a token-carrying registration
- an instance admin can flip the policy to `open`, after which a token-less registration succeeds, and the write lands in the instance audit trail
- a member and an org owner who are not the instance admin cannot flip the switch (403, `requireInstanceAdmin`'s own gate)
- the GET side is gated the same way

`web/tests/register.test.ts`'s existing token-less-registration tests (own-org creation, slug dedup, email/username dedup) now seed the policy to `open` explicitly in `reset()`, since they exercise that behavior once registration is allowed, not the policy gate itself.

Verification:
- `pnpm exec vitest run web/tests/registration-policy.test.ts web/tests/register.test.ts` - 17/17 passing
- Every new assertion broken and restored individually (default flipped to `open`, `off` check disabled, `invite` check widened to refuse a valid token, the instance-admin gate removed, the audit-trail call removed) - each broke exactly the test it backs, then passed again after restoring
- `pnpm -F web check` - 0 errors, 0 warnings
- `pnpm -F @pitchbox/shared typecheck` - clean
- `preflight` (full `pnpm test` against a disposable Postgres) - passed
- Screenshotted `/settings/admin` (registration policy card, open/off both render and persist through a real POST + reload) and `/register` in all three states (`off`, default `invite` with no invite context, `open`) via `uishot`

No migration: `app_config` already exists as a key/value table.
