### PR TITLE
fix(shared): reconstruct the drizzle snapshot chain through 0024

### DIFF
--- a/shared/src/db/migration-audit.ts
+++ b/shared/src/db/migration-audit.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 
 // Drizzle applies a migration only when its journal `when` is greater than the
 // newest `when` already recorded in the database, and prints "migrations
@@ -83,4 +83,70 @@ export function findMissingMigrations(args: {
       return !replacement || !appliedTags.has(replacement);
     })
     .sort((a, b) => a.idx - b.idx);
+}
+
+/** Migration indices the journal records, in no particular order. Reads only
+ * `_journal.json`, not the `.sql` files themselves, so it works without a
+ * real migrations directory on disk (see the test for this). */
+function readJournalIndices(migrationsFolder: string): number[] {
+  const journal: unknown = JSON.parse(
+    readFileSync(`${migrationsFolder}/meta/_journal.json`, 'utf8'),
+  );
+  const entries =
+    journal && typeof journal === 'object' && 'entries' in journal ? journal.entries : [];
+  const out: number[] = [];
+  for (const raw of Array.isArray(entries) ? entries : []) {
+    if (raw && typeof raw === 'object' && 'idx' in raw && typeof raw.idx === 'number') {
+      out.push(raw.idx);
+    }
+  }
+  return out;
+}
+
+const SNAPSHOT_FILE_RE = /^(\d{4})_snapshot\.json$/;
+
+/** Migration indices that have a committed `meta/<idx>_snapshot.json`. */
+function readSnapshotIndices(migrationsFolder: string): number[] {
+  return readdirSync(`${migrationsFolder}/meta`)
+    .map((name) => SNAPSHOT_FILE_RE.exec(name))
+    .filter((m): m is RegExpExecArray => m !== null)
+    .map((m) => Number(m[1]));
+}
+
+export interface SnapshotChainDrift {
+  /** The highest migration index the journal actually records. */
+  latestJournalIdx: number;
+  /** The highest migration index with a committed snapshot, or null if none exist. */
+  latestSnapshotIdx: number | null;
+}
+
+/**
+ * `drizzle-kit generate` diffs `schema.ts` against whichever `meta/*_snapshot.json`
+ * sorts last by filename - not against the journal, and not against every
+ * migration in between. A snapshot that was never committed for the newest
+ * migration makes `generate` diff against a stale state and re-emit DDL for
+ * whatever landed after it, including tables that already exist (#527: the
+ * chain stopped at `0018_snapshot.json` for six migrations - `0019`-`0024` -
+ * each hand-authored because `generate` was already unusable, and `generate`
+ * tried to re-`CREATE TABLE` `instance_audit_log` and `operator_voice_profiles`,
+ * both already applied everywhere).
+ *
+ * Not every journal entry needs its own snapshot - a migration with no
+ * drizzle-visible schema change (`0015`'s data backfill, `0021`'s idempotent
+ * repair, `0022`'s hand-authored CHECK constraint) never gets one from a real
+ * `generate` run either, the same way `0019` - never created at all - never
+ * gets a journal entry. What has to hold is that the *last* migration in the
+ * journal has a snapshot: that is the base the next `generate` will actually
+ * diff against. `null` means the chain reaches the newest migration; a fresh
+ * schema change should re-authenticate that immediately, not a month later
+ * when someone tries to run `generate` and gets nonsense back.
+ */
+export function findSnapshotChainDrift(migrationsFolder: string): SnapshotChainDrift | null {
+  const journalIndices = readJournalIndices(migrationsFolder);
+  if (journalIndices.length === 0) return null;
+  const latestJournalIdx = Math.max(...journalIndices);
+  const snapshotIndices = readSnapshotIndices(migrationsFolder);
+  const latestSnapshotIdx = snapshotIndices.length > 0 ? Math.max(...snapshotIndices) : null;
+  if (latestSnapshotIdx === latestJournalIdx) return null;
+  return { latestJournalIdx, latestSnapshotIdx };
 }

