### PR TITLE
docs(billing): Stripe is the merchant of record, and that constrains the integration

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -1,12 +1,45 @@
 # Billing
 
 Pitchbox is free to self-host: nothing on this page runs unless the deployment is
-the hosted edition. The hosted plans are sold through Stripe Checkout, managed by
-the customer in the Stripe customer portal, and enforced in the app from the plan
-limits Stripe stores on each product.
+the hosted edition. The hosted plans are sold through Stripe Checkout, and the
+plan limits Stripe stores on each product are what the app enforces.
 
 Self-host keeps `PITCHBOX_AUTH=off` and no Stripe keys, and behaves as it always
 has: every limit off, every runner available.
+
+## Stripe is the merchant of record
+
+The hosted edition sells through **Managed Payments**, so Stripe is the seller of
+record for every subscription, not Pitchbox. Stripe calculates, collects, files
+and remits sales tax, VAT and GST in more than 80 countries, handles fraud and
+disputes, and answers transaction-level support. It costs 3.5% per transaction on
+top of the normal processing fee.
+
+That choice is not just a fee, it constrains the integration:
+
+- Checkout Sessions **must** set `managed_payments[enabled]=true` and use API
+  version `2025-03-31.basil` or later.
+- These parameters are **rejected** on such a session: `automatic_tax`,
+  `tax_id_collection`, `subscription_data.default_tax_rates`,
+  `payment_method_collection`, `payment_method_configuration`,
+  `payment_method_options`, `payment_method_types`,
+  `saved_payment_method_options`, `customer_update[name]`,
+  `customer_update[address]`, `shipping_address_collection`, `shipping_options`,
+  `subscription_data.application_fee_percent`, `subscription_data.on_behalf_of`,
+  `subscription_data.transfer_data`, `subscription_data.invoice_settings`.
+- A subscription **cannot be created outside Checkout or a Payment Link**, and
+  one-off invoices and customer invoice items are not available on it. Updating
+  or cancelling an existing subscription through the API still works.
+- Only hosted or embedded Checkout is supported: no Elements, no advanced
+  integration, no Connect, and no custom domain on the checkout page.
+- The customer's card statement reads `LINK.COM* PITCHBOX`.
+- The checkout page is Link-branded ("Sold through Link"), offers card, Apple
+  Pay, Google Pay and Link, and has its own "I'm purchasing as a business"
+  checkbox: that is where a VAT number is collected, which is why
+  `tax_id_collection` is neither available nor needed.
+- **Adaptive Pricing** is on by default, so a customer without an explicit
+  currency on the price pays a converted amount in their own currency. A currency
+  that _is_ declared on the price (see below) is used as-is instead of converted.
 
 ## The plan catalogue lives in Stripe, not in the code
 
@@ -21,13 +54,16 @@ portal configuration, the two webhook endpoints, and the Stripe Tax defaults.
 | Growth | €79     | €790   | 10       | 2,000        | 2,000               | 3     |
 | Scale  | €199    | €1,990 | 30       | 8,000        | 8,000               | 10    |
 
-Annual is ten months of the monthly price (two months free). Prices are quoted
-tax-exclusive: Stripe Tax adds VAT at checkout for the customer's country. USD is
-carried as a `currency_options` entry on each price with the same headline
-number, so a second currency needs no new price ids.
+Annual is ten months of the monthly price (two months free). Prices are
+**tax-exclusive**: Stripe adds the customer's local tax at checkout, so an
+Italian consumer buying Growth pays €79.00 plus €17.38 of IVA. USD is carried as
+a `currency_options` entry on each price at the same headline number ($29 / $79 /
+$199), which is deliberately below the converted euro amount.
 
 The Free plan has no Stripe object. It is the absence of a subscription, and its
-limits live in the app.
+limits live in the app. **There is no trial**: Free is the trial, and it does not
+expire, so `customer.subscription.trial_will_end` never fires even though the
+endpoints subscribe to it.
 
 **The app resolves prices by `lookup_key`, never by id**: `pitchbox_solo_monthly`,
 `pitchbox_solo_yearly`, and the same shape for `growth` and `scale`. Entitlements
@@ -35,6 +71,14 @@ come from the product's `metadata` (`limit_projects`, `limit_runs`,
 `limit_suggestions`, `limit_seats`, `limit_devices`, `limit_concurrency`,
 `limit_budget_usd`, `limit_retention_days`, `limit_premium_models`), so changing
 what a plan includes is a metadata edit plus a script run, not a deploy.
+
+## What happens at a limit, and after a failed payment
+
+- A limit is a **hard refusal** with an upgrade prompt: no silent degrade to a
+  cheaper model, no queueing, no billed overage.
+- A failed payment starts a **14-day grace period** during which the org keeps
+  its plan. Stripe's dunning runs in that window; if nothing succeeds, the org
+  drops to Free and its data stays intact.
 
 ## Running the setup
 
@@ -78,27 +122,61 @@ Both endpoints receive the same seven events:
 - `checkout.session.completed` - the subscription exists, attach it to the org
 - `customer.subscription.created` / `.updated` / `.deleted` - plan, status and
   period changes, including an upgrade, a downgrade and a cancellation
-- `customer.subscription.trial_will_end` - three days before a trial ends
+- `customer.subscription.trial_will_end` - subscribed but unused, since there is
+  no trial
 - `invoice.paid` - the period the org has paid for
 - `invoice.payment_failed` - starts the grace period
 
 The handler lives at `/api/stripe/webhook` and verifies the signature against
 `STRIPE_WEBHOOK_SECRET` before reading the body.
 
