### PR TITLE
chore: release 0.12.3

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.12.2",
+  "version": "0.12.3",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch, to carry #583 into the running image: the mail environment now reaches the blue-green web containers, which is what prod actually runs. Without it v0.12.2 has a verified sending domain and a real key that no process can see.

Also carries #582, which fixed two tests that were red on main because `Tests (Postgres)` does not run on a PR.