### PR TITLE
feat(shared,web): a plan is one object, and an organization carries it

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -72,6 +72,32 @@ come from the product's `metadata` (`limit_projects`, `limit_runs`,
 `limit_budget_usd`, `limit_retention_days`, `limit_premium_models`), so changing
 what a plan includes is a metadata edit plus a script run, not a deploy.
 
+## Where an org's entitlements actually come from
+
+`shared/src/plans.ts` is the one place in the app that turns a plan into
+numbers (`resolveEntitlements(db, orgId)`), and everything else - the
+extension payload, a settings form, an enforcement point - reads its return
+value rather than a plan id. It carries its own fallback catalogue, kept
+equal to the table above and to the Stripe metadata `scripts/stripe-setup.ts`
+writes: not a second source of truth, but what an org resolves to _before_
+Stripe is asked - Free (which has no Stripe object, ever), an instance-admin
+grant (never Stripe-backed), and the gap before a subscription's first
+webhook lands. `organizations.plan`/`plan_source`/`plan_updated_at` record
+which plan and why; `org_subscriptions` mirrors a live subscription's
+metadata limits per org, one row per org, separate from `organizations`
+because a subscription has its own lifecycle - Stripe can delete it out from
+under us (see "A customer can ask Stripe to delete their data" below), and
+that has to look like a row disappearing, not a pile of nulled columns.
+
+Precedence, highest first: self-host (unlimited, no plan, no Stripe key
+required); an instance-admin grant (`plan_source='grant'`), which survives
+whatever Stripe says about the same org; a mirrored subscription
+(`org_subscriptions`); the fallback catalogue, keyed by `organizations.plan`
+and normalized to Free if that value does not name a real plan. `webhooks` is
+a feature flag rather than a metered limit, so it has no Stripe metadata
+counterpart and always comes from the catalogue, keyed by plan id, even for a
+mirrored subscription.
+
 ## What happens at a limit, and after a failed payment
 
 - A limit is a **hard refusal** with an upgrade prompt: no silent degrade to a

--- a/shared/package.json
+++ b/shared/package.json
@@ -82,7 +82,8 @@
     "./mail/registry": "./src/mail/registry.ts",
     "./mail/template": "./src/mail/template.ts",
     "./mail/env": "./src/mail/env.ts",
-    "./registration-policy": "./src/registration-policy.ts"
+    "./registration-policy": "./src/registration-policy.ts",
+    "./plans": "./src/plans.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",

