### PR TITLE
feat(deploy,docs): reproducible Stripe setup script and billing docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
         items: [
           { text: 'Self-hosting', link: '/self-hosting' },
           { text: 'Retention', link: '/retention' },
+          { text: 'Billing', link: '/billing' },
         ],
       },
     ],

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -1,0 +1,104 @@
+# Billing
+
+Pitchbox is free to self-host: nothing on this page runs unless the deployment is
+the hosted edition. The hosted plans are sold through Stripe Checkout, managed by
+the customer in the Stripe customer portal, and enforced in the app from the plan
+limits Stripe stores on each product.
+
+Self-host keeps `PITCHBOX_AUTH=off` and no Stripe keys, and behaves as it always
+has: every limit off, every runner available.
+
+## The plan catalogue lives in Stripe, not in the code
+
+`scripts/stripe-setup.ts` is the source of truth for the catalogue and creates or
+reconciles every object the app needs: three products, six prices, the customer
+portal configuration, the two webhook endpoints, and the Stripe Tax defaults.
+
+| Plan   | Monthly | Annual | Projects | Runs / month | Suggestions / month | Seats |
+| ------ | ------- | ------ | -------- | ------------ | ------------------- | ----- |
+| Free   | 0       | 0      | 1        | 20           | 50                  | 1     |
+| Solo   | €29     | €290   | 3        | 500          | 500                 | 1     |
+| Growth | €79     | €790   | 10       | 2,000        | 2,000               | 3     |
+| Scale  | €199    | €1,990 | 30       | 8,000        | 8,000               | 10    |
+
+Annual is ten months of the monthly price (two months free). Prices are quoted
+tax-exclusive: Stripe Tax adds VAT at checkout for the customer's country. USD is
+carried as a `currency_options` entry on each price with the same headline
+number, so a second currency needs no new price ids.
+
+The Free plan has no Stripe object. It is the absence of a subscription, and its
+limits live in the app.
+
+**The app resolves prices by `lookup_key`, never by id**: `pitchbox_solo_monthly`,
+`pitchbox_solo_yearly`, and the same shape for `growth` and `scale`. Entitlements
+come from the product's `metadata` (`limit_projects`, `limit_runs`,
+`limit_suggestions`, `limit_seats`, `limit_devices`, `limit_concurrency`,
+`limit_budget_usd`, `limit_retention_days`, `limit_premium_models`), so changing
+what a plan includes is a metadata edit plus a script run, not a deploy.
+
+## Running the setup
+
+```bash
+# see what would change, against either mode
+STRIPE_SECRET_KEY=sk_test_... pnpm exec tsx scripts/stripe-setup.ts --dry-run
+
+# apply, capturing any webhook signing secret it has to create
+STRIPE_SECRET_KEY=sk_live_... pnpm exec tsx scripts/stripe-setup.ts \
+  --secrets-out ~/.config/pitchbox-stripe-live-webhooks.env
+```
+
+It is idempotent: an object that already matches is reported `ok` and left alone.
+A price whose amount changed cannot be edited (Stripe prices are immutable), so
+the script creates the new price, moves the lookup key onto it, and deactivates
+the old one. Subscriptions already on the old price keep it until they are
+migrated on purpose.
+
+A webhook signing secret is returned only when the endpoint is created. Pass
+`--secrets-out` or copy it from the run output; Stripe never shows it again.
+
+## Environment
+
+| Variable                      | Where             | What                                                           |
+| ----------------------------- | ----------------- | -------------------------------------------------------------- |
+| `STRIPE_SECRET_KEY`           | web (server only) | `sk_live_…` in production, `sk_test_…` in preview and locally  |
+| `STRIPE_PUBLISHABLE_KEY`      | web               | `pk_live_…` / `pk_test_…`, safe to expose                      |
+| `STRIPE_WEBHOOK_SECRET`       | web (server only) | signing secret of **that deployment's own** endpoint           |
+| `STRIPE_PORTAL_CONFIGURATION` | web (server only) | optional; pins the portal configuration instead of the default |
+| `PITCHBOX_APP_ORIGIN`         | setup script      | defaults to `https://app.pitchbox.app`                         |
+| `PITCHBOX_PREVIEW_ORIGIN`     | setup script      | defaults to `https://preview.pitchbox.app`                     |
+
+Production and preview have **separate webhook endpoints with separate signing
+secrets** on purpose: a preview deployment holding the production secret could
+write production billing state. Never copy one into the other.
+
+## Webhooks
+
+Both endpoints receive the same seven events:
+
+- `checkout.session.completed` - the subscription exists, attach it to the org
+- `customer.subscription.created` / `.updated` / `.deleted` - plan, status and
+  period changes, including an upgrade, a downgrade and a cancellation
+- `customer.subscription.trial_will_end` - three days before a trial ends
+- `invoice.paid` - the period the org has paid for
+- `invoice.payment_failed` - starts the grace period
+
+The handler lives at `/api/stripe/webhook` and verifies the signature against
+`STRIPE_WEBHOOK_SECRET` before reading the body.
+
+## Tax
+
+Stripe Tax is enabled and computes VAT at checkout from the customer's location,
+with prices treated as tax-exclusive. It cannot compute anything for a country
+where the account has no **tax registration**, and registrations are a decision
+about where the business is registered to collect, not a setting to flip: until
+they exist, automatic tax legitimately returns zero.
+
+## What the script cannot do
+
+Some things are only reachable with a live key, or only in the dashboard:
+
+- **Branding** (icon, logo, brand colours) - dashboard only; `POST /v1/account`
+  refuses with `Only live keys can access this method`.
+- **Identity, payout account and public business details** - part of activation.
+- **Tax registrations** - see above.
+- **Subscription email settings** (receipts, dunning) - dashboard only.

