### PR TITLE
chore: release 0.12.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.11.2",
+  "version": "0.12.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Minor, because an account can now come into existence in more than one way, which is a different product than the one v0.11 shipped.

What it carries, all from epic #503:

- `users.email`, nullable and unique on the normalized value (#507)
- `POST /api/auth/register` and a `/register` page, so an invite can finally be accepted by somebody who does not already have an account (#504)
- a registration policy, **invite-only by default**, with an instance-admin switch and an audited write (#505). This is the reason the release waits for it: registration landed open in #504, and a deployment that lets anyone in is not a default I want on a public host.
- self-service password change, revoking every other session (#506)
- forgot password and reset by email, single-use hashed tokens, 20 minute TTL, and the same answer for a known and an unknown address (#509)
- an outbound mail transport with a null default that logs and drops (#508), and invites that send through it while keeping the copyable link for a self-host with nothing configured (#510)
- `pitchbox user:create`, `user:reset-password` and `user:list`, with the password never arriving as an argument (#511)

After this deploys I will verify on prod that a token-less registration is refused with `invite_required`, since that is the assertion the whole release hinges on.