### PR TITLE
feat(shared,web): instance-wide spend ceiling and a lower self-registration default

### DIFF
--- a/shared/src/db/seed-core.ts
+++ b/shared/src/db/seed-core.ts
@@ -5,7 +5,11 @@ import { readFileSync, existsSync } from 'node:fs';
 import { resolve, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ensurePersonalProject } from '../personal-project.js';
-import { ORG_QUOTA_DEFAULTS_FALLBACK } from '../org-quota.js';
+import {
+  ORG_QUOTA_DEFAULTS_FALLBACK,
+  SELF_REGISTRATION_QUOTA_DEFAULTS_FALLBACK,
+  INSTANCE_QUOTA_CEILING_FALLBACK,
+} from '../org-quota.js';
 
 export const QUOTA_DEFAULTS = {
   reddit: {
@@ -150,6 +154,23 @@ export async function seedCore() {
   await db
     .insert(schema.appConfig)
     .values({ key: 'org_quota_defaults', value: ORG_QUOTA_DEFAULTS_FALLBACK })
+    .onConflictDoNothing();
+  // #540: the two gates on opening registration (#423) - a self-created
+  // org's own defaults, lower than org_quota_defaults above, and the
+  // instance-wide ceiling summed across every organization. Seeded the
+  // same way as org_quota_defaults so a fresh install ships with a real
+  // cap on both axes rather than waiting on an operator to visit the
+  // instance admin area first.
+  await db
+    .insert(schema.appConfig)
+    .values({
+      key: 'self_registration_quota_defaults',
+      value: SELF_REGISTRATION_QUOTA_DEFAULTS_FALLBACK,
+    })
+    .onConflictDoNothing();
+  await db
+    .insert(schema.appConfig)
+    .values({ key: 'instance_quota_ceiling', value: INSTANCE_QUOTA_CEILING_FALLBACK })
     .onConflictDoNothing();
 
   const missingSlugs: string[] = [];

--- a/shared/src/org-quota.ts
+++ b/shared/src/org-quota.ts
@@ -75,6 +75,69 @@ export async function loadOrgQuotaDefaults(db: AnyDb): Promise<OrgQuotaDefaults>
   };
 }
 
+/**
+ * The budget/concurrency a *self-registered* org gets at creation - #540.
+ * Deliberately a separate `app_config` key from `org_quota_defaults` above
+ * rather than a smaller value in the same key: raising what an invited or
+ * paying tenant gets (`org_quota_defaults`) must never also raise what a
+ * stranger who typed an email into `/register` gets, and a single shared
+ * key can't express two different numbers for two different trust levels.
+ * Read by `createOrganization`'s no-invite branch only (shared/src/orgs.ts)
+ * - an existing, already-authenticated user creating an additional org via
+ * `POST /api/orgs` still gets `org_quota_defaults`, since that caller
+ * already has an account on this instance, invited or not.
+ */
+export type SelfRegistrationQuotaDefaults = {
+  monthlyRunBudgetUsd: number;
+  maxConcurrentRuns: number;
+};
+
+const SELF_REGISTRATION_QUOTA_DEFAULTS_KEY = 'self_registration_quota_defaults';
+
+// Seeded by seed-core.ts alongside ORG_QUOTA_DEFAULTS_FALLBACK, and the
+// fallback when the app_config row is missing or malformed. Single-digit
+// USD on purpose (#540): a stranger who just registered has had zero
+// human review, unlike an invited or manually-provisioned org.
+export const SELF_REGISTRATION_QUOTA_DEFAULTS_FALLBACK: SelfRegistrationQuotaDefaults = {
+  monthlyRunBudgetUsd: 5,
+  maxConcurrentRuns: 1,
+};
+
+export async function loadSelfRegistrationQuotaDefaults(
+  db: AnyDb,
+): Promise<SelfRegistrationQuotaDefaults> {
+  const [row] = await db
+    .select({ value: schema.appConfig.value })
+    .from(schema.appConfig)
+    .where(eq(schema.appConfig.key, SELF_REGISTRATION_QUOTA_DEFAULTS_KEY))
+    .limit(1);
+  const value = row?.value as Partial<Record<string, unknown>> | undefined;
+  const budget = Number(value?.monthlyRunBudgetUsd);
+  const concurrency = Number(value?.maxConcurrentRuns);
+  return {
+    monthlyRunBudgetUsd:
+      Number.isFinite(budget) && budget > 0
+        ? budget
+        : SELF_REGISTRATION_QUOTA_DEFAULTS_FALLBACK.monthlyRunBudgetUsd,
+    maxConcurrentRuns:
+      Number.isFinite(concurrency) && concurrency > 0
+        ? Math.floor(concurrency)
+        : SELF_REGISTRATION_QUOTA_DEFAULTS_FALLBACK.maxConcurrentRuns,
+  };
+}
+
+/** Persists the self-registration defaults (instance admin area, #540). */
+export async function saveSelfRegistrationQuotaDefaults(
+  db: Db,
+  defaults: SelfRegistrationQuotaDefaults,
+): Promise<SelfRegistrationQuotaDefaults> {
+  await db
+    .insert(schema.appConfig)
+    .values({ key: SELF_REGISTRATION_QUOTA_DEFAULTS_KEY, value: defaults })
+    .onConflictDoUpdate({ target: schema.appConfig.key, set: { value: defaults } });
+  return defaults;
+}
+
 /** First instant (UTC) of the calendar month containing `now`. */
 export function startOfMonthUtc(now: Date): Date {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
@@ -315,4 +378,100 @@ export async function assertOrgConcurrencyAdmitted(
         `operator raises the limit in Settings.`,
     );
   });