--- a/shared/src/db/migrations/meta/0016_snapshot.json
+++ b/shared/src/db/migrations/meta/0016_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "f5ff4917-b327-4acd-9816-f260e5c0d394",
-  "prevId": "722af1c4-aff4-4f60-9d0f-2d824a61b130",
+  "id": "3db68c22-6b19-4236-bde8-e600e2bbf4b0",
+  "prevId": "575bc017-cdb1-4e2f-8515-eef6eae8f691",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1500,6 +1500,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
         "owner": {
           "name": "owner",
           "type": "text",
@@ -1613,6 +1619,19 @@
           "tableTo": "organizations",
           "columnsFrom": [
             "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_sources_project_id_projects_id_fk": {
+          "name": "github_sources_project_id_projects_id_fk",
+          "tableFrom": "github_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
           ],
           "columnsTo": [
             "id"
@@ -3140,119 +3159,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.project_sources": {
-      "name": "project_sources",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "project_id": {
-          "name": "project_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "kind": {
-          "name": "kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "output": {
-          "name": "output",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "fetched_at": {
-          "name": "fetched_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "fetch_error": {
-          "name": "fetch_error",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "project_sources_project_idx": {
-          "name": "project_sources_project_idx",
-          "columns": [
-            {
-              "expression": "project_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "active",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "project_sources_project_id_projects_id_fk": {
-          "name": "project_sources_project_id_projects_id_fk",
-          "tableFrom": "project_sources",
-          "tableTo": "projects",
-          "columnsFrom": [
-            "project_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.projects": {
       "name": "projects",
       "schema": "",
@@ -3293,18 +3199,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "'claude-code'"
-        },
-        "voice_tone": {
-          "name": "voice_tone",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "voice_tone_notes": {
-          "name": "voice_tone_notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",

--- a/shared/src/db/migrations/meta/0017_snapshot.json
+++ b/shared/src/db/migrations/meta/0017_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "f5ff4917-b327-4acd-9816-f260e5c0d394",
-  "prevId": "722af1c4-aff4-4f60-9d0f-2d824a61b130",
+  "id": "722af1c4-aff4-4f60-9d0f-2d824a61b130",
+  "prevId": "3db68c22-6b19-4236-bde8-e600e2bbf4b0",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1500,6 +1500,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
         "owner": {
           "name": "owner",
           "type": "text",
@@ -1613,6 +1619,19 @@
           "tableTo": "organizations",
           "columnsFrom": [
             "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_sources_project_id_projects_id_fk": {
+          "name": "github_sources_project_id_projects_id_fk",
+          "tableFrom": "github_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
           ],
           "columnsTo": [
             "id"
@@ -3123,119 +3142,6 @@
         "project_insights_project_id_projects_id_fk": {
           "name": "project_insights_project_id_projects_id_fk",
           "tableFrom": "project_insights",
-          "tableTo": "projects",
-          "columnsFrom": [
-            "project_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.project_sources": {
-      "name": "project_sources",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "project_id": {
-          "name": "project_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "kind": {
-          "name": "kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "output": {
-          "name": "output",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "fetched_at": {
-          "name": "fetched_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "fetch_error": {
-          "name": "fetch_error",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "project_sources_project_idx": {
-          "name": "project_sources_project_idx",
-          "columns": [
-            {
-              "expression": "project_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "active",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "project_sources_project_id_projects_id_fk": {
-          "name": "project_sources_project_id_projects_id_fk",
-          "tableFrom": "project_sources",
           "tableTo": "projects",
           "columnsFrom": [
             "project_id"

--- a/shared/src/db/migrations/meta/0020_snapshot.json
+++ b/shared/src/db/migrations/meta/0020_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "f5ff4917-b327-4acd-9816-f260e5c0d394",
-  "prevId": "722af1c4-aff4-4f60-9d0f-2d824a61b130",
+  "id": "8ae025cf-7814-4f80-a79e-6aae388cab11",
+  "prevId": "f5ff4917-b327-4acd-9816-f260e5c0d394",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1621,6 +1621,72 @@
           "onUpdate": "no action"
         }
       },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_audit_log": {
+      "name": "instance_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_audit_log_created_idx": {
+          "name": "instance_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},

--- a/shared/src/db/migrations/meta/0023_snapshot.json
+++ b/shared/src/db/migrations/meta/0023_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "f5ff4917-b327-4acd-9816-f260e5c0d394",
-  "prevId": "722af1c4-aff4-4f60-9d0f-2d824a61b130",
+  "id": "8b6b81b5-2514-4da4-9a41-215cb9679af8",
+  "prevId": "8ae025cf-7814-4f80-a79e-6aae388cab11",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1621,6 +1621,72 @@
           "onUpdate": "no action"
         }
       },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_audit_log": {
+      "name": "instance_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_audit_log_created_idx": {
+          "name": "instance_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
@@ -3951,6 +4017,12 @@
           "notNull": true,
           "default": false
         },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -3959,7 +4031,23 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {

--- a/shared/src/db/migrations/meta/0024_snapshot.json
+++ b/shared/src/db/migrations/meta/0024_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "f5ff4917-b327-4acd-9816-f260e5c0d394",
-  "prevId": "722af1c4-aff4-4f60-9d0f-2d824a61b130",
+  "id": "cacac404-dce5-40d7-8bff-7db76b3a7df8",
+  "prevId": "8b6b81b5-2514-4da4-9a41-215cb9679af8",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1627,6 +1627,72 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.instance_audit_log": {
+      "name": "instance_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_audit_log_created_idx": {
+          "name": "instance_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.keyword_watches": {
       "name": "keyword_watches",
       "schema": "",
@@ -2940,6 +3006,101 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_user_idx": {
+          "name": "password_reset_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.platforms": {
       "name": "platforms",
       "schema": "",
@@ -3951,6 +4112,12 @@
           "notNull": true,
           "default": false
         },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -3959,7 +4126,23 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {

--- a/shared/tests/migration-audit.test.ts
+++ b/shared/tests/migration-audit.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, unlinkSync, cpSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, afterEach } from 'vitest';
 import {
   findMissingMigrations,
+  findSnapshotChainDrift,
   readJournalMigrations,
   readSupersededMigrations,
   type JournalMigration,
@@ -96,5 +100,41 @@ describe('migration audit (#493)', () => {
       const replacementWhen = journal.find((m) => m.tag === replacement)?.when ?? 0;
       expect(replacementWhen).toBeGreaterThan(skippedWhen);
     }
+  });
+});
+
+describe('snapshot chain drift (#527)', () => {
+  const tmpDirs: string[] = [];
+  afterEach(() => {
+    while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  });
+
+  it('finds no drift in the real repo chain', () => {
+    expect(findSnapshotChainDrift(migrationsFolder)).toBeNull();
+  });
+
+  it('fails when the newest migration in the journal has no snapshot', () => {
+    // Reproduces #527 directly: copy the real chain, then remove the
+    // snapshot for the newest migration the way it was actually missing
+    // (0024_password_reset_tokens never had one committed until this fix).
+    const dir = mkdtempSync(join(tmpdir(), 'pb-snapshot-drift-'));
+    tmpDirs.push(dir);
+    cpSync(migrationsFolder, dir, { recursive: true });
+    unlinkSync(join(dir, 'meta', '0024_snapshot.json'));
+
+    const drift = findSnapshotChainDrift(dir);
+    expect(drift).toEqual({ latestJournalIdx: 24, latestSnapshotIdx: 23 });
+  });
+
+  it('does not flag a migration that legitimately has no snapshot of its own', () => {
+    // 0021 and 0022 are real journal entries with no drizzle-visible schema
+    // change, so a real `generate` run never produced a snapshot for them
+    // either - only the newest migration's snapshot matters.
+    const dir = mkdtempSync(join(tmpdir(), 'pb-snapshot-drift-'));
+    tmpDirs.push(dir);
+    cpSync(migrationsFolder, dir, { recursive: true });
+    unlinkSync(join(dir, 'meta', '0020_snapshot.json'));
+
+    expect(findSnapshotChainDrift(dir)).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #527

`drizzle-kit generate` diffs `schema.ts` against whichever `meta/*_snapshot.json` sorts last by filename, and that was `0018_snapshot.json`: `0015`-`0017` and `0019`-`0024` landed hand-authored, six of them with real DDL and no snapshot ever committed for them. `generate` treated `0018` as current and tried to re-`CREATE TABLE` `instance_audit_log` and `operator_voice_profiles`, both already applied everywhere.

Reconstructed the missing snapshots in migration order rather than squashing history: `0016` (`operator_voice_profiles`), `0017` (`projects.voice_tone`/`voice_tone_notes`), `0018` (replaced - the real committed one predates `operator_voice_profiles` landing, since `0016` merged after it despite the lower migration number; corrected so the chain reflects cumulative DDL in idx order, which is the order migrations actually apply in), `0020` (`instance_audit_log`), `0023` (`users.email`), `0024` (`password_reset_tokens`). Each one was produced by running `drizzle-kit generate` against a `schema.ts` reconstructed from the matching git history, then diffed byte-for-byte against the already-applied `.sql` for that migration to confirm it reproduces the same DDL before being accepted - every one matched exactly. No `.sql` file touched, no journal entry touched, no squash.

`0015`, `0021` and `0022` stay without a snapshot of their own, same as `0019`: none of them has a drizzle-visible schema change (a data backfill, an idempotent repair, a hand-authored CHECK constraint), so a real `generate` run would never have produced one either. What matters is that the newest migration in the journal has one, since that is the base the next `generate` call actually diffs against.

Added `findSnapshotChainDrift` (`shared/src/db/migration-audit.ts`, extending the #493 audit rather than inventing a second mechanism) plus tests that fail when the chain's newest snapshot falls behind the journal's newest entry - reproduced by removing `0024_snapshot.json` and confirming the check catches it before restoring. Purely file-based, no database needed, so it runs as an ordinary vitest test rather than waiting for a real deploy to notice.

**Verified:**
- `pnpm run migrate:generate` on unchanged `schema.ts` now prints `No schema changes, nothing to migrate`.
- A throwaway one-column change on `organizations` generated exactly `ALTER TABLE "organizations" ADD COLUMN "w527_throwaway_check" text;` and nothing else (reverted, not committed).
- `pnpm -F @pitchbox/shared migrate` against a database dropped and recreated from scratch still reports `migrations applied (24 in journal, all present)`.
- `shared/tests/migration-audit.test.ts` passes (10/10), including the new drift tests; broke the guard by deleting the real repo's `0024_snapshot.json` and watched `finds no drift in the real repo chain` fail with the exact mismatch, then restored and confirmed green again.