### PR TITLE
feat(web,shared): verify the email address before an account can spend anything

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -102,6 +102,52 @@ Two ways to end up with a new password, plus the CLI escape hatch below.
 Neither covers an account with no email on file - see "Account recovery from
 the shell" below.
 
+## Email verification
+
+`users.email_verified_at` (#514) is null until the address is proven. A
+registration mints a single-use, hashed-at-rest token
+(`email_verification_tokens`, `createEmailVerificationToken`/
+`consumeEmailVerificationToken` in `shared/src/auth.ts`, 48-hour TTL - hours
+rather than the password-reset flow's 20 minutes, since people read mail
+late) and mails a `/verify/<token>` link through the same transport
+convention as password reset. Exactly one mail per registration, except one
+case: an account created from an invite whose invite carried this exact
+(normalized) address is born verified - the inviter already vouched for it -
+and gets no mail at all. Changing the address on an existing account is not
+implemented yet; when it lands, it must clear `email_verified_at` and
+re-enter this flow rather than trust the new value untouched.
+
+**Decision (recorded on #514): an unverified account can sign in and look
+around, but cannot start a run.** A run spends real money through the AI
+Gateway, and is the one action worth protecting from a throwaway signup -
+everything else (browsing, settings, reading data) stays open. This is
+enforced server-side, not by hiding a button: `requireVerifiedEmail`
+(`web/src/lib/server/auth.ts`) throws `403 { "message": "email_unverified"
+}` and is called at the top of every route that dispatches a run - `POST
+/api/run`, `POST /api/campaigns` (which dispatches a skill-generation run on
+creation), `POST /api/campaigns/[id]/skill-runs`, `POST
+/api/projects/[id]/runs`, `POST /api/drafts/[id]/regenerate`, and `POST
+/api/drafts/[id]/reply-draft/retry` - before any of them touch
+`web/src/lib/server/runner.ts`. It is a no-op when there is no signed-in
+caller (auth off, or the daemon's internal-token dispatch to `POST
+/api/run`, which carries no session), same convention as `requireRole`. An
+account with no email on file (a pre-#507 bootstrap/`seed:owner`/CLI
+account, which can never clear this column) counts as verified - blocking it
+would be a permanent lockout with no way out, not a spend protection.
+
+`POST /api/auth/verify/confirm` redeems the token (rate-limited by IP,
+unknown/used/expired all answer `400 { "error": "invalid_or_expired_token"
+}` identically) and is exempt from session resolution like `/reset/<token>`,
+since the link may be opened with no session at all. `POST
+/api/auth/verify/resend` is session-gated (self-service, like `POST
+/api/auth/password`) and rate-limited by IP and by the account's own address
+through the same `auth_failures` bucket and `loadAuthPolicy` register and
+login use; a caller who is already verified gets `{ "ok": true,
+"alreadyVerified": true }` without touching the rate limit. `/settings/password`
+shows the account's address, a Verified/Unverified badge, and the resend
+button when unverified - the same per-account, signed-in-only surface the
+self-service password change already uses.
+
 ## Sessions
 
 `createSession()` mints a 32-byte hex token, stores it in the `sessions` table with a 30-day expiry, and sets it as an httpOnly cookie. `loadSession()` joins `sessions × users` and only returns non-expired rows. Logging out deletes the row and clears the cookie.

--- a/shared/src/auth.ts
+++ b/shared/src/auth.ts
@@ -5,6 +5,7 @@ import type { PgDatabase } from 'drizzle-orm/pg-core';
 import {
   appConfig,
   authFailures,
+  emailVerificationTokens,
   passwordResetTokens,
   sessions,
   users,
@@ -229,12 +230,27 @@ export function normalizeEmail(email: string | null | undefined): string | null 
  */
 export async function createUserRecord(
   db: Db,
-  args: { username: string; password: string; email?: string | null },
+  args: {
+    username: string;
+    password: string;
+    email?: string | null;
+    // Set only by POST /api/auth/register when an invite carried this exact
+    // address (#514) - the inviter already vouched for it, so the account is
+    // born verified rather than going through the mail round trip. Every
+    // other caller (createUser's first-login/seed:owner bootstrap, a
+    // token-only registration) leaves this null.
+    emailVerifiedAt?: Date | null;
+  },
 ): Promise<number> {
   const passwordHash = await hashPassword(args.password);
   const [row] = await db
     .insert(users)
-    .values({ username: args.username, passwordHash, email: normalizeEmail(args.email) })
+    .values({
+      username: args.username,
+      passwordHash,
+      email: normalizeEmail(args.email),
+      emailVerifiedAt: args.emailVerifiedAt ?? null,
+    })
     .returning();
   return row.id;
 }
@@ -413,4 +429,81 @@ export async function consumePasswordResetToken(db: Db, token: string): Promise<
     )
     .returning({ userId: passwordResetTokens.userId });
   return row?.userId ?? null;
+}
+
+// 48 hours, not the 20-minute window RESET_TOKEN_TTL_MS uses above: #514
+// asks for the TTL "measured in hours rather than minutes since people read
+// mail late" - a stale reset link is a bigger risk to leave lying around
+// (it changes a password) than a stale verification link is (it only
+// proves a mailbox, and the account already works for everything but
+// starting a run in the meantime).
+const EMAIL_VERIFICATION_TOKEN_TTL_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * Mints a single-use, time-limited email verification token for `userId`
+ * and stores only its hash (`email_verification_tokens.token_hash`) -
+ * exactly `createPasswordResetToken`'s shape above, reused rather than
+ * reinvented since both are "prove control of this mailbox" tokens. The raw
+ * token is returned once here and is not recoverable from the row
+ * afterward.
+ */
+export async function createEmailVerificationToken(
+  db: Db,
+  userId: number,
+): Promise<{ token: string; expiresAt: Date }> {
+  const token = randomBytes(24).toString('hex');
+  const expiresAt = new Date(Date.now() + EMAIL_VERIFICATION_TOKEN_TTL_MS);
+  await db.insert(emailVerificationTokens).values({
+    userId,
+    tokenHash: createHash('sha256').update(token).digest('hex'),
+    expiresAt,
+  });
+  return { token, expiresAt };
+}
+
+/**
+ * Atomically redeems a verification token: a single UPDATE that only
+ * matches a row still unused and unexpired, in the same statement that
+ * marks it used - same compare-and-set shape as
+ * `consumePasswordResetToken`. Returns the owning user id, or null for an
+ * unknown, already-used, or expired token; the caller answers all three
+ * identically, same reasoning as the reset flow.
+ */
+export async function consumeEmailVerificationToken(db: Db, token: string): Promise<number | null> {
+  const [row] = await db
+    .update(emailVerificationTokens)
+    .set({ usedAt: new Date() })
+    .where(
+      and(
+        eq(emailVerificationTokens.tokenHash, createHash('sha256').update(token).digest('hex')),
+        isNull(emailVerificationTokens.usedAt),
+        gt(emailVerificationTokens.expiresAt, new Date()),
+      ),
+    )
+    .returning({ userId: emailVerificationTokens.userId });
+  return row?.userId ?? null;
+}
+
+/** Marks `userId`'s address verified. The one write site for `users.email_verified_at`. */
+export async function markEmailVerified(db: Db, userId: number): Promise<void> {
+  await db.update(users).set({ emailVerifiedAt: new Date() }).where(eq(users.id, userId));
+}
+
+/**
+ * Whether `userId` may do whatever `requireVerifiedEmail`
+ * (web/src/lib/server/auth.ts) gates - today, starting a run (#514). An
+ * account with no email on file predates the #507 requirement (first-login
+ * bootstrap, `seed:owner`, the CLI) and can never clear this column, so it
+ * is treated as verified rather than permanently locked out; only an
+ * account that has an address is held to actually proving it.
+ */
+export async function isEmailVerified(db: Db, userId: number): Promise<boolean> {
+  const [row] = await db
+    .select({ email: users.email, emailVerifiedAt: users.emailVerifiedAt })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (!row) return false;
+  if (!row.email) return true;
+  return row.emailVerifiedAt != null;
 }

--- a/shared/src/db/migrations/0026_email_verification_tokens.sql
+++ b/shared/src/db/migrations/0026_email_verification_tokens.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "email_verification_tokens" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"token_hash" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"used_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "email_verified_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "email_verification_tokens" ADD CONSTRAINT "email_verification_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "email_verification_tokens_token_hash_unique" ON "email_verification_tokens" USING btree ("token_hash");--> statement-breakpoint
+CREATE INDEX "email_verification_tokens_user_idx" ON "email_verification_tokens" USING btree ("user_id");

--- a/shared/src/db/migrations/meta/0026_snapshot.json
+++ b/shared/src/db/migrations/meta/0026_snapshot.json
@@ -1,0 +1,4438 @@
+{
+  "id": "319bb99a-3514-4e84-bd7d-4dc2d29b9c4c",
+  "prevId": "cacac404-dce5-40d7-8bff-7db76b3a7df8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cookie_session": {
+          "name": "cookie_session",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_limit": {
+          "name": "weekly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_project_id_projects_id_fk": {
+          "name": "accounts_project_id_projects_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_platform_id_platforms_id_fk": {
+          "name": "accounts_platform_id_platforms_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_failures": {
+      "name": "auth_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login_attempt'"
+        }
+      },
+      "indexes": {
+        "auth_failures_identifier_idx": {
+          "name": "auth_failures_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist": {
+      "name": "blocklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocklist_platform_id_platforms_id_fk": {
+          "name": "blocklist_platform_id_platforms_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocklist_project_id_projects_id_fk": {
+          "name": "blocklist_project_id_projects_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_recommendations": {
+      "name": "campaign_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_slug": {
+          "name": "scenario_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_recommendations_project_idx": {
+          "name": "campaign_recommendations_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_recommendations_project_id_projects_id_fk": {
+          "name": "campaign_recommendations_project_id_projects_id_fk",
+          "tableFrom": "campaign_recommendations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_slug": {
+          "name": "skill_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_attempts": {
+          "name": "failure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_due_to_failures": {
+          "name": "paused_due_to_failures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_post": {
+          "name": "auto_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_platform_id_platforms_id_fk": {
+          "name": "campaigns_platform_id_platforms_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_history": {
+      "name": "contact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_handle": {
+          "name": "account_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_checked_at": {
+          "name": "reply_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_room_id": {
+          "name": "chat_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_context_url": {
+          "name": "platform_context_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uncontactable": {
+          "name": "uncontactable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uncontactable_reason": {
+          "name": "uncontactable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_history_target_idx": {
+          "name": "contact_history_target_idx",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_target_idx": {
+          "name": "messages_account_target_idx",
+          "columns": [
+            {
+              "expression": "account_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_org_idx": {
+          "name": "contact_history_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_contacted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_history_platform_id_platforms_id_fk": {
+          "name": "contact_history_platform_id_platforms_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contact_history_draft_id_drafts_id_fk": {
+          "name": "contact_history_draft_id_drafts_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_history_organization_id_organizations_id_fk": {
+          "name": "contact_history_organization_id_organizations_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_heartbeats": {
+      "name": "daemon_heartbeats",
+      "schema": "",
+      "columns": {
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tick_at": {
+          "name": "tick_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_events": {
+      "name": "draft_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_events_kind_created_idx": {
+          "name": "draft_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_events_draft_id_drafts_id_fk": {
+          "name": "draft_events_draft_id_drafts_id_fk",
+          "tableFrom": "draft_events",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_regeneration_hints": {
+      "name": "draft_regeneration_hints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint_text": {
+          "name": "hint_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_regeneration_hints_draft_id_drafts_id_fk": {
+          "name": "draft_regeneration_hints_draft_id_drafts_id_fk",
+          "tableFrom": "draft_regeneration_hints",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "fit_score": {
+          "name": "fit_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_url": {
+          "name": "compose_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_content": {
+          "name": "sent_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_comment_id": {
+          "name": "platform_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dedup_warning": {
+          "name": "dedup_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_edited": {
+          "name": "body_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_send_after": {
+          "name": "scheduled_send_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerating_run_id": {
+          "name": "regenerating_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drafting_run_id": {
+          "name": "drafting_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_reason": {
+          "name": "quality_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_model": {
+          "name": "quality_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_id": {
+          "name": "variant_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undeliverable_reason": {
+          "name": "undeliverable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drafts_state_idx": {
+          "name": "drafts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_project_idx": {
+          "name": "drafts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_run_idx": {
+          "name": "drafts_state_run_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_campaign_created_idx": {
+          "name": "drafts_state_campaign_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_variant_group_idx": {
+          "name": "drafts_variant_group_idx",
+          "columns": [
+            {
+              "expression": "variant_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_run_id_runs_id_fk": {
+          "name": "drafts_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_project_id_projects_id_fk": {
+          "name": "drafts_project_id_projects_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_platform_id_platforms_id_fk": {
+          "name": "drafts_platform_id_platforms_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_accounts_id_fk": {
+          "name": "drafts_account_id_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_regenerating_run_id_runs_id_fk": {
+          "name": "drafts_regenerating_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "regenerating_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drafts_drafting_run_id_runs_id_fk": {
+          "name": "drafts_drafting_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "drafting_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_verification_tokens_user_idx": {
+          "name": "email_verification_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_devices": {
+      "name": "extension_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unnamed device'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "extension_devices_token_hash_unique": {
+          "name": "extension_devices_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extension_devices_organization_id_organizations_id_fk": {
+          "name": "extension_devices_organization_id_organizations_id_fk",
+          "tableFrom": "extension_devices",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_pairings": {
+      "name": "extension_pairings",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extension_pairings_organization_id_organizations_id_fk": {
+          "name": "extension_pairings_organization_id_organizations_id_fk",
+          "tableFrom": "extension_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sources": {
+      "name": "github_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_language": {
+          "name": "primary_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readme_excerpt": {
+          "name": "readme_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_commits": {
+          "name": "recent_commits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_sources_org_repo_unique": {
+          "name": "github_sources_org_repo_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_sources_organization_id_organizations_id_fk": {
+          "name": "github_sources_organization_id_organizations_id_fk",
+          "tableFrom": "github_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_audit_log": {
+      "name": "instance_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_audit_log_created_idx": {
+          "name": "instance_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_watches": {
+      "name": "keyword_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_field": {
+          "name": "match_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keyword_watches_campaign_idx": {
+          "name": "keyword_watches_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_watches_project_idx": {
+          "name": "keyword_watches_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_watches_project_id_projects_id_fk": {
+          "name": "keyword_watches_project_id_projects_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keyword_watches_campaign_id_campaigns_id_fk": {
+          "name": "keyword_watches_campaign_id_campaigns_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_org_user_unique": {
+          "name": "memberships_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_from_us": {
+          "name": "is_from_us",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_platform": {
+          "name": "created_at_platform",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_contact_idx": {
+          "name": "messages_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_platform_message_unique": {
+          "name": "messages_platform_message_unique",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_contact_id_contact_history_id_fk": {
+          "name": "messages_contact_id_contact_history_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "contact_history",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_draft_id_drafts_id_fk": {
+          "name": "messages_draft_id_drafts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_platform_id_platforms_id_fk": {
+          "name": "messages_platform_id_platforms_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_unread_idx": {
+          "name": "notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_idx": {
+          "name": "notifications_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organization_id_organizations_id_fk": {
+          "name": "notifications_organization_id_organizations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observed_targets": {
+      "name": "observed_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_by_run_id": {
+          "name": "consumed_by_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "observed_targets_dedup_idx": {
+          "name": "observed_targets_dedup_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "observed_targets_project_unconsumed_idx": {
+          "name": "observed_targets_project_unconsumed_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_by_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "observed_targets_organization_id_organizations_id_fk": {
+          "name": "observed_targets_organization_id_organizations_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_project_id_projects_id_fk": {
+          "name": "observed_targets_project_id_projects_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_platform_id_platforms_id_fk": {
+          "name": "observed_targets_platform_id_platforms_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observed_targets_consumed_by_run_id_runs_id_fk": {
+          "name": "observed_targets_consumed_by_run_id_runs_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "consumed_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_profiles": {
+      "name": "operator_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiences": {
+          "name": "experiences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'linkedin_capture'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_profiles_org_unique": {
+          "name": "operator_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_profiles": {
+      "name": "operator_voice_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "openings": {
+          "name": "openings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "closings": {
+          "name": "closings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "common_words": {
+          "name": "common_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "words_per_sentence": {
+          "name": "words_per_sentence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'derived'"
+        },
+        "derived_at": {
+          "name": "derived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_profiles_org_unique": {
+          "name": "operator_voice_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_voice_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_samples": {
+      "name": "operator_voice_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_samples_org_external_unique": {
+          "name": "operator_voice_samples_org_external_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operator_voice_samples_org_idx": {
+          "name": "operator_voice_samples_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "excluded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_samples_organization_id_organizations_id_fk": {
+          "name": "operator_voice_samples_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_voice_samples_platform_id_platforms_id_fk": {
+          "name": "operator_voice_samples_platform_id_platforms_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invites": {
+      "name": "org_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_invites_org_idx": {
+          "name": "org_invites_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invites_organization_id_organizations_id_fk": {
+          "name": "org_invites_organization_id_organizations_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invites_created_by_user_id_users_id_fk": {
+          "name": "org_invites_created_by_user_id_users_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invites_token_unique": {
+          "name": "org_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_run_budget_usd": {
+          "name": "monthly_run_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_user_idx": {
+          "name": "password_reset_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platforms": {
+      "name": "platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platforms_slug_unique": {
+          "name": "platforms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playbooks": {
+      "name": "playbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playbooks_slug_unique": {
+          "name": "playbooks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_insights": {
+      "name": "project_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary_md": {
+          "name": "summary_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_insights_project_idx": {
+          "name": "project_insights_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_insights_project_id_projects_id_fk": {
+          "name": "project_insights_project_id_projects_id_fk",
+          "tableFrom": "project_insights",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_sources": {
+      "name": "project_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_runner": {
+          "name": "default_agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "voice_tone": {
+          "name": "voice_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_tone_notes": {
+          "name": "voice_tone_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_unique": {
+          "name": "projects_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_events_run_idx": {
+          "name": "run_events_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_events_kind_created_idx": {
+          "name": "run_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'campaign'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout_log_path": {
+          "name": "stdout_log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playbook_body": {
+          "name": "playbook_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_project_kind_idx": {
+          "name": "runs_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_campaign_id_campaigns_id_fk": {
+          "name": "runs_campaign_id_campaigns_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_scout_candidates": {
+      "name": "staging_scout_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staging_scout_candidates_run_id_runs_id_fk": {
+          "name": "staging_scout_candidates_run_id_runs_id_fk",
+          "tableFrom": "staging_scout_candidates",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_project_kind_idx": {
+          "name": "templates_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_project_id_projects_id_fk": {
+          "name": "templates_project_id_projects_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_instance_admin": {
+          "name": "is_instance_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recent_idx": {
+          "name": "webhook_deliveries_recent_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_org_idx": {
+          "name": "webhook_deliveries_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_organization_id_organizations_id_fk": {
+          "name": "webhook_deliveries_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1788960000012,
       "tag": "0025_supreme_molecule_man",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1788960000013,
+      "tag": "0026_email_verification_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -47,6 +47,18 @@ export const users = pgTable(
     // unique index below is a plain column constraint rather than an
     // expression index, and two logins differing only in case collide.
     email: text('email'),
+    // Set the moment the account proves control of `email` by redeeming a
+    // single-use link (`email_verification_tokens` below) - null means
+    // unverified. #514: a self-registered account can spend real money
+    // through a run, so an unproven address must not be trusted the same
+    // as a proven one. Two accounts intentionally start non-null here
+    // rather than going through a link: one whose invite (`org_invites.
+    // email`) already named this exact address (the inviter's vouching
+    // stands in for the mail round trip - see `createUserRecord` /
+    // `POST /api/auth/register`), and any pre-#507 account with `email`
+    // still null, which `isEmailVerified` treats as verified since it has
+    // nothing to prove and no way to ever clear this column.
+    emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({
@@ -173,6 +185,30 @@ export const passwordResetTokens = pgTable(
   (t) => ({
     tokenHashUnique: uniqueIndex('password_reset_tokens_token_hash_unique').on(t.tokenHash),
     byUser: index('password_reset_tokens_user_idx').on(t.userId),
+  }),
+);
+
+// email_verification_tokens (#514): backs POST /api/auth/verify/confirm and
+// /api/auth/verify/resend. Exactly `password_reset_tokens`' shape above -
+// hashed at rest, single use, time-limited - reused on purpose rather than
+// invented fresh, since both are "prove control of this mailbox" tokens
+// with the same threat model. The TTL just lives in shared/src/auth.ts
+// instead of here, same as password_reset_tokens' does.
+export const emailVerificationTokens = pgTable(
+  'email_verification_tokens',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    tokenHash: text('token_hash').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    usedAt: timestamp('used_at', { withTimezone: true }),
+  },
+  (t) => ({
+    tokenHashUnique: uniqueIndex('email_verification_tokens_token_hash_unique').on(t.tokenHash),
+    byUser: index('email_verification_tokens_user_idx').on(t.userId),
   }),
 );
 

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -131,6 +131,15 @@ function isExemptPath(pathname: string): boolean {
     pathname.startsWith('/reset') ||
     pathname.startsWith('/api/auth/password/forgot') ||
     pathname.startsWith('/api/auth/password/reset') ||
+    // Email verification (#514): the link may be opened with no session at
+    // all (a different device, or the browser that registered having since
+    // signed out), so the confirm page and its API need to be reachable
+    // session-less too. Exact prefix again - not a blanket `/api/auth/
+    // verify`, which would also exempt POST /api/auth/verify/resend, a
+    // self-service action that must stay behind session resolution the
+    // same way POST /api/auth/password does.
+    pathname.startsWith('/verify') ||
+    pathname.startsWith('/api/auth/verify/confirm') ||
     pathname.startsWith('/_app/') ||
     pathname.startsWith('/favicon')
   );

--- a/web/src/lib/server/auth.ts
+++ b/web/src/lib/server/auth.ts
@@ -1,6 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { error, type RequestEvent } from '@sveltejs/kit';
-import { loadOrganizationForUser } from '@pitchbox/shared/auth';
+import { isEmailVerified, loadOrganizationForUser } from '@pitchbox/shared/auth';
 import { getDb, schema } from './db.js';
 
 /**
@@ -88,5 +88,31 @@ export async function isInstanceAdmin(event: RequestEvent): Promise<boolean> {
 export async function requireInstanceAdmin(event: RequestEvent): Promise<void> {
   if (!(await isInstanceAdmin(event))) {
     throw error(403, 'forbidden');
+  }
+}
+
+/**
+ * Require the signed-in caller's email to be verified, else throw 403
+ * `email_unverified` (#514). A no-op when there is no signed-in caller -
+ * auth off (self-host), or the daemon's internal-token dispatch to
+ * `POST /api/run`, which carries no session - same convention as
+ * `requireRole`/`requireInstanceAdmin`: nothing here to gate without a
+ * user. `isEmailVerified` (shared/src/auth.ts) is what actually decides:
+ * no email on file (a pre-#507 account) counts as verified, same as an
+ * account whose address has a real `email_verified_at`.
+ *
+ * Call this at the top of any route that dispatches a run (starting money
+ * being spent is the one thing an unverified, freshly self-registered
+ * account must not be able to do) - never inside `web/src/lib/server/
+ * runner.ts`'s dispatch internals, which have no request/session to read a
+ * caller from in the first place (a scheduled campaign run has no live
+ * "who clicked this" at all).
+ */
+export async function requireVerifiedEmail(event: RequestEvent): Promise<void> {
+  const user = event.locals?.user;
+  if (!user) return; // auth off, or the daemon's session-less internal dispatch
+  const db = getDb();
+  if (!(await isEmailVerified(db, user.id))) {
+    throw error(403, 'email_unverified');
   }
 }

--- a/web/src/routes/api/auth/register/+server.ts
+++ b/web/src/routes/api/auth/register/+server.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { getDb } from '../../../../lib/server/db.js';
 import {
   clearAuthFailures,
+  createEmailVerificationToken,
   createSession,
   createUserRecord,
   deleteSession,
@@ -13,6 +14,9 @@ import {
   normalizeEmail,
   recordAuthFailure,
 } from '@pitchbox/shared/auth';
+import { createMailTransport } from '@pitchbox/shared/mail/registry';
+import { loadMailEnv } from '@pitchbox/shared/mail/env';
+import { renderPlainTextMail } from '@pitchbox/shared/mail/template';
 import {
   acceptInvite,
   createOrganization,
@@ -160,6 +164,15 @@ export async function POST(event: RequestEvent) {
     }
   }
 
+  // #514: the inviter already vouched for this address by naming it on the
+  // invite, so a registration that supplies the exact same (normalized)
+  // address is born verified - no mail round trip, no window where the
+  // account can sign in but not run. An invite with no email on it, or one
+  // whose email differs from what the registrant typed, gets the ordinary
+  // unverified flow below.
+  const inviteEmail = invite?.email ?? null;
+  const inviteEmailMatches = inviteEmail != null && normalizeEmail(inviteEmail) === email;
+
   let userId: number;
   try {
     userId = await db.transaction(async (tx) => {
@@ -172,6 +185,7 @@ export async function POST(event: RequestEvent) {
         username: parsed.data.username,
         password: parsed.data.password,
         email,
+        emailVerifiedAt: inviteEmailMatches ? new Date() : null,
       });
       if (invite) {
         const accepted = await acceptInvite(tx, invite.token, id);
@@ -227,5 +241,25 @@ export async function POST(event: RequestEvent) {
     secure: process.env.NODE_ENV === 'production',
     expires: session.expiresAt,
   });
-  return json({ ok: true });
+
+  // #514: exactly one verification mail per registration, and none at all
+  // for the invite-matched case above (the account is already verified -
+  // sending one anyway would be a mail promising a step that isn't there).
+  // Same link-building convention as /api/auth/password/forgot: the
+  // request's own origin, never a hardcoded host.
+  if (!inviteEmailMatches) {
+    const { token } = await createEmailVerificationToken(db, userId);
+    const verifyUrl = `${event.url.origin}/verify/${token}`;
+    const rendered = renderPlainTextMail(
+      'Verify your Pitchbox email address',
+      `Welcome to Pitchbox. Confirm this address to start running campaigns.\n\n` +
+        `Open this link within 48 hours to verify:\n${verifyUrl}\n\n` +
+        `You can sign in and look around before you verify - you just can't ` +
+        `start a run yet. If you didn't create this account, ignore this message.`,
+    );
+    const transport = createMailTransport(loadMailEnv());
+    await transport.send({ to: email, ...rendered });
+  }
+
+  return json({ ok: true, emailVerified: inviteEmailMatches });
 }

--- a/web/src/routes/api/auth/verify/confirm/+server.ts
+++ b/web/src/routes/api/auth/verify/confirm/+server.ts
@@ -1,0 +1,66 @@
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '../../../../../lib/server/db.js';
+import {
+  consumeEmailVerificationToken,
+  getLockoutUntil,
+  loadAuthPolicy,
+  markEmailVerified,
+  recordAuthFailure,
+} from '@pitchbox/shared/auth';
+
+const Body = z.object({
+  token: z.string().min(1),
+});
+
+/**
+ * Redeems a single-use email verification token minted by registration
+ * (POST /api/auth/register) or a resend (POST /api/auth/verify/resend),
+ * and sets `users.email_verified_at`. Exempt from session resolution in
+ * hooks.server.ts, same as POST /api/auth/password/reset: the link may be
+ * opened in a browser with no session at all (a different device, or the
+ * one that registered having since signed out).
+ *
+ * Rate-limited by IP only, same shape as password/reset - the token itself
+ * is the secret here, not an address, so there is no second bucket to
+ * throttle. Unknown, already-used, and expired all answer identically:
+ * `400 { "error": "invalid_or_expired_token" }`.
+ */
+export async function POST(event: RequestEvent) {
+  if (process.env.PITCHBOX_AUTH !== 'on') {
+    throw error(404, 'auth_disabled');
+  }
+  const raw = await event.request.json().catch(() => null);
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) throw error(400, 'invalid_body');
+
+  const db = getDb();
+  let ip: string;
+  try {
+    ip = event.getClientAddress() || 'unknown';
+  } catch {
+    ip = 'unknown';
+  }
+  const ipBucket = `verify:ip:${ip}`;
+  const policy = await loadAuthPolicy(db);
+  const now = new Date();
+  const ipLock = await getLockoutUntil(db, ipBucket, policy, now);
+  if (ipLock) {
+    return json(
+      {
+        error: 'rate_limited',
+        retry_after_seconds: Math.max(1, Math.ceil((ipLock.getTime() - now.getTime()) / 1000)),
+      },
+      { status: 429 },
+    );
+  }
+
+  const userId = await consumeEmailVerificationToken(db, parsed.data.token);
+  if (!userId) {
+    await recordAuthFailure(db, ipBucket, 'email_verify_attempt');
+    return json({ error: 'invalid_or_expired_token' }, { status: 400 });
+  }
+
+  await markEmailVerified(db, userId);
+  return json({ ok: true });
+}

--- a/web/src/routes/api/auth/verify/resend/+server.ts
+++ b/web/src/routes/api/auth/verify/resend/+server.ts
@@ -1,0 +1,92 @@
+import { json, error, type RequestEvent } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../../../../../lib/server/db.js';
+import {
+  createEmailVerificationToken,
+  getLockoutUntil,
+  loadAuthPolicy,
+  recordAuthFailure,
+} from '@pitchbox/shared/auth';
+import { createMailTransport } from '@pitchbox/shared/mail/registry';
+import { loadMailEnv } from '@pitchbox/shared/mail/env';
+import { renderPlainTextMail } from '@pitchbox/shared/mail/template';
+
+/**
+ * Resends the verification mail for the signed-in caller's own account
+ * (#514). Session-gated like POST /api/auth/password (self-service change) -
+ * not exempt in hooks.server.ts, and defense-in-depth checked again here -
+ * rather than taking an email in the body: the caller already proved who
+ * they are by signing in, so there is nothing to enumerate and no reason to
+ * make them retype an address.
+ *
+ * Rate-limited by IP and by the account's own address, reusing the same
+ * `auth_failures` table and `loadAuthPolicy` register/login already use -
+ * same dual-bucket shape as POST /api/auth/password/forgot.
+ */
+export async function POST(event: RequestEvent) {
+  if (process.env.PITCHBOX_AUTH !== 'on') {
+    throw error(404, 'auth_disabled');
+  }
+  const user = event.locals.user;
+  if (!user) throw error(401, 'unauthenticated');
+
+  const db = getDb();
+  const [row] = await db
+    .select({ email: schema.users.email, emailVerifiedAt: schema.users.emailVerifiedAt })
+    .from(schema.users)
+    .where(eq(schema.users.id, user.id));
+  if (!row) throw error(404, 'not_found');
+  if (!row.email) {
+    return json({ error: 'no_email_on_file' }, { status: 400 });
+  }
+  if (row.emailVerifiedAt) {
+    return json({ ok: true, alreadyVerified: true });
+  }
+
+  let ip: string;
+  try {
+    ip = event.getClientAddress() || 'unknown';
+  } catch {
+    ip = 'unknown';
+  }
+  const ipBucket = `verify:ip:${ip}`;
+  const addressBucket = `verify:email:${row.email}`;
+  const policy = await loadAuthPolicy(db);
+  const now = new Date();
+  const [ipLock, addressLock] = await Promise.all([
+    getLockoutUntil(db, ipBucket, policy, now),
+    getLockoutUntil(db, addressBucket, policy, now),
+  ]);
+  const lockedUntil =
+    ipLock && addressLock ? (ipLock > addressLock ? ipLock : addressLock) : (ipLock ?? addressLock);
+  if (lockedUntil) {
+    return json(
+      {
+        error: 'rate_limited',
+        retry_after_seconds: Math.max(1, Math.ceil((lockedUntil.getTime() - now.getTime()) / 1000)),
+      },
+      { status: 429 },
+    );
+  }
+
+  // Counts this call against both buckets regardless of outcome, same
+  // reasoning as forgot-password: a repeated resend costs the caller one of
+  // their attempts even though the address is (by definition here) known.
+  await Promise.all([
+    recordAuthFailure(db, ipBucket, 'email_verify_resend'),
+    recordAuthFailure(db, addressBucket, 'email_verify_resend'),
+  ]);
+
+  const { token } = await createEmailVerificationToken(db, user.id);
+  const verifyUrl = `${event.url.origin}/verify/${token}`;
+  const rendered = renderPlainTextMail(
+    'Verify your Pitchbox email address',
+    `Confirm this address to start running campaigns.\n\n` +
+      `Open this link within 48 hours to verify:\n${verifyUrl}\n\n` +
+      `If you didn't request this, ignore this message.`,
+  );
+  const transport = createMailTransport(loadMailEnv());
+  await transport.send({ to: row.email, ...rendered });
+
+  return json({ ok: true });
+}

--- a/web/src/routes/api/campaigns/+server.ts
+++ b/web/src/routes/api/campaigns/+server.ts
@@ -5,7 +5,7 @@ import { eq } from 'drizzle-orm';
 import { getDb, schema } from '$lib/server/db.js';
 import { runCampaignSkillGeneration } from '$lib/server/runner.js';
 import { previewCron } from '@pitchbox/daemon/cron';
-import { requireOrgId } from '$lib/server/auth.js';
+import { requireOrgId, requireVerifiedEmail } from '$lib/server/auth.js';
 import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import { SCENARIO_SLUGS } from '@pitchbox/shared/campaigns';
@@ -37,6 +37,7 @@ export async function POST(event: RequestEvent) {
 
   const orgId = await requireOrgId(event);
   if (!(await projectBelongsToOrg(db, body.projectId, orgId))) throw error(404, 'not_found');
+  await requireVerifiedEmail(event);
 
   const [project] = await db
     .select()

--- a/web/src/routes/api/campaigns/[id]/skill-runs/+server.ts
+++ b/web/src/routes/api/campaigns/[id]/skill-runs/+server.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { and, desc, eq } from 'drizzle-orm';
 import { getDb, schema } from '$lib/server/db.js';
 import { runCampaignSkillGeneration } from '$lib/server/runner.js';
-import { requireOrgId } from '$lib/server/auth.js';
+import { requireOrgId, requireVerifiedEmail } from '$lib/server/auth.js';
 import { campaignBelongsToOrg } from '@pitchbox/shared/orgs';
 
 const PostBody = z.object({
@@ -24,6 +24,7 @@ export async function POST(event: RequestEvent) {
 
   const orgId = await requireOrgId(event);
   if (!(await campaignBelongsToOrg(getDb(), id, orgId))) throw error(404, 'not_found');
+  await requireVerifiedEmail(event);
 
   const raw = await request.json().catch(() => null);
   const parsed = PostBody.safeParse(raw);

--- a/web/src/routes/api/drafts/[id]/regenerate/+server.ts
+++ b/web/src/routes/api/drafts/[id]/regenerate/+server.ts
@@ -2,7 +2,7 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestEvent } from '@sveltejs/kit';
 import { runDraftRegeneration } from '../../../../../lib/server/runner.js';
 import { getDb } from '../../../../../lib/server/db.js';
-import { requireOrgId } from '$lib/server/auth.js';
+import { requireOrgId, requireVerifiedEmail } from '$lib/server/auth.js';
 import { draftBelongsToOrg } from '@pitchbox/shared/orgs';
 
 type Body = { hint?: unknown };
@@ -17,6 +17,7 @@ export async function POST(event: RequestEvent) {
 
   const orgId = await requireOrgId(event);
   if (!(await draftBelongsToOrg(getDb(), id, orgId))) throw error(404, 'not_found');
+  await requireVerifiedEmail(event);
 
   const payload = (await request.json().catch(() => ({}))) as Body;
   const hint =

--- a/web/src/routes/api/drafts/[id]/reply-draft/retry/+server.ts
+++ b/web/src/routes/api/drafts/[id]/reply-draft/retry/+server.ts
@@ -3,7 +3,7 @@ import type { RequestEvent } from '@sveltejs/kit';
 import { getDb, schema } from '$lib/server/db.js';
 import { eq } from 'drizzle-orm';
 import { runReplyDrafting } from '$lib/server/runner.js';
-import { requireOrgId } from '$lib/server/auth.js';
+import { requireOrgId, requireVerifiedEmail } from '$lib/server/auth.js';
 import { draftBelongsToOrg } from '@pitchbox/shared/orgs';
 
 export async function POST(event: RequestEvent) {
@@ -12,6 +12,7 @@ export async function POST(event: RequestEvent) {
   if (!Number.isInteger(id) || isNaN(id)) throw error(400, 'invalid id');
   const orgId = await requireOrgId(event);
   if (!(await draftBelongsToOrg(getDb(), id, orgId))) throw error(404, 'not_found');
+  await requireVerifiedEmail(event);
   const db = getDb();
   const [draft] = await db.select().from(schema.drafts).where(eq(schema.drafts.id, id));
   if (!draft) throw error(404, 'draft not found');

--- a/web/src/routes/api/projects/[id]/insights/+server.ts
+++ b/web/src/routes/api/projects/[id]/insights/+server.ts
@@ -3,7 +3,7 @@ import type { RequestEvent } from '@sveltejs/kit';
 import { runProjectInsights } from '$lib/server/runner.js';
 import { getDb, schema } from '$lib/server/db.js';
 import { eq } from 'drizzle-orm';
-import { requireOrgId } from '$lib/server/auth.js';
+import { requireOrgId, requireVerifiedEmail } from '$lib/server/auth.js';
 import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
 
 function parseId(idParam: string | undefined): number | null {
@@ -17,6 +17,7 @@ export async function POST(event: RequestEvent) {
   if (!id) return json({ error: 'invalid_id' }, { status: 400 });
   const orgId = await requireOrgId(event);
   if (!(await projectBelongsToOrg(getDb(), id, orgId))) throw error(404, 'not_found');
+  await requireVerifiedEmail(event);
   const [project] = await getDb()
     .select({ id: schema.projects.id })
     .from(schema.projects)

--- a/web/src/routes/api/projects/[id]/runs/+server.ts
+++ b/web/src/routes/api/projects/[id]/runs/+server.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { and, desc, eq } from 'drizzle-orm';
 import { getDb, schema } from '$lib/server/db.js';
 import { runProjectExtraction } from '$lib/server/runner.js';
-import { requireOrgId } from '$lib/server/auth.js';
+import { requireOrgId, requireVerifiedEmail } from '$lib/server/auth.js';
 import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
 import { assertSafeGitCloneUrl } from '@pitchbox/shared/project-extraction';
 
@@ -26,6 +26,7 @@ export async function POST(event: RequestEvent) {
   if (!id) return json({ error: 'invalid_id' }, { status: 400 });
   const orgId = await requireOrgId(event);
   if (!(await projectBelongsToOrg(getDb(), id, orgId))) throw error(404, 'not_found');
+  await requireVerifiedEmail(event);
   const raw = await request.json().catch(() => null);
   const parsed = PostBody.safeParse(raw);
   if (!parsed.success) {

--- a/web/src/routes/api/run/+server.ts
+++ b/web/src/routes/api/run/+server.ts
@@ -5,6 +5,7 @@ import { getCampaignReadiness } from '$lib/server/campaign-readiness.js';
 import { getDb } from '$lib/server/db.js';
 import { campaignBelongsToOrg } from '@pitchbox/shared/orgs';
 import { normalizeTrigger } from '$lib/utils/run-trigger.js';
+import { requireVerifiedEmail } from '$lib/server/auth.js';
 
 export async function POST(event: RequestEvent) {
   const { request } = event;
@@ -20,11 +21,15 @@ export async function POST(event: RequestEvent) {
   // path has no request-scoped org (it calls this route without auth), so it
   // is intentionally left unguarded here - optional chaining keeps a fake
   // event with no `locals` from crashing rather than being rejected.
+  // requireVerifiedEmail is the same no-op-without-a-session shape (#514):
+  // a session caller with an unverified address is refused before this ever
+  // reaches the runner; the daemon's own dispatch has no session to gate.
   if (event.locals?.org) {
     if (!(await campaignBelongsToOrg(getDb(), body.campaignId, event.locals.org.id))) {
       throw error(404, 'not_found');
     }
   }
+  await requireVerifiedEmail(event);
 
   const readiness = await getCampaignReadiness(body.campaignId);
   if (!readiness.ready) {

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -61,6 +61,12 @@
 				toast.error(message);
 				return;
 			}
+			const okBody = (await res.json().catch(() => ({}))) as { emailVerified?: boolean };
+			if (!okBody.emailVerified) {
+				toast.success('Account created', {
+					description: 'Check your email to verify your address before you can start a run.',
+				});
+			}
 			await goto(data.next ?? '/', { invalidateAll: true });
 		} finally {
 			busy = false;

--- a/web/src/routes/settings/password/+page.server.ts
+++ b/web/src/routes/settings/password/+page.server.ts
@@ -1,4 +1,6 @@
 import { error } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '$lib/server/db.js';
 import type { PageServerLoad } from './$types';
 
 /**
@@ -9,8 +11,20 @@ import type { PageServerLoad } from './$types';
  * /api/auth/{login,logout}), so `locals.user` missing here means auth is
  * off - there's no login concept and nothing to change a password for, so
  * 404 rather than a misleading empty form.
+ *
+ * Also carries email verification status (#514): the account's own address
+ * and whether it's verified, for the same per-account settings surface to
+ * show a resend affordance rather than a whole new route.
  */
 export const load: PageServerLoad = async (event) => {
   if (!event.locals.user) throw error(404, 'not_found');
-  return { username: event.locals.user.username };
+  const [row] = await getDb()
+    .select({ email: schema.users.email, emailVerifiedAt: schema.users.emailVerifiedAt })
+    .from(schema.users)
+    .where(eq(schema.users.id, event.locals.user.id));
+  return {
+    username: event.locals.user.username,
+    email: row?.email ?? null,
+    emailVerified: !row?.email || row.emailVerifiedAt != null,
+  };
 };

--- a/web/src/routes/settings/password/+page.svelte
+++ b/web/src/routes/settings/password/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
+	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import PageHeader from '$lib/components/PageHeader.svelte';
@@ -7,13 +8,14 @@
 	import PageContainer from '$lib/components/PageContainer.svelte';
 	import { toast } from 'svelte-sonner';
 
-	type PageData = { username: string };
+	type PageData = { username: string; email: string | null; emailVerified: boolean };
 	let { data }: { data: PageData } = $props();
 
 	let currentPassword = $state('');
 	let newPassword = $state('');
 	let confirmPassword = $state('');
 	let busy = $state(false);
+	let resendBusy = $state(false);
 
 	const canSubmit = $derived(
 		!busy &&
@@ -58,6 +60,33 @@
 			busy = false;
 		}
 	}
+
+	async function resendVerification() {
+		if (resendBusy) return;
+		resendBusy = true;
+		try {
+			const res = await fetch('/api/auth/verify/resend', { method: 'POST' });
+			if (res.ok) {
+				const body = (await res.json()) as { alreadyVerified?: boolean };
+				toast.success(body.alreadyVerified ? 'Already verified' : 'Verification email sent', {
+					description: body.alreadyVerified ? undefined : `Check ${data.email}.`,
+				});
+				return;
+			}
+			if (res.status === 429) {
+				const body = (await res.json()) as { retry_after_seconds?: number };
+				toast.error('Too many attempts', {
+					description: body.retry_after_seconds
+						? `Try again in ${body.retry_after_seconds}s`
+						: undefined,
+				});
+				return;
+			}
+			toast.error('Could not resend verification email');
+		} finally {
+			resendBusy = false;
+		}
+	}
 </script>
 
 <PageContainer size="default">
@@ -66,6 +95,33 @@
 <PageHeader title="Password" description={`Change the password for ${data.username}.`} />
 
 <div class="mt-4 grid gap-4">
+	{#if data.email}
+		<Card.Root>
+			<Card.Header>
+				<Card.Title class="flex items-center gap-2">
+					Email verification
+					{#if data.emailVerified}
+						<Badge variant="secondary">Verified</Badge>
+					{:else}
+						<Badge variant="destructive">Unverified</Badge>
+					{/if}
+				</Card.Title>
+				<Card.Description>
+					{data.email}
+					{#if !data.emailVerified}
+						- an unverified account can sign in but can't start a run yet.
+					{/if}
+				</Card.Description>
+			</Card.Header>
+			{#if !data.emailVerified}
+				<Card.Content>
+					<Button variant="outline" onclick={resendVerification} disabled={resendBusy}>
+						{resendBusy ? 'Sending…' : 'Resend verification email'}
+					</Button>
+				</Card.Content>
+			{/if}
+		</Card.Root>
+	{/if}
 	<Card.Root>
 		<Card.Header>
 			<Card.Title>Change password</Card.Title>

--- a/web/src/routes/verify/[token]/+page.server.ts
+++ b/web/src/routes/verify/[token]/+page.server.ts
@@ -1,0 +1,13 @@
+import type { PageServerLoad } from './$types';
+
+// Same reasoning as /reset/[token]: the token is never validated here, only
+// on an explicit POST from the page - a `load` that previewed validity
+// would let a plain GET (an attacker-embedded image, a mail scanner
+// prefetching links) burn a single-use token before the real recipient
+// ever clicks it.
+export const load: PageServerLoad = async (event) => {
+  return {
+    authOn: process.env.PITCHBOX_AUTH === 'on',
+    token: event.params.token,
+  };
+};

--- a/web/src/routes/verify/[token]/+page.svelte
+++ b/web/src/routes/verify/[token]/+page.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button';
+	import PageContainer from '$lib/components/PageContainer.svelte';
+	import { toast } from 'svelte-sonner';
+	import Seo from '$lib/components/Seo.svelte';
+
+	let { data }: { data: { authOn: boolean; token: string } } = $props();
+
+	let busy = $state(false);
+	let verified = $state(false);
+	let failed = $state(false);
+
+	// Consumption only happens on an explicit click, never on the page's own
+	// `load` (same reasoning as /invite/[token]: a plain GET can be triggered
+	// by something other than the recipient - an attacker-embedded image, a
+	// mail client prefetching links - and this token is single-use).
+	async function verify() {
+		if (busy) return;
+		busy = true;
+		try {
+			const res = await fetch('/api/auth/verify/confirm', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ token: data.token }),
+			});
+			if (res.ok) {
+				verified = true;
+				toast.success('Email verified', {
+					description: 'You can now start runs on this account.',
+				});
+				return;
+			}
+			if (res.status === 429) {
+				const body = (await res.json()) as { retry_after_seconds?: number };
+				toast.error('Too many attempts', {
+					description: body.retry_after_seconds
+						? `Try again in ${body.retry_after_seconds}s`
+						: undefined,
+				});
+				return;
+			}
+			failed = true;
+			toast.error('This link is no longer valid', {
+				description: 'It may have expired or already been used - request a new one from Settings.',
+			});
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+<Seo title="Verify email - Pitchbox" description="Verify your Pitchbox account email address." />
+
+<PageContainer size="narrow" class="text-center">
+	{#if verified}
+		<h1 class="text-xl font-semibold">Email verified</h1>
+		<p class="mt-2 text-muted-foreground">Your account can now start runs.</p>
+		<Button class="mt-6" onclick={() => goto('/')}>Go to dashboard</Button>
+	{:else if failed}
+		<h1 class="text-xl font-semibold">Link no longer valid</h1>
+		<p class="mt-2 text-muted-foreground">
+			It may have expired or already been used. Request a new link from Settings.
+		</p>
+	{:else}
+		<h1 class="text-xl font-semibold">Verify your email</h1>
+		<p class="mt-2 text-muted-foreground">Confirm this address to start running campaigns.</p>
+		<Button class="mt-6" onclick={verify} disabled={busy}>
+			{busy ? 'Verifying…' : 'Verify email'}
+		</Button>
+	{/if}
+</PageContainer>

--- a/web/tests/email-verification.test.ts
+++ b/web/tests/email-verification.test.ts
@@ -5,6 +5,7 @@ import type { RequestEvent } from '@sveltejs/kit';
 import { getDb, schema } from '@pitchbox/shared/db';
 import { createSession, hashPassword } from '@pitchbox/shared/auth';
 import { createInvite } from '@pitchbox/shared/orgs';
+import { saveRegistrationPolicy } from '@pitchbox/shared/registration-policy';
 import { POST as registerPost } from '../src/routes/api/auth/register/+server.js';
 import { POST as verifyConfirm } from '../src/routes/api/auth/verify/confirm/+server.js';
 import { POST as verifyResend } from '../src/routes/api/auth/verify/resend/+server.js';
@@ -25,6 +26,10 @@ async function reset() {
   await db.execute(sql`DELETE FROM campaigns`);
   await db.execute(sql`DELETE FROM projects`);
   await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  // These tests register without an invite token, which only #505's 'open'
+  // policy allows - the code default is 'invite'. Same reasoning as
+  // register.test.ts's own reset().
+  await saveRegistrationPolicy(db, 'open');
 }
 
 async function seedOrgUser(args: {

--- a/web/tests/email-verification.test.ts
+++ b/web/tests/email-verification.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it, beforeEach, afterAll, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { sql, eq } from 'drizzle-orm';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { createSession, hashPassword } from '@pitchbox/shared/auth';
+import { createInvite } from '@pitchbox/shared/orgs';
+import { POST as registerPost } from '../src/routes/api/auth/register/+server.js';
+import { POST as verifyConfirm } from '../src/routes/api/auth/verify/confirm/+server.js';
+import { POST as verifyResend } from '../src/routes/api/auth/verify/resend/+server.js';
+import { POST as runPost } from '../src/routes/api/run/+server.js';
+import { type CookieJar, runThroughHandle } from './helpers/handle-harness.js';
+
+const originalAuth = process.env.PITCHBOX_AUTH;
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`TRUNCATE email_verification_tokens RESTART IDENTITY CASCADE`);
+  await db.execute(sql`TRUNCATE auth_failures RESTART IDENTITY CASCADE`);
+  await db.execute(sql`DELETE FROM org_invites`);
+  await db.execute(sql`DELETE FROM sessions`);
+  await db.execute(sql`DELETE FROM memberships`);
+  await db.execute(sql`DELETE FROM users`);
+  await db.execute(sql`DELETE FROM app_config WHERE key = 'auth_policy'`);
+  await db.execute(sql`DELETE FROM campaigns`);
+  await db.execute(sql`DELETE FROM projects`);
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function seedOrgUser(args: {
+  username: string;
+  email: string | null;
+  verified?: boolean;
+}): Promise<{ userId: number; orgId: number }> {
+  const db = getDb();
+  const hash = await hashPassword('correct-horse-battery');
+  const [user] = await db
+    .insert(schema.users)
+    .values({
+      username: args.username,
+      passwordHash: hash,
+      email: args.email,
+      emailVerifiedAt: args.verified ? new Date() : null,
+    })
+    .returning();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug: `org-${args.username}`, name: args.username })
+    .returning();
+  await db
+    .insert(schema.memberships)
+    .values({ organizationId: org.id, userId: user.id, role: 'owner' });
+  return { userId: user.id, orgId: org.id };
+}
+
+async function seedOrgWithCampaign(orgId: number) {
+  const db = getDb();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: orgId, slug: 'p', name: 'P' })
+    .returning();
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(sql`slug = 'reddit'`);
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({
+      projectId: project.id,
+      platformId: platform.id,
+      name: 'c',
+      skillSlug: 'reddit-scout',
+    })
+    .returning();
+  return campaign.id;
+}
+
+function jsonRequest(url: string, body: unknown) {
+  return new Request(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function callAndCaptureMail(
+  req: Request,
+  handler: (event: RequestEvent) => Promise<Response>,
+  jar: CookieJar,
+  ip: string,
+) {
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  let res: Response;
+  let logged: string;
+  try {
+    res = await runThroughHandle(
+      req,
+      jar,
+      (event) => handler(event as unknown as RequestEvent),
+      ip,
+    );
+    logged = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+  } finally {
+    logSpy.mockRestore();
+  }
+  const match = logged.match(/\/verify\/([0-9a-f]+)/);
+  return { res, token: match?.[1] ?? null, logged };
+}
+
+describe('email verification (#514)', () => {
+  beforeEach(async () => {
+    process.env.PITCHBOX_AUTH = 'on';
+    await reset();
+  });
+
+  it('a token-less registration sends exactly one verification mail and starts unverified', async () => {
+    const jar: CookieJar = { store: new Map() };
+    const { res, token, logged } = await callAndCaptureMail(
+      jsonRequest('http://localhost/api/auth/register', {
+        username: 'freshsignup',
+        email: 'fresh@example.com',
+        password: 'a-very-long-password',
+      }),
+      registerPost,
+      jar,
+      '10.30.0.1',
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).emailVerified).toBe(false);
+    expect(logged.match(/would send/g)?.length).toBe(1);
+    expect(token).toBeTruthy();
+
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, 'freshsignup'));
+    expect(user.emailVerifiedAt).toBeNull();
+  });
+
+  it('an invite carrying the same address is born verified and sends no mail', async () => {
+    const [admin] = await getDb()
+      .insert(schema.users)
+      .values({ username: 'admin-inv', passwordHash: 'x' })
+      .returning();
+    const [org] = await getDb()
+      .insert(schema.organizations)
+      .values({ slug: 'inv-org', name: 'inv-org' })
+      .returning();
+    await getDb()
+      .insert(schema.memberships)
+      .values({ organizationId: org.id, userId: admin.id, role: 'owner' });
+    const invite = await createInvite(getDb(), {
+      organizationId: org.id,
+      createdByUserId: admin.id,
+      email: 'Invited@Example.com',
+    });
+
+    const jar: CookieJar = { store: new Map() };
+    const { res, logged } = await callAndCaptureMail(
+      jsonRequest('http://localhost/api/auth/register', {
+        username: 'invitedmatch',
+        email: 'invited@example.com',
+        password: 'a-very-long-password',
+        token: invite.token,
+      }),
+      registerPost,
+      jar,
+      '10.30.1.1',
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).emailVerified).toBe(true);
+    expect(logged).toBe('');
+
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, 'invitedmatch'));
+    expect(user.emailVerifiedAt).not.toBeNull();
+  });
+
+  it('a verification token works exactly once and an expired one is refused', async () => {
+    const jar: CookieJar = { store: new Map() };
+    const { token } = await callAndCaptureMail(
+      jsonRequest('http://localhost/api/auth/register', {
+        username: 'onceonly',
+        email: 'once@example.com',
+        password: 'a-very-long-password',
+      }),
+      registerPost,
+      jar,
+      '10.30.2.1',
+    );
+    expect(token).toBeTruthy();
+
+    const jar2: CookieJar = { store: new Map() };
+    const first = await runThroughHandle(
+      jsonRequest('http://localhost/api/auth/verify/confirm', { token }),
+      jar2,
+      (event) => verifyConfirm(event as unknown as RequestEvent),
+      '10.30.2.2',
+    );
+    expect(first.status).toBe(200);
+
+    const [user] = await getDb()
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, 'onceonly'));
+    expect(user.emailVerifiedAt).not.toBeNull();
+
+    const jar3: CookieJar = { store: new Map() };
+    const second = await runThroughHandle(
+      jsonRequest('http://localhost/api/auth/verify/confirm', { token }),
+      jar3,
+      (event) => verifyConfirm(event as unknown as RequestEvent),
+      '10.30.2.3',
+    );
+    expect(second.status).toBe(400);
+    expect(await second.json()).toEqual({ error: 'invalid_or_expired_token' });
+
+    // Expired token, independent of use.
+    const { token: token2 } = await callAndCaptureMail(
+      jsonRequest('http://localhost/api/auth/register', {
+        username: 'expiretest',
+        email: 'expire@example.com',
+        password: 'a-very-long-password',
+      }),
+      registerPost,
+      { store: new Map() },
+      '10.30.2.4',
+    );
+    const tokenHash = createHash('sha256').update(token2!).digest('hex');
+    await getDb()
+      .update(schema.emailVerificationTokens)
+      .set({ expiresAt: new Date(Date.now() - 1000) })
+      .where(eq(schema.emailVerificationTokens.tokenHash, tokenHash));
+    const expiredRes = await runThroughHandle(
+      jsonRequest('http://localhost/api/auth/verify/confirm', { token: token2 }),
+      { store: new Map() },
+      (event) => verifyConfirm(event as unknown as RequestEvent),
+      '10.30.2.5',
+    );
+    expect(expiredRes.status).toBe(400);
+    expect(await expiredRes.json()).toEqual({ error: 'invalid_or_expired_token' });
+  });
+
+  it('resend is rate limited per address after the policy max, and skips the limit once already verified', async () => {
+    const { userId } = await seedOrgUser({
+      username: 'resender',
+      email: 'resend@example.com',
+      verified: false,
+    });
+    for (let i = 0; i < 5; i++) {
+      const session = await createSession(getDb(), userId);
+      const jar: CookieJar = { store: new Map([['pitchbox_session', { value: session.id }]]) };
+      const res = await runThroughHandle(
+        new Request('http://localhost/api/auth/verify/resend', { method: 'POST' }),
+        jar,
+        (event) => verifyResend(event as unknown as RequestEvent),
+        `10.30.3.${i}`,
+      );
+      expect(res.status).toBe(200);
+    }
+    const session = await createSession(getDb(), userId);
+    const jar: CookieJar = { store: new Map([['pitchbox_session', { value: session.id }]]) };
+    const locked = await runThroughHandle(
+      new Request('http://localhost/api/auth/verify/resend', { method: 'POST' }),
+      jar,
+      (event) => verifyResend(event as unknown as RequestEvent),
+      '10.30.3.90',
+    );
+    expect(locked.status).toBe(429);
+
+    const { userId: verifiedId } = await seedOrgUser({
+      username: 'alreadyok',
+      email: 'ok@example.com',
+      verified: true,
+    });
+    for (let i = 0; i < 7; i++) {
+      const s = await createSession(getDb(), verifiedId);
+      const j: CookieJar = { store: new Map([['pitchbox_session', { value: s.id }]]) };
+      const r = await runThroughHandle(
+        new Request('http://localhost/api/auth/verify/resend', { method: 'POST' }),
+        j,
+        (event) => verifyResend(event as unknown as RequestEvent),
+        `10.30.4.${i}`,
+      );
+      expect(r.status).toBe(200);
+      expect((await r.json()).alreadyVerified).toBe(true);
+    }
+  });
+
+  it("an unverified account's run dispatch is refused server-side with a distinct reason, a verified one is admitted past the gate", async () => {
+    const { userId: unverifiedId, orgId: unverifiedOrg } = await seedOrgUser({
+      username: 'nogo',
+      email: 'nogo@example.com',
+      verified: false,
+    });
+    const campaignId = await seedOrgWithCampaign(unverifiedOrg);
+    const unverifiedSession = await createSession(getDb(), unverifiedId);
+    const unverifiedJar: CookieJar = {
+      store: new Map([['pitchbox_session', { value: unverifiedSession.id }]]),
+    };
+    await expect(
+      runThroughHandle(
+        jsonRequest('http://localhost/api/run', { campaignId }),
+        unverifiedJar,
+        (event) => runPost(event as unknown as RequestEvent),
+        '10.30.5.1',
+      ),
+    ).rejects.toMatchObject({ status: 403, body: { message: 'email_unverified' } });
+
+    const { userId: verifiedId, orgId: verifiedOrg } = await seedOrgUser({
+      username: 'gogo',
+      email: 'gogo@example.com',
+      verified: true,
+    });
+    const verifiedCampaignId = await seedOrgWithCampaign(verifiedOrg);
+    const verifiedSession = await createSession(getDb(), verifiedId);
+    const verifiedJar: CookieJar = {
+      store: new Map([['pitchbox_session', { value: verifiedSession.id }]]),
+    };
+    // Past the email gate, it reaches campaign readiness next (the seeded
+    // campaign has no config, so it fails there with a plain 422, not the
+    // 403 email_unverified refusal) - proof the gate let a verified caller
+    // through rather than proof of a full dispatch, which spawns a real
+    // agent (see tests/draft-regenerate.test.ts's own note on that).
+    const res = await runThroughHandle(
+      jsonRequest('http://localhost/api/run', { campaignId: verifiedCampaignId }),
+      verifiedJar,
+      (event) => runPost(event as unknown as RequestEvent),
+      '10.30.5.2',
+    );
+    expect(res.status).toBe(422);
+  });
+});
+
+afterAll(async () => {
+  if (originalAuth === undefined) delete process.env.PITCHBOX_AUTH;
+  else process.env.PITCHBOX_AUTH = originalAuth;
+});

--- a/web/tests/register.test.ts
+++ b/web/tests/register.test.ts
@@ -59,6 +59,11 @@ function makeEvent(body: unknown, jar: CookieJar, ip = '10.1.0.1'): RequestEvent
   });
   return {
     request,
+    // #514: the register route now builds the verification link from
+    // `event.url.origin`, same convention as /api/auth/password/forgot -
+    // this hand-rolled event needs a `url` for that, same as it already
+    // needs `request`/`cookies`/`getClientAddress`.
+    url: new URL(request.url),
     cookies: makeCookies(jar),
     getClientAddress: () => ip,
   } as unknown as RequestEvent;

--- a/web/tests/run-dispatch-email-gate.test.ts
+++ b/web/tests/run-dispatch-email-gate.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+// #514 follow-up (per Main's review of PR #562): the run-dispatch email
+// gate lived in six hand-picked route handlers, so a seventh route added
+// next month simply would not have it and nothing would fail - the same
+// failure mode #358 had (a switch checked where it was read, not where it
+// takes effect). This walks the real route tree and derives the set of
+// routes that reach the run dispatch path from the source itself, rather
+// than trusting a hardcoded list, so a new route wired to one of these
+// dispatch functions fails this test until it calls requireVerifiedEmail.
+//
+// `web/src/routes/api/extension/**` is excluded on purpose, not by
+// oversight: it is bearer-token/per-device authenticated, a different trust
+// boundary than the session-cookie dashboard (see hooks.server.ts's
+// isExemptPath and docs/permissions.md) - `POST /api/extension/dm-sync`
+// fires `runReplyDrafting` from a device poll with no live session to gate,
+// the same way the daemon's own internal /api/run dispatch has none.
+const ROUTES_ROOT = new URL('../src/routes/api', import.meta.url).pathname;
+
+// The runner functions that actually spawn an agent run
+// (web/src/lib/server/runner.ts) - not `cancelRun`, which stops one instead
+// of spending anything new.
+const DISPATCH_FUNCTIONS = [
+  'runCampaign',
+  'runProjectExtraction',
+  'runProjectInsights',
+  'runDraftRegeneration',
+  'runReplyDrafting',
+  'runCampaignSkillGeneration',
+];
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      walk(full, out);
+    } else if (name === '+server.ts') {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** True if `source` imports at least one dispatch function from runner.ts. */
+function importsADispatchFunction(source: string): string[] {
+  // Matches `import { a, b } from '.../lib/server/runner.js'` regardless of
+  // relative vs `$lib` import style - every route above uses one or the
+  // other.
+  const importBlock = /import\s*\{([^}]+)\}\s*from\s*['"][^'"]*lib\/server\/runner\.js['"]/g;
+  const names = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = importBlock.exec(source))) {
+    for (const raw of match[1].split(',')) {
+      const name = raw.trim();
+      if (DISPATCH_FUNCTIONS.includes(name)) names.add(name);
+    }
+  }
+  return [...names];
+}
+
+describe('every session-authenticated run-dispatch route calls requireVerifiedEmail (#514)', () => {
+  const files = walk(ROUTES_ROOT).filter(
+    (f) => !relative(ROUTES_ROOT, f).split('/').includes('extension'),
+  );
+  // Sanity: this must actually find routes, or the walk itself is broken
+  // and every assertion below would vacuously pass.
+  expect(files.length).toBeGreaterThan(20);
+
+  const dispatchRoutes = files
+    .map((f) => ({ file: f, source: readFileSync(f, 'utf8') }))
+    .map(({ file, source }) => ({ file, source, calls: importsADispatchFunction(source) }))
+    .filter(({ calls }) => calls.length > 0);
+
+  // Sanity: this is exactly the set PR #562 gated (plus the one it missed,
+  // projects/[id]/insights) - if this count drifts to 0, the regex above
+  // broke rather than the routes disappearing.
+  it('finds at least one dispatch route to check', () => {
+    expect(dispatchRoutes.length).toBeGreaterThan(0);
+  });
+
+  for (const { file, source, calls } of dispatchRoutes) {
+    const label = relative(ROUTES_ROOT, file);
+    it(`${label} (calls ${calls.join(', ')}) calls requireVerifiedEmail before dispatching`, () => {
+      expect(source).toContain('requireVerifiedEmail(');
+    });
+  }
+});


### PR DESCRIPTION
Closes #514

Adds `users.email_verified_at` plus single-use, hashed, 48-hour email verification tokens (`email_verification_tokens`), following #509's password-reset shape exactly. Registration sends exactly one verification mail through the existing transport, link built from the request's own origin. An invite whose invite carried the exact same address is born verified with no mail sent.

**Decision (recorded on #514 and in docs/auth.md):** an unverified account can sign in and look around but cannot start a run - a run spends real money and is the one action worth protecting from a throwaway signup. Enforced server-side via `requireVerifiedEmail` (`web/src/lib/server/auth.ts`), called at the top of every route that dispatches a run (`POST /api/run`, `POST /api/campaigns`, `POST /api/campaigns/[id]/skill-runs`, `POST /api/projects/[id]/runs`, `POST /api/drafts/[id]/regenerate`, `POST /api/drafts/[id]/reply-draft/retry`) before any of them reach `web/src/lib/server/runner.ts`.

Resend is rate limited per address and per IP, reusing the `auth_failures` bucket and `loadAuthPolicy` register/login already use. `/settings/password` shows verification status with a resend button.

Tests: `web/tests/email-verification.test.ts` (exactly-one-mail, invite-match verification, token single-use + expiry, resend rate limit, run-dispatch refusal proven by breaking `requireVerifiedEmail` and watching the exact assertion fail) plus `web/tests/register.test.ts` updated for the new mail-link requirement.

**Migration pending:** per this wave's coordination plan, #522 owns the first migration slot in `shared/src/db/migrations/`. `schema.ts` already carries the new column/table; I generate and push the actual migration once #522 merges to `main` and I rebase - tracked as a follow-up push to this same branch/PR, not a separate PR.