### PR TITLE
chore: release 0.12.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch, and the reason it cannot wait: prod now has a real Resend key and a verified `pitchbox.app` sending domain, and until #579 is in the running image none of it reaches the process. This carries #579 plus tonight's three account gates that landed after v0.12.1: the assistant's spend is ledgered on every suggestion rather than only on the accepted ones (#522), an instance-wide spend ceiling with a lower default for a self-registered org (#540), and email verification with a run-dispatch gate that is enforced server-side (#514).

Registration stays invite-only by default. Nothing here opens it.