### PR TITLE
fix(deploy): the mail env has to be in the blue-green overlay too

### DIFF
--- a/docker-compose.bluegreen.yml
+++ b/docker-compose.bluegreen.yml
@@ -38,6 +38,20 @@ x-web-common: &web-common
     PITCHBOX_AUTH: ${PITCHBOX_AUTH:-off}
     PITCHBOX_OWNER_USERNAME: ${PITCHBOX_OWNER_USERNAME:-}
     PITCHBOX_OWNER_PASSWORD: ${PITCHBOX_OWNER_PASSWORD:-}
+    # Outbound mail (#508, #514, #580), and here for the same reason as the
+    # token above: a value added only to the base `web` never reaches a
+    # blue-green deployment. Measured on prod 2026-09-09 - #579 added these
+    # to the base service, the release went out, and the active web still
+    # had no MAIL_PROVIDER, so a verified Resend domain and a real key sent
+    # nothing.
+    MAIL_PROVIDER: ${MAIL_PROVIDER:-}
+    MAIL_FROM: ${MAIL_FROM:-}
+    RESEND_API_KEY: ${RESEND_API_KEY:-}
+    SMTP_HOST: ${SMTP_HOST:-}
+    SMTP_PORT: ${SMTP_PORT:-}
+    SMTP_SECURE: ${SMTP_SECURE:-}
+    SMTP_USER: ${SMTP_USER:-}
+    SMTP_PASS: ${SMTP_PASS:-}
   healthcheck:
     test:
       [

--- a/tests/docker-mail-env.test.ts
+++ b/tests/docker-mail-env.test.ts
@@ -36,6 +36,21 @@ function webServiceBlock(): string {
   return next < 0 ? rest : rest.slice(0, next + 1);
 }
 
+/** The blue-green overlay's `x-web-common` anchor, which is what a deployed
+ * web container actually gets: that overlay disables the base `web` service
+ * and replaces its whole `environment` block, so a variable present only in
+ * the base file reaches nothing in production. Not theory: #579 added these
+ * to the base file alone, shipped, and prod's active web came up with no
+ * MAIL_PROVIDER (#580). */
+function blueGreenCommonBlock(): string {
+  const src = readFileSync(join(root, 'docker-compose.bluegreen.yml'), 'utf8');
+  const start = src.indexOf('x-web-common:');
+  if (start < 0) throw new Error('docker-compose.bluegreen.yml has no x-web-common anchor');
+  const rest = src.slice(start);
+  const next = rest.search(/\nservices:\n/);
+  return next < 0 ? rest : rest.slice(0, next);
+}
+
 describe('the deployed app receives the mail configuration it reads', () => {
   it('finds the variables to check, rather than passing on an empty set', () => {
     const vars = mailEnvVarsReadByTheLoader();
@@ -45,9 +60,18 @@ describe('the deployed app receives the mail configuration it reads', () => {
   });
 
   it.each(mailEnvVarsReadByTheLoader())(
-    'passes %s into the web container, interpolated from the deployment environment',
+    'passes %s into the base web service, interpolated from the deployment environment',
     (name) => {
       expect(webServiceBlock()).toMatch(
+        new RegExp(`^\\s+${name}: \\$\\{${name}(:-[^}]*)?\\}$`, 'm'),
+      );
+    },
+  );
+
+  it.each(mailEnvVarsReadByTheLoader())(
+    'passes %s into the blue-green web containers, which are what production runs',
+    (name) => {
+      expect(blueGreenCommonBlock()).toMatch(
         new RegExp(`^\\s+${name}: \\$\\{${name}(:-[^}]*)?\\}$`, 'm'),
       );
     },


### PR DESCRIPTION
#579 was half a fix and v0.12.2 proved it. A blue-green deployment does not run the base `web` service at all: `docker-compose.bluegreen.yml` puts it behind a `_disabled` profile and gives `web-blue`/`web-green` their own `environment` block through the `x-web-common` anchor. So the release went out, prod's active web came up, and `docker exec pitchbox-web-blue printenv MAIL_PROVIDER` was still empty with a verified `pitchbox.app` sending domain and a real key sitting in `.env`.

The overlay's own comment already recorded this trap, measured on preview a day earlier for `PITCHBOX_INTERNAL_TOKEN`: "this overlay replaces the base service's whole `environment` block, so a variable added only to the base never reaches a blue-green deployment." I read that file after the fact rather than before, which is the actual lesson.

`tests/docker-mail-env.test.ts` now checks both places, so the next variable that reaches only the base service fails the build instead of shipping. Proven by dropping `MAIL_PROVIDER` from the overlay and watching exactly that case fail: 17 tests, 1 failed on the mutation, 17/17 restored.

Closes #580 properly this time. The deployment verification is `printenv` inside the running container, not the file on disk.