+## Emails and support, which are mostly not ours
+
+Under Managed Payments, Stripe sends receipts, invoices, refund and credit-note
+notifications directly to the customer from Link, with PDFs attached. The receipt
+settings in the Dashboard do not affect those. What is still configurable is the
+upcoming-renewal reminder and the failed-payment (dunning) emails, in
+**Subscription and email settings** in the Stripe Dashboard.
+
+Two consequences worth knowing before support is promised anywhere:
+
+- Stripe answers payment and subscription support through Link support, and
+  escalates to the account's support email (`support@pitchbox.app`). **If nobody
+  replies within 48 hours, Stripe may issue a refund without approval.**
+- A customer can ask Stripe to delete their data, which cancels their
+  subscription and deletes the matching Stripe objects (customer, invoices,
+  subscription, charges) from our account too. The app must tolerate a
+  subscription disappearing without a cancellation request of its own.
+
+## Where a customer manages a subscription
+
+Two places, and both are real: Stripe gives every Managed Payments customer
+[link.com](https://link.com) for order history, cancellation, payment method and
+billing address, and the app offers the same through the **Stripe customer
+portal** (configuration created by the setup script, plan switching over the six
+prices, cancellation at period end with a reason, invoice history), returning to
+`/settings/billing`.
+
 ## Tax
 
-Stripe Tax is enabled and computes VAT at checkout from the customer's location,
-with prices treated as tax-exclusive. It cannot compute anything for a country
-where the account has no **tax registration**, and registrations are a decision
-about where the business is registered to collect, not a setting to flip: until
-they exist, automatic tax legitimately returns zero.
+Stripe handles indirect tax for the countries Managed Payments covers: it
+calculates it at checkout, withholds it from the payout, and files and remits it.
+Reports carry `withheld_tax` and `fee_net_of_withheld_tax` columns to separate it
+from processing fees. For a country outside that coverage the seller stays
+responsible, and Stripe Tax computes it at no extra charge.
+
+Because Stripe is the merchant of record, the account needs no tax registration
+of its own for the covered countries. The Stripe Tax defaults the setup script
+writes (`exclusive`, tax code `txcd_10103001`, head office) stay in place: they
+are what a non-Managed-Payments session would use, and the product tax code is
+also what classifies the product for Stripe's own calculation.
 
 ## What the script cannot do
 
-Some things are only reachable with a live key, or only in the dashboard:
+Some things are only reachable in the dashboard, whatever key you hold:
 
-- **Branding** (icon, logo, brand colours) - dashboard only; `POST /v1/account`
-  refuses with `Only live keys can access this method`.
-- **Identity, payout account and public business details** - part of activation.
-- **Tax registrations** - see above.
-- **Subscription email settings** (receipts, dunning) - dashboard only.
+- **Branding** (icon, logo, brand colours) and the **public business details**
+  (support email, website, statement descriptor). `POST /v1/account` refuses on
+  your own account even with a live key.
+- **Identity, payout account and activation.**
+- **Managed Payments** itself, and the subscription email settings.


### PR DESCRIPTION
I enabled Managed Payments on the account, so Stripe is now the seller of record for every hosted subscription. That is a 3.5% add-on per transaction in exchange for Stripe calculating, filing and remitting VAT and sales tax in 80+ countries, plus fraud, disputes and transaction support. The reason is the seller's own regime: an Italian forfettario sole trader charges no VAT domestically while B2C digital services elsewhere in the EU are a separate question with an OSS threshold, so the self-handled path meant registrations and filings.

The part that matters for the code, verified against a real Checkout Session rather than read off a marketing page:

- a session must set `managed_payments[enabled]=true` with `Stripe-Version: 2025-03-31.basil` or later
- sixteen parameters are rejected on such a session, including `automatic_tax` and `tax_id_collection`, so #550 cannot use either. Stripe's own checkout has an "I'm purchasing as a business" checkbox, which is where a VAT number is collected
- a subscription cannot be created outside Checkout or a Payment Link, and one-off invoices and invoice items are unavailable on it
- only hosted or embedded Checkout: no Elements, no Connect, no custom domain on the checkout page
- the statement reads `LINK.COM* PITCHBOX`
- Adaptive Pricing is on by default, so a currency not declared on the price is converted automatically; a declared one is used as-is, which is what keeps USD at parity
- Stripe sends receipts and invoices itself from Link and those are not configurable; renewal and dunning emails still are
- support escalates to `support@pitchbox.app`, and if nobody answers within 48 hours Stripe may refund without approval
- a customer data-deletion request cancels the subscription and deletes the Stripe objects from our account, so the app has to tolerate a subscription vanishing with no cancellation of its own

Measured in test mode: Growth monthly showed €79.00 plus €17.38 IVA for an Italian address (€96.38) and €15.01 VAT for a German one, on a Link-branded page. The customer portal still works alongside link.com, so #552 keeps its shape.

This also records the decisions the v2.0 issues were waiting on: no trial (Free is the trial, no expiry), a limit is a hard refusal rather than a degrade or billed overage, 14 days of grace after a failed payment, and USD at numeric parity. The full decision set is a comment on #542.

Docs only, no code touched. Refs #542, #550, #587.