### PR TITLE
fix(deploy): pass the mail configuration into the app container

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -38,6 +38,23 @@ services:
       PITCHBOX_EDITION: cloud
       # The SDK runner's only remote - reaches every model through the AI Gateway.
       AI_GATEWAY_API_KEY: ${AI_GATEWAY_API_KEY:?set AI_GATEWAY_API_KEY in .env}
+      # Outbound mail (#508, #514): a deployment secret read from the
+      # environment like AI_GATEWAY_API_KEY above, never from app_config
+      # (shared/src/mail/env.ts explains why). Unset means the null
+      # transport, which logs and drops - the right default for a
+      # self-host with nothing configured, and the reason these have to be
+      # listed here explicitly: this compose file enumerates the
+      # environment rather than passing the whole .env through, so a value
+      # that is only in .env never reaches the process. That is exactly
+      # how a configured Resend key sat in prod's .env doing nothing.
+      MAIL_PROVIDER: ${MAIL_PROVIDER:-}
+      MAIL_FROM: ${MAIL_FROM:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-}
+      SMTP_SECURE: ${SMTP_SECURE:-}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/tests/docker-mail-env.test.ts
+++ b/tests/docker-mail-env.test.ts
@@ -47,7 +47,9 @@ describe('the deployed app receives the mail configuration it reads', () => {
   it.each(mailEnvVarsReadByTheLoader())(
     'passes %s into the web container, interpolated from the deployment environment',
     (name) => {
-      expect(webServiceBlock()).toMatch(new RegExp(`^\\s+${name}: \\$\\{${name}(:-[^}]*)?\\}$`, 'm'));
+      expect(webServiceBlock()).toMatch(
+        new RegExp(`^\\s+${name}: \\$\\{${name}(:-[^}]*)?\\}$`, 'm'),
+      );
     },
   );
 });

--- a/tests/docker-mail-env.test.ts
+++ b/tests/docker-mail-env.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * `docker-compose.app.yml` enumerates the container's environment rather than
+ * passing the whole `.env` through, so a variable the code reads but the
+ * compose file does not list simply never reaches the process - and the
+ * failure is silent, because `loadMailEnv` falls back to the null transport,
+ * which logs and drops. That is not hypothetical: on 2026-09-09 prod held a
+ * real Resend key in `/opt/apps/pitchbox/.env` and sent nothing, because none
+ * of the mail variables were in this file.
+ *
+ * So this reads the variables `shared/src/mail/env.ts` actually looks up and
+ * asserts the web service passes each one through from the deployment
+ * environment. It fails when somebody adds a mail variable to the loader and
+ * forgets the deployment. No YAML parser on purpose: this repo has none, and
+ * the shape being checked is one line per variable.
+ */
+const root = join(import.meta.dirname, '..');
+
+function mailEnvVarsReadByTheLoader(): string[] {
+  const src = readFileSync(join(root, 'shared/src/mail/env.ts'), 'utf8');
+  const names = new Set<string>();
+  for (const m of src.matchAll(/\benv\.([A-Z][A-Z0-9_]*)/g)) names.add(m[1]);
+  return [...names].sort();
+}
+
+/** The `web:` service's own block, cut at the next service at the same indent. */
+function webServiceBlock(): string {
+  const src = readFileSync(join(root, 'docker-compose.app.yml'), 'utf8');
+  const start = src.indexOf('\n  web:\n');
+  if (start < 0) throw new Error('docker-compose.app.yml has no web service');
+  const rest = src.slice(start + 1);
+  const next = rest.slice(1).search(/\n {2}\w[\w-]*:\n/);
+  return next < 0 ? rest : rest.slice(0, next + 1);
+}
+
+describe('the deployed app receives the mail configuration it reads', () => {
+  it('finds the variables to check, rather than passing on an empty set', () => {
+    const vars = mailEnvVarsReadByTheLoader();
+    expect(vars).toContain('MAIL_PROVIDER');
+    expect(vars).toContain('RESEND_API_KEY');
+    expect(vars.length).toBeGreaterThan(4);
+  });
+
+  it.each(mailEnvVarsReadByTheLoader())(
+    'passes %s into the web container, interpolated from the deployment environment',
+    (name) => {
+      expect(webServiceBlock()).toMatch(new RegExp(`^\\s+${name}: \\$\\{${name}(:-[^}]*)?\\}$`, 'm'));
+    },
+  );
+});


### PR DESCRIPTION
Found while setting Resend up on prod for #514's verification mail, and it is the kind of hole that reports success: `docker-compose.app.yml` enumerates the container's environment instead of passing the whole `.env` through, and none of the mail variables were on that list. I wrote a real key into `/opt/apps/pitchbox/.env`, recreated the containers, and `printenv MAIL_PROVIDER` inside the running web container came back empty. `loadMailEnv` then does exactly what it promises for an unconfigured self-host: falls back to the null transport, which logs and drops. So verification mail, password resets and invites would all have looked configured and sent nothing.

The web service now passes `MAIL_PROVIDER`, `MAIL_FROM`, `RESEND_API_KEY` and the five `SMTP_*` values. The daemon deliberately does not: nothing in it sends mail today, and I would rather add it when the reply poller or the webhook sender actually needs it than pass a credential into a process that has no use for it.

`tests/docker-mail-env.test.ts` derives the variable names from `shared/src/mail/env.ts` rather than hardcoding them, so adding a mail variable to the loader and forgetting the deployment fails the build. Proven by dropping `RESEND_API_KEY` from the compose file and watching that exact case fail, then restoring it: 9/9 green.

Under epic #503. Prod's Resend setup itself (domain verified, sending-only key scoped to `pitchbox.app`, keys written to both deployed environments) is done and not part of this diff.

Closes #580.