### PR TITLE
feat(shared,web): which models a plan may run on

### DIFF
--- a/shared/src/ai/model-functions.ts
+++ b/shared/src/ai/model-functions.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm';
 import type { PgDatabase } from 'drizzle-orm/pg-core';
 import { appConfig } from '../db/schema.js';
+import { loadGatewayCatalogue } from './gateway-catalogue.js';
 
 // Which model does which job (#411). Before this, the only knob was
 // `runner_configs`, keyed by runner slug and shared by every plane, which is
@@ -206,4 +207,58 @@ export async function resolveModelForRun(
 ): Promise<string | undefined> {
   if (!runnerTakesGatewayModel(args.runnerSlug)) return undefined;
   return resolveFunctionModel(db, modelFunctionForPlaybook(args.playbookSlug));
+}
+
+/**
+ * A model counts as "premium" once the Gateway catalogue prices its output
+ * tokens at or above this line (#547). What actually matters is the run
+ * cost, not the per-token number: measured on the preview database, the
+ * same `campaign` kind costs $0.17 to $0.37 per run on the Claude-class
+ * agentic path against $0.0051 on `google/gemini-3.1-flash-lite`
+ * (`FAST_DEFAULT` above) - a 30x-plus gap driven entirely by which model
+ * ran it. Flash Lite prices output at $0.0000006/token; Claude Sonnet-class
+ * models, the cheapest ones actually capable of the agentic path, start at
+ * $0.000015/token, 25x higher. $0.000005/token sits between the two with
+ * headroom on both sides, so a routine vendor pricing update does not flip
+ * the classification.
+ */
+export const PREMIUM_OUTPUT_PRICE_PER_TOKEN_USD = 0.000005;
+
+/**
+ * Classifies a Gateway model id by price rather than by name, so a new
+ * Claude/GPT-class model needs no allow-list edit to count as premium. A
+ * model the catalogue cannot price - an unknown id, a self-host deployment
+ * with no Gateway key, a transient catalogue fetch failure - counts as
+ * premium too: the safe direction when the alternative is silently letting
+ * an unpriced model through a plan's gate.
+ */
+export async function isPremiumModel(modelId: string): Promise<boolean> {
+  const catalogue = await loadGatewayCatalogue();
+  const model = catalogue.models.find((m) => m.id === modelId);
+  if (!model || model.outputPerToken == null) return true;
+  return model.outputPerToken >= PREMIUM_OUTPUT_PRICE_PER_TOKEN_USD;
+}
+
+/**
+ * The premium-model gate (#547), applied at every point a model is resolved
+ * for a dispatch - never in the admin form, which only hides an option
+ * rather than enforcing anything (`shared/src/edition.ts` makes the same
+ * argument for runner slugs). `modelId` is whatever the caller already
+ * resolved - an admin's `model_functions` pin, an operator's
+ * `runner_configs` pin, or the coded default - and an org whose plan does
+ * not allow premium models runs on `fn`'s coded default fast model
+ * regardless of which of those it was. A plan that does allow premium
+ * models never reaches `isPremiumModel`, so a self-host deployment
+ * (unlimited on every axis) never pays for a Gateway catalogue fetch it has
+ * no key for. This is not a substitute for the org's own USD run budget
+ * (`shared/src/org-quota.ts`) - it is what keeps that budget from being hit
+ * in three runs.
+ */
+export async function gateModelForPlan(
+  fn: ModelFunction,
+  modelId: string,
+  allowPremium: boolean,
+): Promise<string> {
+  if (allowPremium) return modelId;
+  return (await isPremiumModel(modelId)) ? defaultModelForFunction(fn) : modelId;
 }