+}
+
+/**
+ * The instance-wide monthly Gateway ceiling - #540. Opening registration
+ * (#423) turns a per-org cap into an unbounded instance-wide one: a hundred
+ * self-registered orgs each safely under their own budget still sums to a
+ * real bill nobody capped. `null` means unlimited, the same convention as
+ * `organizations.monthlyRunBudgetUsd` - an operator who genuinely wants no
+ * instance-wide ceiling (a single-tenant self-host, say) can still choose
+ * that explicitly, but a missing/unset app_config row falls back to a real
+ * number rather than to unlimited, so the ceiling protects a fresh install
+ * before anyone has visited the instance admin area to configure one.
+ */
+export type InstanceQuotaCeiling = {
+  monthlyBudgetUsd: number | null;
+};
+
+const INSTANCE_QUOTA_CEILING_KEY = 'instance_quota_ceiling';
+
+// Seeded by seed-core.ts alongside the other quota defaults, and the
+// fallback when the app_config row is missing or holds something
+// malformed. Sized so a hundred self-registered orgs at their own
+// SELF_REGISTRATION_QUOTA_DEFAULTS_FALLBACK budget ($5 each) still sit
+// under it - the ceiling is a backstop for every org's own budget being
+// raised or exceeded together, not a number tuned to never bite.
+export const INSTANCE_QUOTA_CEILING_FALLBACK: InstanceQuotaCeiling = {
+  monthlyBudgetUsd: 500,
+};
+
+export async function loadInstanceQuotaCeiling(db: AnyDb): Promise<InstanceQuotaCeiling> {
+  const [row] = await db
+    .select({ value: schema.appConfig.value })
+    .from(schema.appConfig)
+    .where(eq(schema.appConfig.key, INSTANCE_QUOTA_CEILING_KEY))
+    .limit(1);
+  if (!row) return { ...INSTANCE_QUOTA_CEILING_FALLBACK };
+  const raw = (row.value as { monthlyBudgetUsd?: unknown } | undefined)?.monthlyBudgetUsd;
+  if (raw === null) return { monthlyBudgetUsd: null }; // explicit unlimited.
+  const n = Number(raw);
+  return {
+    monthlyBudgetUsd:
+      Number.isFinite(n) && n >= 0 ? n : INSTANCE_QUOTA_CEILING_FALLBACK.monthlyBudgetUsd,
+  };
+}
+
+/** Persists the instance-wide ceiling (instance admin area, #540). */
+export async function saveInstanceQuotaCeiling(
+  db: Db,
+  ceiling: InstanceQuotaCeiling,
+): Promise<InstanceQuotaCeiling> {
+  const value = { monthlyBudgetUsd: ceiling.monthlyBudgetUsd };
+  await db
+    .insert(schema.appConfig)
+    .values({ key: INSTANCE_QUOTA_CEILING_KEY, value })
+    .onConflictDoUpdate({ target: schema.appConfig.key, set: { value } });
+  return ceiling;
+}
+
+/**
+ * Sum of every organization's month-to-date Gateway spend - the
+ * instance-wide total #540 checks the ceiling against. Calls
+ * `getOrgMonthToDateCostUsd` once per organization and adds the results,
+ * rather than re-deriving its own SUM query, so this total always agrees
+ * with the per-org figure the dashboard and org-quota settings show, and so
+ * whatever a sibling change teaches `getOrgMonthToDateCostUsd` about what
+ * counts as spend (#522: the in-page assistant's own Gateway calls, which
+ * carry no `runs` row today) is picked up here automatically, with no
+ * second place to update.
+ */
+export async function getInstanceMonthToDateCostUsd(
+  db: Db,
+  now: Date = new Date(),
+): Promise<number> {
+  const orgs = await db.select({ id: schema.organizations.id }).from(schema.organizations);
+  if (orgs.length === 0) return 0;
+  const totals = await Promise.all(orgs.map((o) => getOrgMonthToDateCostUsd(db, o.id, now)));
+  return totals.reduce((sum, t) => sum + t, 0);
+}
+
+/**
+ * Instance-wide quota snapshot: remaining monthly USD Gateway budget across
+ * every organization (null = unlimited, `instance_quota_ceiling` explicitly
+ * set to null). A `remainingUsd` of 0 or negative means the instance is
+ * over its ceiling - checked in `web/src/lib/server/runner.ts` next to the
+ * per-org check, with its own refusal reason (`instance_quota_exhausted`,
+ * shared/src/runlog/classify-failure.ts) so an operator reading a failed
+ * run can tell "this tenant is out of budget" from "the instance is".
+ */
+export async function getInstanceQuotaSnapshot(
+  db: Db,
+  now: Date = new Date(),
+): Promise<{ remainingUsd: number | null }> {
+  const ceiling = await loadInstanceQuotaCeiling(db);
+  if (ceiling.monthlyBudgetUsd == null) return { remainingUsd: null };
+  const spentUsd = await getInstanceMonthToDateCostUsd(db, now);
+  return { remainingUsd: ceiling.monthlyBudgetUsd - spentUsd };
 }

--- a/shared/src/orgs.ts
+++ b/shared/src/orgs.ts
@@ -12,7 +12,7 @@ import {
   users,
 } from './db/schema.js';
 import { ensurePersonalProject } from './personal-project.js';