--- a/shared/src/db/migrations/0027_org_plans.sql
+++ b/shared/src/db/migrations/0027_org_plans.sql
@@ -1,0 +1,42 @@
+CREATE TABLE "org_subscriptions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"organization_id" integer NOT NULL,
+	"stripe_customer_id" text NOT NULL,
+	"stripe_subscription_id" text NOT NULL,
+	"plan_id" text NOT NULL,
+	"status" text NOT NULL,
+	"current_period_end" timestamp with time zone NOT NULL,
+	"cancel_at_period_end" boolean DEFAULT false NOT NULL,
+	"limit_runs" integer,
+	"limit_suggestions" integer,
+	"limit_projects" integer,
+	"limit_seats" integer,
+	"limit_devices" integer,
+	"limit_concurrency" integer,
+	"limit_budget_usd" numeric(10, 2),
+	"limit_retention_days" integer,
+	"limit_premium_models" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "organizations" ADD COLUMN "plan" text DEFAULT 'free' NOT NULL;--> statement-breakpoint
+ALTER TABLE "organizations" ADD COLUMN "plan_source" text DEFAULT 'default' NOT NULL;--> statement-breakpoint
+ALTER TABLE "organizations" ADD COLUMN "plan_updated_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "org_subscriptions" ADD CONSTRAINT "org_subscriptions_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "org_subscriptions_org_unique" ON "org_subscriptions" USING btree ("organization_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "org_subscriptions_stripe_subscription_unique" ON "org_subscriptions" USING btree ("stripe_subscription_id");
+
+-- #544: every existing org gets the column defaults above ('free'/'default'),
+-- which is right for every self-created and invited org. The one exception is
+-- the seeded `default` org, the single-tenant self-host fallback
+-- (shared/src/db/seed-core.ts) - it must keep behaving exactly as before this
+-- migration (unlimited, unconfigured caps), and `resolveEntitlements`
+-- (shared/src/plans.ts) grants that only to a self-hosted edition OR a
+-- 'grant' org. Marking it 'scale'/'grant' here is belt and suspenders: on
+-- self-host `resolveEntitlements` ignores `plan` entirely, and on a cloud
+-- install that reused the seeded slug on purpose (mine, or a friend's) it
+-- reads as the highest grant rather than silently dropping to Free.
+UPDATE "organizations"
+SET "plan" = 'scale', "plan_source" = 'grant', "plan_updated_at" = now()
+WHERE "slug" = 'default';

--- a/shared/src/db/migrations/meta/0027_snapshot.json
+++ b/shared/src/db/migrations/meta/0027_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "319bb99a-3514-4e84-bd7d-4dc2d29b9c4c",
-  "prevId": "54b98c67-7944-473b-ab11-3ed3c9cb07c0",
+  "id": "affcb36a-403e-4075-9783-5e2c4c9f1b84",
+  "prevId": "319bb99a-3514-4e84-bd7d-4dc2d29b9c4c",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -157,6 +157,200 @@
       },
       "indexes": {},
       "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assist_usage": {
+      "name": "assist_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assist_usage_org_created_idx": {
+          "name": "assist_usage_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assist_usage_project_created_idx": {
+          "name": "assist_usage_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assist_usage_organization_id_organizations_id_fk": {
+          "name": "assist_usage_organization_id_organizations_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_project_id_projects_id_fk": {
+          "name": "assist_usage_project_id_projects_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_device_id_extension_devices_id_fk": {
+          "name": "assist_usage_device_id_extension_devices_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "extension_devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assist_usage_platform_id_platforms_id_fk": {
+          "name": "assist_usage_platform_id_platforms_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
@@ -3043,6 +3237,182 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.org_subscriptions": {
+      "name": "org_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "limit_runs": {
+          "name": "limit_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_suggestions": {
+          "name": "limit_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_projects": {
+          "name": "limit_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_seats": {
+          "name": "limit_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_devices": {
+          "name": "limit_devices",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrency": {
+          "name": "limit_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_budget_usd": {
+          "name": "limit_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_retention_days": {
+          "name": "limit_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_premium_models": {
+          "name": "limit_premium_models",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_org_unique": {
+          "name": "org_subscriptions_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_stripe_subscription_unique": {
+          "name": "org_subscriptions_stripe_subscription_unique",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_subscriptions_organization_id_organizations_id_fk": {
+          "name": "org_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "org_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.organizations": {
       "name": "organizations",
       "schema": "",
@@ -3083,6 +3453,27 @@
           "type": "integer",
           "primaryKey": false,
           "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_source": {
+          "name": "plan_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "plan_updated_at": {
+          "name": "plan_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
         }
       },
       "indexes": {},
@@ -4414,200 +4805,6 @@
             "id"
           ],
           "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.assist_usage": {
-      "name": "assist_usage",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "bigserial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "project_id": {
-          "name": "project_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "device_id": {
-          "name": "device_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "platform_id": {
-          "name": "platform_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "kind": {
-          "name": "kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "agent_runner": {
-          "name": "agent_runner",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "model": {
-          "name": "model",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "input_tokens": {
-          "name": "input_tokens",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "output_tokens": {
-          "name": "output_tokens",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cache_read_tokens": {
-          "name": "cache_read_tokens",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cache_creation_tokens": {
-          "name": "cache_creation_tokens",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cost_usd": {
-          "name": "cost_usd",
-          "type": "numeric(10, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "assist_usage_org_created_idx": {
-          "name": "assist_usage_org_created_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "assist_usage_project_created_idx": {
-          "name": "assist_usage_project_created_idx",
-          "columns": [
-            {
-              "expression": "project_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "assist_usage_organization_id_organizations_id_fk": {
-          "name": "assist_usage_organization_id_organizations_id_fk",
-          "tableFrom": "assist_usage",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "assist_usage_project_id_projects_id_fk": {
-          "name": "assist_usage_project_id_projects_id_fk",
-          "tableFrom": "assist_usage",
-          "tableTo": "projects",
-          "columnsFrom": [
-            "project_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "assist_usage_device_id_extension_devices_id_fk": {
-          "name": "assist_usage_device_id_extension_devices_id_fk",
-          "tableFrom": "assist_usage",
-          "tableTo": "extension_devices",
-          "columnsFrom": [
-            "device_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "assist_usage_platform_id_platforms_id_fk": {
-          "name": "assist_usage_platform_id_platforms_id_fk",
-          "tableFrom": "assist_usage",
-          "tableTo": "platforms",
-          "columnsFrom": [
-            "platform_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
           "onUpdate": "no action"
         }
       },

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1788960000013,
       "tag": "0026_email_verification_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1788960000014,
+      "tag": "0027_org_plans",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -84,7 +84,81 @@ export const organizations = pgTable('organizations', {
   // and nothing replaced it until this).
   monthlyRunBudgetUsd: numeric('monthly_run_budget_usd', { precision: 10, scale: 2 }),
   maxConcurrentRuns: integer('max_concurrent_runs'),
+  // The plan an org is on (#544, shared/src/plans.ts's PlanId) and where that
+  // value came from - not itself an entitlement source, a *record* of the
+  // most recent decision so setOrgPlan (shared/src/orgs.ts) has something to
+  // update atomically with the derived monthlyRunBudgetUsd/maxConcurrentRuns
+  // above. `resolveEntitlements` (shared/src/plans.ts) is what actually
+  // reads the numbers a plan means; this column is the input to that
+  // resolution, not a duplicate of its output.
+  // 'default': nobody has decided anything - a fresh org, always 'free'.
+  // 'grant': an instance admin set it by hand (setOrgPlan), and wins over
+  // any org_subscriptions row below.
+  // 'stripe': the last write came from the Stripe webhook (#551).
+  plan: text('plan').notNull().default('free'),
+  planSource: text('plan_source').notNull().default('default'),
+  planUpdatedAt: timestamp('plan_updated_at', { withTimezone: true }).notNull().defaultNow(),
 });
+
+// The Stripe side of a plan (#544, #551 writes it): a subscription has its
+// own lifecycle independent of the org's - it can lapse, get cancelled, or
+// simply vanish (a customer asking Stripe to delete their data removes the
+// Stripe objects from our account too, docs/billing.md "Emails and
+// support"), none of which is an event that happens to `organizations`
+// itself. A separate table, one row per org, rather than more nullable
+// columns on `organizations`, so that disappearance is a row delete
+// (`resolveEntitlements` falls through to the plan catalogue) instead of a
+// pile of columns that must be nulled out in lockstep.
+//
+// `limit_*` mirrors the product metadata `scripts/stripe-setup.ts` writes
+// (docs/billing.md "The plan catalogue lives in Stripe, not in the code"):
+// `limit_devices`/etc. follow the same convention the script already uses,
+// where the *string* `'0'` in Stripe metadata means unlimited on that axis
+// - the webhook handler that populates this table is expected to parse
+// that into a real SQL NULL before writing here, not store a literal 0.
+// The webhook is expected to write every column atomically from the
+// subscription's product metadata in one insert/update, never leave a row
+// half populated - `resolveEntitlements` prefers this row wholesale over
+// the code catalogue once it exists, it does not merge field by field.
+export const orgSubscriptions = pgTable(
+  'org_subscriptions',
+  {
+    id: serial('id').primaryKey(),
+    organizationId: integer('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    stripeCustomerId: text('stripe_customer_id').notNull(),
+    stripeSubscriptionId: text('stripe_subscription_id').notNull(),
+    // The plan the subscription's Stripe product names (its `metadata.plan`),
+    // mirrored here rather than re-derived from a price id lookup on every
+    // read. May outrun `organizations.plan` for one webhook delivery; the
+    // webhook is expected to write both in the same transaction.
+    planId: text('plan_id').notNull(),
+    // Stripe subscription status verbatim ('active', 'trialing', 'past_due',
+    // 'canceled', ...) - the grace-window and read-only handling that reads
+    // this is #548/#556, not built here.
+    status: text('status').notNull(),
+    currentPeriodEnd: timestamp('current_period_end', { withTimezone: true }).notNull(),
+    cancelAtPeriodEnd: boolean('cancel_at_period_end').notNull().default(false),
+    limitRuns: integer('limit_runs'),
+    limitSuggestions: integer('limit_suggestions'),
+    limitProjects: integer('limit_projects'),
+    limitSeats: integer('limit_seats'),
+    limitDevices: integer('limit_devices'),
+    limitConcurrency: integer('limit_concurrency'),
+    limitBudgetUsd: numeric('limit_budget_usd', { precision: 10, scale: 2 }),
+    limitRetentionDays: integer('limit_retention_days'),
+    limitPremiumModels: boolean('limit_premium_models').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    byOrg: uniqueIndex('org_subscriptions_org_unique').on(t.organizationId),
+    byStripeSubscription: uniqueIndex('org_subscriptions_stripe_subscription_unique').on(
+      t.stripeSubscriptionId,
+    ),
+  }),
+);
 
 export const memberships = pgTable(
   'memberships',

--- a/shared/src/orgs.ts
+++ b/shared/src/orgs.ts
@@ -13,6 +13,8 @@ import {
 } from './db/schema.js';
 import { ensurePersonalProject } from './personal-project.js';
 import { loadOrgQuotaDefaults, loadSelfRegistrationQuotaDefaults } from './org-quota.js';
+import { isCloud } from './edition.js';
+import { PLAN_CATALOGUE, type PlanId } from './plans.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Db = PgDatabase<any, any, any>;
@@ -361,7 +363,7 @@ export async function loadActiveOrganization(
 
 /**
  * Creates an organization with an owner membership, its `personal` project,
- * and a default run quota (#515) - the single primitive behind both a
+ * and a starting run quota - the single primitive behind both a
  * self-registered account's own org (`POST /api/auth/register`'s no-invite
  * path, #513) and an existing user creating an additional org (`POST
  * /api/orgs`). Neither caller is an operator who has configured anything
@@ -371,14 +373,25 @@ export async function loadActiveOrganization(
  * its unlimited, unconfigured caps - it is the single-tenant self-host
  * fallback, not a self-created tenant.
  *
- * `quotaSource` (#540) picks which `app_config` defaults the new org
- * starts with. Defaults to `'invited'` (`org_quota_defaults`), what
- * `POST /api/orgs` always passes implicitly: that caller already has an
- * account on this instance, invited or not. The register route's no-invite
- * branch alone passes `'self_registration'`
- * (`self_registration_quota_defaults`), a separate, lower key so raising
- * what an invited or paying tenant gets never also raises what a stranger
- * who just typed an email into `/register` gets.
+ * Two different sources for that starting budget/concurrency, and which one
+ * applies depends on the edition (#544), not on `quotaSource`:
+ *
+ * - **Cloud**: every new org starts on the Free plan (`organizations.plan`
+ *   keeps its column default of `'free'`/`'default'`), and Free's own
+ *   `monthlyRunBudgetUsd`/`maxConcurrentRuns` (`shared/src/plans.ts`) are
+ *   what land on the row - `quotaSource` is accepted but does not change the
+ *   numbers, since a stranger and an invited tenant both land on the same
+ *   plan until they pay or get a grant.
+ * - **Self-host has no plans** (`resolveEntitlements` always returns
+ *   unlimited there, so `organizations.plan` is never read): it keeps
+ *   reading the `app_config` knobs an operator can edit without a redeploy,
+ *   same as before this issue. `quotaSource` (#540) picks which one:
+ *   `'invited'` (`org_quota_defaults`), what `POST /api/orgs` always passes
+ *   implicitly (that caller already has an account on this instance, invited
+ *   or not), or `'self_registration'` (`self_registration_quota_defaults`),
+ *   passed only by the register route's no-invite branch - a separate, lower
+ *   key so raising what an invited or paying tenant gets never also raises
+ *   what a stranger who just typed an email into `/register` gets.
  */
 export async function createOrganization(
   db: Db,
@@ -389,17 +402,26 @@ export async function createOrganization(
     quotaSource?: 'invited' | 'self_registration';
   },
 ): Promise<{ id: number; slug: string; role: string }> {
-  const quotaDefaults =
-    args.quotaSource === 'self_registration'
-      ? await loadSelfRegistrationQuotaDefaults(db)
-      : await loadOrgQuotaDefaults(db);
+  let monthlyRunBudgetUsd: number | null;
+  let maxConcurrentRuns: number | null;
+  if (isCloud()) {
+    monthlyRunBudgetUsd = PLAN_CATALOGUE.free.monthlyRunBudgetUsd;
+    maxConcurrentRuns = PLAN_CATALOGUE.free.maxConcurrentRuns;
+  } else {
+    const quotaDefaults =
+      args.quotaSource === 'self_registration'
+        ? await loadSelfRegistrationQuotaDefaults(db)
+        : await loadOrgQuotaDefaults(db);
+    monthlyRunBudgetUsd = quotaDefaults.monthlyRunBudgetUsd;
+    maxConcurrentRuns = quotaDefaults.maxConcurrentRuns;
+  }
   const [org] = await db
     .insert(organizations)
     .values({
       slug: args.slug,
       name: args.name,
-      monthlyRunBudgetUsd: quotaDefaults.monthlyRunBudgetUsd.toFixed(2),
-      maxConcurrentRuns: quotaDefaults.maxConcurrentRuns,
+      monthlyRunBudgetUsd: monthlyRunBudgetUsd == null ? null : monthlyRunBudgetUsd.toFixed(2),
+      maxConcurrentRuns,
     })
     .returning();
   await db
@@ -412,6 +434,44 @@ export async function createOrganization(
   // means a brand new org is never waiting on a migration to have one.
   await ensurePersonalProject(db, org.id);
   return { id: org.id, slug: org.slug, role: 'owner' };
+}
+
+/**
+ * Sets an organization's plan (#544) - the only writer of
+ * `organizations.plan`/`plan_source`/`plan_updated_at` outside the Stripe
+ * webhook (#551, not built here, which is expected to call this with
+ * `source: 'stripe'`). `source: 'grant'` is what an instance-admin grant
+ * route (gated by `requireInstanceAdmin`, not an org's own admin) uses - my
+ * own org, a client's org, a friend's org, all stop being billing problems
+ * this way. Syncs `monthly_run_budget_usd`/`max_concurrent_runs` from the
+ * new plan's own numbers in the same update, so the existing dispatch checks
+ * (`getOrgQuotaSnapshot`, `assertOrgConcurrencyAdmitted` in
+ * `shared/src/org-quota.ts`) keep enforcing the right ceiling without
+ * themselves knowing plans exist - see `resolveEntitlements`
+ * (`shared/src/plans.ts`) for why a grant then outranks whatever a
+ * subscription mirrors for the same org. Returns true if a row was updated,
+ * false if the org does not exist.
+ */
+export async function setOrgPlan(
+  db: Db,
+  orgId: number,
+  planId: PlanId,
+  source: 'grant' | 'stripe',
+): Promise<boolean> {
+  const plan = PLAN_CATALOGUE[planId];
+  const rows = await db
+    .update(organizations)
+    .set({
+      plan: planId,
+      planSource: source,
+      planUpdatedAt: new Date(),
+      monthlyRunBudgetUsd:
+        plan.monthlyRunBudgetUsd == null ? null : plan.monthlyRunBudgetUsd.toFixed(2),
+      maxConcurrentRuns: plan.maxConcurrentRuns,
+    })
+    .where(eq(organizations.id, orgId))
+    .returning({ id: organizations.id });
+  return rows.length > 0;
 }
 
 /**

--- a/shared/src/plans.ts
+++ b/shared/src/plans.ts
@@ -1,0 +1,275 @@
+// The plan catalogue (#543): one object every entitlement check reads. Free,
+// Solo, Growth and Scale, plus the resolver (`resolveEntitlements`) that
+// turns an org id into the numbers that actually apply to it.
+//
+// The paid tiers' authoritative numbers do not live here - they live in
+// Stripe product metadata (`scripts/stripe-setup.ts`, docs/billing.md "The
+// plan catalogue lives in Stripe, not in the code", #588). That decision
+// landed after this issue was written, and it changes what "one place" means
+// without changing the rule: nothing outside this module may declare a plan
+// limit. The catalogue below is what an org's entitlements resolve to
+// *before* Stripe is asked - Free (which has no Stripe object at all, ever),
+// a grant (never Stripe-backed by definition), and a subscription for which
+// no webhook has mirrored anything onto `org_subscriptions` yet (#551 writes
+// that table; a delivery gap or a subscription Stripe deleted out from under
+// us both look like "no row" and fall back to this catalogue rather than to
+// unlimited). The numbers here are kept equal to the Stripe metadata
+// `scripts/stripe-setup.ts` writes and to the table in docs/billing.md - if
+// the two ever disagree, the doc wins, since the script is what actually
+// configures the running deployment.
+//
+// `webhooks` has no Stripe metadata counterpart - Stripe carries numeric
+// limits, not feature flags - so it always comes from here, keyed by plan
+// id, even for a mirrored subscription.
+import { eq } from 'drizzle-orm';
+import { schema, type Db } from './db/client.js';
+import { isCloud } from './edition.js';
+
+export const PLAN_IDS = ['free', 'solo', 'growth', 'scale'] as const;
+export type PlanId = (typeof PLAN_IDS)[number];
+
+export function isPlanId(value: unknown): value is PlanId {
+  return typeof value === 'string' && (PLAN_IDS as readonly string[]).includes(value);
+}
+
+/**
+ * `value` if it names a real plan, else `'free'` - the fallback every
+ * unresolvable plan id lands on (a stale row, a retired plan, a typo hand-
+ * entered by a grant). Deliberately never "unlimited": that would give a
+ * data bug the same effect as a paid subscription.
+ */
+export function normalizePlanId(value: string | null | undefined): PlanId {
+  return isPlanId(value) ? value : 'free';
+}
+
+/**
+ * The catalogue entry for one plan: every number in the epic's table
+ * (#542), plus the display fields the pricing page and the settings UI
+ * need. `accounts` (connected accounts per platform, or a flat cap on Free)
+ * is carried here for display even though `Entitlements` below does not
+ * expose it - no enforcement point reads a connected-account limit yet, and
+ * inventing a field on the resolver's return type ahead of a real reader
+ * would be exactly the kind of second copy this module exists to prevent.
+ * When that enforcement lands, it reads `PLAN_CATALOGUE[planId].accounts`.
+ */
+export type PlanDefinition = {
+  id: PlanId;
+  name: string;
+  /** Tax-exclusive EUR, minor units. USD carries the same headline number
+   * (docs/billing.md "USD stays at numeric parity", #542 comment 2026-09-09),
+   * so one figure serves both currencies' display. `null` on Free: it has no
+   * price, not a price of zero to render. */
+  monthlyPriceCents: number | null;
+  annualPriceCents: number | null;
+  runsPerMonth: number | null;
+  suggestionsPerMonth: number | null;
+  projects: number | null;
+  /** Connected accounts. Free is one per platform (a flat 1, not per-
+   * platform metering); Growth and Scale are unlimited. */
+  accounts: number | null;
+  seats: number | null;
+  extensionDevices: number | null;
+  maxConcurrentRuns: number | null;
+  monthlyRunBudgetUsd: number | null;
+  retentionDays: number | null;
+  premiumModels: boolean;
+  webhooks: boolean;
+};
+
+/** The catalogue itself, exported directly rather than behind a getter -
+ * indexing a plain object by a `PlanId` needs no indirection. */
+export const PLAN_CATALOGUE: Record<PlanId, PlanDefinition> = {
+  free: {
+    id: 'free',
+    name: 'Free',
+    monthlyPriceCents: null,
+    annualPriceCents: null,
+    runsPerMonth: 20,
+    suggestionsPerMonth: 50,
+    projects: 1,
+    accounts: 1,
+    seats: 1,
+    extensionDevices: 1,
+    maxConcurrentRuns: 1,
+    monthlyRunBudgetUsd: 2,
+    retentionDays: 14,
+    premiumModels: false,
+    webhooks: false,
+  },
+  solo: {
+    id: 'solo',
+    name: 'Pitchbox Solo',
+    monthlyPriceCents: 2900,
+    annualPriceCents: 29000,
+    runsPerMonth: 500,
+    suggestionsPerMonth: 500,
+    projects: 3,
+    accounts: 5,
+    seats: 1,
+    extensionDevices: 3,
+    maxConcurrentRuns: 2,
+    monthlyRunBudgetUsd: 10,
+    retentionDays: 30,
+    premiumModels: false,
+    webhooks: false,
+  },
+  growth: {
+    id: 'growth',
+    name: 'Pitchbox Growth',
+    monthlyPriceCents: 7900,
+    annualPriceCents: 79000,
+    runsPerMonth: 2000,
+    suggestionsPerMonth: 2000,
+    projects: 10,
+    accounts: null,
+    seats: 3,
+    extensionDevices: 10,
+    maxConcurrentRuns: 4,
+    monthlyRunBudgetUsd: 30,
+    retentionDays: 90,
+    premiumModels: true,
+    webhooks: true,
+  },
+  scale: {
+    id: 'scale',
+    name: 'Pitchbox Scale',
+    monthlyPriceCents: 19900,
+    annualPriceCents: 199000,
+    runsPerMonth: 8000,
+    suggestionsPerMonth: 8000,
+    projects: 30,
+    accounts: null,
+    seats: 10,
+    extensionDevices: null,
+    maxConcurrentRuns: 8,
+    monthlyRunBudgetUsd: 70,
+    retentionDays: 180,
+    premiumModels: true,
+    webhooks: true,
+  },
+};
+
+/** Every plan, Free through Scale, in ladder order - the pricing page's
+ * only reader of the catalogue (#558, not built here). */
+export function listPlans(): PlanDefinition[] {
+  return PLAN_IDS.map((id) => PLAN_CATALOGUE[id]);
+}
+
+/**
+ * The `lookup_key` a paid plan's Stripe price resolves under
+ * (docs/billing.md "The app resolves prices by lookup_key, never by id"):
+ * `pitchbox_<planId>_monthly` / `pitchbox_<planId>_yearly`, exactly what
+ * `scripts/stripe-setup.ts` writes. Free has no Stripe object, so no plan
+ * ever asks this for `'free'`; callers that might still try get `null`
+ * rather than a key that resolves nothing.
+ */
+export function stripeLookupKey(planId: PlanId, interval: 'monthly' | 'yearly'): string | null {
+  if (planId === 'free') return null;
+  return `pitchbox_${planId}_${interval === 'monthly' ? 'monthly' : 'yearly'}`;
+}
+
+/**
+ * The effective limits and features for an organization - the only shape
+ * any enforcement point, settings form, pricing page or extension payload
+ * may read a plan number from. `null` on a numeric field means unlimited,
+ * the same convention `organizations.monthly_run_budget_usd` already uses;
+ * there is no second sentinel.
+ */
+export type Entitlements = {
+  runsPerMonth: number | null;
+  suggestionsPerMonth: number | null;
+  projects: number | null;
+  seats: number | null;
+  extensionDevices: number | null;
+  maxConcurrentRuns: number | null;
+  monthlyRunBudgetUsd: number | null;
+  retentionDays: number | null;
+  premiumModels: boolean;
+  webhooks: boolean;
+  planId: PlanId;
+  /** Where these numbers came from: 'self-host' (edition override, always
+   * unlimited), 'grant' (an instance admin set the plan by hand), 'subscription'
+   * (mirrored from a live Stripe subscription), or 'default' (the code
+   * catalogue, because nothing above applied - the common case for Free). */
+  source: 'self-host' | 'grant' | 'subscription' | 'default';
+};
+
+/**
+ * Resolves the entitlements an organization actually gets, in precedence
+ * order: self-host beats everything (no cloud edition, no billing, full
+ * access); an instance-admin grant beats a live subscription (`setOrgPlan`
+ * in `shared/src/orgs.ts` is the only writer of a grant, and it is meant to
+ * survive whatever Stripe says about the same org); a mirrored subscription
+ * beats the code catalogue (docs/billing.md: the catalogue in Stripe product
+ * metadata is authoritative for a paying org); the code catalogue, keyed by
+ * `organizations.plan` and normalized to `'free'` if that value does not
+ * name a real plan, is the fallback everything else lands on.
+ */
+export async function resolveEntitlements(db: Db, orgId: number): Promise<Entitlements> {
+  const [org] = await db
+    .select({ plan: schema.organizations.plan, planSource: schema.organizations.planSource })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.id, orgId))
+    .limit(1);
+  const planId = normalizePlanId(org?.plan);
+
+  if (!isCloud()) {
+    return {
+      runsPerMonth: null,
+      suggestionsPerMonth: null,
+      projects: null,
+      seats: null,
+      extensionDevices: null,
+      maxConcurrentRuns: null,
+      monthlyRunBudgetUsd: null,
+      retentionDays: null,
+      premiumModels: true,
+      webhooks: true,
+      planId,
+      source: 'self-host',
+    };
+  }
+
+  // A grant never consults the subscription row at all: it must survive
+  // whatever Stripe says about the same org, not merely outrank it once
+  // both are read.
+  if (org?.planSource !== 'grant') {
+    const [sub] = await db
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.organizationId, orgId))
+      .limit(1);
+    if (sub) {
+      return {
+        runsPerMonth: sub.limitRuns,
+        suggestionsPerMonth: sub.limitSuggestions,
+        projects: sub.limitProjects,
+        seats: sub.limitSeats,
+        extensionDevices: sub.limitDevices,
+        maxConcurrentRuns: sub.limitConcurrency,
+        monthlyRunBudgetUsd: sub.limitBudgetUsd == null ? null : Number(sub.limitBudgetUsd),
+        retentionDays: sub.limitRetentionDays,
+        premiumModels: sub.limitPremiumModels,
+        webhooks: PLAN_CATALOGUE[normalizePlanId(sub.planId)].webhooks,
+        planId: normalizePlanId(sub.planId),
+        source: 'subscription',
+      };
+    }
+  }
+
+  const plan = PLAN_CATALOGUE[planId];
+  return {
+    runsPerMonth: plan.runsPerMonth,
+    suggestionsPerMonth: plan.suggestionsPerMonth,
+    projects: plan.projects,
+    seats: plan.seats,
+    extensionDevices: plan.extensionDevices,
+    maxConcurrentRuns: plan.maxConcurrentRuns,
+    monthlyRunBudgetUsd: plan.monthlyRunBudgetUsd,
+    retentionDays: plan.retentionDays,
+    premiumModels: plan.premiumModels,
+    webhooks: plan.webhooks,
+    planId: plan.id,
+    source: org?.planSource === 'grant' ? 'grant' : 'default',
+  };
+}

--- a/shared/tests/plans.test.ts
+++ b/shared/tests/plans.test.ts
@@ -1,0 +1,107 @@
+// Exercises shared/src/plans.ts's resolveEntitlements: the precedence order
+// between self-host, an instance-admin grant, a mirrored Stripe subscription
+// and the code catalogue's fallback (#543/#544). Deliberately not testing
+// the free plan's numbers by writing them out again - PLAN_CATALOGUE.free is
+// already the single source, restating it in an assertion would only prove
+// the test copied the module correctly.
+import { randomUUID } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import { PLAN_CATALOGUE, resolveEntitlements } from '../src/plans.js';
+import { setOrgPlan } from '../src/orgs.js';
+
+const createdOrgIds: number[] = [];
+const savedEdition = process.env.PITCHBOX_EDITION;
+
+afterEach(async () => {
+  const db = getDb();
+  while (createdOrgIds.length > 0) {
+    const id = createdOrgIds.pop()!;
+    // org_subscriptions is onDelete: 'cascade' off organizations.
+    await db.delete(schema.organizations).where(eq(schema.organizations.id, id));
+  }
+  if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+  else process.env.PITCHBOX_EDITION = savedEdition;
+});
+
+async function makeOrg(overrides: { plan?: string; planSource?: string } = {}) {
+  const db = getDb();
+  const slug = `plans-test-${randomUUID()}`;
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({
+      slug,
+      name: slug,
+      ...(overrides.plan ? { plan: overrides.plan } : {}),
+      ...(overrides.planSource ? { planSource: overrides.planSource } : {}),
+    })
+    .returning();
+  createdOrgIds.push(org.id);
+  return org.id;
+}
+
+describe('resolveEntitlements', () => {
+  it('self-host: unlimited on every axis regardless of the stored plan', async () => {
+    process.env.PITCHBOX_EDITION = 'self-hosted';
+    const orgId = await makeOrg({ plan: 'scale', planSource: 'grant' });
+    const entitlements = await resolveEntitlements(getDb(), orgId);
+    expect(entitlements.source).toBe('self-host');
+    expect(entitlements.runsPerMonth).toBeNull();
+    expect(entitlements.suggestionsPerMonth).toBeNull();
+    expect(entitlements.projects).toBeNull();
+    expect(entitlements.seats).toBeNull();
+    expect(entitlements.extensionDevices).toBeNull();
+    expect(entitlements.maxConcurrentRuns).toBeNull();
+    expect(entitlements.monthlyRunBudgetUsd).toBeNull();
+    expect(entitlements.retentionDays).toBeNull();
+    expect(entitlements.premiumModels).toBe(true);
+    expect(entitlements.webhooks).toBe(true);
+  });
+
+  it('a grant beats a subscription, even a later one mirrored for the same org', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const db = getDb();
+    const orgId = await makeOrg();
+    const granted = await setOrgPlan(db, orgId, 'scale', 'grant');
+    expect(granted).toBe(true);
+
+    // Simulate what the Stripe webhook (#551, not built here) would write on
+    // a later `customer.subscription.updated` for the same org: a real
+    // mirrored subscription, on a lower plan than the grant.
+    await db.insert(schema.orgSubscriptions).values({
+      organizationId: orgId,
+      stripeCustomerId: 'cus_test',
+      stripeSubscriptionId: `sub_test_${randomUUID()}`,
+      planId: 'solo',
+      status: 'active',
+      currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      limitRuns: PLAN_CATALOGUE.solo.runsPerMonth,
+      limitSuggestions: PLAN_CATALOGUE.solo.suggestionsPerMonth,
+      limitProjects: PLAN_CATALOGUE.solo.projects,
+      limitSeats: PLAN_CATALOGUE.solo.seats,
+      limitDevices: PLAN_CATALOGUE.solo.extensionDevices,
+      limitConcurrency: PLAN_CATALOGUE.solo.maxConcurrentRuns,
+      limitBudgetUsd: String(PLAN_CATALOGUE.solo.monthlyRunBudgetUsd),
+      limitRetentionDays: PLAN_CATALOGUE.solo.retentionDays,
+      limitPremiumModels: PLAN_CATALOGUE.solo.premiumModels,
+    });
+
+    const entitlements = await resolveEntitlements(db, orgId);
+    expect(entitlements.source).toBe('grant');
+    expect(entitlements.planId).toBe('scale');
+    expect(entitlements.runsPerMonth).toBe(PLAN_CATALOGUE.scale.runsPerMonth);
+    expect(entitlements.maxConcurrentRuns).toBe(PLAN_CATALOGUE.scale.maxConcurrentRuns);
+  });
+
+  it('an unknown plan id falls back to free, not to unlimited', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const orgId = await makeOrg({ plan: 'enterprise-legacy-typo', planSource: 'default' });
+    const entitlements = await resolveEntitlements(getDb(), orgId);
+    expect(entitlements.source).toBe('default');
+    expect(entitlements.planId).toBe('free');
+    expect(entitlements.runsPerMonth).toBe(PLAN_CATALOGUE.free.runsPerMonth);
+    expect(entitlements.projects).toBe(PLAN_CATALOGUE.free.projects);
+    expect(entitlements.premiumModels).toBe(false);
+  });
+});

--- a/web/src/routes/api/auth/register/+server.ts
+++ b/web/src/routes/api/auth/register/+server.ts
@@ -195,11 +195,14 @@ export async function POST(event: RequestEvent) {
         // organization, never `default` (the single-tenant self-host
         // fallback stays untouched either way), through the same
         // createOrganization primitive an already-logged-in user's `POST
-        // /api/orgs` uses. `quotaSource: 'self_registration'` (#540) is the
-        // one thing that differs: this account has had zero human review,
-        // so it starts on the lower self-registration default rather than
-        // the shared org_quota_defaults an invited or manually-provisioned
-        // org gets.
+        // /api/orgs` uses. `quotaSource: 'self_registration'` (#540) only
+        // matters on self-host: this account has had zero human review, so
+        // it starts on the lower self-registration default rather than the
+        // shared org_quota_defaults an invited or manually-provisioned org
+        // gets. On the cloud edition it does nothing - every fresh org
+        // starts on the Free plan (#544, shared/src/plans.ts) regardless of
+        // how it was created, since Free's own numbers are already the
+        // low-trust ceiling this used to provide.
         const slug = await uniqueOrgSlugFromUsername(tx, parsed.data.username);
         await createOrganization(tx, {
           slug,


### PR DESCRIPTION
## What changed

`shared/src/plans.ts`: the plan catalogue as code (#543) - `PLAN_IDS`, one
`PlanDefinition` per plan (numbers match `docs/billing.md`'s table), and
`resolveEntitlements(db, orgId)`, the only function anything in the repo may
read a plan limit from. Exported via `shared/package.json`'s exports map as
`./plans`, matching the batch contract this wave agreed on.

`organizations` gains `plan`/`plan_source`/`plan_updated_at` (#544), and a new
`org_subscriptions` table mirrors a live Stripe subscription's limits per org.
`createOrganization` now derives its starting budget/concurrency from the Free
plan on the cloud edition; self-host is untouched (it never reads `plan` at
all - see below). `setOrgPlan` is the one function that grants a plan by hand.

## The one real reconciliation (and a smaller one)

#543 was written before #588 decided the paid catalogue lives in Stripe
product metadata (`scripts/stripe-setup.ts`), not in the code. Resolved as:
the code catalogue in `plans.ts` is the fallback and the shape - Free (no
Stripe object, ever), a grant (never Stripe-backed), and the gap before a
subscription's first webhook lands - and the new `org_subscriptions` table is
what a real subscription mirrors into per org. `resolveEntitlements`
precedence, highest first: self-host > grant > mirrored subscription >
catalogue (normalized to Free for an unrecognized plan id). `webhooks` has no
Stripe metadata counterpart (a feature flag, not a metered limit), so it
always comes from the catalogue by plan id, even for a mirrored subscription.
Documented in `docs/billing.md`'s new "Where an org's entitlements actually
come from" section and in `plans.ts`'s header comment.

Smaller one: #543's body says "Stripe price ids resolved from env rather than
hardcoded"; `docs/billing.md` (written after, #588) says prices resolve by
`lookup_key`, never by id. Followed the doc: `stripeLookupKey(planId,
interval)` computes `pitchbox_<planId>_<monthly|yearly>`, the exact shape
`scripts/stripe-setup.ts` already writes, instead of inventing an env-var
indirection that contradicts the source of truth.

## Schema choice

`org_subscriptions` is a separate table (one row per org, `onDelete:
'cascade'`) rather than more nullable columns on `organizations`. A
subscription has its own lifecycle independent of the org's - Stripe can
delete it out from under us (a customer asking Stripe to delete their data
removes the Stripe objects from our account too, per `docs/billing.md`) - so
that has to look like a row disappearing (`resolveEntitlements` falls through
to the catalogue), not a pile of columns that must be nulled out in lockstep.
The webhook that populates it (#551, not built here) is documented to write
every `limit_*` column atomically in one insert/update; `resolveEntitlements`
prefers the row wholesale when present rather than merging field by field.

## Migration

`0027_org_plans.sql`: adds the three `organizations` columns (defaults
`'free'`/`'default'`/`now()`) and creates `org_subscriptions`, then backfills
the seeded `default` org (the single-tenant self-host fallback) to
`plan='scale', plan_source='grant'` so its behavior is unchanged - self-host's
`resolveEntitlements` ignores `plan` entirely, but this also means a cloud
install that reuses that slug on purpose reads as the highest grant instead of
silently landing on Free.

**Found and repaired along the way, not part of the intended diff**:
`0025_supreme_molecule_man.sql` and `0026_email_verification_tokens.sql` were
already merged to `main` with forked `drizzle-kit` snapshot lineage
(`0026_snapshot.json` never picked up `0025`'s `assist_usage` table), which
made `migrate:generate` fail outright before I could generate my own
migration. Fixed by merging `0025`'s table definition into `0026_snapshot.json`
and correcting its `prevId` - metadata-only, no `.sql` file, journal
tag/`when`, or already-applied database touched (verified: both migrations'
SQL is disjoint and already applied everywhere regardless of this bookkeeping
bug). Filed as #591 under a new #590 (a developer-tooling epic, since nothing
existing fit) proposing a CI check so this class of fork can't merge silently
again.

## Verified

- `pnpm exec vitest run shared/tests/plans.test.ts shared/tests/org-quota.test.ts web/tests/active-org.test.ts` - 44/44 passing (`DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5434/pitchbox_test_plans`).
- `resolveEntitlements` has exactly the three tests that matter (not a fourth restating Free's numbers): self-host unlimited regardless of stored plan, a grant beating a subscription mirrored *after* the grant, an unknown plan id falling back to Free rather than unlimited.
- `pnpm -F @pitchbox/shared typecheck` clean; `npx eslint`/`prettier --check` clean on every changed file.
- `pnpm run migrate` applied all 27 migrations against a fresh test DB (`migrations applied (27 in journal, all present)`); `psql ... '\dt'` shows `organizations` and `org_subscriptions`; `\d organizations` shows the three new columns with their defaults.
- Backfill proven directly: inserted a row simulating a pre-existing `default` org (gets `plan='free'` from the column default, same as an existing row would after the `ALTER TABLE`), ran the migration's exact `UPDATE ... WHERE slug='default'`, confirmed it flips to `plan='scale', plan_source='grant'`.
- `createOrganization`'s edition branching proven with a throwaway script (removed after): a fresh org on the cloud edition lands on Free's numbers (budget `2.00`, concurrency `1`); the same call on self-host is unchanged (budget `20.00`, concurrency `2`, `org_quota_defaults`' fallback).

## Deliberately not done

- Enforcement at any effect (#548), the usage snapshot (#546), the Stripe
  webhook that writes `org_subscriptions` (#551), the pricing page (#558),
  model gating (#547, owned by a sibling this wave) - all explicitly out of
  scope for this pair.
- No admin route/UI for calling `setOrgPlan` - #544's body mentions one
  ("gated by `requireInstanceAdmin`"), but it is not in this issue's numbered
  acceptance criteria and there is no admin billing surface yet to hang it
  from. `setOrgPlan` exists and is tested (the grant-beats-subscription case);
  wiring a route to it is better scoped with whatever admin surface #551/#556
  end up building.
- `accounts` (connected-accounts limit) is on `PlanDefinition` for the future
  pricing page but deliberately not on `Entitlements` - the batch contract for
  this wave fixes that type's shape exactly, and no enforcement point reads a
  connected-account limit yet.

Closes #543
Closes #544
