### PR TITLE
fix(tests): main's full suite was red on two tests it never ran on a PR

### DIFF
--- a/web/tests/gateway-concurrency-dispatch.test.ts
+++ b/web/tests/gateway-concurrency-dispatch.test.ts
@@ -128,16 +128,36 @@ async function runRow(runId: number) {
 
 /** dispatchRun's completion write runs off `handle.result`'s own promise
  * chain, outside runCampaign's own await for a real dispatch (see
- * gateway-budget-dispatch.test.ts) - `run:finished` on the realtime bus is
- * the actual completion signal. */
-function waitForRunFinished(orgId: number): Promise<void> {
-  const { promise, resolve } = Promise.withResolvers<void>();
+ * gateway-budget-dispatch.test.ts), so `run:finished` on the realtime bus is
+ * the actual completion signal.
+ *
+ * It has to be subscribed BEFORE dispatching and matched on the event's own
+ * `runId`. The previous version subscribed once per expected run after
+ * dispatching and resolved on the first `run:finished` each subscriber saw -
+ * and since the bus broadcasts to every subscriber, a single event resolved
+ * all of them, so with three runs in flight the test read the rows while two
+ * were still `running`. That passed in isolation and only failed under the
+ * full suite, which is where it was caught (main, 2026-09-09). */
+function runFinishedWatcher(orgId: number) {
+  const finished = new Set<number>();
+  const waiting = new Map<number, () => void>();
   const unsubscribe = subscribe(orgId, (evt) => {
     if (evt.kind !== 'run:finished') return;
-    unsubscribe();
-    resolve();
+    const runId = (evt.data as { runId?: number } | undefined)?.runId;
+    if (typeof runId !== 'number') return;
+    finished.add(runId);
+    waiting.get(runId)?.();
+    waiting.delete(runId);
   });
-  return promise;
+  return {
+    finished(runId: number): Promise<void> {
+      if (finished.has(runId)) return Promise.resolve();
+      const { promise, resolve } = Promise.withResolvers<void>();
+      waiting.set(runId, resolve);
+      return promise;
+    },
+    stop: unsubscribe,
+  };
 }
 
 describe('cloud run dispatch is concurrency-capped (#485)', () => {
@@ -188,23 +208,32 @@ describe('cloud run dispatch is concurrency-capped (#485)', () => {
   it('lets a run start once the org is under its concurrency cap', async () => {
     const { orgId, campaignIds } = await seedCloudOrg('conc-under-cap', 2, 1);
 
-    const finished = waitForRunFinished(orgId);
-    const { runId } = await runCampaign(campaignIds[0]);
-    await finished;
+    const watcher = runFinishedWatcher(orgId);
+    try {
+      const { runId } = await runCampaign(campaignIds[0]);
+      await watcher.finished(runId);
 
-    expect(createCalls).toBe(1);
-    expect((await runRow(runId))?.status).not.toBe('running');
+      expect(createCalls).toBe(1);
+      expect((await runRow(runId))?.status).not.toBe('running');
+    } finally {
+      watcher.stop();
+    }
   });
 
   it('is never capped when max_concurrent_runs is unset (unlimited)', async () => {
     const { orgId, campaignIds } = await seedCloudOrg('conc-unlimited', null, 3);
 
-    const results = await Promise.all(campaignIds.map((id) => runCampaign(id)));
-    await Promise.all(results.map(() => waitForRunFinished(orgId)));
+    const watcher = runFinishedWatcher(orgId);
+    try {
+      const results = await Promise.all(campaignIds.map((id) => runCampaign(id)));
+      await Promise.all(results.map(({ runId }) => watcher.finished(runId)));
 
-    expect(createCalls).toBe(3);
-    for (const { runId } of results) {
-      expect((await runRow(runId))?.status).not.toBe('running');
+      expect(createCalls).toBe(3);
+      for (const { runId } of results) {
+        expect((await runRow(runId))?.status).not.toBe('running');
+      }
+    } finally {
+      watcher.stop();
     }
   });
 

--- a/web/tests/registration-policy.test.ts
+++ b/web/tests/registration-policy.test.ts
@@ -55,13 +55,19 @@ async function seedOrgOwner(orgSlug: string) {
 }
 
 function registerEvent(body: unknown, jar: CookieJar): RequestEvent {
-  const request = new Request('http://localhost/api/auth/register', {
+  const url = 'http://localhost/api/auth/register';
+  const request = new Request(url, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   });
   return {
     request,
+    // The route builds the verification link from the request's own origin
+    // (#514, web/src/lib/trusted-origins.js), so a synthetic event without a
+    // url makes it throw rather than answer - which is a fixture gap, not a
+    // route defect.
+    url: new URL(url),
     cookies: makeCookies(jar),
     getClientAddress: () => '10.2.0.1',
   } as unknown as RequestEvent;


### PR DESCRIPTION
`Tests (Postgres)` only runs on push to `main`, so both of these landed green on their own PRs and turned `main` red at 53eb8ab.

`web/tests/registration-policy.test.ts` hand-rolls a `RequestEvent`, and #514 made the register route build the verification link from the request's own origin, so the route threw `Cannot read properties of undefined (reading 'origin')`. A fixture gap rather than a route defect: the synthetic event now carries the url its own `Request` already had.

`web/tests/gateway-concurrency-dispatch.test.ts` is the more interesting one. It waited for completion by subscribing once per expected run **after** dispatching, and each subscriber resolved on the first `run:finished` it saw. The bus broadcasts to every subscriber, so a single event resolved all three waiters and the test then read the rows while two runs were still `running` - which is exactly the `expected 'running' not to be 'running'` failure. It passed in isolation and only failed under the full suite, where the runs are slower. The watcher now subscribes before dispatch and matches on the event's own `runId`.

I could not make the second one fail on demand in isolation, and I would rather say that than dress up a proof: the runs finish before the assertion locally no matter which semantics the waiter has, which is why the defect only ever showed up under load. The evidence is the failing run on `main` and a full local suite that is now green: 297 files, 2209 tests, all passing.

This blocks the v0.12.2 tag, since a release tag does not go on a red commit.