### PR TITLE
feat(shared,web): a self-registered account gets its own org and a real quota default

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -52,10 +52,17 @@ registers an owner of it. Instead, in one transaction:
 - **With a valid token**: the account is created and `acceptInvite` joins the
   inviting org with the invited role - never `default`, no org of its own.
 - **With no token** (only reachable under `open`): the account gets its own
-  single-owner organization (`createOrganization`, slug derived from the
-  username and collision-suffixed). #513 owns the real policy here (slug
-  source, quota, role nuance); this is a narrow stand-in so open sign-up
-  isn't accidentally invite-only.
+  single-owner organization, created by the same `createOrganization`
+  primitive `POST /api/orgs` uses for a logged-in user's additional org
+  (#513). Its slug derives from the username (already collected, already
+  unique-ish for login), lowercased and collision-suffixed against
+  `organizations.slug` rather than the email local part, which the registrant
+  did not choose. The org starts with a default monthly run budget and
+  concurrency cap from `app_config.org_quota_defaults` (#515) instead of the
+  unlimited `null` every other column default gives - see
+  [cloud-runner.md](cloud-runner.md) ("How cost and quota work"). The seeded
+  `default` org and the `personal`-project convention ([orgs.md](orgs.md))
+  are untouched by either branch above.
 
 An invalid, expired, revoked or already-consumed token refuses the whole
 registration (no account is created): `400 { "error":

--- a/docs/cloud-runner.md
+++ b/docs/cloud-runner.md
@@ -154,15 +154,18 @@ run's own spend crosses the line - normalized to the `quota_exhausted`
 failure reason `shared/src/runlog/classify-failure.ts` already recognizes via
 its existing `QUOTA_PATTERNS`, with no classifier change needed.
 
-**Known gap: concurrency is unenforced.** `concurrencyCap` is part of the
-snapshot above, but nothing reads it on the cloud runner's dispatch path.
-The earlier runner-service design enforced it from an in-memory per-org
-session count at WebSocket admission (CLD-P5, see "Historical design
-record"); that mechanism left with the runner service, and #419 wires only
-the USD budget check. An org today can dispatch as many concurrent `cloud`
-runs as it can trigger, each independently budget-checked at its own start,
-with no cap on how many run at once. Listed under "Open questions" rather
-than silently assumed fixed.
+**Concurrency (#485).** `concurrencyCap` is part of the snapshot above, and
+`assertOrgConcurrencyAdmitted` (`shared/src/org-quota.ts`) enforces it: after
+`dispatchRun` inserts a run's `status: 'running'` row, it takes an
+org-scoped `pg_advisory_xact_lock`, ranks every currently-`running` row for
+the org by insertion order, and refuses this one if its rank exceeds
+`max_concurrent_runs` - a message that says "concurrency limit", never
+"quota", so `classifyFailure` tags it `concurrency_exhausted` rather than
+`quota_exhausted`. The earlier runner-service design enforced the same idea
+from an in-memory per-org session count at WebSocket admission (CLD-P5, see
+"Historical design record"); that mechanism left with the runner service,
+and this replaces it with a Postgres-backed check that survives the process
+restarting mid-run.
 
 ## Environment variables a cloud deployment needs
 
@@ -189,12 +192,9 @@ update --init` for the cloud edition to work.
 
 ## Open questions
 
-- **[OPEN] Concurrency cap is unenforced.** See "How cost and quota work"
-  above. `max_concurrent_runs` is stored and surfaced in Settings, but
-  nothing on the current dispatch path reads it. Needs either an
-  in-process per-org counter (single instance) or a DB-backed one
-  (multi-instance), mirroring the design the old runner service used before
-  it was removed.
+- ~~**Concurrency cap is unenforced.**~~ Closed by #485:
+  `assertOrgConcurrencyAdmitted` now enforces `max_concurrent_runs` on every
+  cloud-runner dispatch. See "How cost and quota work" above.
 - **[OPEN] No per-scenario step ceiling override.** `DEFAULT_STEP_CEILING`
   (12) is a single constant for every playbook. A playbook that genuinely
   needs more steps has no way to ask for them short of raising the shared

--- a/shared/src/db/seed-core.ts
+++ b/shared/src/db/seed-core.ts
@@ -5,6 +5,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { resolve, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ensurePersonalProject } from '../personal-project.js';
+import { ORG_QUOTA_DEFAULTS_FALLBACK } from '../org-quota.js';
 
 export const QUOTA_DEFAULTS = {
   reddit: {
@@ -141,6 +142,14 @@ export async function seedCore() {
   await db
     .insert(schema.appConfig)
     .values({ key: 'quota_defaults', value: QUOTA_DEFAULTS })
+    .onConflictDoNothing();
+  // #515: a self-created org's default run budget/concurrency, read by
+  // createOrganization (shared/src/orgs.ts) via loadOrgQuotaDefaults. Kept
+  // next to quota_defaults on purpose - both are instance-wide, operator-
+  // editable-without-a-redeploy app_config rows.
+  await db
+    .insert(schema.appConfig)
+    .values({ key: 'org_quota_defaults', value: ORG_QUOTA_DEFAULTS_FALLBACK })
     .onConflictDoNothing();
 
   const missingSlugs: string[] = [];

--- a/shared/src/org-quota.ts
+++ b/shared/src/org-quota.ts
@@ -4,7 +4,16 @@
 // per-account quota helper's style (shared/src/quota.ts) but is org-scoped and
 // budget/concurrency based rather than per-account daily/weekly counts.
 import { and, eq, gte, inArray, or, sql } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
 import { schema, type Db } from './db/client.js';
+
+// The loose handle personal-project.ts documents and orgs.ts already uses,
+// rather than the strict `Db` above: loadOrgQuotaDefaults is called from
+// createOrganization (shared/src/orgs.ts), which may be holding a
+// transaction handle mid-registration, and the strict schema-bound type
+// rejects that handle.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDb = PgDatabase<any, any, any>;
 
 /**
  * An org's quota snapshot: remaining monthly USD run budget and concurrency
@@ -17,6 +26,53 @@ export interface OrgQuotaSnapshot {
   remainingUsd: number | null;
   /** Max concurrent runs allowed for this org, or null if unlimited. */
   concurrencyCap: number | null;
+}
+
+/**
+ * The default budget/concurrency an org gets at creation when nobody has
+ * configured one - #515: null on `organizations.monthly_run_budget_usd` /
+ * `max_concurrent_runs` means unlimited, and a self-created org (open
+ * registration, or an existing user spinning up an additional org via
+ * `POST /api/orgs`) must never start there. Read from `app_config` next to
+ * `quota_defaults` so an operator can change the numbers without a
+ * redeploy; seeded by seed-core.ts alongside `quota_defaults`.
+ */
+export type OrgQuotaDefaults = {
+  monthlyRunBudgetUsd: number;
+  maxConcurrentRuns: number;
+};
+
+const ORG_QUOTA_DEFAULTS_KEY = 'org_quota_defaults';
+
+// Used both as the seed-core.ts value and as the fallback when the
+// app_config row is missing entirely (a fresh install that ran migrations
+// but not seed:core) or holds something malformed. Numbers are deliberately
+// modest: enough for a real evaluation of the product in a month, not
+// enough to run up a meaningful Gateway bill on an account nobody vetted.
+export const ORG_QUOTA_DEFAULTS_FALLBACK: OrgQuotaDefaults = {
+  monthlyRunBudgetUsd: 20,
+  maxConcurrentRuns: 2,
+};
+
+export async function loadOrgQuotaDefaults(db: AnyDb): Promise<OrgQuotaDefaults> {
+  const [row] = await db
+    .select({ value: schema.appConfig.value })
+    .from(schema.appConfig)
+    .where(eq(schema.appConfig.key, ORG_QUOTA_DEFAULTS_KEY))
+    .limit(1);
+  const value = row?.value as Partial<Record<string, unknown>> | undefined;
+  const budget = Number(value?.monthlyRunBudgetUsd);
+  const concurrency = Number(value?.maxConcurrentRuns);
+  return {
+    monthlyRunBudgetUsd:
+      Number.isFinite(budget) && budget > 0
+        ? budget
+        : ORG_QUOTA_DEFAULTS_FALLBACK.monthlyRunBudgetUsd,
+    maxConcurrentRuns:
+      Number.isFinite(concurrency) && concurrency > 0
+        ? Math.floor(concurrency)
+        : ORG_QUOTA_DEFAULTS_FALLBACK.maxConcurrentRuns,
+  };
 }
 
 /** First instant (UTC) of the calendar month containing `now`. */

--- a/shared/src/orgs.ts
+++ b/shared/src/orgs.ts
@@ -12,6 +12,7 @@ import {
   users,
 } from './db/schema.js';
 import { ensurePersonalProject } from './personal-project.js';
+import { loadOrgQuotaDefaults } from './org-quota.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Db = PgDatabase<any, any, any>;
@@ -358,13 +359,31 @@ export async function loadActiveOrganization(
   return rows[0];
 }
 
+/**
+ * Creates an organization with an owner membership, its `personal` project,
+ * and a default run quota (#515) - the single primitive behind both a
+ * self-registered account's own org (`POST /api/auth/register`'s no-invite
+ * path, #513) and an existing user creating an additional org (`POST
+ * /api/orgs`). Neither caller is an operator who has configured anything
+ * for this org yet, so it must never start on `null` (unlimited) the way a
+ * manually-provisioned org can. The seeded `default` org bypasses this
+ * function entirely (inserted directly by createUser/seed-core) and keeps
+ * its unlimited, unconfigured caps - it is the single-tenant self-host
+ * fallback, not a self-created tenant.
+ */
 export async function createOrganization(
   db: Db,
   args: { slug: string; name: string; ownerUserId: number },
 ): Promise<{ id: number; slug: string; role: string }> {
+  const quotaDefaults = await loadOrgQuotaDefaults(db);
   const [org] = await db
     .insert(organizations)
-    .values({ slug: args.slug, name: args.name })
+    .values({
+      slug: args.slug,
+      name: args.name,
+      monthlyRunBudgetUsd: quotaDefaults.monthlyRunBudgetUsd.toFixed(2),
+      maxConcurrentRuns: quotaDefaults.maxConcurrentRuns,
+    })
     .returning();
   await db
     .insert(memberships)
@@ -380,13 +399,13 @@ export async function createOrganization(
 
 /**
  * Derives an available organization slug from a username, for the register
- * route's no-invite path (open sign-up, #505). #513 owns the real policy
- * here - where the slug should really come from (username vs. email local
- * part), the new org's name and quota, and what a later-invited owner of
- * their own org keeps - this is a narrow, unopinionated stand-in so open
- * sign-up is not accidentally invite-only in the meantime. Collision-
- * suffixed with a numeric counter against `organizations.slug`'s unique
- * constraint.
+ * route's no-invite path (open sign-up, #505). Settled by #513: the
+ * username is what open registration already collects and already needs to
+ * be unique-ish for login, so the slug rides on it rather than the email
+ * local part, which the registrant did not choose and may well share with
+ * a colleague's shared inbox alias. Collision-suffixed with a numeric
+ * counter against `organizations.slug`'s unique constraint, since the
+ * person was never asked to pick a slug of their own.
  */
 export async function uniqueOrgSlugFromUsername(db: Db, username: string): Promise<string> {
   const base =

--- a/web/src/routes/api/auth/register/+server.ts
+++ b/web/src/routes/api/auth/register/+server.ts
@@ -177,12 +177,13 @@ export async function POST(event: RequestEvent) {
         const accepted = await acceptInvite(tx, invite.token, id);
         if (!accepted) throw new InviteRaceError();
       } else {
-        // #513 owns the real self-registration org policy (slug source,
-        // quota, role nuance, what an invited-later user keeps). This is a
-        // narrow, unopinionated stand-in so open sign-up (#505) is not
-        // accidentally invite-only in the meantime: every stranger gets
-        // their own single-owner org through the existing createOrganization
-        // primitive, never `default`.
+        // #513: a stranger with no invite gets their own single-owner
+        // organization, never `default` (the single-tenant self-host
+        // fallback stays untouched either way), through the same
+        // createOrganization primitive an already-logged-in user's `POST
+        // /api/orgs` uses - including its default run quota (#515), since
+        // this account is exactly the "nobody has configured anything for
+        // this org yet" case that default exists for.
         const slug = await uniqueOrgSlugFromUsername(tx, parsed.data.username);
         await createOrganization(tx, {
           slug,

--- a/web/tests/register.test.ts
+++ b/web/tests/register.test.ts
@@ -4,6 +4,12 @@ import type { RequestEvent } from '@sveltejs/kit';
 import { getDb, schema } from '@pitchbox/shared/db';
 import { createInvite, findOrgBySlug, listUserOrganizations } from '@pitchbox/shared/orgs';
 import { saveRegistrationPolicy } from '@pitchbox/shared/registration-policy';
+import {
+  assertOrgConcurrencyAdmitted,
+  getOrgQuotaFields,
+  getOrgQuotaSnapshot,
+  ORG_QUOTA_DEFAULTS_FALLBACK,
+} from '@pitchbox/shared/org-quota';
 import { POST as register } from '../src/routes/api/auth/register/+server.js';
 import { load as inviteLoad } from '../src/routes/invite/[token]/+page.server.js';
 import { type CookieJar, makeCookies, runThroughHandle } from './helpers/handle-harness.js';
@@ -76,6 +82,9 @@ describe('POST /api/auth/register', () => {
       role: 'admin',
       createdByUserId: adminId,
     });
+    const orgCountBefore = (
+      await getDb().select({ id: schema.organizations.id }).from(schema.organizations)
+    ).length;
 
     const jar: CookieJar = { store: new Map() };
     const res = await callRegister(
@@ -100,6 +109,13 @@ describe('POST /api/auth/register', () => {
     expect(orgs).toHaveLength(1);
     expect(orgs[0].slug).toBe('acme');
     expect(orgs[0].role).toBe('admin');
+
+    // #513: an invited registration must get nothing new - joining the
+    // inviting org, never a second organization of its own.
+    const orgCountAfter = (
+      await getDb().select({ id: schema.organizations.id }).from(schema.organizations)
+    ).length;
+    expect(orgCountAfter).toBe(orgCountBefore);
 
     const [invRow] = await getDb()
       .select()
@@ -173,7 +189,7 @@ describe('POST /api/auth/register', () => {
     expect(user).toBeUndefined();
   });
 
-  it('a stranger with no invite registers into their own new organization, not default', async () => {
+  it('a stranger with no invite registers into their own new organization, not default, on the settled default quota', async () => {
     const jar: CookieJar = { store: new Map() };
     const res = await callRegister(
       { username: 'solo-founder', email: 'solo@example.com', password: 'a-very-long-password' },
@@ -189,6 +205,79 @@ describe('POST /api/auth/register', () => {
     expect(orgs).toHaveLength(1);
     expect(orgs[0].slug).not.toBe('default');
     expect(orgs[0].role).toBe('owner');
+
+    // #515: a self-created org starts on the documented default budget and
+    // concurrency cap, never the unbounded `null` a bare column default
+    // would leave it on.
+    const fields = await getOrgQuotaFields(getDb(), orgs[0].id);
+    expect(fields).toEqual(ORG_QUOTA_DEFAULTS_FALLBACK);
+  });
+
+  it("a self-created org's default caps are enforced by the existing concurrency and budget assertions, not a new check", async () => {
+    const jar: CookieJar = { store: new Map() };
+    const res = await callRegister(
+      {
+        username: 'quota-check',
+        email: 'quota-check@example.com',
+        password: 'a-very-long-password',
+      },
+      jar,
+    );
+    expect(res.status).toBe(200);
+
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, 'quota-check'));
+    const orgs = await listUserOrganizations(getDb(), user.id);
+    const orgId = orgs[0].id;
+    const fields = await getOrgQuotaFields(getDb(), orgId);
+    if (!fields || fields.monthlyRunBudgetUsd == null || fields.maxConcurrentRuns == null) {
+      throw new Error('org has no quota fields');
+    }
+
+    const [project] = await getDb()
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.organizationId, orgId));
+
+    // Fill every concurrency slot the default allows, then one more -
+    // assertOrgConcurrencyAdmitted (shared/src/org-quota.ts, the same
+    // function the cloud dispatch path calls) has to refuse it.
+    let extraRunId = 0;
+    for (let i = 0; i < fields.maxConcurrentRuns + 1; i++) {
+      const [run] = await getDb()
+        .insert(schema.runs)
+        .values({
+          kind: 'project_extraction',
+          projectId: project.id,
+          trigger: 'manual',
+          status: 'running',
+        })
+        .returning({ id: schema.runs.id });
+      extraRunId = run.id;
+    }
+    await expect(assertOrgConcurrencyAdmitted(getDb(), orgId, extraRunId)).rejects.toThrow(
+      /concurrency limit/i,
+    );
+
+    // Spend one dollar past the default monthly budget - getOrgQuotaSnapshot
+    // (the same function the cloud dispatch path reads before starting a
+    // run) has to report a negative remaining balance, not the unlimited
+    // `null` a manually-provisioned org's untouched columns would give.
+    await getDb()
+      .insert(schema.runs)
+      .values({
+        kind: 'project_extraction',
+        projectId: project.id,
+        trigger: 'manual',
+        status: 'success',
+        costUsd: String(fields.monthlyRunBudgetUsd + 1),
+        startedAt: new Date(),
+      });
+    const snapshot = await getOrgQuotaSnapshot(getDb(), orgId);
+    expect(snapshot.remainingUsd).not.toBeNull();
+    expect(snapshot.remainingUsd as number).toBeLessThan(0);
   });
 
   it('two strangers whose usernames collide on the derived slug get distinct organizations', async () => {


### PR DESCRIPTION
Replaces the #504/#513 stand-in with the settled policy for what a self-registered account gets, and adds the quota half from #515.

## Policy settled

- `createOrganization` (`shared/src/orgs.ts`) is now the single primitive behind both a self-registered account's own org (`POST /api/auth/register`'s no-invite path) and an existing user's `POST /api/orgs`. Neither caller is an operator who has configured anything for the new org, so neither should start unlimited.
- Slug still derives from the username (already collected, already unique-ish for login), lowercased and collision-suffixed - not the email local part, which the registrant did not choose.
- The registrant is still the sole `owner`. An invited registration still joins the inviter's org with the invited role and creates nothing new - no second organization.
- The seeded `default` org (single-tenant self-host fallback) and the `personal`-project convention are untouched by either registration branch.

## Quota half (#515)

- `createOrganization` now sets `organizations.monthly_run_budget_usd` / `max_concurrent_runs` from a new `app_config.org_quota_defaults` row (seeded next to `quota_defaults`, falls back to $20/month and 2 concurrent runs if the row is ever missing) instead of leaving both columns `null` (unlimited).
- Enforcement is the existing `assertOrgConcurrencyAdmitted` and `getOrgQuotaSnapshot` (`shared/src/org-quota.ts`) - no new check invented for a self-created org.
- Out of scope here (left for whoever picks up the rest of #515): per-IP registration throttling (already covered by the existing `auth_failures` rate limiting on `/api/auth/register`) and a cap on how many orgs one account may create via `POST /api/orgs`.

## Schema

No migration. `organizations.monthly_run_budget_usd` / `max_concurrent_runs` and the generic `app_config` table already exist; this only changes what gets written into them at creation time.

## Docs

- `docs/auth.md`: settled registration-org paragraph (was the "#513 owns the real policy" stand-in note).
- `docs/cloud-runner.md`: fixed a stale "concurrency is unenforced" note - `assertOrgConcurrencyAdmitted` (#485) already closed that; left over from before that PR landed.

## Tests (`web/tests/register.test.ts`)

- Extended the invited-registration test: asserts the organizations table's row count is unchanged, not just that the invitee's own membership set has length 1 - catches a regression where an org is created but not joined, which the pre-existing assertion alone would miss.
- Extended the "stranger registers into their own org" test: asserts the new org's quota fields equal the settled `ORG_QUOTA_DEFAULTS_FALLBACK`, not null.
- Added a new test that fills the default org's concurrency cap and exceeds its default budget, then confirms the existing `assertOrgConcurrencyAdmitted` / `getOrgQuotaSnapshot` refuse it - proving the cap is real, not just a stored number.
- The slug-collision test is unchanged and still passes.

Every new assertion was proven to bite: I reverted the quota-defaults wiring in `createOrganization` and watched the settled-quota and caps-enforced tests fail with the exact null/unlimited symptom, then restored it and confirmed green. Separately, I injected a spurious `createOrganization` call into the invite branch and (with the pre-existing `orgs.toHaveLength(1)` checks temporarily removed to isolate it) watched the new organizations-row-count assertion fail on its own, then reverted.

Closes #513
Closes #515