--- a/scripts/stripe-setup.ts
+++ b/scripts/stripe-setup.ts
@@ -1,0 +1,528 @@
+// Create or reconcile the Stripe objects Pitchbox billing depends on: the plan
+// catalogue (products + prices), the customer portal configuration, the two
+// webhook endpoints, and the Stripe Tax defaults.
+//
+// This file is the source of truth for the catalogue. The app never hardcodes a
+// price id: it resolves prices by `lookup_key` and reads entitlements from the
+// product metadata this script writes, so test mode and live mode can be brought
+// to the same shape by running it twice with different keys.
+//
+//   STRIPE_SECRET_KEY=sk_test_... pnpm exec tsx scripts/stripe-setup.ts --dry-run
+//   STRIPE_SECRET_KEY=sk_live_... pnpm exec tsx scripts/stripe-setup.ts \
+//     --secrets-out ~/.config/pitchbox-stripe-live-webhooks.env
+//
+// It is idempotent: an object that already matches is left alone, a changed
+// field is patched, and a price whose amount changed is replaced (the old one is
+// deactivated and the lookup key moves to the new one, which is the only way to
+// reprice in Stripe since prices are immutable).
+//
+// Nothing here carries the legal entity: the head office address, the tax
+// registrations and the payout account are set once during activation, in the
+// dashboard, and are deliberately not repo-facing. `--head-office` reads the
+// address from the environment when it has to be set from a script.
+import { writeFile } from 'node:fs/promises';
+
+type Money = { eur: number; usd: number };
+
+type Plan = {
+  slug: string;
+  name: string;
+  description: string;
+  monthly: Money;
+  yearly: Money;
+  limits: Record<string, string>;
+};
+
+type Metadata = Record<string, string>;
+
+type StripeList<T> = { data: T[] };
+
+type StripeAccount = { id: string; charges_enabled: boolean; payouts_enabled: boolean };
+
+type StripeProduct = {
+  id: string;
+  name: string;
+  description: string | null;
+  tax_code: string | null;
+  metadata: Metadata;
+};
+
+type StripePrice = {
+  id: string;
+  product: string;
+  active: boolean;
+  currency: string;
+  unit_amount: number | null;
+  lookup_key: string | null;
+  tax_behavior: string;
+  metadata: Metadata;
+  recurring: { interval: string } | null;
+  currency_options?: Record<string, { unit_amount: number | null; tax_behavior: string }>;
+};
+
+type StripePortalConfiguration = { id: string; is_default: boolean; metadata: Metadata };
+
+type StripeWebhookEndpoint = {
+  id: string;
+  url: string;
+  status: string;
+  enabled_events: string[];
+  metadata: Metadata;
+  secret?: string;
+};
+
+type StripeTaxSettings = { status: string };
+
+// SaaS, business use. The same code on every plan; it drives what Stripe Tax
+// computes per country.
+const TAX_CODE = 'txcd_10103001';
+
+// Amounts are minor units. USD is carried as a `currency_options` entry on the
+// same price rather than as a parallel price object, so adding a currency never
+// changes an id the app resolves. USD deliberately mirrors the EUR figure
+// instead of tracking the exchange rate: same headline number in both.
+const PLANS: Plan[] = [
+  {
+    slug: 'solo',
+    name: 'Pitchbox Solo',
+    description:
+      'For one operator: 3 projects, 500 agent runs and 500 in-page suggestions a month, 5 connected accounts, fast models.',
+    monthly: { eur: 2900, usd: 2900 },
+    yearly: { eur: 29000, usd: 29000 },
+    limits: {
+      limit_projects: '3',
+      limit_runs: '500',
+      limit_suggestions: '500',
+      limit_seats: '1',
+      limit_devices: '3',
+      limit_concurrency: '2',
+      limit_budget_usd: '10',
+      limit_retention_days: '30',
+      limit_premium_models: 'false',
+    },
+  },
+  {
+    slug: 'growth',
+    name: 'Pitchbox Growth',
+    description:
+      'For a small team: 10 projects, 2,000 agent runs and 2,000 suggestions a month, 3 seats, premium models, webhooks.',
+    monthly: { eur: 7900, usd: 7900 },
+    yearly: { eur: 79000, usd: 79000 },
+    limits: {
+      limit_projects: '10',
+      limit_runs: '2000',
+      limit_suggestions: '2000',
+      limit_seats: '3',
+      limit_devices: '10',
+      limit_concurrency: '4',
+      limit_budget_usd: '30',
+      limit_retention_days: '90',
+      limit_premium_models: 'true',
+    },
+  },
+  {
+    slug: 'scale',
+    name: 'Pitchbox Scale',
+    description:
+      'For an agency: 30 projects, 8,000 agent runs and 8,000 suggestions a month, 10 seats, premium models, 180-day retention.',
+    monthly: { eur: 19900, usd: 19900 },
+    yearly: { eur: 199000, usd: 199000 },
+    limits: {
+      limit_projects: '30',
+      limit_runs: '8000',
+      limit_suggestions: '8000',
+      limit_seats: '10',
+      limit_devices: '0',
+      limit_concurrency: '8',
+      limit_budget_usd: '70',
+      limit_retention_days: '180',
+      limit_premium_models: 'true',
+    },
+  },
+];
+
+const WEBHOOK_EVENTS = [
+  'checkout.session.completed',
+  'customer.subscription.created',
+  'customer.subscription.updated',
+  'customer.subscription.deleted',
+  'customer.subscription.trial_will_end',
+  'invoice.paid',
+  'invoice.payment_failed',
+];
+
+const APP_ORIGIN = process.env.PITCHBOX_APP_ORIGIN ?? 'https://app.pitchbox.app';
+const PREVIEW_ORIGIN = process.env.PITCHBOX_PREVIEW_ORIGIN ?? 'https://preview.pitchbox.app';
+const SITE_ORIGIN = process.env.PITCHBOX_SITE_ORIGIN ?? 'https://pitchbox.app';
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const WITH_HEAD_OFFICE = args.includes('--head-office');
+const SECRETS_OUT = args[args.indexOf('--secrets-out') + 1] ?? null;
+
+const KEY = process.env.STRIPE_SECRET_KEY;
+if (!KEY) {
+  console.error('STRIPE_SECRET_KEY is required (sk_test_... or sk_live_...)');
+  process.exit(1);
+}
+const LIVE = KEY.startsWith('sk_live_');
+
+function form(value: unknown, prefix = '', out = new URLSearchParams()): URLSearchParams {
+  if (value === null || value === undefined) return out;
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => form(item, `${prefix}[${i}]`, out));
+    return out;
+  }
+  if (typeof value === 'object') {
+    for (const [k, v] of Object.entries(value)) {
+      form(v, prefix ? `${prefix}[${k}]` : k, out);
+    }
+    return out;
+  }
+  out.append(prefix, String(value));
+  return out;
+}
+
+async function stripe<T>(path: string, body?: unknown, method?: string): Promise<T> {
+  const verb = method ?? (body ? 'POST' : 'GET');
+  const res = await fetch(`https://api.stripe.com/v1/${path}`, {
+    method: verb,
+    headers: {
+      Authorization: `Bearer ${KEY}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body ? form(body) : undefined,
+  });
+  const payload: unknown = await res.json();
+  if (!res.ok) {
+    let message = '';
+    if (payload && typeof payload === 'object' && 'error' in payload) {
+      const err = payload.error;
+      if (err && typeof err === 'object' && 'message' in err && typeof err.message === 'string') {
+        message = err.message;
+      }
+    }
+    throw new Error(`${verb} /v1/${path} -> ${res.status} ${message}`);
+  }
+  // Stripe's response shape is documented per endpoint; the callers below name
+  // the fields they read, and a wrong shape surfaces immediately as undefined.
+  return payload as T;
+}
+
+function log(action: string, detail: string) {
+  console.log(`${action.padEnd(9)} ${detail}`);
+}
+
+async function ensureProduct(plan: Plan): Promise<StripeProduct> {
+  const list = await stripe<StripeList<StripeProduct>>('products?limit=100');
+  const existing = list.data.find((p) => p.metadata?.plan === plan.slug);
+  const metadata: Metadata = { plan: plan.slug, ...plan.limits };
+  const payload = {
+    name: plan.name,
+    description: plan.description,
+    tax_code: TAX_CODE,
+    metadata,
+  };
+  if (!existing) {
+    if (DRY_RUN) {
+      log('create', `product ${plan.name}`);
+      return {
+        id: `dry_${plan.slug}`,
+        name: plan.name,
+        description: plan.description,
+        tax_code: TAX_CODE,
+        metadata,
+      };
+    }
+    const created = await stripe<StripeProduct>('products', { ...payload, active: true });
+    log('created', `product ${plan.name} ${created.id}`);
+    return created;
+  }
+  const drift =
+    existing.name !== payload.name ||
+    existing.description !== payload.description ||
+    existing.tax_code !== TAX_CODE ||
+    Object.entries(metadata).some(([k, v]) => existing.metadata?.[k] !== v);
+  if (!drift) {
+    log('ok', `product ${plan.name} ${existing.id}`);
+    return existing;
+  }
+  if (DRY_RUN) {
+    log('update', `product ${plan.name} ${existing.id}`);
+    return existing;
+  }
+  const updated = await stripe<StripeProduct>(`products/${existing.id}`, payload);
+  log('updated', `product ${plan.name} ${existing.id}`);
+  return updated;
+}
+
+async function ensurePrice(
+  plan: Plan,
+  product: StripeProduct,
+  interval: 'month' | 'year',
+): Promise<StripePrice> {
+  const amounts = interval === 'month' ? plan.monthly : plan.yearly;
+  const lookupKey = `pitchbox_${plan.slug}_${interval}ly`;
+  const list = await stripe<StripeList<StripePrice>>(
+    `prices?product=${product.id}&limit=100&expand[]=data.currency_options`,
+  );
+  const active = list.data.filter((p) => p.active && p.recurring?.interval === interval);
+  const match =
+    active.find((p) => p.lookup_key === lookupKey) ??
+    active.find((p) => p.metadata?.interval === interval);
+
+  if (match && match.currency === 'eur' && match.unit_amount === amounts.eur) {
+    const patch: Record<string, unknown> = {};
+    if (match.lookup_key !== lookupKey) patch.lookup_key = lookupKey;
+    // `tax_behavior` is writable exactly once, while it is still `unspecified`.
+    if (match.tax_behavior === 'unspecified') patch.tax_behavior = 'exclusive';
+    if (match.currency_options?.usd?.unit_amount !== amounts.usd) {
+      patch.currency_options = { usd: { unit_amount: amounts.usd } };
+    }
+    if (match.metadata?.plan !== plan.slug || match.metadata?.interval !== interval) {
+      patch.metadata = { plan: plan.slug, interval };
+    }
+    if (Object.keys(patch).length === 0) {
+      log('ok', `price ${lookupKey} ${match.id}`);
+      return match;
+    }
+    if (DRY_RUN) {
+      log('update', `price ${lookupKey} ${match.id} (${Object.keys(patch).join(', ')})`);
+      return match;
+    }
+    const updated = await stripe<StripePrice>(`prices/${match.id}`, patch);
+    log('updated', `price ${lookupKey} ${match.id} (${Object.keys(patch).join(', ')})`);
+    return updated;
+  }
+
+  // Amount changed, or there is no price yet: prices are immutable, so create a
+  // new one and move the lookup key onto it. Subscriptions already on the old
+  // price keep it until they are explicitly migrated.
+  if (DRY_RUN) {
+    log(match ? 'reprice' : 'create', `price ${lookupKey} ${amounts.eur} eur / ${amounts.usd} usd`);
+    return (
+      match ?? {
+        id: `dry_${lookupKey}`,
+        product: product.id,
+        active: true,
+        currency: 'eur',
+        unit_amount: amounts.eur,
+        lookup_key: lookupKey,
+        tax_behavior: 'exclusive',
+        metadata: { plan: plan.slug, interval },
+        recurring: { interval },
+      }
+    );
+  }
+  const created = await stripe<StripePrice>('prices', {
+    product: product.id,
+    currency: 'eur',
+    unit_amount: amounts.eur,
+    recurring: { interval },
+    tax_behavior: 'exclusive',
+    lookup_key: lookupKey,
+    transfer_lookup_key: match ? true : undefined,
+    currency_options: { usd: { unit_amount: amounts.usd, tax_behavior: 'exclusive' } },
+    metadata: { plan: plan.slug, interval },
+  });
+  log('created', `price ${lookupKey} ${created.id}`);
+  if (match) {
+    await stripe<StripePrice>(`prices/${match.id}`, { active: false });
+    log('retired', `price ${match.id} (replaced by ${created.id})`);
+  }
+  return created;
+}
+
+async function ensurePortal(catalogue: { product: StripeProduct; prices: StripePrice[] }[]) {
+  const payload = {
+    business_profile: {
+      headline: 'Manage your Pitchbox subscription',
+      privacy_policy_url: `${SITE_ORIGIN}/privacy`,
+      terms_of_service_url: `${SITE_ORIGIN}/terms`,
+    },
+    default_return_url: `${APP_ORIGIN}/settings/billing`,
+    features: {
+      customer_update: { enabled: true, allowed_updates: ['address', 'email', 'tax_id'] },
+      invoice_history: { enabled: true },
+      payment_method_update: { enabled: true },
+      subscription_cancel: {
+        enabled: true,
+        mode: 'at_period_end',
+        proration_behavior: 'none',
+        cancellation_reason: {
+          enabled: true,
+          options: ['too_expensive', 'missing_features', 'switched_service', 'unused', 'other'],
+        },
+      },
+      subscription_update: {
+        enabled: true,
+        default_allowed_updates: ['price'],
+        proration_behavior: 'create_prorations',
+        products: catalogue.map(({ product, prices }) => ({
+          product: product.id,
+          prices: prices.map((p) => p.id),
+        })),
+      },
+    },
+    metadata: { pitchbox: 'portal' },
+  };
+  // The portal configuration and the tax settings are written unconditionally:
+  // the payload above is the full desired state, so a PATCH with it is the diff.
+  const list = await stripe<StripeList<StripePortalConfiguration>>(
+    'billing_portal/configurations?limit=100',
+  );
+  const existing =
+    list.data.find((c) => c.metadata?.pitchbox === 'portal') ?? list.data.find((c) => c.is_default);
+  if (DRY_RUN) {
+    log(existing ? 'update' : 'create', `portal configuration ${existing?.id ?? ''}`.trim());
+    return existing ?? { id: 'dry_portal', is_default: true, metadata: { pitchbox: 'portal' } };
+  }
+  const saved = existing
+    ? await stripe<StripePortalConfiguration>(
+        `billing_portal/configurations/${existing.id}`,
+        payload,
+      )
+    : await stripe<StripePortalConfiguration>('billing_portal/configurations', payload);
+  log(existing ? 'synced' : 'created', `portal configuration ${saved.id}`);
+  return saved;
+}
+
+async function ensureWebhook(url: string, label: string) {
+  const list = await stripe<StripeList<StripeWebhookEndpoint>>('webhook_endpoints?limit=100');
+  const existing = list.data.find((w) => w.url === url);
+  if (existing) {
+    const sameEvents =
+      existing.enabled_events.length === WEBHOOK_EVENTS.length &&
+      WEBHOOK_EVENTS.every((e) => existing.enabled_events.includes(e));
+    if (sameEvents && existing.status === 'enabled') {
+      log('ok', `webhook ${label} ${existing.id}`);
+      return { endpoint: existing, secret: null };
+    }
+    if (DRY_RUN) {
+      log('update', `webhook ${label} ${existing.id}`);
+      return { endpoint: existing, secret: null };
+    }
+    const updated = await stripe<StripeWebhookEndpoint>(`webhook_endpoints/${existing.id}`, {
+      enabled_events: WEBHOOK_EVENTS,
+      disabled: false,
+    });
+    log('updated', `webhook ${label} ${updated.id}`);
+    return { endpoint: updated, secret: null };
+  }
+  if (DRY_RUN) {
+    log('create', `webhook ${label} ${url}`);
+    return {
+      endpoint: {
+        id: 'dry_webhook',
+        url,
+        status: 'enabled',
+        enabled_events: WEBHOOK_EVENTS,
+        metadata: {},
+      },
+      secret: null,
+    };
+  }
+  const created = await stripe<StripeWebhookEndpoint>('webhook_endpoints', {
+    url,
+    enabled_events: WEBHOOK_EVENTS,
+    description: `Pitchbox ${label}`,
+    metadata: { pitchbox: label },
+  });
+  log('created', `webhook ${label} ${created.id}`);
+  // The signing secret comes back only on creation, never again.
+  return { endpoint: created, secret: created.secret ?? null };
+}
+
+async function ensureTax() {
+  const current = await stripe<StripeTaxSettings>('tax/settings');
+  const payload: Record<string, unknown> = {
+    defaults: { tax_behavior: 'exclusive', tax_code: TAX_CODE },
+  };
+  if (WITH_HEAD_OFFICE) {
+    const parts = ['LINE1', 'CITY', 'POSTAL_CODE', 'STATE', 'COUNTRY'];
+    const missing = parts.filter((k) => !process.env[`STRIPE_HEAD_OFFICE_${k}`]);
+    if (missing.length) {
+      throw new Error(
+        `--head-office needs STRIPE_HEAD_OFFICE_${missing.join(', STRIPE_HEAD_OFFICE_')}`,
+      );
+    }
+    payload.head_office = {
+      address: {
+        line1: process.env.STRIPE_HEAD_OFFICE_LINE1,
+        city: process.env.STRIPE_HEAD_OFFICE_CITY,
+        postal_code: process.env.STRIPE_HEAD_OFFICE_POSTAL_CODE,
+        state: process.env.STRIPE_HEAD_OFFICE_STATE,
+        country: process.env.STRIPE_HEAD_OFFICE_COUNTRY,
+      },
+    };
+  }
+  if (DRY_RUN) {
+    log('update', `tax settings (status ${current.status})`);
+    return current;
+  }
+  const saved = await stripe<StripeTaxSettings>('tax/settings', payload);
+  log('synced', `tax settings status=${saved.status}`);
+  if (saved.status !== 'active') {
+    console.warn(
+      '  tax is not active yet: set the head office address (dashboard, or --head-office with STRIPE_HEAD_OFFICE_*)',
+    );
+  }
+  return saved;
+}
+
+async function main() {
+  const account = await stripe<StripeAccount>('account');
+  console.log(
+    `account  ${account.id} (${LIVE ? 'LIVE' : 'test'}) charges_enabled=${account.charges_enabled} payouts_enabled=${account.payouts_enabled}`,
+  );
+  if (LIVE && !account.charges_enabled) {
+    console.warn('  live account cannot charge yet: finish activation in the dashboard first');
+  }
+  console.log('');
+
+  const catalogue: { product: StripeProduct; prices: StripePrice[] }[] = [];
+  for (const plan of PLANS) {
+    const product = await ensureProduct(plan);
+    const monthly = await ensurePrice(plan, product, 'month');
+    const yearly = await ensurePrice(plan, product, 'year');
+    catalogue.push({ product, prices: [monthly, yearly] });
+  }
+  console.log('');
+
+  const portal = await ensurePortal(catalogue);
+  const production = await ensureWebhook(`${APP_ORIGIN}/api/stripe/webhook`, 'production');
+  const preview = await ensureWebhook(`${PREVIEW_ORIGIN}/api/stripe/webhook`, 'preview');
+  await ensureTax();
+
+  const secrets: string[] = [];
+  if (production.secret) secrets.push(`STRIPE_WEBHOOK_SECRET=${production.secret}`);
+  if (preview.secret) secrets.push(`STRIPE_WEBHOOK_SECRET_PREVIEW=${preview.secret}`);
+
+  console.log('');
+  console.log('catalogue');
+  for (const { product, prices } of catalogue) {
+    console.log(`  ${(product.metadata?.plan ?? product.id).padEnd(8)} ${product.id}`);
+    for (const p of prices) console.log(`    ${(p.lookup_key ?? '-').padEnd(24)} ${p.id}`);
+  }
+  console.log(`  portal   ${portal.id}`);
+  console.log(`  webhook  ${production.endpoint.id} -> ${production.endpoint.url}`);
+  console.log(`  webhook  ${preview.endpoint.id} -> ${preview.endpoint.url}`);
+
+  if (secrets.length && SECRETS_OUT) {
+    await writeFile(SECRETS_OUT, `${secrets.join('\n')}\n`, { mode: 0o600 });
+    console.log(`\nwrote ${secrets.length} webhook signing secret(s) to ${SECRETS_OUT} (mode 600)`);
+  } else if (secrets.length) {
+    console.log(
+      `\n${secrets.length} webhook endpoint(s) were created. Their signing secrets print once:`,
+    );
+    for (const s of secrets) console.log(`  ${s}`);
+    console.log(
+      'Store them now, or re-run with --secrets-out <path>. Stripe never shows them again.',
+    );
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
The Stripe side of monetization was configured by hand while setting up the account. This puts it in the repo so it can be re-run, reviewed and applied to a second account (test or live) without a dashboard session.

`scripts/stripe-setup.ts` creates or reconciles the plan catalogue (3 products, 6 prices), the customer portal configuration, the two webhook endpoints and the Stripe Tax defaults. It is idempotent: an object that already matches is reported `ok` and left alone. A price whose amount changed cannot be edited, since Stripe prices are immutable, so it creates the new price, moves the lookup key onto it and deactivates the old one.

Two things change in how the app is meant to read the catalogue, and both remove a hardcoded id:

- every price now carries a stable `lookup_key` (`pitchbox_solo_monthly`, `pitchbox_growth_yearly`, and so on), so the app resolves a price by key instead of by id
- entitlements stay in the product `metadata` (`limit_projects`, `limit_runs`, `limit_suggestions`, `limit_seats`, …), so changing what a plan includes is a metadata edit plus a script run rather than a deploy

`docs/billing.md` documents the catalogue, the env vars each deployment needs, why production and preview hold separate webhook signing secrets, and the short list of things the script deliberately cannot do (branding, activation, tax registrations, subscription emails: all live-key or dashboard only).

Verified by running it against the real test-mode account: a `--dry-run` that predicted exactly the two patches each existing price needed, the same run applied, and a third run reporting every product and price `ok`. The portal configuration and the tax settings are written unconditionally, since the payload is the full desired state, and now say `synced` rather than claiming an update.

Nothing in this PR touches the app itself, so there is no behavioural change to test. Refs #549.

One thing this surfaced: the portal configuration points at `https://pitchbox.app/privacy` and `/terms`, and both are 404 today. Filed separately as #586.