-import { loadOrgQuotaDefaults } from './org-quota.js';
+import { loadOrgQuotaDefaults, loadSelfRegistrationQuotaDefaults } from './org-quota.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Db = PgDatabase<any, any, any>;
@@ -370,12 +370,29 @@ export async function loadActiveOrganization(
  * function entirely (inserted directly by createUser/seed-core) and keeps
  * its unlimited, unconfigured caps - it is the single-tenant self-host
  * fallback, not a self-created tenant.
+ *
+ * `quotaSource` (#540) picks which `app_config` defaults the new org
+ * starts with. Defaults to `'invited'` (`org_quota_defaults`), what
+ * `POST /api/orgs` always passes implicitly: that caller already has an
+ * account on this instance, invited or not. The register route's no-invite
+ * branch alone passes `'self_registration'`
+ * (`self_registration_quota_defaults`), a separate, lower key so raising
+ * what an invited or paying tenant gets never also raises what a stranger
+ * who just typed an email into `/register` gets.
  */
 export async function createOrganization(
   db: Db,
-  args: { slug: string; name: string; ownerUserId: number },
+  args: {
+    slug: string;
+    name: string;
+    ownerUserId: number;
+    quotaSource?: 'invited' | 'self_registration';
+  },
 ): Promise<{ id: number; slug: string; role: string }> {
-  const quotaDefaults = await loadOrgQuotaDefaults(db);
+  const quotaDefaults =
+    args.quotaSource === 'self_registration'
+      ? await loadSelfRegistrationQuotaDefaults(db)
+      : await loadOrgQuotaDefaults(db);
   const [org] = await db
     .insert(organizations)
     .values({

--- a/shared/src/runlog/classify-failure.ts
+++ b/shared/src/runlog/classify-failure.ts
@@ -12,6 +12,7 @@ export type RunFailureReason =
   | 'runner_missing'
   | 'auth_expired'
   | 'quota_exhausted'
+  | 'instance_quota_exhausted'
   | 'concurrency_exhausted'
   | 'playbook_error'
   | 'playbook_incomplete'
@@ -28,6 +29,7 @@ export const RUN_FAILURE_REASONS: readonly RunFailureReason[] = [
   'runner_missing',
   'auth_expired',
   'quota_exhausted',
+  'instance_quota_exhausted',
   'concurrency_exhausted',
   'playbook_error',
   'playbook_incomplete',
@@ -78,6 +80,16 @@ const QUOTA_PATTERNS = [
   'rate limit', // distinct from runlog "rate-limit" kind: this catches text mentions
   'rate-limit',
 ];
+
+// #540: the instance-wide monthly Gateway ceiling (checked in
+// web/src/lib/server/runner.ts next to the per-org budget above,
+// shared/src/org-quota.ts's getInstanceQuotaSnapshot) is a different
+// failure from an org's own budget - "this tenant is out of budget" is on
+// the operator's tenant, "the instance is out of budget" is on the
+// operator running the deployment. Its refusal text deliberately says
+// "instance-wide" rather than "quota", so it needs its own pattern and its
+// own reason rather than folding into `quota_exhausted`.
+const INSTANCE_QUOTA_PATTERNS = ['instance-wide'];
 
 // #485: the org's concurrency cap (organizations.max_concurrent_runs) is a
 // different failure than the budget above - "you already have N runs going"
@@ -146,6 +158,7 @@ export function classifyFailure(events: ParsedEvent[], exitCode: number | null):
   if (STEP_LIMIT_PATTERNS.some((p) => haystack.includes(p))) return 'step_limit_reached';
   if (SDK_TIMEOUT_PATTERNS.some((p) => haystack.includes(p))) return 'agent_timeout';
   if (AUTH_PATTERNS.some((p) => haystack.includes(p))) return 'auth_expired';
+  if (INSTANCE_QUOTA_PATTERNS.some((p) => haystack.includes(p))) return 'instance_quota_exhausted';
   if (QUOTA_PATTERNS.some((p) => haystack.includes(p))) return 'quota_exhausted';
   if (CONCURRENCY_PATTERNS.some((p) => haystack.includes(p))) return 'concurrency_exhausted';
   if (NETWORK_PATTERNS.some((p) => haystack.includes(p))) return 'network';

--- a/shared/tests/runlog/classify-failure.test.ts
+++ b/shared/tests/runlog/classify-failure.test.ts
@@ -47,6 +47,21 @@ describe('classifyFailure', () => {
     ).toBe('concurrency_exhausted');
   });
 
+  it('detects instance_quota_exhausted on the instance ceiling refusal text, distinctly from quota_exhausted and concurrency_exhausted (#540)', () => {
+    expect(
+      classifyFailure(
+        [
+          ev(
+            'This deployment is $1.50 over its instance-wide monthly Gateway ceiling and ' +
+              'cannot start another cloud run until next month or until an operator raises ' +
+              'the ceiling in Settings.',
+          ),
+        ],
+        1,
+      ),
+    ).toBe('instance_quota_exhausted');
+  });
+
   it('detects network failures on common Node error codes', () => {
     expect(classifyFailure([ev('fetch failed: ECONNREFUSED 127.0.0.1:5180')], 1)).toBe('network');
     expect(classifyFailure([ev('getaddrinfo ENOTFOUND api.example.com')], 1)).toBe('network');

--- a/web/src/lib/server/runner.ts
+++ b/web/src/lib/server/runner.ts
@@ -16,7 +16,11 @@ import {
 } from '@pitchbox/shared/draft-regenerate';
 import { startReplyDrafting } from '@pitchbox/shared/reply-drafter';
 import { getRunOrgId } from '@pitchbox/shared/orgs';
-import { getOrgQuotaSnapshot, assertOrgConcurrencyAdmitted } from '@pitchbox/shared/org-quota';
+import {
+  getOrgQuotaSnapshot,
+  assertOrgConcurrencyAdmitted,
+  getInstanceQuotaSnapshot,
+} from '@pitchbox/shared/org-quota';
 import type { ScenarioSlug } from '@pitchbox/shared/campaigns';
 import { getDb, schema } from './db.js';
 import { and, desc, eq } from 'drizzle-orm';
@@ -168,6 +172,22 @@ async function dispatchRun(
     // exact refusal `quota_exhausted` too, the same reason a mid-stream
     // crossing gets, with no separate classifier branch needed.
     if (slug === 'cloud' && orgId != null) {
+      // #540: checked before the per-org budget below, and with its own
+      // wording and its own classifyFailure reason
+      // (`instance_quota_exhausted`) - opening registration (#423) turns a
+      // per-org cap into an unbounded instance-wide one, and an operator
+      // reading a failed run has to be able to tell "this tenant is out of
+      // budget" (on them) from "the instance is out of budget" (on me).
+      // The message says "instance-wide" rather than "quota" on purpose,
+      // so it never collides with QUOTA_PATTERNS below.
+      const instanceQuota = await getInstanceQuotaSnapshot(db);
+      if (instanceQuota.remainingUsd != null && instanceQuota.remainingUsd <= 0) {
+        throw new Error(
+          `This deployment is $${Math.abs(instanceQuota.remainingUsd).toFixed(2)} over its ` +
+            `instance-wide monthly Gateway ceiling and cannot start another cloud run until ` +
+            `next month or until an operator raises the ceiling in Settings.`,
+        );
+      }
       const quota = await getOrgQuotaSnapshot(db, orgId);
       if (quota.remainingUsd != null && quota.remainingUsd <= 0) {
         throw new Error(

--- a/web/src/routes/api/auth/register/+server.ts
+++ b/web/src/routes/api/auth/register/+server.ts
@@ -181,14 +181,17 @@ export async function POST(event: RequestEvent) {
         // organization, never `default` (the single-tenant self-host
         // fallback stays untouched either way), through the same
         // createOrganization primitive an already-logged-in user's `POST
-        // /api/orgs` uses - including its default run quota (#515), since
-        // this account is exactly the "nobody has configured anything for
-        // this org yet" case that default exists for.
+        // /api/orgs` uses. `quotaSource: 'self_registration'` (#540) is the
+        // one thing that differs: this account has had zero human review,
+        // so it starts on the lower self-registration default rather than
+        // the shared org_quota_defaults an invited or manually-provisioned
+        // org gets.
         const slug = await uniqueOrgSlugFromUsername(tx, parsed.data.username);
         await createOrganization(tx, {
           slug,
           name: defaultOrgName(parsed.data.username),
           ownerUserId: id,
+          quotaSource: 'self_registration',
         });
       }
       return id;

--- a/web/src/routes/api/settings/admin/spend-ceiling/+server.ts
+++ b/web/src/routes/api/settings/admin/spend-ceiling/+server.ts
@@ -1,0 +1,77 @@
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '$lib/server/db.js';
+import { requireInstanceAdmin } from '$lib/server/auth.js';
+import {
+  loadInstanceQuotaCeiling,
+  saveInstanceQuotaCeiling,
+  loadSelfRegistrationQuotaDefaults,
+  saveSelfRegistrationQuotaDefaults,
+  getInstanceMonthToDateCostUsd,
+  getInstanceQuotaSnapshot,
+} from '@pitchbox/shared/org-quota';
+import { recordInstanceAudit } from '@pitchbox/shared/instance-audit';
+
+// GET + PUT the two #540 knobs behind opening registration (#423) to strangers:
+// the instance-wide monthly Gateway ceiling (web/src/lib/server/runner.ts checks
+// it next to the per-org budget) and the caps a self-registered org starts with
+// (shared/src/orgs.ts's createOrganization, `self_registration` quotaSource).
+// Instance-wide config like default-runner/quota/retention/webhooks, so both
+// GET and PUT need the stricter requireInstanceAdmin rather than the per-org
+// 'admin' role - a self-created-org admin must never see or raise the ceiling
+// that is meant to bound exactly that kind of org.
+
+const Body = z.object({
+  instanceMonthlyBudgetUsd: z.number().finite().nonnegative().nullable(),
+  selfRegistrationMonthlyRunBudgetUsd: z.number().finite().positive(),
+  selfRegistrationMaxConcurrentRuns: z.number().int().positive(),
+});
+
+async function spendCeilingResponse() {
+  const db = getDb();
+  const [ceiling, selfRegistrationDefaults, monthToDateCostUsd, snapshot] = await Promise.all([
+    loadInstanceQuotaCeiling(db),
+    loadSelfRegistrationQuotaDefaults(db),
+    getInstanceMonthToDateCostUsd(db),
+    getInstanceQuotaSnapshot(db),
+  ]);
+  return json({
+    instanceMonthlyBudgetUsd: ceiling.monthlyBudgetUsd,
+    selfRegistrationMonthlyRunBudgetUsd: selfRegistrationDefaults.monthlyRunBudgetUsd,
+    selfRegistrationMaxConcurrentRuns: selfRegistrationDefaults.maxConcurrentRuns,
+    monthToDateCostUsd,
+    remainingUsd: snapshot.remainingUsd,
+  });
+}
+
+export async function GET(event: RequestEvent) {
+  await requireInstanceAdmin(event);
+  return spendCeilingResponse();
+}
+
+export async function PUT(event: RequestEvent) {
+  await requireInstanceAdmin(event);
+  const raw = await event.request.json().catch(() => null);
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) throw error(400, 'invalid_body');
+
+  const db = getDb();
+  const before = {
+    instanceCeiling: await loadInstanceQuotaCeiling(db),
+    selfRegistrationDefaults: await loadSelfRegistrationQuotaDefaults(db),
+  };
+  const [instanceCeiling, selfRegistrationDefaults] = await Promise.all([
+    saveInstanceQuotaCeiling(db, { monthlyBudgetUsd: parsed.data.instanceMonthlyBudgetUsd }),
+    saveSelfRegistrationQuotaDefaults(db, {
+      monthlyRunBudgetUsd: parsed.data.selfRegistrationMonthlyRunBudgetUsd,
+      maxConcurrentRuns: parsed.data.selfRegistrationMaxConcurrentRuns,
+    }),
+  ]);
+  await recordInstanceAudit(db, {
+    key: 'spend_ceiling',
+    actor: event.locals.user ?? null,
+    before,
+    after: { instanceCeiling, selfRegistrationDefaults },
+  });
+  return spendCeilingResponse();
+}

--- a/web/src/routes/settings/admin/+page.svelte
+++ b/web/src/routes/settings/admin/+page.svelte
@@ -5,7 +5,7 @@
   import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
   import { SelectField } from '$lib/components/ui/select-field';
-  import { Info, Bot, Gauge, Archive, Webhook, ScrollText } from '@lucide/svelte';
+  import { Info, Bot, Gauge, Archive, Webhook, ScrollText, CircleDollarSign } from '@lucide/svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
   import PageContainer from '$lib/components/PageContainer.svelte';
   import Seo from '$lib/components/Seo.svelte';
@@ -85,6 +85,12 @@
       icon: Gauge,
       label: 'Quota',
       description: 'Per-platform posting quota defaults shared by every organization.',
+    },
+    {
+      href: '/settings/admin/spend-ceiling',
+      icon: CircleDollarSign,
+      label: 'Spend ceiling',
+      description: 'Instance-wide Gateway ceiling and the caps a self-registered organization starts with.',
     },
     {
       href: '/settings/retention',

--- a/web/src/routes/settings/admin/spend-ceiling/+page.server.ts
+++ b/web/src/routes/settings/admin/spend-ceiling/+page.server.ts
@@ -1,0 +1,33 @@
+import type { PageServerLoad } from './$types';
+import { getDb } from '$lib/server/db.js';
+import { requireInstanceAdmin } from '$lib/server/auth.js';
+import {
+  loadInstanceQuotaCeiling,
+  loadSelfRegistrationQuotaDefaults,
+  getInstanceMonthToDateCostUsd,
+  getInstanceQuotaSnapshot,
+} from '@pitchbox/shared/org-quota';
+
+// The two gates on opening registration (#423) to strangers - #540. The
+// area's `+layout.server.ts` already gates the whole subtree; this loader
+// gates itself again the same way settings/admin/models does: the write
+// path next door does the same, and the API is the boundary that holds
+// when somebody types a URL rather than following a link that was hidden
+// from them.
+export const load: PageServerLoad = async (event) => {
+  await requireInstanceAdmin(event);
+  const db = getDb();
+  const [ceiling, selfRegistrationDefaults, monthToDateCostUsd, snapshot] = await Promise.all([
+    loadInstanceQuotaCeiling(db),
+    loadSelfRegistrationQuotaDefaults(db),
+    getInstanceMonthToDateCostUsd(db),
+    getInstanceQuotaSnapshot(db),
+  ]);
+  return {
+    instanceMonthlyBudgetUsd: ceiling.monthlyBudgetUsd,
+    selfRegistrationMonthlyRunBudgetUsd: selfRegistrationDefaults.monthlyRunBudgetUsd,
+    selfRegistrationMaxConcurrentRuns: selfRegistrationDefaults.maxConcurrentRuns,
+    monthToDateCostUsd,
+    remainingUsd: snapshot.remainingUsd,
+  };
+};

--- a/web/src/routes/settings/admin/spend-ceiling/+page.svelte
+++ b/web/src/routes/settings/admin/spend-ceiling/+page.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  import * as Card from '$lib/components/ui/card';
+  import * as Alert from '$lib/components/ui/alert';
+  import { Info } from '@lucide/svelte';
+  import { Button } from '$lib/components/ui/button';
+  import { Input } from '$lib/components/ui/input';
+  import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageContainer from '$lib/components/PageContainer.svelte';
+  import Seo from '$lib/components/Seo.svelte';
+  import { toast } from 'svelte-sonner';
+  import { invalidateAll } from '$app/navigation';
+  import { untrack } from 'svelte';
+
+  type PageData = {
+    instanceMonthlyBudgetUsd: number | null;
+    selfRegistrationMonthlyRunBudgetUsd: number;
+    selfRegistrationMaxConcurrentRuns: number;
+    monthToDateCostUsd: number;
+    remainingUsd: number | null;
+  };
+  let { data }: { data: PageData } = $props();
+
+  function money(n: number): string {
+    return n.toLocaleString(undefined, { style: 'currency', currency: 'USD' });
+  }
+
+  // The instance ceiling is blank-for-unlimited, same convention as the
+  // per-org budget field on settings/organization. The self-registration
+  // defaults are never unlimited (createOrganization's no-invite path
+  // always needs a real number to write onto the new org), so those two
+  // fields stay plain numbers with no blank state.
+  function toDraft(n: number | null): string {
+    return n == null ? '' : String(n);
+  }
+  let instanceBudgetDraft = $state(
+    untrack(() => toDraft(data.instanceMonthlyBudgetUsd)),
+  );
+  let selfRegBudgetDraft = $state(
+    untrack(() => String(data.selfRegistrationMonthlyRunBudgetUsd)),
+  );
+  let selfRegConcurrencyDraft = $state(
+    untrack(() => String(data.selfRegistrationMaxConcurrentRuns)),
+  );
+  let saving = $state(false);
+
+  async function save() {
+    if (saving) return;
+    const instanceRaw = instanceBudgetDraft.trim();
+    if (instanceRaw !== '' && Number(instanceRaw) < 0) {
+      toast.error('Instance ceiling cannot be negative');
+      return;
+    }
+    const selfRegBudget = Number(selfRegBudgetDraft.trim());
+    if (!Number.isFinite(selfRegBudget) || selfRegBudget <= 0) {
+      toast.error('Self-registration budget must be a positive number');
+      return;
+    }
+    const selfRegConcurrency = Number(selfRegConcurrencyDraft.trim());
+    if (!Number.isInteger(selfRegConcurrency) || selfRegConcurrency <= 0) {
+      toast.error('Self-registration concurrency must be a positive whole number');
+      return;
+    }
+    saving = true;
+    try {
+      const res = await fetch('/api/settings/admin/spend-ceiling', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          instanceMonthlyBudgetUsd: instanceRaw === '' ? null : Number(instanceRaw),
+          selfRegistrationMonthlyRunBudgetUsd: selfRegBudget,
+          selfRegistrationMaxConcurrentRuns: selfRegConcurrency,
+        }),
+      });
+      if (!res.ok) {
+        toast.error(res.status === 403 ? 'You need instance-admin access for that' : 'Could not save');
+        return;
+      }
+      toast.success('Spend ceiling saved');
+      await invalidateAll();
+    } catch {
+      toast.error('Could not save');
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<Seo
+  title="Settings - Spend ceiling"
+  description="The instance-wide Gateway ceiling and what a self-registered organization starts with."
+/>
+
+<PageContainer size="default">
+  <PageHeader
+    title="Spend ceiling"
+    description="Opening registration to strangers turns a per-organization cap into an unbounded instance-wide one. These two numbers are the backstop: an instance-wide monthly ceiling summed across every organization, and the caps a self-registered organization starts with, separate from what an invited or manually-provisioned organization gets."
+  />
+
+  <Alert.Root class="mb-6">
+    <Info class="size-4" />
+    <Alert.Description>
+      A run refused by the instance ceiling fails with its own reason, distinct from an
+      organization's own budget, so it's clear on which side of the line the money ran out.
+    </Alert.Description>
+  </Alert.Root>
+
+  <Card.Root class="max-w-2xl">
+    <Card.Header>
+      <Card.Title class="text-base">Instance-wide monthly ceiling</Card.Title>
+      <p class="text-sm text-muted-foreground">
+        Summed month-to-date Gateway spend across every organization on this deployment. Leave
+        blank for unlimited.
+      </p>
+    </Card.Header>
+    <Card.Content class="flex flex-col gap-4">
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div class="flex flex-col gap-1.5">
+          <label class="text-sm font-medium" for="instance-budget">Monthly ceiling (USD)</label>
+          <Input
+            id="instance-budget"
+            type="number"
+            min="0"
+            step="0.01"
+            placeholder="Unlimited"
+            bind:value={instanceBudgetDraft}
+          />
+        </div>
+      </div>
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Month-to-date spend</span>
+          <span class="text-sm text-muted-foreground">{money(data.monthToDateCostUsd)}</span>
+        </div>
+        <div class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Remaining</span>
+          <span class="text-sm text-muted-foreground">
+            {data.remainingUsd == null ? 'Unlimited' : money(data.remainingUsd)}
+          </span>
+        </div>
+      </div>
+    </Card.Content>
+  </Card.Root>
+
+  <Card.Root class="mt-6 max-w-2xl">
+    <Card.Header>
+      <Card.Title class="text-base">Self-registration defaults</Card.Title>
+      <p class="text-sm text-muted-foreground">
+        What a stranger who signs up with no invite starts with (`/register`'s no-invite path).
+        Separate from the invited-organization defaults on purpose: raising what a paying or
+        invited tenant gets never raises what a stranger gets.
+      </p>
+    </Card.Header>
+    <Card.Content class="flex flex-col gap-4">
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div class="flex flex-col gap-1.5">
+          <label class="text-sm font-medium" for="self-reg-budget">Monthly run budget (USD)</label>
+          <Input
+            id="self-reg-budget"
+            type="number"
+            min="0.01"
+            step="0.01"
+            bind:value={selfRegBudgetDraft}
+          />
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <label class="text-sm font-medium" for="self-reg-concurrency">Max concurrent runs</label>
+          <Input
+            id="self-reg-concurrency"
+            type="number"
+            min="1"
+            step="1"
+            bind:value={selfRegConcurrencyDraft}
+          />
+        </div>
+      </div>
+    </Card.Content>
+  </Card.Root>
+
+  <div class="mt-6">
+    <Button onclick={save} loading={saving}>Save</Button>
+  </div>
+</PageContainer>

--- a/web/tests/gateway-instance-ceiling-dispatch.test.ts
+++ b/web/tests/gateway-instance-ceiling-dispatch.test.ts
@@ -1,0 +1,223 @@
+// #540: opening registration to strangers (#423) turns a per-org cap into an
+// unbounded instance-wide one - a hundred self-registered orgs each safely
+// under their own budget still sums to a real bill nobody capped. This file
+// proves the instance-wide ceiling refuses a dispatch through the real path
+// (runCampaign -> dispatchRun), exercised across a SECOND organization
+// rather than by asserting on getInstanceQuotaSnapshot's return value
+// directly: an org whose own budget is fine still gets refused once some
+// other org's spend has pushed the instance-wide total over the ceiling,
+// and with its own distinct reason (instance_quota_exhausted), never the
+// per-org quota_exhausted.
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import {
+  saveInstanceQuotaCeiling,
+  getInstanceMonthToDateCostUsd,
+} from '@pitchbox/shared/org-quota';
+import type {
+  AgentRunHandle,
+  AgentRunOptions,
+  AgentRunner,
+  AgentRunResult,
+} from '@pitchbox/shared/agents';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+import { subscribe } from '../src/lib/server/events.js';
+import { clearDetectionCache } from '@pitchbox/shared/agents/detect';
+
+let createCalls = 0;
+let fakeResult: AgentRunResult = { exitCode: 0, logPath: '/dev/null' };
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'cloud',
+    run(_opts: AgentRunOptions): AgentRunHandle {
+      createCalls += 1;
+      return { result: Promise.resolve(fakeResult), cancel: () => {} };
+    },
+  }),
+}));
+
+// Dynamic on purpose - vi.mock above is hoisted, same pattern as
+// gateway-budget-dispatch.test.ts.
+const { runCampaign } = await import('../src/lib/server/runner.js');
+
+async function reset() {
+  const db = getDb();
+  await db.execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  createCalls = 0;
+  fakeResult = { exitCode: 0, logPath: '/dev/null' };
+}
+
+async function platformId(slug: string): Promise<number> {
+  const [platform] = await getDb()
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, slug));
+  if (!platform) throw new Error(`platform "${slug}" is not seeded - did global-setup run?`);
+  return platform.id;
+}
+
+/** A 'cloud'-runner campaign under an org with the given monthly budget (or
+ * unlimited, when omitted) - its own per-org axis, kept generous throughout
+ * this file since every test here is about the instance-wide axis instead. */
+async function seedCloudCampaign(
+  slug: string,
+  monthlyRunBudgetUsd: string | null = null,
+): Promise<{ orgId: number; campaignId: number }> {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, monthlyRunBudgetUsd })
+    .returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `${slug}-proj`,
+      name: `${slug} p`,
+      defaultAgentRunner: 'cloud',
+    })
+    .returning();
+  const platform = await platformId('reddit');
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({
+      projectId: project.id,
+      platformId: platform,
+      name: 'c',
+      skillSlug: 'reddit-scout',
+      agentRunner: 'cloud',
+    })
+    .returning();
+  return { orgId: org.id, campaignId: campaign.id };
+}
+
+async function runRow(runId: number) {
+  const [row] = await getDb()
+    .select({
+      status: schema.runs.status,
+      error: schema.runs.error,
+      failureReason: schema.runs.failureReason,
+    })
+    .from(schema.runs)
+    .where(eq(schema.runs.id, runId));
+  return row;
+}
+
+function waitForRunFinished(orgId: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const unsubscribe = subscribe(orgId, (evt) => {
+    if (evt.kind !== 'run:finished') return;
+    unsubscribe();
+    resolve();
+  });
+  return promise;
+}
+
+describe('cloud run dispatch is instance-wide-ceiling-gated (#540)', () => {
+  const savedGatewayKey = process.env.AI_GATEWAY_API_KEY;
+
+  beforeEach(async () => {
+    await reset();
+    process.env.AI_GATEWAY_API_KEY = 'test-key';
+    clearDetectionCache();
+  });
+  afterEach(() => {
+    if (savedGatewayKey === undefined) delete process.env.AI_GATEWAY_API_KEY;
+    else process.env.AI_GATEWAY_API_KEY = savedGatewayKey;
+    clearDetectionCache();
+  });
+
+  it("refuses a second organization's run once a first organization's spend pushed the instance ceiling over, even though the second organization's own budget is fine", async () => {
+    await saveInstanceQuotaCeiling(getDb(), { monthlyBudgetUsd: 2 });
+
+    // Org A spends $3, over the $2 instance ceiling by itself - its own
+    // budget is unlimited (null), so nothing on its axis would refuse this.
+    const orgA = await seedCloudCampaign('inst-ceiling-org-a');
+    fakeResult = {
+      exitCode: 0,
+      logPath: '/dev/null',
+      usage: {
+        inputTokens: 100,
+        outputTokens: 100,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUsd: 3,
+        costReported: true,
+      },
+    };
+    const aFinished = waitForRunFinished(orgA.orgId);
+    await runCampaign(orgA.campaignId);
+    await aFinished;
+    expect(createCalls).toBe(1);
+
+    const instanceTotal = await getInstanceMonthToDateCostUsd(getDb());
+    expect(instanceTotal).toBeCloseTo(3, 4);
+
+    // Org B is a completely different organization with its own unlimited
+    // per-org budget - the only thing that can refuse it is the
+    // instance-wide ceiling org A's spend already crossed.
+    const orgB = await seedCloudCampaign('inst-ceiling-org-b');
+    const started = Date.now();
+    const { runId } = await runCampaign(orgB.campaignId);
+    const run = await runRow(runId);
+
+    // Refused before ever reaching createAgentRunner a second time - not a
+    // downstream failure, and not org B's own budget (it has none).
+    expect(createCalls).toBe(1);
+    expect(run?.status).toBe('failed');
+    expect(run?.error).toMatch(/instance-wide monthly.*ceiling/i);
+    expect(run?.error).not.toMatch(/quota/i);
+    expect(run?.failureReason).toBe('instance_quota_exhausted');
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  it('lets a run start when the instance total is still under the ceiling', async () => {
+    await saveInstanceQuotaCeiling(getDb(), { monthlyBudgetUsd: 100 });
+    const { orgId, campaignId } = await seedCloudCampaign('inst-ceiling-under');
+
+    const finished = waitForRunFinished(orgId);
+    const { runId } = await runCampaign(campaignId);
+    await finished;
+
+    expect(createCalls).toBe(1);
+    expect((await runRow(runId))?.status).not.toBe('running');
+  });
+
+  it('treats an explicit null ceiling as unlimited, never refusing on the instance axis', async () => {
+    await saveInstanceQuotaCeiling(getDb(), { monthlyBudgetUsd: null });
+    const orgA = await seedCloudCampaign('inst-ceiling-unlimited-a');
+    fakeResult = {
+      exitCode: 0,
+      logPath: '/dev/null',
+      usage: {
+        inputTokens: 100,
+        outputTokens: 100,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUsd: 1_000,
+        costReported: true,
+      },
+    };
+    const aFinished = waitForRunFinished(orgA.orgId);
+    await runCampaign(orgA.campaignId);
+    await aFinished;
+
+    const orgB = await seedCloudCampaign('inst-ceiling-unlimited-b');
+    const bFinished = waitForRunFinished(orgB.orgId);
+    const { runId } = await runCampaign(orgB.campaignId);
+    await bFinished;
+
+    // Neither dispatch was pre-empted by the instance-wide check (both
+    // reached createAgentRunner) - the terminal status itself is
+    // irrelevant here, since the fake runner never creates a draft and so
+    // always ends in playbook_incomplete downstream of the budget gate,
+    // same as the sibling budget-dispatch suite's "under budget" case.
+    expect(createCalls).toBe(2);
+    expect((await runRow(runId))?.status).not.toBe('running');
+  });
+});

--- a/web/tests/instance-admin-gating.test.ts
+++ b/web/tests/instance-admin-gating.test.ts
@@ -12,6 +12,10 @@ import {
   GET as modelFunctionsGet,
   POST as modelFunctionsPost,
 } from '../src/routes/api/settings/model-functions/+server.js';
+import {
+  GET as spendCeilingGet,
+  PUT as spendCeilingPut,
+} from '../src/routes/api/settings/admin/spend-ceiling/+server.js';
 import { clearModelFunctionCache } from '@pitchbox/shared/ai/model-functions';
 import { type CookieJar, runThroughHandle } from './helpers/handle-harness.js';
 
@@ -258,6 +262,53 @@ describe('instance-admin gating on global config routes', () => {
       await expect(runThroughHandle(req, jar, modelFunctionsPost as any)).rejects.toMatchObject({
         status: 400,
       });
+    });
+  });
+
+  describe('/api/settings/admin/spend-ceiling (via real handle)', () => {
+    // #540: the instance-wide ceiling and the self-registration defaults
+    // are exactly the config a self-created-org admin must never reach -
+    // they are meant to bound that admin's own org, among every other one.
+    const body = {
+      instanceMonthlyBudgetUsd: 250,
+      selfRegistrationMonthlyRunBudgetUsd: 5,
+      selfRegistrationMaxConcurrentRuns: 1,
+    };
+
+    it('an org admin who is not instance-admin is forbidden on the read (403)', async () => {
+      const jar = await sessionFor('iag-spend-admin-r', 'admin', false);
+      const req = new Request('http://localhost/api/settings/admin/spend-ceiling');
+      await expect(runThroughHandle(req, jar, spendCeilingGet as any)).rejects.toMatchObject({
+        status: 403,
+      });
+    });
+
+    it('an org admin who is not instance-admin is forbidden on the write (403)', async () => {
+      const jar = await sessionFor('iag-spend-admin-w', 'admin', false);
+      const req = new Request('http://localhost/api/settings/admin/spend-ceiling', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      await expect(runThroughHandle(req, jar, spendCeilingPut as any)).rejects.toMatchObject({
+        status: 403,
+      });
+    });
+
+    it('an instance-admin writes it and reads the new values back (200)', async () => {
+      const jar = await sessionFor('iag-spend-iadmin', 'admin', true);
+      const putReq = new Request('http://localhost/api/settings/admin/spend-ceiling', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const putRes = await runThroughHandle(putReq, jar, spendCeilingPut as any);
+      expect(putRes.status).toBe(200);
+
+      const getReq = new Request('http://localhost/api/settings/admin/spend-ceiling');
+      const getRes = await runThroughHandle(getReq, jar, spendCeilingGet as any);
+      expect(getRes.status).toBe(200);
+      expect(await getRes.json()).toMatchObject(body);
     });
   });
 });