--- a/shared/tests/model-premium-gate.test.ts
+++ b/shared/tests/model-premium-gate.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import type { GatewayCatalogue } from '../src/ai/gateway-catalogue.js';
+import {
+  PREMIUM_OUTPUT_PRICE_PER_TOKEN_USD,
+  defaultModelForFunction,
+  gateModelForPlan,
+  isPremiumModel,
+} from '../src/ai/model-functions.js';
+
+// #547: the cost of a run is decided by the model, not by the plan - measured
+// on the preview database, the same `campaign` kind costs $0.17 to $0.37 per
+// run on the Claude-class agentic path against $0.0051 on
+// `google/gemini-3.1-flash-lite` (the fast default every function falls back
+// to, #411). This is the resolution function the acceptance criterion asks
+// for a test on, not the admin form: an org whose plan does not allow
+// premium models must land on the fast default regardless of what
+// `app_config.model_functions` or `runner_configs` pinned, and a model the
+// catalogue cannot price counts as premium, the safe direction.
+//
+// `loadGatewayCatalogue` is mocked rather than hit for real: a self-host test
+// box has no `AI_GATEWAY_API_KEY`, and the classification under test is the
+// price-threshold math, not the Gateway's own catalogue endpoint. The
+// per-token fixtures below reuse real published numbers already established
+// in this repo (shared/tests/agents/sdk/event-normalizer.test.ts): Gemini 3.1
+// Flash Lite prices output at $0.0000006/token, a Claude Sonnet-class model
+// at $0.000015/token.
+
+let catalogue: GatewayCatalogue = { models: [], unavailable: null, fetchedAt: new Date() };
+
+vi.mock('../src/ai/gateway-catalogue.js', () => ({
+  loadGatewayCatalogue: () => Promise.resolve(catalogue),
+}));
+
+function setModels(models: GatewayCatalogue['models']): void {
+  catalogue = { models, unavailable: null, fetchedAt: new Date() };
+}
+
+const FLASH_LITE = 'google/gemini-3.1-flash-lite';
+const OPUS = 'anthropic/claude-opus-4.1';
+
+beforeEach(() => {
+  setModels([
+    {
+      id: FLASH_LITE,
+      name: 'Gemini 3.1 Flash Lite',
+      inputPerToken: 0.00000015,
+      outputPerToken: 0.0000006,
+    },
+    { id: OPUS, name: 'Claude Opus 4.1', inputPerToken: 0.000015, outputPerToken: 0.000075 },
+  ]);
+});
+
+describe('isPremiumModel', () => {
+  it('classifies the fast default, well under the threshold, as not premium', async () => {
+    expect(await isPremiumModel(FLASH_LITE)).toBe(false);
+  });
+
+  it('classifies a Claude-class model, well over the threshold, as premium', async () => {
+    expect(await isPremiumModel(OPUS)).toBe(true);
+  });
+
+  it('classifies output pricing exactly at the threshold as premium', async () => {
+    setModels([
+      {
+        id: 'x/at-threshold',
+        name: 'At threshold',
+        inputPerToken: 0,
+        outputPerToken: PREMIUM_OUTPUT_PRICE_PER_TOKEN_USD,
+      },
+    ]);
+    expect(await isPremiumModel('x/at-threshold')).toBe(true);
+  });
+
+  it('treats an id the catalogue has no entry for as premium, the safe direction', async () => {
+    expect(await isPremiumModel('made-up/does-not-exist')).toBe(true);
+  });
+
+  it('treats a catalogue entry with no output price as premium', async () => {
+    setModels([{ id: 'x/unpriced', name: 'Unpriced', inputPerToken: null, outputPerToken: null }]);
+    expect(await isPremiumModel('x/unpriced')).toBe(true);
+  });
+});
+
+describe('gateModelForPlan (#547)', () => {
+  it('forces a plan without premium models onto the fast default even with Opus pinned for that function', async () => {
+    expect(await gateModelForPlan('campaign_draft', OPUS, false)).toBe(
+      defaultModelForFunction('campaign_draft'),
+    );
+  });
+
+  it('leaves a premium-allowed plan unaffected', async () => {
+    expect(await gateModelForPlan('campaign_draft', OPUS, true)).toBe(OPUS);
+  });
+
+  it('leaves a non-premium plan alone when the pinned model is already cheap', async () => {
+    expect(await gateModelForPlan('campaign_draft', FLASH_LITE, false)).toBe(FLASH_LITE);
+  });
+
+  it('resolves an unknown model id as premium regardless of plan', async () => {
+    expect(await gateModelForPlan('assist_suggest', 'made-up/does-not-exist', false)).toBe(
+      defaultModelForFunction('assist_suggest'),
+    );
+  });
+
+  it('never touches the catalogue for a premium-allowed plan', async () => {
+    setModels([]);
+    // An empty catalogue would classify anything as premium (unpriceable);
+    // an allowed plan must never even ask, which this proves indirectly -
+    // the pinned id comes back unchanged despite no catalogue entry for it.
+    expect(await gateModelForPlan('campaign_draft', OPUS, true)).toBe(OPUS);
+  });
+});

