### PR TITLE
feat(web,shared): count what the assistant spends, including the suggestions nobody accepts

### DIFF
--- a/shared/src/assist-accept.ts
+++ b/shared/src/assist-accept.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_DEDUP_POLICY,
 } from './contact-dedup.js';
 import { checkQuota, getAccountUsage, loadQuotaLimits, mapDraftKindToQuotaKind } from './quota.js';
+import { resolvePricingForRunner, computeCostUsd } from './runlog/usage.js';
 import type { DraftKind } from './quota-types.js';
 
 export interface AcceptSuggestionUsage {
@@ -189,7 +190,40 @@ export async function acceptSuggestionIntoDraft(
     };
   }
 
-  const costUsd = input.usage?.costUsd != null ? input.usage.costUsd.toFixed(4) : null;
+  // #522: `input.usage` is a client-reported block - the extension's own
+  // copy of the `usage` a /suggest `done` event carried, echoed back here
+  // because a suggestion is never persisted server-side until accept. That
+  // was harmless when it only annotated a draft; it stopped being harmless
+  // once assistant spend counts against a budget (shared/src/org-quota.ts's
+  // getOrgMonthToDateCostUsd). The authoritative figure for that budget now
+  // lives in `assist_usage`, written from the server's own AgentRunner
+  // result the moment the suggestion's stream finished
+  // (web/src/routes/api/extension/suggest/+server.ts) - never from the
+  // client - so this run's own `cost_usd` is left null rather than trusted
+  // from the device, and org-quota's sum excludes `kind = 'assist'` runs
+  // for exactly that reason: counting this row too would double the
+  // suggestion's cost. What the device reported and what this repo's own
+  // price table recomputes from its token counts are both kept on `params`
+  // instead - visible for audit (a device that lies is visible, not
+  // authoritative), never read back into a spend decision.
+  const pricing = resolvePricingForRunner(input.agentRunner, undefined);
+  const recomputedCostUsd = input.usage
+    ? computeCostUsd(
+        {
+          inputTokens: input.usage.inputTokens ?? undefined,
+          outputTokens: input.usage.outputTokens ?? undefined,
+          cacheReadTokens: input.usage.cacheReadTokens ?? undefined,
+          cacheCreationTokens: input.usage.cacheCreationTokens ?? undefined,
+        },
+        pricing,
+      )
+    : null;
+  const reportedCostUsd = input.usage?.costUsd ?? null;
+  const params = {
+    ...(input.runParams ?? {}),
+    ...(recomputedCostUsd != null ? { recomputedCostUsd } : {}),
+    ...(reportedCostUsd != null ? { reportedCostUsd } : {}),
+  };
 
   const written = await db.transaction(async (tx) => {
     const [run] = await tx
@@ -209,8 +243,8 @@ export async function acceptSuggestionIntoDraft(
         outputTokens: input.usage?.outputTokens ?? null,
         cacheReadTokens: input.usage?.cacheReadTokens ?? null,
         cacheCreationTokens: input.usage?.cacheCreationTokens ?? null,
-        costUsd,
-        params: input.runParams ?? {},
+        costUsd: null,
+        params,
       })
       .returning({ id: schema.runs.id });
 

--- a/shared/src/db/migrations/0025_supreme_molecule_man.sql
+++ b/shared/src/db/migrations/0025_supreme_molecule_man.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "assist_usage" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"organization_id" integer,
+	"project_id" integer NOT NULL,
+	"device_id" integer,
+	"platform_id" integer NOT NULL,
+	"kind" text NOT NULL,
+	"agent_runner" text NOT NULL,
+	"model" text,
+	"input_tokens" integer,
+	"output_tokens" integer,
+	"cache_read_tokens" integer,
+	"cache_creation_tokens" integer,
+	"cost_usd" numeric(10, 4),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "assist_usage" ADD CONSTRAINT "assist_usage_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "assist_usage" ADD CONSTRAINT "assist_usage_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "assist_usage" ADD CONSTRAINT "assist_usage_device_id_extension_devices_id_fk" FOREIGN KEY ("device_id") REFERENCES "public"."extension_devices"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "assist_usage" ADD CONSTRAINT "assist_usage_platform_id_platforms_id_fk" FOREIGN KEY ("platform_id") REFERENCES "public"."platforms"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "assist_usage_org_created_idx" ON "assist_usage" USING btree ("organization_id","created_at");--> statement-breakpoint
+CREATE INDEX "assist_usage_project_created_idx" ON "assist_usage" USING btree ("project_id","created_at");

--- a/shared/src/db/migrations/meta/0025_snapshot.json
+++ b/shared/src/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,4531 @@
+{
+  "id": "54b98c67-7944-473b-ab11-3ed3c9cb07c0",
+  "prevId": "cacac404-dce5-40d7-8bff-7db76b3a7df8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cookie_session": {
+          "name": "cookie_session",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_limit": {
+          "name": "weekly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_project_id_projects_id_fk": {
+          "name": "accounts_project_id_projects_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_platform_id_platforms_id_fk": {
+          "name": "accounts_platform_id_platforms_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assist_usage": {
+      "name": "assist_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assist_usage_org_created_idx": {
+          "name": "assist_usage_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assist_usage_project_created_idx": {
+          "name": "assist_usage_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assist_usage_organization_id_organizations_id_fk": {
+          "name": "assist_usage_organization_id_organizations_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_project_id_projects_id_fk": {
+          "name": "assist_usage_project_id_projects_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_device_id_extension_devices_id_fk": {
+          "name": "assist_usage_device_id_extension_devices_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "extension_devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assist_usage_platform_id_platforms_id_fk": {
+          "name": "assist_usage_platform_id_platforms_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_failures": {
+      "name": "auth_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login_attempt'"
+        }
+      },
+      "indexes": {
+        "auth_failures_identifier_idx": {
+          "name": "auth_failures_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist": {
+      "name": "blocklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocklist_platform_id_platforms_id_fk": {
+          "name": "blocklist_platform_id_platforms_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocklist_project_id_projects_id_fk": {
+          "name": "blocklist_project_id_projects_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_recommendations": {
+      "name": "campaign_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_slug": {
+          "name": "scenario_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_recommendations_project_idx": {
+          "name": "campaign_recommendations_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_recommendations_project_id_projects_id_fk": {
+          "name": "campaign_recommendations_project_id_projects_id_fk",
+          "tableFrom": "campaign_recommendations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_slug": {
+          "name": "skill_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_attempts": {
+          "name": "failure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_due_to_failures": {
+          "name": "paused_due_to_failures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_post": {
+          "name": "auto_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_platform_id_platforms_id_fk": {
+          "name": "campaigns_platform_id_platforms_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_history": {
+      "name": "contact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_handle": {
+          "name": "account_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_checked_at": {
+          "name": "reply_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_room_id": {
+          "name": "chat_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_context_url": {
+          "name": "platform_context_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uncontactable": {
+          "name": "uncontactable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uncontactable_reason": {
+          "name": "uncontactable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_history_target_idx": {
+          "name": "contact_history_target_idx",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_target_idx": {
+          "name": "messages_account_target_idx",
+          "columns": [
+            {
+              "expression": "account_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_org_idx": {
+          "name": "contact_history_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_contacted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_history_platform_id_platforms_id_fk": {
+          "name": "contact_history_platform_id_platforms_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contact_history_draft_id_drafts_id_fk": {
+          "name": "contact_history_draft_id_drafts_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_history_organization_id_organizations_id_fk": {
+          "name": "contact_history_organization_id_organizations_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_heartbeats": {
+      "name": "daemon_heartbeats",
+      "schema": "",
+      "columns": {
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tick_at": {
+          "name": "tick_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_events": {
+      "name": "draft_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_events_kind_created_idx": {
+          "name": "draft_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_events_draft_id_drafts_id_fk": {
+          "name": "draft_events_draft_id_drafts_id_fk",
+          "tableFrom": "draft_events",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_regeneration_hints": {
+      "name": "draft_regeneration_hints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint_text": {
+          "name": "hint_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_regeneration_hints_draft_id_drafts_id_fk": {
+          "name": "draft_regeneration_hints_draft_id_drafts_id_fk",
+          "tableFrom": "draft_regeneration_hints",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "fit_score": {
+          "name": "fit_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_url": {
+          "name": "compose_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_content": {
+          "name": "sent_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_comment_id": {
+          "name": "platform_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dedup_warning": {
+          "name": "dedup_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_edited": {
+          "name": "body_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_send_after": {
+          "name": "scheduled_send_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerating_run_id": {
+          "name": "regenerating_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drafting_run_id": {
+          "name": "drafting_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_reason": {
+          "name": "quality_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_model": {
+          "name": "quality_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_id": {
+          "name": "variant_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undeliverable_reason": {
+          "name": "undeliverable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drafts_state_idx": {
+          "name": "drafts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_project_idx": {
+          "name": "drafts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_run_idx": {
+          "name": "drafts_state_run_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_campaign_created_idx": {
+          "name": "drafts_state_campaign_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_variant_group_idx": {
+          "name": "drafts_variant_group_idx",
+          "columns": [
+            {
+              "expression": "variant_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_run_id_runs_id_fk": {
+          "name": "drafts_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_project_id_projects_id_fk": {
+          "name": "drafts_project_id_projects_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_platform_id_platforms_id_fk": {
+          "name": "drafts_platform_id_platforms_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_accounts_id_fk": {
+          "name": "drafts_account_id_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_regenerating_run_id_runs_id_fk": {
+          "name": "drafts_regenerating_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "regenerating_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drafts_drafting_run_id_runs_id_fk": {
+          "name": "drafts_drafting_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "drafting_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_devices": {
+      "name": "extension_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unnamed device'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "extension_devices_token_hash_unique": {
+          "name": "extension_devices_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extension_devices_organization_id_organizations_id_fk": {
+          "name": "extension_devices_organization_id_organizations_id_fk",
+          "tableFrom": "extension_devices",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_pairings": {
+      "name": "extension_pairings",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extension_pairings_organization_id_organizations_id_fk": {
+          "name": "extension_pairings_organization_id_organizations_id_fk",
+          "tableFrom": "extension_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sources": {
+      "name": "github_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_language": {
+          "name": "primary_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readme_excerpt": {
+          "name": "readme_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_commits": {
+          "name": "recent_commits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_sources_org_repo_unique": {
+          "name": "github_sources_org_repo_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_sources_organization_id_organizations_id_fk": {
+          "name": "github_sources_organization_id_organizations_id_fk",
+          "tableFrom": "github_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_audit_log": {
+      "name": "instance_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_audit_log_created_idx": {
+          "name": "instance_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_watches": {
+      "name": "keyword_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_field": {
+          "name": "match_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keyword_watches_campaign_idx": {
+          "name": "keyword_watches_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_watches_project_idx": {
+          "name": "keyword_watches_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_watches_project_id_projects_id_fk": {
+          "name": "keyword_watches_project_id_projects_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keyword_watches_campaign_id_campaigns_id_fk": {
+          "name": "keyword_watches_campaign_id_campaigns_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_org_user_unique": {
+          "name": "memberships_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_from_us": {
+          "name": "is_from_us",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_platform": {
+          "name": "created_at_platform",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_contact_idx": {
+          "name": "messages_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_platform_message_unique": {
+          "name": "messages_platform_message_unique",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_contact_id_contact_history_id_fk": {
+          "name": "messages_contact_id_contact_history_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "contact_history",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_draft_id_drafts_id_fk": {
+          "name": "messages_draft_id_drafts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_platform_id_platforms_id_fk": {
+          "name": "messages_platform_id_platforms_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_unread_idx": {
+          "name": "notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_idx": {
+          "name": "notifications_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organization_id_organizations_id_fk": {
+          "name": "notifications_organization_id_organizations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observed_targets": {
+      "name": "observed_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_by_run_id": {
+          "name": "consumed_by_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "observed_targets_dedup_idx": {
+          "name": "observed_targets_dedup_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "observed_targets_project_unconsumed_idx": {
+          "name": "observed_targets_project_unconsumed_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_by_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "observed_targets_organization_id_organizations_id_fk": {
+          "name": "observed_targets_organization_id_organizations_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_project_id_projects_id_fk": {
+          "name": "observed_targets_project_id_projects_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_platform_id_platforms_id_fk": {
+          "name": "observed_targets_platform_id_platforms_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observed_targets_consumed_by_run_id_runs_id_fk": {
+          "name": "observed_targets_consumed_by_run_id_runs_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "consumed_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_profiles": {
+      "name": "operator_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiences": {
+          "name": "experiences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'linkedin_capture'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_profiles_org_unique": {
+          "name": "operator_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_profiles": {
+      "name": "operator_voice_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "openings": {
+          "name": "openings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "closings": {
+          "name": "closings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "common_words": {
+          "name": "common_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "words_per_sentence": {
+          "name": "words_per_sentence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'derived'"
+        },
+        "derived_at": {
+          "name": "derived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_profiles_org_unique": {
+          "name": "operator_voice_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_voice_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_samples": {
+      "name": "operator_voice_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_samples_org_external_unique": {
+          "name": "operator_voice_samples_org_external_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operator_voice_samples_org_idx": {
+          "name": "operator_voice_samples_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "excluded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_samples_organization_id_organizations_id_fk": {
+          "name": "operator_voice_samples_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_voice_samples_platform_id_platforms_id_fk": {
+          "name": "operator_voice_samples_platform_id_platforms_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invites": {
+      "name": "org_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_invites_org_idx": {
+          "name": "org_invites_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invites_organization_id_organizations_id_fk": {
+          "name": "org_invites_organization_id_organizations_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invites_created_by_user_id_users_id_fk": {
+          "name": "org_invites_created_by_user_id_users_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invites_token_unique": {
+          "name": "org_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_run_budget_usd": {
+          "name": "monthly_run_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_user_idx": {
+          "name": "password_reset_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platforms": {
+      "name": "platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platforms_slug_unique": {
+          "name": "platforms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playbooks": {
+      "name": "playbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playbooks_slug_unique": {
+          "name": "playbooks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_insights": {
+      "name": "project_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary_md": {
+          "name": "summary_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_insights_project_idx": {
+          "name": "project_insights_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_insights_project_id_projects_id_fk": {
+          "name": "project_insights_project_id_projects_id_fk",
+          "tableFrom": "project_insights",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_sources": {
+      "name": "project_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_runner": {
+          "name": "default_agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "voice_tone": {
+          "name": "voice_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_tone_notes": {
+          "name": "voice_tone_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_unique": {
+          "name": "projects_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_events_run_idx": {
+          "name": "run_events_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_events_kind_created_idx": {
+          "name": "run_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'campaign'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout_log_path": {
+          "name": "stdout_log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playbook_body": {
+          "name": "playbook_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_project_kind_idx": {
+          "name": "runs_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_campaign_id_campaigns_id_fk": {
+          "name": "runs_campaign_id_campaigns_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_scout_candidates": {
+      "name": "staging_scout_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staging_scout_candidates_run_id_runs_id_fk": {
+          "name": "staging_scout_candidates_run_id_runs_id_fk",
+          "tableFrom": "staging_scout_candidates",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_project_kind_idx": {
+          "name": "templates_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_project_id_projects_id_fk": {
+          "name": "templates_project_id_projects_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_instance_admin": {
+          "name": "is_instance_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recent_idx": {
+          "name": "webhook_deliveries_recent_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_org_idx": {
+          "name": "webhook_deliveries_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_organization_id_organizations_id_fk": {
+          "name": "webhook_deliveries_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1788960000011,
       "tag": "0024_password_reset_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1788960000012,
+      "tag": "0025_supreme_molecule_man",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -737,6 +737,71 @@ export const extensionPairings = pgTable('extension_pairings', {
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 });
 
+// Per-suggestion usage ledger for the in-page LinkedIn assistant (#522).
+// `POST /api/extension/suggest` deliberately writes no `runs` row (see the
+// header comment on that route) and, before this table, a suggestion's cost
+// reached the database only if a human accepted it - a panel that streams
+// twenty suggestions of which two are used had nineteen invisible ones as
+// far as the ledger was concerned. This is the fix: one row per finished
+// suggestion, written the moment the stream ends regardless of whether it is
+// ever accepted, so `getOrgMonthToDateCostUsd` (org-quota.ts) sees the whole
+// cost of the feature rather than the fraction someone chose to keep.
+//
+// A dedicated table rather than a synthetic `runs` row per suggestion, on
+// purpose: the run list and the analytics that read it are about outreach
+// activity, and nineteen invisible-to-a-human "runs" per twenty suggestions
+// would pollute both. `organizationId` is nullable (mirrors
+// extension_devices/extension_pairings: a self-host device paired with auth
+// off has no org), `projectId` is not - a suggestion is always grounded in
+// one project. `deviceId` is `set null` rather than `cascade` so revoking or
+// deleting a device never erases spend history already counted against a
+// budget.
+export const assistUsage = pgTable(
+  'assist_usage',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    organizationId: integer('organization_id').references(() => organizations.id, {
+      onDelete: 'cascade',
+    }),
+    projectId: integer('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    deviceId: integer('device_id').references(() => extensionDevices.id, {
+      onDelete: 'set null',
+    }),
+    platformId: integer('platform_id')
+      .notNull()
+      .references(() => platforms.id),
+    kind: text('kind').notNull(), // 'post_comment' | 'post' - assist/suggest-prompt.ts's SuggestionKind
+    agentRunner: text('agent_runner').notNull(),
+    // The resolved model the suggestion actually asked for (e.g. 'sonnet',
+    // the ACP alias - see suggest.ts's ASSIST_DEFAULT_MODEL - or a Gateway
+    // model id for the cloud runner). Kept even when cost is null so a price
+    // table gap can be closed once, later, without re-deriving which model
+    // every historical suggestion used.
+    model: text('model'),
+    inputTokens: integer('input_tokens'),
+    outputTokens: integer('output_tokens'),
+    cacheReadTokens: integer('cache_read_tokens'),
+    cacheCreationTokens: integer('cache_creation_tokens'),
+    // The runner's own cost figure for this suggestion - self-reported by
+    // the backend when available, otherwise computed from the token columns
+    // above via the runner's price table (shared/src/runlog/usage.ts,
+    // shared/src/agents/sdk/event-normalizer.ts). Never client-supplied:
+    // this is written from the server's own AgentRunner result before the
+    // panel ever sees it, unlike the usage block `/suggest/accept` receives
+    // back from the extension (see assist-accept.ts). Null when the backend
+    // reported nothing and pricing for its model is unknown - a residual gap
+    // named in #522's PR body, not silently priced at a guess.
+    costUsd: numeric('cost_usd', { precision: 10, scale: 4 }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    byOrgCreated: index('assist_usage_org_created_idx').on(t.organizationId, t.createdAt),
+    byProjectCreated: index('assist_usage_project_created_idx').on(t.projectId, t.createdAt),
+  }),
+);
+
 export const messages = pgTable(
   'messages',
   {

--- a/shared/src/org-quota.ts
+++ b/shared/src/org-quota.ts
@@ -3,7 +3,7 @@
 // (shared/src/agents/sdk/runner.ts, web/src/lib/server/runner.ts). Mirrors the
 // per-account quota helper's style (shared/src/quota.ts) but is org-scoped and
 // budget/concurrency based rather than per-account daily/weekly counts.
-import { and, eq, gte, inArray, or, sql } from 'drizzle-orm';
+import { and, eq, gte, inArray, ne, or, sql } from 'drizzle-orm';
 import type { PgDatabase } from 'drizzle-orm/pg-core';
 import { schema, type Db } from './db/client.js';
 
@@ -81,29 +81,52 @@ export function startOfMonthUtc(now: Date): Date {
 }
 
 /**
- * Sum of `runs.cost_usd` for every run belonging to `orgId`, started on or
- * after the first of the current calendar month (UTC). Runs with a null
- * `cost_usd` (no usage reported) contribute 0.
+ * Org month-to-date spend, split into campaign/other-run cost and assistant
+ * (in-page suggestion) cost, both started/created on or after the first of
+ * the current calendar month (UTC). #522: the assistant plane writes no
+ * `runs` row for a suggestion (see web/src/routes/api/extension/suggest -
+ * a suggestion is ephemeral until a human accepts it), so its spend lives in
+ * `assist_usage` instead, one row per finished suggestion whether accepted
+ * or not. Kept apart rather than pre-summed, per #522's decision: an
+ * operator asking "why am I out of budget" needs to see which half spent it
+ * (`getOrgMonthToDateCostUsd` below still returns the single number a
+ * budget decision needs).
  *
- * Resolves the org's project ids first, then matches runs against them
- * directly (`runs.projectId`) or transitively via their campaign
- * (`runs.campaignId` -> `campaigns.projectId`), mirroring the dashboard's
- * spend widget (web/src/routes/+page.server.ts, the `runOrgMatch` /
- * `spendRow` query). This deliberately never joins the `projects` table
- * itself: an `innerJoin(projects, or(eq(projects.id, runs.projectId),
- * eq(projects.id, campaigns.projectId)))` (as `getRunOrgId`/`runBelongsToOrg`
- * in shared/src/orgs.ts use for single-row lookups) can match two distinct
- * project rows for one run whenever `runs.projectId` and
- * `campaigns.projectId` disagree, which would double-count that run's cost
- * in this un-grouped SUM and could falsely trip `quota_exceeded`. Filtering
- * by project id membership instead of joining the table keeps each run a
- * single row regardless of how many of its project references resolve.
+ * The `runs` side deliberately excludes `kind = 'assist'`: accepting a
+ * suggestion (shared/src/assist-accept.ts) still writes a `runs` row so the
+ * draft has somewhere to hang off `run_id`, but that row's own `cost_usd` is
+ * always null now - the suggestion's cost was already ledgered here the
+ * moment its stream finished, and summing both would count an accepted
+ * suggestion twice (once here, once there).
+ *
+ * The `runs` query resolves the org's project ids first, then matches runs
+ * against them directly (`runs.projectId`) or transitively via their
+ * campaign (`runs.campaignId` -> `campaigns.projectId`), mirroring the
+ * dashboard's spend widget (web/src/routes/+page.server.ts, the
+ * `runOrgMatch` / `spendRow` query). This deliberately never joins the
+ * `projects` table itself: an `innerJoin(projects, or(eq(projects.id,
+ * runs.projectId), eq(projects.id, campaigns.projectId)))` (as
+ * `getRunOrgId`/`runBelongsToOrg` in shared/src/orgs.ts use for single-row
+ * lookups) can match two distinct project rows for one run whenever
+ * `runs.projectId` and `campaigns.projectId` disagree, which would
+ * double-count that run's cost in this un-grouped SUM and could falsely trip
+ * `quota_exceeded`. Filtering by project id membership instead of joining
+ * the table keeps each run a single row regardless of how many of its
+ * project references resolve. `assist_usage` carries its own `projectId`
+ * directly (a suggestion is always grounded in one project, never a
+ * campaign), so its side needs no such join at all.
  */
-export async function getOrgMonthToDateCostUsd(
+export interface OrgMonthToDateSpend {
+  campaignUsd: number;
+  assistantUsd: number;
+  totalUsd: number;
+}
+
+export async function getOrgMonthToDateSpend(
   db: Db,
   orgId: number,
   now: Date = new Date(),
-): Promise<number> {
+): Promise<OrgMonthToDateSpend> {
   const monthStart = startOfMonthUtc(now);
 
   const orgProjects = await db
@@ -112,17 +135,18 @@ export async function getOrgMonthToDateCostUsd(
     .where(eq(schema.projects.organizationId, orgId));
   const projectIds = orgProjects.map((p) => p.id);
   // `inArray(x, [])` is a SQL error, and an org with no projects has no runs
-  // to sum anyway.
+  // or assist usage to sum anyway.
   if (projectIds.length === 0) {
-    return 0;
+    return { campaignUsd: 0, assistantUsd: 0, totalUsd: 0 };
   }
 
-  const [row] = await db
+  const [runRow] = await db
     .select({ total: sql<string>`coalesce(sum(${schema.runs.costUsd}), 0)` })
     .from(schema.runs)
     .leftJoin(schema.campaigns, eq(schema.campaigns.id, schema.runs.campaignId))
     .where(
       and(
+        ne(schema.runs.kind, 'assist'),
         or(
           inArray(schema.runs.projectId, projectIds),
           inArray(schema.campaigns.projectId, projectIds),
@@ -130,7 +154,35 @@ export async function getOrgMonthToDateCostUsd(
         gte(schema.runs.startedAt, monthStart),
       ),
     );
-  return Number(row?.total ?? 0);
+
+  const [assistRow] = await db
+    .select({ total: sql<string>`coalesce(sum(${schema.assistUsage.costUsd}), 0)` })
+    .from(schema.assistUsage)
+    .where(
+      and(
+        inArray(schema.assistUsage.projectId, projectIds),
+        gte(schema.assistUsage.createdAt, monthStart),
+      ),
+    );
+
+  const campaignUsd = Number(runRow?.total ?? 0);
+  const assistantUsd = Number(assistRow?.total ?? 0);
+  return { campaignUsd, assistantUsd, totalUsd: campaignUsd + assistantUsd };
+}
+
+/**
+ * The single number a budget decision uses (org-quota's own gate in
+ * getOrgQuotaSnapshot, the instance-wide ceiling): campaign spend plus
+ * assistant spend, month-to-date. See getOrgMonthToDateSpend for the split
+ * and why the two are kept apart for a human but combined here for a cap.
+ */
+export async function getOrgMonthToDateCostUsd(
+  db: Db,
+  orgId: number,
+  now: Date = new Date(),
+): Promise<number> {
+  const { totalUsd } = await getOrgMonthToDateSpend(db, orgId, now);
+  return totalUsd;
 }
 
 /**

--- a/shared/tests/migration-audit.test.ts
+++ b/shared/tests/migration-audit.test.ts
@@ -115,15 +115,25 @@ describe('snapshot chain drift (#527)', () => {
 
   it('fails when the newest migration in the journal has no snapshot', () => {
     // Reproduces #527 directly: copy the real chain, then remove the
-    // snapshot for the newest migration the way it was actually missing
-    // (0024_password_reset_tokens never had one committed until this fix).
+    // snapshot for whichever migration is currently newest, the way it was
+    // actually missing (0024_password_reset_tokens never had one committed
+    // until that fix). Derived from the real journal rather than a literal
+    // migration number: the repo's newest migration moves forward every time
+    // one lands (#522 added 0025), and a hardcoded "24" here would silently
+    // stop reproducing #527 the moment a later migration shipped - it would
+    // delete an unrelated, no-longer-newest snapshot and report no drift for
+    // the wrong reason instead of failing loudly.
+    const latestIdx = Math.max(...readJournalMigrations(migrationsFolder).map((m) => m.idx));
+
     const dir = mkdtempSync(join(tmpdir(), 'pb-snapshot-drift-'));
     tmpDirs.push(dir);
     cpSync(migrationsFolder, dir, { recursive: true });
-    unlinkSync(join(dir, 'meta', '0024_snapshot.json'));
+    unlinkSync(join(dir, 'meta', `${String(latestIdx).padStart(4, '0')}_snapshot.json`));
 
     const drift = findSnapshotChainDrift(dir);
-    expect(drift).toEqual({ latestJournalIdx: 24, latestSnapshotIdx: 23 });
+    expect(drift).not.toBeNull();
+    expect(drift!.latestJournalIdx).toBe(latestIdx);
+    expect(drift!.latestSnapshotIdx).not.toBe(latestIdx);
   });
 
   it('does not flag a migration that legitimately has no snapshot of its own', () => {

--- a/shared/tests/org-quota.test.ts
+++ b/shared/tests/org-quota.test.ts
@@ -13,6 +13,7 @@ import { getDb, getPool, schema } from '../src/db/client.js';
 import {
   assertOrgConcurrencyAdmitted,
   getOrgMonthToDateCostUsd,
+  getOrgMonthToDateSpend,
   getOrgQuotaFields,
   getOrgQuotaSnapshot,
   setOrgQuota,
@@ -66,6 +67,51 @@ async function makeRun(opts: { projectId: number; costUsd: string | null; starte
     status: 'success',
     costUsd: opts.costUsd,
     startedAt: opts.startedAt,
+  });
+}
+/** A `kind: 'assist'` run - what accepting a suggestion writes
+ * (shared/src/assist-accept.ts) to hang the resulting draft's `run_id` off.
+ * `costUsd` defaults to null (#522: the accept path never sets it anymore),
+ * but can be overridden to prove the org total ignores it regardless. */
+async function makeAssistRun(opts: {
+  projectId: number;
+  costUsd?: string | null;
+  startedAt: Date;
+}) {
+  const db = getDb();
+  await db.insert(schema.runs).values({
+    kind: 'assist',
+    projectId: opts.projectId,
+    trigger: 'manual',
+    status: 'success',
+    costUsd: opts.costUsd ?? null,
+    startedAt: opts.startedAt,
+  });
+}
+
+/** One row of the #522 assist-usage ledger: what `/api/extension/suggest`
+ * writes for every suggestion, streamed and accepted or not, the moment its
+ * stream finishes. */
+async function makeAssistUsage(opts: {
+  organizationId: number | null;
+  projectId: number;
+  costUsd: string | null;
+  createdAt: Date;
+}) {
+  const db = getDb();
+  const [platform] = await db
+    .select({ id: schema.platforms.id })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'));
+  await db.insert(schema.assistUsage).values({
+    organizationId: opts.organizationId,
+    projectId: opts.projectId,
+    deviceId: null,
+    platformId: platform.id,
+    kind: 'post_comment',
+    agentRunner: 'claude-code',
+    costUsd: opts.costUsd,
+    createdAt: opts.createdAt,
   });
 }
 
@@ -247,6 +293,128 @@ describe('getOrgMonthToDateCostUsd', () => {
   });
 });
 
+// #522: the org total must see the LinkedIn assistant's spend too, not only
+// campaign/project runs - see the doc comment on getOrgMonthToDateSpend for
+// why assist_usage exists as a separate ledger.
+describe('getOrgMonthToDateCostUsd: assistant usage (#522)', () => {
+  it('a suggestion that was streamed and never accepted still counts toward the org total', async () => {
+    const { orgId, projectId } = await setupOrg();
+    const now = new Date('2026-07-15T12:00:00Z');
+    // No runs row at all - exactly what /api/extension/suggest leaves behind
+    // for a suggestion nobody accepted.
+    await makeAssistUsage({
+      organizationId: orgId,
+      projectId,
+      costUsd: '0.0090',
+      createdAt: now,
+    });
+
+    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    expect(total).toBeCloseTo(0.009, 4);
+  });
+
+  it('adds assistant spend on top of campaign spend rather than replacing it', async () => {
+    const { orgId, projectId } = await setupOrg();
+    const now = new Date('2026-07-15T12:00:00Z');
+    await makeRun({ projectId, costUsd: '5.0000', startedAt: now });
+    await makeAssistUsage({ organizationId: orgId, projectId, costUsd: '0.5000', createdAt: now });
+
+    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    expect(total).toBeCloseTo(5.5, 4);
+  });
+
+  it('twenty suggestions with two accepted are counted twenty times, not twice', async () => {
+    const { orgId, projectId } = await setupOrg();
+    const now = new Date('2026-07-15T12:00:00Z');
+    // Every suggestion ledgers its own cost the moment its stream finishes,
+    // whether or not a human ever accepts it.
+    for (let i = 0; i < 20; i += 1) {
+      await makeAssistUsage({
+        organizationId: orgId,
+        projectId,
+        costUsd: '0.0100',
+        createdAt: now,
+      });
+    }
+    // Two of those twenty were accepted - shared/src/assist-accept.ts writes
+    // a `runs` row (kind: 'assist') to hang the resulting draft off, but
+    // never sets that row's own cost_usd (#522).
+    await makeAssistRun({ projectId, startedAt: now });
+    await makeAssistRun({ projectId, startedAt: now });
+
+    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    expect(total).toBeCloseTo(0.2, 4);
+  });
+
+  it('ignores an assist run even if its own cost_usd were somehow set, so accepting never double-counts', async () => {
+    const { orgId, projectId } = await setupOrg();
+    const now = new Date('2026-07-15T12:00:00Z');
+    await makeAssistUsage({ organizationId: orgId, projectId, costUsd: '0.0090', createdAt: now });
+    // A defensive scenario: an assist run whose cost_usd was set to the same
+    // figure the assist_usage row already carries. If getOrgMonthToDateCostUsd
+    // summed kind='assist' runs too, this suggestion would count twice.
+    await makeAssistRun({ projectId, costUsd: '0.0090', startedAt: now });
+
+    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    expect(total).toBeCloseTo(0.009, 4);
+  });
+
+  it('never counts a different org assist usage row', async () => {
+    const orgA = await setupOrg();
+    const orgB = await setupOrg();
+    const now = new Date('2026-07-15T12:00:00Z');
+    await makeAssistUsage({
+      organizationId: orgA.orgId,
+      projectId: orgA.projectId,
+      costUsd: '1.0000',
+      createdAt: now,
+    });
+    await makeAssistUsage({
+      organizationId: orgB.orgId,
+      projectId: orgB.projectId,
+      costUsd: '2.0000',
+      createdAt: now,
+    });
+
+    expect(await getOrgMonthToDateCostUsd(getDb(), orgA.orgId, now)).toBeCloseTo(1, 4);
+    expect(await getOrgMonthToDateCostUsd(getDb(), orgB.orgId, now)).toBeCloseTo(2, 4);
+  });
+});
+
+describe('getOrgMonthToDateSpend', () => {
+  it('keeps campaign and assistant spend apart, and sums them into a total', async () => {
+    const { orgId, projectId } = await setupOrg();
+    const now = new Date('2026-07-15T12:00:00Z');
+    await makeRun({ projectId, costUsd: '5.0000', startedAt: now });
+    await makeAssistUsage({ organizationId: orgId, projectId, costUsd: '1.2500', createdAt: now });
+
+    const spend = await getOrgMonthToDateSpend(getDb(), orgId, now);
+    expect(spend.campaignUsd).toBeCloseTo(5, 4);
+    expect(spend.assistantUsd).toBeCloseTo(1.25, 4);
+    expect(spend.totalUsd).toBeCloseTo(6.25, 4);
+  });
+
+  it('only counts assist usage from on or after the first of the month', async () => {
+    const { orgId, projectId } = await setupOrg();
+    const now = new Date('2026-07-15T12:00:00Z');
+    await makeAssistUsage({
+      organizationId: orgId,
+      projectId,
+      costUsd: '9.0000',
+      createdAt: new Date('2026-06-30T23:59:59Z'),
+    });
+    await makeAssistUsage({
+      organizationId: orgId,
+      projectId,
+      costUsd: '0.5000',
+      createdAt: new Date('2026-07-01T00:00:00Z'),
+    });
+
+    const spend = await getOrgMonthToDateSpend(getDb(), orgId, now);
+    expect(spend.assistantUsd).toBeCloseTo(0.5, 4);
+  });
+});
+
 describe('getOrgQuotaSnapshot', () => {
   it('computes remainingUsd as budget minus month-to-date spend when a budget is set', async () => {
     const { orgId, projectId } = await setupOrg({ monthlyRunBudgetUsd: '100.00' });
@@ -264,6 +432,28 @@ describe('getOrgQuotaSnapshot', () => {
 
     const snapshot = await getOrgQuotaSnapshot(getDb(), orgId, now);
     expect(snapshot.remainingUsd).toBeCloseTo(-5.0, 4);
+  });
+
+  // #522 acceptance: the existing per-org budget check
+  // (web/src/lib/server/runner.ts reads getOrgQuotaSnapshot before every
+  // cloud-runner dispatch) has to be able to refuse a run on assistant
+  // spend alone, with zero campaign runs ever having happened.
+  it('goes over budget from assistant usage alone, with no campaign runs at all', async () => {
+    const { orgId, projectId } = await setupOrg({ monthlyRunBudgetUsd: '5.00' });
+    const now = new Date('2026-07-15T12:00:00Z');
+    for (let i = 0; i < 10; i += 1) {
+      await makeAssistUsage({
+        organizationId: orgId,
+        projectId,
+        costUsd: '0.6000',
+        createdAt: now,
+      });
+    }
+
+    const snapshot = await getOrgQuotaSnapshot(getDb(), orgId, now);
+    expect(snapshot.remainingUsd).toBeCloseTo(-1.0, 4);
+    expect(snapshot.remainingUsd).not.toBeNull();
+    expect(snapshot.remainingUsd!).toBeLessThanOrEqual(0);
   });
 
   it('returns remainingUsd: null (unlimited) when the org has no configured budget', async () => {

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -48,6 +48,12 @@ export interface SuggestionResult {
   /** True when the model explicitly declined to write a draft. */
   skipped: boolean;
   ms: number;
+  /** The model this suggestion actually asked for - resolveAssistRunnerConfig's
+   * result, so an unpinned runner reports ASSIST_DEFAULT_MODEL rather than
+   * undefined. Carried through so a caller that ledgers usage (#522's
+   * assist_usage row) knows which model to price it against, even on a
+   * suggestion whose cost couldn't be computed at all. */
+  model?: string;
   usage?: {
     inputTokens: number;
     outputTokens: number;
@@ -201,10 +207,8 @@ export function runSuggestion(args: {
       ? await resolveFunctionModel(db, 'assist_suggest')
       : undefined;
     if (cancelled) throw new Cancelled();
-    const runner = createAgentRunner(
-      args.runnerSlug,
-      resolveAssistRunnerConfig(config, functionModel),
-    );
+    const resolvedConfig = resolveAssistRunnerConfig(config, functionModel);
+    const runner = createAgentRunner(args.runnerSlug, resolvedConfig);
 
     // The agent still gets a working directory, and it must not be the repo:
     // this session has no tools attached, but a cwd it could read is a cwd it
@@ -261,6 +265,7 @@ export function runSuggestion(args: {
         draft: envelope.draft,
         skipped: envelope.skipped,
         ms: Date.now() - started,
+        model: resolvedConfig.model,
         usage: run.usage
           ? {
               inputTokens: run.usage.inputTokens,

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,5 +1,5 @@
 import { getDb, schema } from '$lib/server/db.js';
-import { and, desc, eq, gte, inArray, isNotNull, or, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNotNull, ne, or, sql } from 'drizzle-orm';
 import { listProjects } from '@pitchbox/shared/projects';
 import { resolveOrgId } from '$lib/server/auth.js';
 
@@ -32,7 +32,7 @@ export async function load(event: import('@sveltejs/kit').RequestEvent) {
       },
       recentRuns: [],
       campaigns: [],
-      spend: { cost24h: 0, cost7d: 0 },
+      spend: { cost24h: 0, cost7d: 0, assistCost24h: 0, assistCost7d: 0 },
     };
   }
 
@@ -126,6 +126,11 @@ export async function load(event: import('@sveltejs/kit').RequestEvent) {
     .limit(5);
 
   // ----- Spend (last 24h / 7d) -----
+  // Campaign/other-run cost excludes `kind = 'assist'` on purpose: an
+  // accepted suggestion's own `runs` row always has a null `cost_usd` now
+  // (shared/src/assist-accept.ts) - the assistant's spend lives entirely in
+  // `assist_usage` below, ledgered once per suggestion whether accepted or
+  // not (#522). Summing both would double an accepted suggestion's cost.
   const [spendRow] = await db
     .select({
       cost24h: sql<
@@ -137,10 +142,25 @@ export async function load(event: import('@sveltejs/kit').RequestEvent) {
     })
     .from(schema.runs)
     .leftJoin(schema.campaigns, eq(schema.campaigns.id, schema.runs.campaignId))
-    .where(runOrgMatch);
+    .where(and(ne(schema.runs.kind, 'assist'), runOrgMatch));
+
+  const [assistSpendRow] = await db
+    .select({
+      cost24h: sql<
+        string | null
+      >`COALESCE(SUM(cost_usd) FILTER (WHERE created_at >= ${since24h}), 0)`,
+      cost7d: sql<
+        string | null
+      >`COALESCE(SUM(cost_usd) FILTER (WHERE created_at >= ${since7d}), 0)`,
+    })
+    .from(schema.assistUsage)
+    .where(inArray(schema.assistUsage.projectId, projectIds));
+
   const spend = {
     cost24h: Number(spendRow?.cost24h ?? 0),
     cost7d: Number(spendRow?.cost7d ?? 0),
+    assistCost24h: Number(assistSpendRow?.cost24h ?? 0),
+    assistCost7d: Number(assistSpendRow?.cost7d ?? 0),
   };
 
   // ----- Run stats (last 7 days, campaign runs only - the three cards on

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -10,6 +10,7 @@
 		TrendingUp,
 		AlertTriangle,
 		DollarSign,
+		Bot,
 	} from '@lucide/svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import Seo from '$lib/components/Seo.svelte';
@@ -59,7 +60,7 @@
 			runStats7d: { total: number; success: number; failed: number; running: number };
 			recentRuns: Run[];
 			campaigns: Campaign[];
-			spend: { cost24h: number; cost7d: number };
+			spend: { cost24h: number; cost7d: number; assistCost24h: number; assistCost7d: number };
 		};
 	} = $props();
 
@@ -145,10 +146,16 @@
 		hint="Last 7 days"
 	/>
 	<StatCard
-		label="Spend (24h / 7d)"
+		label="Campaign spend (24h / 7d)"
 		value={`$${data.spend.cost24h.toFixed(2)}`}
 		icon={DollarSign}
 		hint={`$${data.spend.cost7d.toFixed(2)} over the last 7 days`}
+	/>
+	<StatCard
+		label="Assistant spend (24h / 7d)"
+		value={`$${data.spend.assistCost24h.toFixed(2)}`}
+		icon={Bot}
+		hint={`$${data.spend.assistCost7d.toFixed(2)} over the last 7 days - LinkedIn suggestions, separate from campaign spend`}
 	/>
 	<StatCard
 		label="Unique people contacted"

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -307,17 +307,51 @@ export async function POST(event: RequestEvent) {
       cancel = handle.cancel;
 
       handle.result
-        .then((res) => {
+        .then(async (res) => {
           if (settled) return;
           settled = true;
-          send('done', {
-            reasoning: res.reasoning,
-            draft: res.draft,
-            skipped: res.skipped,
-            usage: res.usage,
-            ms: res.ms,
-          });
-          controller.close();
+
+          // #522: ledgered the moment the suggestion finishes, not only if
+          // a human later accepts it - see the header comment on this
+          // route and shared/src/org-quota.ts's getOrgMonthToDateCostUsd.
+          // A ledger write failing must never keep the human from getting
+          // their answer, so it's caught and logged rather than left to
+          // reject this handler (which would also skip 'done' below).
+          await db
+            .insert(schema.assistUsage)
+            .values({
+              organizationId: auth.organizationId,
+              projectId: project.id,
+              deviceId: auth.deviceId,
+              platformId: platform.id,
+              kind: body.kind,
+              agentRunner: project.defaultAgentRunner,
+              model: res.model ?? null,
+              inputTokens: res.usage?.inputTokens ?? null,
+              outputTokens: res.usage?.outputTokens ?? null,
+              cacheReadTokens: res.usage?.cacheReadTokens ?? null,
+              cacheCreationTokens: res.usage?.cacheCreationTokens ?? null,
+              costUsd: res.usage?.costUsd != null ? res.usage.costUsd.toFixed(4) : null,
+            })
+            .catch((err: unknown) => {
+              console.error('failed to record assist usage:', err);
+            });
+
+          try {
+            send('done', {
+              reasoning: res.reasoning,
+              draft: res.draft,
+              skipped: res.skipped,
+              usage: res.usage,
+              ms: res.ms,
+            });
+            controller.close();
+          } catch (err) {
+            // The panel disconnected while the usage write above was in
+            // flight - the suggestion is already ledgered, there's simply
+            // nobody left to deliver it to.
+            console.error('failed to deliver done event:', err);
+          }
         })
         .catch((err: unknown) => {
           if (settled) return;

--- a/web/src/routes/api/settings/org-quota/+server.ts
+++ b/web/src/routes/api/settings/org-quota/+server.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { getDb } from '$lib/server/db.js';
 import { requireOrgId, requireRole } from '$lib/server/auth.js';
 import {
-  getOrgMonthToDateCostUsd,
+  getOrgMonthToDateSpend,
   getOrgQuotaFields,
   getOrgQuotaSnapshot,
   setOrgQuota,
@@ -27,14 +27,19 @@ async function quotaResponse(orgId: number) {
   const db = getDb();
   const fields = await getOrgQuotaFields(db, orgId);
   if (!fields) throw error(404, 'not_found');
-  const [monthToDateCostUsd, snapshot] = await Promise.all([
-    getOrgMonthToDateCostUsd(db, orgId),
+  const [spend, snapshot] = await Promise.all([
+    getOrgMonthToDateSpend(db, orgId),
     getOrgQuotaSnapshot(db, orgId),
   ]);
   return json({
     monthlyRunBudgetUsd: fields.monthlyRunBudgetUsd,
     maxConcurrentRuns: fields.maxConcurrentRuns,
-    monthToDateCostUsd,
+    monthToDateCostUsd: spend.totalUsd,
+    // #522: campaign and assistant spend shown apart, so an operator asking
+    // "why am I out of budget" can see which half spent it - the cap itself
+    // (remainingUsd below) still runs on the combined total.
+    campaignUsd: spend.campaignUsd,
+    assistantUsd: spend.assistantUsd,
     remainingUsd: snapshot.remainingUsd,
   });
 }

--- a/web/src/routes/settings/organization/+page.server.ts
+++ b/web/src/routes/settings/organization/+page.server.ts
@@ -3,7 +3,7 @@ import { eq } from 'drizzle-orm';
 import { getDb, schema } from '../../../lib/server/db.js';
 import { resolveOrgId } from '../../../lib/server/auth.js';
 import { listOrgMembers, listPendingInvites } from '@pitchbox/shared/orgs';
-import { getOrgMonthToDateCostUsd, getOrgQuotaSnapshot } from '@pitchbox/shared/org-quota';
+import { getOrgMonthToDateSpend, getOrgQuotaSnapshot } from '@pitchbox/shared/org-quota';
 
 export const load: PageServerLoad = async (event) => {
   const authOn = process.env.PITCHBOX_AUTH === 'on';
@@ -44,17 +44,21 @@ export const load: PageServerLoad = async (event) => {
     monthlyRunBudgetUsd: number | null;
     maxConcurrentRuns: number | null;
     monthToDateCostUsd: number;
+    campaignUsd: number;
+    assistantUsd: number;
     remainingUsd: number | null;
   } | null = null;
   if (canManage && org) {
-    const [monthToDateCostUsd, snapshot] = await Promise.all([
-      getOrgMonthToDateCostUsd(db, orgId),
+    const [spend, snapshot] = await Promise.all([
+      getOrgMonthToDateSpend(db, orgId),
       getOrgQuotaSnapshot(db, orgId),
     ]);
     quota = {
       monthlyRunBudgetUsd: org.monthlyRunBudgetUsd == null ? null : Number(org.monthlyRunBudgetUsd),
       maxConcurrentRuns: org.maxConcurrentRuns,
-      monthToDateCostUsd,
+      monthToDateCostUsd: spend.totalUsd,
+      campaignUsd: spend.campaignUsd,
+      assistantUsd: spend.assistantUsd,
       remainingUsd: snapshot.remainingUsd,
     };
   }

--- a/web/src/routes/settings/organization/+page.svelte
+++ b/web/src/routes/settings/organization/+page.svelte
@@ -34,6 +34,8 @@
     monthlyRunBudgetUsd: number | null;
     maxConcurrentRuns: number | null;
     monthToDateCostUsd: number;
+    campaignUsd: number;
+    assistantUsd: number;
     remainingUsd: number | null;
   };
   type PageData = {
@@ -499,6 +501,16 @@
               <span class="text-sm font-medium">Remaining budget</span>
               <span class="text-sm text-muted-foreground">
                 {data.quota.remainingUsd == null ? 'Unlimited' : money(data.quota.remainingUsd)}
+              </span>
+            </div>
+            <div class="flex flex-col gap-1">
+              <span class="text-sm font-medium">Campaign spend</span>
+              <span class="text-sm text-muted-foreground">{money(data.quota.campaignUsd)}</span>
+            </div>
+            <div class="flex flex-col gap-1">
+              <span class="text-sm font-medium">Assistant spend</span>
+              <span class="text-sm text-muted-foreground">
+                {money(data.quota.assistantUsd)} - LinkedIn suggestions, not campaign runs
               </span>
             </div>
           </div>

--- a/web/tests/extension-suggest-accept.test.ts
+++ b/web/tests/extension-suggest-accept.test.ts
@@ -212,7 +212,18 @@ describe('POST /api/extension/suggest/accept', () => {
       cacheReadTokens: 812,
       cacheCreationTokens: 0,
     });
-    expect(runs[0].costUsd).toBe('0.0091');
+    // #522: the accept path's `usage.costUsd` is a number the extension
+    // echoed back from an earlier `done` event - it never authorises this
+    // run's own cost_usd anymore (that would double-count against
+    // assist_usage, which ledgered the real figure server-side when the
+    // suggestion's stream finished). Both the device's claim and this
+    // repo's own recompute from the token counts land on `params` instead,
+    // visible for audit rather than authoritative for any budget decision.
+    expect(runs[0].costUsd).toBeNull();
+    expect(runs[0].params).toMatchObject({
+      reportedCostUsd: POST_BODY.usage.costUsd,
+      recomputedCostUsd: 0.0009,
+    });
     expect(runs[0].finishedAt).not.toBeNull();
 
     const drafts = await getDb().select().from(schema.drafts);
@@ -228,6 +239,31 @@ describe('POST /api/extension/suggest/accept', () => {
       version: 0,
     });
     expect(drafts[0].sourceRef).toMatchObject({ externalId: POST_BODY.post.urn });
+  });
+
+  // #522: a device that lies about its cost must be visible, not
+  // authoritative - recomputedCostUsd is what a budget decision would use
+  // (via assist_usage, not this row), reportedCostUsd is what the device
+  // claimed. The two land in `params` precisely so a mismatch like this one
+  // is something an operator can find.
+  it('recomputes the run cost from token counts rather than trusting a device that misreports it', async () => {
+    const { org, project, platform } = await seedOrgProject('acc-lying-device');
+    await seedAccount(project.id, platform.id);
+    await mintDevice(org.id, 'tokLying');
+
+    const res = await accept({
+      request: request('tokLying', {
+        ...POST_BODY,
+        projectId: project.id,
+        usage: { ...POST_BODY.usage, costUsd: 0 },
+      }),
+    } as never);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+
+    const [run] = await getDb().select().from(schema.runs);
+    expect(run.costUsd).toBeNull();
+    expect(run.params).toMatchObject({ reportedCostUsd: 0, recomputedCostUsd: 0.0009 });
   });
 
   // A feed post carries no URN at all (docs/linkedin-integration-design.md,

--- a/web/tests/extension-suggest-usage.test.ts
+++ b/web/tests/extension-suggest-usage.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type { AgentRunHandle, AgentRunOptions, AgentRunner } from '@pitchbox/shared/agents';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+import { DRAFT_MARKER } from '@pitchbox/shared/assist/envelope';
+
+/**
+ * #522: `POST /api/extension/suggest` writes no `runs` row and, before this
+ * table, a suggestion's cost reached the database only if a human accepted
+ * it - a panel that streamed twenty suggestions of which two were used had
+ * nineteen invisible ones as far as the ledger was concerned. This file
+ * pins the fix: `assist_usage` gets one row per finished suggestion,
+ * attributed to the org/device/project, the moment the stream ends -
+ * whether or not anyone ever accepts it.
+ *
+ * In its own module (and so a fresh in-memory rate-limiter budget) for the
+ * same reason extension-suggest-retune.test.ts is: extension-suggest.test.ts's
+ * own comment records it is already at 19 of its 20-per-minute per-device
+ * budget, and `TRUNCATE ... RESTART IDENTITY` hands every test in a file
+ * device id 1, so the limiter (keyed on that id for the whole file's run)
+ * would refuse most of the calls this file needs.
+ */
+
+const REASONING = 'Noticed the cache change and the specific number.';
+const DRAFT = 'A specific thing that happened.';
+const ENVELOPE_CHUNKS = [`${REASONING}\n`, DRAFT_MARKER, '\n', DRAFT];
+let responseChunks: string[] = ENVELOPE_CHUNKS;
+/** Set by a test to make the fake agent report no usage at all - the panel
+ * still gets its answer, but there is nothing to ledger a cost from. */
+let usage: {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  costUsd: number | null;
+  costReported: boolean;
+} | null = {
+  inputTokens: 2,
+  outputTokens: 40,
+  cacheReadTokens: 780,
+  cacheCreationTokens: 0,
+  costUsd: 0.004,
+  costReported: true,
+};
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'fake',
+    run(opts: AgentRunOptions): AgentRunHandle {
+      for (const c of responseChunks) opts.onTextChunk?.(c);
+      return {
+        result: Promise.resolve({
+          exitCode: 0,
+          logPath: '/dev/null',
+          usage: usage ?? undefined,
+        }),
+        cancel: () => {},
+      };
+    },
+  }),
+}));
+
+// Dynamic, matching every other route test in this repo: `vi.mock` above is
+// hoisted, but the mocked module graph must not resolve until after that
+// registration runs, and a static import of a route module this early would
+// race it.
+const { POST: suggest } = await import('../src/routes/api/extension/suggest/+server.js');
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, contact_history, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+  responseChunks = ENVELOPE_CHUNKS;
+  usage = {
+    inputTokens: 2,
+    outputTokens: 40,
+    cacheReadTokens: 780,
+    cacheCreationTokens: 0,
+    costUsd: 0.004,
+    costReported: true,
+  };
+}
+
+async function seedOrgProject(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug, description: `about ${slug}` })
+    .returning();
+  const [platform] = await db
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'));
+  await saveLinkedInAssistSettings(db, org.id, {
+    ...defaultLinkedInAssistSettings(),
+    enabled: true,
+    projectId: project.id,
+  });
+  return { org, project, platform };
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  const [device] = await getDb()
+    .insert(schema.extensionDevices)
+    .values({ organizationId, tokenHash: tokenHash(token), label: 'test' })
+    .returning();
+  return device;
+}
+
+function request(token: string | null, body: unknown) {
+  return new Request('http://x/api/extension/suggest', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+async function readEvents(res: Response): Promise<Array<{ kind: string; data: unknown }>> {
+  const text = await res.text();
+  return text
+    .split('\n\n')
+    .map((block) => {
+      const kind = /^event: (.+)$/m.exec(block)?.[1];
+      const data = /^data: (.+)$/m.exec(block)?.[1];
+      return kind && data ? { kind, data: JSON.parse(data) } : null;
+    })
+    .filter((e): e is { kind: string; data: unknown } => e !== null);
+}
+
+const POST_BODY = {
+  kind: 'post_comment' as const,
+  post: {
+    urn: 'urn:li:activity:7000000000000000003',
+    authorName: 'Giulia Bianchi',
+    text: 'We cut p99 in half.',
+  },
+};
+
+describe('assist_usage ledger (#522)', () => {
+  beforeEach(reset);
+
+  it('ledgers the suggestion the moment the stream finishes, even though nobody accepted it', async () => {
+    const { org, project, platform } = await seedOrgProject('org-ledger');
+    const device = await mintDevice(org.id, 'tok-ledger');
+
+    const res = await suggest({
+      request: request('tok-ledger', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    await readEvents(res);
+
+    const rows = await getDb().select().from(schema.assistUsage);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      organizationId: org.id,
+      projectId: project.id,
+      deviceId: device.id,
+      platformId: platform.id,
+      kind: 'post_comment',
+      agentRunner: project.defaultAgentRunner,
+      inputTokens: 2,
+      outputTokens: 40,
+      cacheReadTokens: 780,
+      cacheCreationTokens: 0,
+    });
+    expect(Number(rows[0].costUsd)).toBeCloseTo(0.004, 4);
+    // No draft, no run - a suggestion stays ephemeral until accepted; the
+    // ledger is the only trace it ever happened.
+    expect(await getDb().select().from(schema.drafts)).toHaveLength(0);
+    expect(await getDb().select().from(schema.runs)).toHaveLength(0);
+  });
+
+  it('ledgers every suggestion separately - repeated suggestions leave one row each, not one aggregate', async () => {
+    const { org, project } = await seedOrgProject('org-ledger-many');
+    await mintDevice(org.id, 'tok-ledger-many');
+
+    for (let i = 0; i < 4; i += 1) {
+      const res = await suggest({
+        request: request('tok-ledger-many', { ...POST_BODY, projectId: project.id }),
+      } as never);
+      await readEvents(res);
+    }
+
+    const rows = await getDb()
+      .select()
+      .from(schema.assistUsage)
+      .where(eq(schema.assistUsage.projectId, project.id));
+    expect(rows).toHaveLength(4);
+    // Every row priced independently, not split across an aggregate.
+    for (const row of rows) {
+      expect(Number(row.costUsd)).toBeCloseTo(0.004, 4);
+    }
+  });
+
+  it('records the model the suggestion actually resolved to', async () => {
+    const { org, project } = await seedOrgProject('org-ledger-model');
+    await mintDevice(org.id, 'tok-ledger-model');
+
+    const res = await suggest({
+      request: request('tok-ledger-model', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    await readEvents(res);
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.assistUsage)
+      .where(eq(schema.assistUsage.projectId, project.id));
+    // ASSIST_DEFAULT_MODEL: no operator pinned a model for this project's
+    // (unpinned) runner, so the suggestion asked for the fast default.
+    expect(row.model).toBe('sonnet');
+  });
+
+  it('still ledgers a row, with null cost, when the runner reports no usage at all', async () => {
+    const { org, project } = await seedOrgProject('org-ledger-nousage');
+    await mintDevice(org.id, 'tok-ledger-nousage');
+    usage = null;
+
+    const res = await suggest({
+      request: request('tok-ledger-nousage', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    await readEvents(res);
+
+    const rows = await getDb()
+      .select()
+      .from(schema.assistUsage)
+      .where(eq(schema.assistUsage.projectId, project.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].costUsd).toBeNull();
+    expect(rows[0].inputTokens).toBeNull();
+  });
+
+  it('never ledgers a refused suggestion - the kill switch cuts it off before the model ever runs', async () => {
+    const db = getDb();
+    const slug = 'org-ledger-killswitch';
+    const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+    const [project] = await db
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: `p-${slug}`, name: slug })
+      .returning();
+    // No saveLinkedInAssistSettings call - the assistant stays off by
+    // default, refusing before runSuggestion is ever invoked.
+    await mintDevice(org.id, 'tok-ledger-killswitch');
+
+    const res = await suggest({
+      request: request('tok-ledger-killswitch', { ...POST_BODY, projectId: project.id }),
+    } as never);
+    const body = (await res.json()) as { refused?: string };
+    expect(body.refused).toBeTruthy();
+
+    expect(await getDb().select().from(schema.assistUsage)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #522

Under epic #520.

## What was broken

`POST /api/extension/suggest` deliberately writes no `runs` row (a suggestion is ephemeral until accepted), and the usage in its `done` event only reached the database if a human accepted, where `assist-accept.ts` puts it on the synthetic `assist` run. So the expensive half of the feature (the model deliberates 10-14s before its first token, #360) was free as far as the ledger was concerned: a panel that streams twenty suggestions of which two are used had nineteen invisible ones. That cannot survive #515/#540's per-org spend cap.

## Storage shape

Added a dedicated `assist_usage` table (migration `0025`), not a synthetic `runs` row per suggestion. A `runs` row per suggestion would pollute the run list and the analytics that read it (both are about outreach activity), and nineteen invisible "runs" per twenty suggestions is worse than a separate ledger. One row is written by `/api/extension/suggest` the moment a suggestion's stream finishes, whether or not it is ever accepted, attributed to the organization, project, device and platform, carrying the token split, the resolved model and the runner's own cost figure.

## Cost: server-recomputed where it matters, and where it doesn't

The `assist_usage` row's cost comes straight from `runSuggestion`'s `AgentRunner` result - the same trust boundary a campaign run's cost already has (self-reported by the backend when available, otherwise computed from the token columns via the runner's price table, `shared/src/runlog/usage.ts`). It never touches the client, so there was nothing to "recompute" there - it already isn't client-reported.

What *is* client-reported is the `usage` block `POST /api/extension/suggest/accept` receives back from the extension (the panel's own copy of an earlier `done` event, echoed back because a suggestion is never persisted server-side until accept). Before this PR, `assist-accept.ts` trusted that number outright for the `runs.cost_usd` it wrote. Now it recomputes from the reported token counts via `resolvePricingForRunner`/`computeCostUsd` and never writes the client's number as authoritative: the run's own `cost_usd` stays `null` (the real figure already lives in `assist_usage`, so writing another one here would double-count on accept), and both the device's claim and the recompute land on `runs.params` (`reportedCostUsd`/`recomputedCostUsd`) - visible for audit, never read back into a spend decision. A device that lies about its cost is now visible rather than authoritative; proved in `web/tests/extension-suggest-accept.test.ts`'s new "recomputes the run cost from token counts rather than trusting a device that misreports it" test (reports `$0`, ledger keeps the correct `$0.0009`).

**Residual gap, named rather than closed**: `ASSIST_DEFAULT_MODEL` (`'sonnet'`, the ACP CLI's own alias) is not a key in `runlog/usage.ts`'s `CLAUDE_MODEL_PRICING` (`'claude-sonnet-4-6'` etc.), so an unpinned self-host suggestion whose `claude-code` subprocess doesn't self-report `total_cost_usd` prices as `costUsd: null` in `assist_usage`. The row still stores the model id and every token count, so the recompute can happen in one place later once that alias is added - not this PR's scope, since it's a pricing-table gap that predates it and touches `runlog/usage.ts`, a file no issue in this wave owns.

## Org total and the dashboard

`getOrgMonthToDateCostUsd` (`shared/src/org-quota.ts`) now sums campaign/other-run cost (excluding `kind = 'assist'` runs, whose own `cost_usd` is always null now) plus `assist_usage`, so #515/#540's existing per-org budget check can refuse a run on assistant spend alone with zero campaign runs ever having happened (`getOrgQuotaSnapshot` test: `goes over budget from assistant usage alone, with no campaign runs at all`). A new `getOrgMonthToDateSpend` returns the breakdown (`campaignUsd`/`assistantUsd`/`totalUsd`): one number for the cap, two for a human asking which half spent the budget - shown apart on the home dashboard ("Campaign spend" / "Assistant spend" stat cards) and on the organization settings quota card (which already showed "Month-to-date spend"/"Remaining budget"; now also shows "Campaign spend"/"Assistant spend" underneath).

## Tests (each proven to bite by breaking the code under it and watching it fail, then restoring)

- `web/tests/extension-suggest-usage.test.ts` (new file, its own module for a fresh in-memory rate-limiter budget - `extension-suggest.test.ts`'s own comment records it's already near its per-file device budget): a streamed-and-ignored suggestion is ledgered with the right org/project/device/tokens/cost and leaves no draft or run; repeated suggestions ledger one row each; a runner reporting no usage still ledgers a row with null cost; a refused suggestion (kill switch) never ledgers at all.
- `shared/tests/org-quota.test.ts`: assistant usage counted in the org total even with zero runs; assistant spend adds to (not replaces) campaign spend; twenty suggestions with two accepted count twenty times not twice; an assist run's own `cost_usd`, even if somehow set, is ignored (the double-count guard); cross-org isolation; `getOrgMonthToDateSpend`'s breakdown; a budget refusal triggers from assistant usage alone.
- `web/tests/extension-suggest-accept.test.ts`: updated the existing happy-path assertion (previously pinned the client-reported `$0.0091` as authoritative - exactly the bug this issue fixes) to assert the run's `cost_usd` is null and `params` carries both the recomputed and reported figures; added the "lying device" test above.
- `shared/tests/migration-audit.test.ts`: its snapshot-drift regression test hardcoded migration `24` as "the newest" and broke the instant `0025` existed - fixed to derive the newest index from the real journal at test time (identical assertions/coverage, proved it still fails when `findSnapshotChainDrift` is broken).

Migration `0025` is the first slot per the wave's coordination; journal `when` bumped past the existing (deliberately future-dated) entries since drizzle-kit's wall-clock timestamp came out lower.

## Verification

- `pnpm exec vitest run shared/tests/org-quota.test.ts shared/tests/migration-audit.test.ts shared/tests/assist-run-kind.test.ts web/tests/extension-suggest.test.ts web/tests/extension-suggest-usage.test.ts web/tests/extension-suggest-accept.test.ts web/tests/extension-suggest-retune.test.ts web/tests/extension-suggest-voice.test.ts` - 101 passed.
- `pnpm -F web check` - 0 errors, 0 warnings.
- `npx eslint` + `npx prettier --check` on every changed file (svelte files are outside both tools' configured scope in this repo) - clean.