--- a/web/tests/orgs-create.test.ts
+++ b/web/tests/orgs-create.test.ts
@@ -3,6 +3,11 @@ import { sql } from 'drizzle-orm';
 import type { RequestEvent } from '@sveltejs/kit';
 import { getDb, schema } from '@pitchbox/shared/db';
 import { createSession } from '@pitchbox/shared/auth';
+import {
+  getOrgQuotaFields,
+  ORG_QUOTA_DEFAULTS_FALLBACK,
+  SELF_REGISTRATION_QUOTA_DEFAULTS_FALLBACK,
+} from '@pitchbox/shared/org-quota';
 import { POST } from '../src/routes/api/orgs/+server.js';
 
 async function reset() {
@@ -44,6 +49,22 @@ describe('POST /api/orgs', () => {
       .from(schema.organizations)
       .where(sql`slug = 'cr-new'`);
     expect(stored.activeOrganizationId).toBe(org.id);
+  });
+
+  it('gets the invited/existing-user quota defaults, never the lower self-registration ones (#540) - even though this caller may themselves have self-registered', async () => {
+    const u = await seedUser('cr-quota');
+    const res = await POST(
+      event(u.sessionId, u.userId, { slug: 'cr-quota-org', name: 'Quota Co' }),
+    );
+    expect(res.status).toBe(201);
+    const db = getDb();
+    const [org] = await db
+      .select()
+      .from(schema.organizations)
+      .where(sql`slug = 'cr-quota-org'`);
+    const fields = await getOrgQuotaFields(db, org.id);
+    expect(fields).toEqual(ORG_QUOTA_DEFAULTS_FALLBACK);
+    expect(fields).not.toEqual(SELF_REGISTRATION_QUOTA_DEFAULTS_FALLBACK);
   });
 
   it('rejects a duplicate slug', async () => {

--- a/web/tests/register.test.ts
+++ b/web/tests/register.test.ts
@@ -9,6 +9,7 @@ import {
   getOrgQuotaFields,
   getOrgQuotaSnapshot,
   ORG_QUOTA_DEFAULTS_FALLBACK,
+  SELF_REGISTRATION_QUOTA_DEFAULTS_FALLBACK,
 } from '@pitchbox/shared/org-quota';
 import { POST as register } from '../src/routes/api/auth/register/+server.js';
 import { load as inviteLoad } from '../src/routes/invite/[token]/+page.server.js';
@@ -189,7 +190,7 @@ describe('POST /api/auth/register', () => {
     expect(user).toBeUndefined();
   });
 
-  it('a stranger with no invite registers into their own new organization, not default, on the settled default quota', async () => {
+  it('a stranger with no invite registers into their own new organization, not default, on the lower self-registration default quota (#540) - distinct from org_quota_defaults', async () => {
     const jar: CookieJar = { store: new Map() };
     const res = await callRegister(
       { username: 'solo-founder', email: 'solo@example.com', password: 'a-very-long-password' },
@@ -206,11 +207,14 @@ describe('POST /api/auth/register', () => {
     expect(orgs[0].slug).not.toBe('default');
     expect(orgs[0].role).toBe('owner');
 
-    // #515: a self-created org starts on the documented default budget and
-    // concurrency cap, never the unbounded `null` a bare column default
-    // would leave it on.
+    // #540: a self-registered stranger's org starts on the lower
+    // self-registration default, never the shared org_quota_defaults an
+    // invited or manually-provisioned org gets (#515 introduced that
+    // shared default; #540 split it in two) - and never the unbounded
+    // `null` a bare column default would leave it on.
     const fields = await getOrgQuotaFields(getDb(), orgs[0].id);
-    expect(fields).toEqual(ORG_QUOTA_DEFAULTS_FALLBACK);
+    expect(fields).toEqual(SELF_REGISTRATION_QUOTA_DEFAULTS_FALLBACK);
+    expect(fields).not.toEqual(ORG_QUOTA_DEFAULTS_FALLBACK);
   });
 
   it("a self-created org's default caps are enforced by the existing concurrency and budget assertions, not a new check", async () => {


### PR DESCRIPTION
Closes #540.

Opening registration to strangers (#423) turns a per-org cap into an unbounded instance-wide one. This adds the second gate, under epic #503:

- **An instance-wide monthly Gateway ceiling**, summed across every organization (`shared/src/org-quota.ts`'s `getInstanceMonthToDateCostUsd`). Checked in `web/src/lib/server/runner.ts` next to the per-org budget, with its own refusal wording ("instance-wide" rather than "quota") and its own classify-failure reason, `instance_quota_exhausted`, distinct from `quota_exhausted` and `concurrency_exhausted`.
- **A separate, lower default for a self-registered org.** `createOrganization` (`shared/src/orgs.ts`) takes a new `quotaSource` parameter; only the register route's no-invite branch passes `'self_registration'`, reading `self_registration_quota_defaults` instead of the shared `org_quota_defaults` an invited or manually-provisioned org gets. `POST /api/orgs` is unchanged (still `org_quota_defaults`), since that caller already has an account on the instance.
- **Both keys readable and editable** at `/settings/admin/spend-ceiling`, instance-admin gated like every other instance-wide write, with an instance audit trail entry.

**Defaults chosen:** self-registration budget **$5/mo**, **1** concurrent run - single-digit USD as asked, tighter than the existing $20/2-run org default, since a self-registered stranger has had zero human review. Instance ceiling **$500/mo** - a hundred self-registered orgs at their own $5 default still sit under it, so it is a real backstop rather than a number tuned to never bite. Both are seeded in `seed-core.ts` alongside `org_quota_defaults` so a fresh install ships capped rather than waiting on an operator to visit the admin area first (the issue only asked me to seed the self-registration default; I extended the same treatment to the instance ceiling for the same reason - a fresh install should never be unbounded by default given what this issue is closing).

**Composition with #522:** my instance sum calls `getOrgMonthToDateCostUsd` once per organization and adds the results, rather than re-deriving its own query - so once #522 extends that function to include assistant spend, the instance ceiling picks it up automatically, with no follow-up line needed on my side. Confirmed with AssistSpend over IRC that #522 widens `getOrgMonthToDateCostUsd`'s own summation rather than renaming or bypassing it.

**No migration**: both new keys (`instance_quota_ceiling`, `self_registration_quota_defaults`) live in the existing `app_config` key-value table.

**Tests** (`pnpm exec vitest run`, all passing): 
- `web/tests/gateway-instance-ceiling-dispatch.test.ts` - the instance refusal exercised through a *second* organization whose own budget is fine, through the real `runCampaign -> dispatchRun` path, plus the under-ceiling and explicit-null-unlimited cases.
- `shared/tests/runlog/classify-failure.test.ts` - the new `instance_quota_exhausted` pattern, distinct from `quota_exhausted`/`concurrency_exhausted`.
- `web/tests/register.test.ts` / `web/tests/orgs-create.test.ts` - the two defaults proven distinct (self-registration vs. invited/`POST /api/orgs`).
- `web/tests/instance-admin-gating.test.ts` - the new admin route's role gate (403 for an org admin who isn't instance-admin, 200 for one who is).

Every new assertion above was proven to bite: broke the corresponding code path, watched the exact test fail, restored, confirmed green again.

`pnpm -F @pitchbox/shared typecheck`, `pnpm -F web check`, `npx eslint`/`npx prettier --check` on touched files all clean.

Did not touch `shared/src/org-quota.ts`'s existing exports' signatures, `web/src/routes/api/extension/suggest/+server.ts`, `web/src/routes/api/auth/register/+server.ts`'s invite branch, `shared/src/mail/`, any migration, or `docs/design/DECISIONS.md`.