--- a/web/src/lib/server/runner.ts
+++ b/web/src/lib/server/runner.ts
@@ -1,7 +1,13 @@
 import { createAgentRunner } from '@pitchbox/shared/agents/registry';
 import type { AgentRunner } from '@pitchbox/shared/agents';
 import { loadRunnerConfig } from '@pitchbox/shared/agents/config';
-import { resolveModelForRun } from '@pitchbox/shared/ai/model-functions';
+import {
+  resolveModelForRun,
+  modelFunctionForPlaybook,
+  gateModelForPlan,
+  runnerTakesGatewayModel,
+} from '@pitchbox/shared/ai/model-functions';
+import { resolveEntitlements } from '@pitchbox/shared/plans';
 import { detectRunner, isDetectionConclusive } from '@pitchbox/shared/agents/detect';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import type { AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
@@ -230,8 +236,23 @@ async function dispatchRun(
       runnerSlug: slug,
       playbookSlug: opts.playbookSlug,
     });
-    const withModel =
+    let withModel =
       functionModel && !config.model?.trim() ? { ...config, model: functionModel } : config;
+    // The premium-model gate (#547): whatever the model above resolved to,
+    // an org whose plan does not allow premium models runs on the coded
+    // fast default instead - checked after every pin so neither
+    // `runner_configs` nor `model_functions` can reach around it. Only the
+    // `cloud` slug asks the Gateway for a model at all, and `orgId` is the
+    // same one the budget/concurrency checks above already resolved.
+    if (runnerTakesGatewayModel(slug) && withModel.model && orgId != null) {
+      const entitlements = await resolveEntitlements(db, orgId);
+      const gated = await gateModelForPlan(
+        modelFunctionForPlaybook(opts.playbookSlug),
+        withModel.model,
+        entitlements.premiumModels,
+      );
+      if (gated !== withModel.model) withModel = { ...withModel, model: gated };
+    }
     runner = createAgentRunner(run.agentRunner, withModel);
   } catch (err) {
     const errMsg = String(err instanceof Error ? err.message : err);

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -6,7 +6,12 @@ import { createAgentRunner } from '@pitchbox/shared/agents/registry';
 import type { AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
 import { loadRunnerConfig, type RunnerConfig } from '@pitchbox/shared/agents/config';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
-import { resolveFunctionModel, runnerTakesGatewayModel } from '@pitchbox/shared/ai/model-functions';
+import {
+  resolveFunctionModel,
+  runnerTakesGatewayModel,
+  gateModelForPlan,
+} from '@pitchbox/shared/ai/model-functions';
+import { resolveEntitlements } from '@pitchbox/shared/plans';
 import {
   buildSuggestionPrompt,
   type CurrentProject,
@@ -207,7 +212,21 @@ export function runSuggestion(args: {
       ? await resolveFunctionModel(db, 'assist_suggest')
       : undefined;
     if (cancelled) throw new Cancelled();
-    const resolvedConfig = resolveAssistRunnerConfig(config, functionModel);
+    let resolvedConfig = resolveAssistRunnerConfig(config, functionModel);
+    // The premium-model gate (#547), next to resolveAssistRunnerConfig
+    // rather than inside it: an org whose plan does not allow premium
+    // models answers in the panel on the function's coded fast default
+    // regardless of what an operator pinned here or in `model_functions`.
+    if (runnerTakesGatewayModel(args.runnerSlug) && resolvedConfig.model && args.orgId != null) {
+      const entitlements = await resolveEntitlements(db, args.orgId);
+      const gated = await gateModelForPlan(
+        'assist_suggest',
+        resolvedConfig.model,
+        entitlements.premiumModels,
+      );
+      if (gated !== resolvedConfig.model) resolvedConfig = { ...resolvedConfig, model: gated };
+    }
+    if (cancelled) throw new Cancelled();
     const runner = createAgentRunner(args.runnerSlug, resolvedConfig);
 
     // The agent still gets a working directory, and it must not be the repo:


### PR DESCRIPTION
## What changed

The cost of a run is decided by the model, not by the plan. Measured on the preview database (see #547): the same `campaign` kind costs $0.17 to $0.37 per run on the Claude-class agentic path against $0.0051 on `google/gemini-3.1-flash-lite`, which is what every function defaults to since #411. This adds the gate that keeps a plan's ceiling from being one pinned model away from a 40x cost jump.

- `shared/src/ai/model-functions.ts`: `PREMIUM_OUTPUT_PRICE_PER_TOKEN_USD` ($0.000005/output token, the measured numbers from #547 are in the comment above it), `isPremiumModel` (classifies a Gateway model id by the catalogue's own per-token output price, `shared/src/ai/gateway-catalogue.ts`), and `gateModelForPlan(fn, modelId, allowPremium)` - the actual resolution function, and what the tests target.
- Wired into both dispatch points, after every existing pin so neither can reach around it:
  - `web/src/lib/server/runner.ts`'s `dispatchRun`, right after the `runner_configs`/`model_functions` merge that used to be the last word on which model a run gets.
  - `web/src/lib/server/suggest.ts`'s `runSuggestion`, next to `resolveAssistRunnerConfig` rather than inside it - kept that function's signature and existing tests untouched since another agent in this wave (HouseStyleChecker) touches a different part of the same file.
- An id the Gateway catalogue cannot price - unknown, self-host with no Gateway key, a transient fetch failure - counts as premium, the safe direction. A plan that does allow premium models never even asks the catalogue.
- This is not a substitute for the org's own USD run budget (`shared/src/org-quota.ts`); it is what keeps that budget from being hit in three runs instead of a hundred.

## What I verified

- `pnpm exec vitest run shared/tests/model-premium-gate.test.ts shared/tests/model-functions.test.ts` - 17/17 passing. Covers: a plan without premium models forces the fast default even with Opus pinned for that function; a premium-allowed plan is unaffected; an unknown model id resolves as premium; pricing exactly at the threshold counts as premium; a premium-allowed plan never touches the catalogue at all.
- Proved the gate actually bites: temporarily replaced `gateModelForPlan`'s body with `return modelId;`, reran the suite, watched the two enforcement tests fail with the expected pinned-model-instead-of-default mismatch, then restored it and reran green.
- `npx eslint` / `npx prettier --check` on the four changed files.
- `pnpm -F @pitchbox/shared typecheck` - clean.
- `pnpm -F web check` legitimately fails right now with two "Cannot find module '@pitchbox/shared/plans'" errors - see Dependency below. I verified this is the *only* failure by temporarily stubbing `shared/src/plans.ts` locally (uncommitted, matching the batch's locked contract exactly) and rerunning: `pnpm -F web check` came back with 0 errors, and the full existing `web/tests/runner-defaults.test.ts` plus every `web/tests/extension-suggest*.test.ts` file (67 tests total) still passed against the stub's permissive default. The stub was never committed.

## Dependency

Consumes `resolveEntitlements` from `@pitchbox/shared/plans`, which the PlanCatalogue agent is building in this same wave and has not merged yet. This PR's CI will be red on the `quality` job until that lands - expected, not a bug in this change. Once PlanCatalogue's PR merges I will rebase onto `origin/main` and re-run the suite above against the real resolver before merging this one.

## What I deliberately did not do

- No allow-list of model ids. Classification is by the Gateway catalogue's price, per the issue.
- No change to `resolveAssistRunnerConfig`'s own signature or behavior - the gate composes around its result instead, to keep this diff narrow next to HouseStyleChecker's work in the same file.
- No change to the admin models form (`web/src/routes/settings/admin/models`) - enforcement lives at dispatch, a form that hides an option is not enforcement.

Closes #547
