### PR TITLE
feat(shared,cli): check house style in code, not just ask for it in a prompt

### DIFF
--- a/cli/src/commands/drafts.ts
+++ b/cli/src/commands/drafts.ts
@@ -22,6 +22,7 @@ import {
 import { notify } from '@pitchbox/shared/notifications';
 import { getProjectOrgId } from '@pitchbox/shared/orgs';
 import { loadQualityRubric } from '@pitchbox/shared/quality-judge';
+import { enforceHouseStyle, type StyleFinding } from '@pitchbox/shared/style-check';
 import { buildRedditComposeUrl } from '@pitchbox/shared/platforms/reddit';
 import { buildHackernewsComposeUrl } from '@pitchbox/shared/platforms/hackernews';
 import { buildMastodonComposeUrl } from '@pitchbox/shared/platforms/mastodon';
@@ -324,10 +325,38 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
     allowed.push(d);
   }
 
-  const rows = allowed.flatMap((d) => {
+  // House style (#572) is enforced here, deterministically, before
+  // persistence. `drafts:create` runs after the agent turn that wrote the
+  // draft has already exited, so there is no live model to send a targeted
+  // rewrite instruction back to - `enforceHouseStyle`'s `rewrite` argument
+  // is left unset on purpose. Mechanical repair still runs unconditionally
+  // (a banned character never reaches the inbox), and any structural
+  // finding it cannot fix mechanically travels with the draft in
+  // `metadata.styleFindings` rather than being silently accepted: a
+  // suggestion the operator can fix beats one he does not know is wrong.
+  // Applies to `body` and `title` - the two fields a target actually reads;
+  // `reasoning` is operator-facing only and is never sent.
+  const styled = await Promise.all(
+    allowed.map(async (d) => {
+      const bodyResult = await enforceHouseStyle(d.body);
+      const titleResult = d.title != null ? await enforceHouseStyle(d.title) : null;
+      const variantResults = d.variants
+        ? await Promise.all(d.variants.map((v) => enforceHouseStyle(v)))
+        : null;
+      return {
+        ...d,
+        styledBody: bodyResult.text,
+        styledTitle: titleResult ? titleResult.text : (d.title ?? null),
+        styleFindings: [...bodyResult.findings, ...(titleResult?.findings ?? [])],
+        styledVariants: variantResults ? variantResults.map((r) => r.text) : null,
+        variantStyleFindings: variantResults ? variantResults.map((r) => r.findings) : null,
+      };
+    }),
+  );
+
+  const rows = styled.flatMap((d) => {
     const baseMeta = d.subreddit ? { ...d.metadata, subreddit: d.subreddit } : d.metadata;
-    const variantBodies = d.variants && d.variants.length > 0 ? [d.body, ...d.variants] : null;
-    if (!variantBodies) {
+    if (!d.styledVariants) {
       return [
         {
           runId,
@@ -338,14 +367,14 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
           state: 'pending_review' as const,
           fitScore: d.fitScore ?? null,
           targetUser: d.targetUser ?? null,
-          title: d.title ?? null,
-          body: d.body,
+          title: d.styledTitle,
+          body: d.styledBody,
           composeUrl: buildComposeUrl(platform?.slug ?? null, {
             kind: d.kind,
             targetUser: d.targetUser ?? null,
             subreddit: d.subreddit ?? null,
-            title: d.title ?? null,
-            body: d.body,
+            title: d.styledTitle,
+            body: d.styledBody,
             subject: offerSubject,
             instanceUrl: accountsById.get(d.accountId)?.instanceUrl ?? null,
             sourceRef: d.sourceRef,
@@ -353,7 +382,17 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
           }),
           reasoning: d.reasoning ?? null,
           sourceRef: d.sourceRef,
-          metadata: baseMeta,
+          metadata:
+            d.styleFindings.length > 0
+              ? {
+                  ...baseMeta,
+                  styleFindings: d.styleFindings.map((f: StyleFinding) => ({
+                    ruleId: f.ruleId,
+                    message: f.message,
+                    span: f.span,
+                  })),
+                }
+              : baseMeta,
           dedupWarning: d.dedupWarning ?? null,
           variantGroupId: null as string | null,
           variantLabel: null as string | null,
@@ -364,7 +403,24 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
         },
       ];
     }
-    const grouped = groupVariants(variantBodies.map((b) => ({ body: b })));
+    const seeds = [d.styledBody, ...d.styledVariants].map((body, i) => {
+      const findings: StyleFinding[] =
+        i === 0 ? d.styleFindings : (d.variantStyleFindings?.[i - 1] ?? []);
+      return {
+        body,
+        metadata:
+          findings.length > 0
+            ? {
+                styleFindings: findings.map((f) => ({
+                  ruleId: f.ruleId,
+                  message: f.message,
+                  span: f.span,
+                })),
+              }
+            : undefined,
+      };
+    });
+    const grouped = groupVariants(seeds);
     return grouped.rows.map((r) => ({
       runId,
       projectId: campaign.projectId,
@@ -374,13 +430,13 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
       state: 'pending_review' as const,
       fitScore: d.fitScore ?? null,
       targetUser: d.targetUser ?? null,
-      title: d.title ?? null,
+      title: d.styledTitle,
       body: r.body,
       composeUrl: buildComposeUrl(platform?.slug ?? null, {
         kind: d.kind,
         targetUser: d.targetUser ?? null,
         subreddit: d.subreddit ?? null,
-        title: d.title ?? null,
+        title: d.styledTitle,
         body: r.body,
         subject: offerSubject,
         instanceUrl: accountsById.get(d.accountId)?.instanceUrl ?? null,
@@ -389,7 +445,7 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
       }),
       reasoning: d.reasoning ?? null,
       sourceRef: d.sourceRef,
-      metadata: baseMeta,
+      metadata: { ...baseMeta, ...(r.metadata ?? {}) },
       dedupWarning: d.dedupWarning ?? null,
       variantGroupId: r.variantGroupId,
       variantLabel: r.variantLabel,

--- a/cli/tests/commands/drafts-create.test.ts
+++ b/cli/tests/commands/drafts-create.test.ts
@@ -94,6 +94,71 @@ describe('pitchbox drafts:create', () => {
     expect(drafts[0].qualityModel).toBeNull();
   });
 
+  it('enforces house style on the body through drafts:create (#572): mechanical repair applies, and a structural finding travels with the draft instead of being silently accepted', async () => {
+    const db = getDb();
+    const [platform] = await db
+      .select()
+      .from(schema.platforms)
+      .where(eq(schema.platforms.slug, 'reddit'));
+    const [org] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(sql`slug = 'default'`);
+    const [project] = await db
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'style-demo', name: 'D' })
+      .returning();
+    const [account] = await db
+      .insert(schema.accounts)
+      .values({ projectId: project.id, platformId: platform.id, handle: 'alice', role: 'personal' })
+      .returning();
+    const [campaign] = await db
+      .insert(schema.campaigns)
+      .values({
+        projectId: project.id,
+        platformId: platform.id,
+        name: 'c',
+        skillSlug: 'reddit-scout',
+        config: {},
+      })
+      .returning();
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ campaignId: campaign.id, trigger: 'manual', status: 'running' })
+      .returning();
+
+    const payload = JSON.stringify([
+      {
+        accountId: account.id,
+        kind: 'dm',
+        subreddit: 'rpg',
+        targetUser: 'carol',
+        // An em dash (character-level: mechanically repaired) plus a
+        // rhetorical-question opener (structural: not mechanically
+        // fixable, no live model on this path to send it back to).
+        body: 'Ever wondered why builds are slow\u2014ours got faster this week?',
+        metadata: {},
+      },
+    ]);
+
+    const out = cli(`drafts:create --run=${run.id}`, payload);
+    const lines = out.trim().split('\n');
+    const res = JSON.parse(lines[lines.length - 1]);
+    expect(res.ok).toBe(true);
+    expect(res.data.inserted).toBe(1);
+
+    const [draft] = await db.select().from(schema.drafts).where(eq(schema.drafts.runId, run.id));
+    // The em dash is gone, replaced with a comma, and nothing else changed.
+    expect(draft.body).toBe('Ever wondered why builds are slow, ours got faster this week?');
+    // The rhetorical-question opener could not be mechanically repaired and
+    // has no live model to round-trip against here: it is shown, not
+    // dropped.
+    const metadata = draft.metadata as { styleFindings?: Array<{ ruleId: string }> };
+    expect(metadata.styleFindings).toBeDefined();
+    expect(metadata.styleFindings!.map((f) => f.ruleId)).toContain('rhetorical-question-opener');
+    expect(metadata.styleFindings!.map((f) => f.ruleId)).not.toContain('em-dash');
+  });
+
   it('persists an inline quality score supplied at creation (issue #41)', async () => {
     const db = getDb();
     const [platform] = await db

--- a/shared/package.json
+++ b/shared/package.json
@@ -29,6 +29,7 @@
     "./comment-target": "./src/comment-target.ts",
     "./templates": "./src/templates.ts",
     "./house-style": "./src/house-style.ts",
+    "./style-check": "./src/style-check.ts",
     "./assist/suggest-prompt": "./src/assist/suggest-prompt.ts",
     "./assist/envelope": "./src/assist/envelope.ts",
     "./assist/context": "./src/assist/context.ts",

--- a/shared/src/style-check.ts
+++ b/shared/src/style-check.ts
@@ -1,0 +1,495 @@
+// shared/src/style-check.ts (#572)
+//
+// The house style (`shared/src/house-style.ts`) used to be a request: the
+// prompt asked for it, and nothing checked what came back. A banned em dash,
+// a "not just X but Y", a wrap-up closer - all of it shipped whenever the
+// model slipped, and the slip rate is exactly what decides whether a draft
+// reads as machine-written.
+//
+// Every rule here is mechanical: a fixed set of characters, phrases and
+// shapes that either are or are not present in a string. That is why it
+// belongs in code (~/.config/agents/skills/moving-work-out-of-the-model):
+// sharpening the prompt's wording improves the average and never fixes the
+// tail, and a rule that only runs when it is convenient is the same rule not
+// running. `checkStyle` therefore takes no options and skips nothing - not on
+// draft length, not on retune, not on input shape. If a check cannot run on
+// some input, that is a bug in the check, not a reason to make it optional.
+//
+// Two kinds of finding:
+//   - "character": a banned punctuation character. `applyMechanicalRepairs`
+//     fixes these deterministically, with no model in the loop.
+//   - "structural": a construction (a tricolon, a rhetorical-question opener)
+//     that cannot be mechanically rewritten. `enforceHouseStyle` sends these
+//     back to the model exactly once, naming the span, and re-checks after.
+//     A finding still present past that round trip is never silently
+//     dropped: it travels with the draft so a human sees it (moving-work
+//     -out-of-the-model's "change the evidence, do not weaken the check").
+//
+// Accent and diacritic characters are never touched by any rule below: every
+// pattern targets a specific punctuation code point or an ASCII phrase, never
+// a broad character class that could catch a letter. `shared/tests
+// /style-check.test.ts` asserts this directly against Italian and French text
+// carrying "è", "più", "café" and friends.
+
+export type StyleRuleKind = 'character' | 'structural';
+
+export interface StyleFinding {
+  /** Stable id, e.g. "em-dash", "tricolon". Never renamed once shipped: a
+   * caller may persist it (drafts.metadata). */
+  ruleId: string;
+  kind: StyleRuleKind;
+  /** One sentence, written for the operator who sees the finding, not for a
+   * log. */
+  message: string;
+  /** The offending text, verbatim, as it appears in the checked string. */
+  span: string;
+  /** Offsets into the string `checkStyle` was called with. */
+  start: number;
+  end: number;
+  /** Present only on a "character" finding: the exact mechanical
+   * replacement `applyMechanicalRepairs` makes for this span. */
+  repair?: string;
+}
+
+interface Rule {
+  id: string;
+  kind: StyleRuleKind;
+  message: string;
+  /** Every match in `text`, earliest first, never overlapping. */
+  scan(text: string): Array<{ start: number; end: number; repair?: string }>;
+}
+
+function regexRule(
+  id: string,
+  kind: StyleRuleKind,
+  message: string,
+  pattern: RegExp,
+  repair?: (match: string) => string,
+): Rule {
+  if (!pattern.global) throw new Error(`style-check rule "${id}": pattern must be global`);
+  return {
+    id,
+    kind,
+    message,
+    scan(text) {
+      const out: Array<{ start: number; end: number; repair?: string }> = [];
+      for (const m of text.matchAll(pattern)) {
+        const start = m.index ?? 0;
+        const end = start + m[0].length;
+        out.push({ start, end, repair: repair?.(m[0]) });
+      }
+      return out;
+    },
+  };
+}
+
+/** Matches a list of literal phrases case-insensitively, anywhere in the
+ * text. Each phrase is escaped, so none of them are read as regex syntax. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function phraseRule(id: string, kind: StyleRuleKind, message: string, phrases: string[]): Rule {
+  const pattern = new RegExp(`(?:${phrases.map(escapeRegExp).join('|')})`, 'giu');
+  return regexRule(id, kind, message, pattern);
+}
+
+// ---------------------------------------------------------------------------
+// Character-level rules (house-style.ts: "Characters to never emit").
+// Each swaps one banned code point (or a spaced pair of them) for plain
+// ASCII; the repair is a pure function of the matched text, so
+// `applyMechanicalRepairs` never needs the surrounding string.
+// ---------------------------------------------------------------------------
+
+const CHARACTER_RULES: Rule[] = [
+  // An em dash, with any whitespace immediately touching it, becomes ", " -
+  // proper comma punctuation whether the source wrote it tight ("word—word")
+  // or spaced ("word — word"). Nothing else in the string is touched.
+  regexRule(
+    'em-dash',
+    'character',
+    'Em dash: house style asks for plain ASCII punctuation instead.',
+    /\s*\u2014\s*/gu,
+    () => ', ',
+  ),
+  // A curly double quote becomes a straight one, one code point at a time.
+  regexRule(
+    'curly-quote',
+    'character',
+    'Curly double quote: house style asks for a straight quote.',
+    /[\u201C\u201D]/gu,
+    () => '"',
+  ),
+  // A curly apostrophe or single quote becomes a straight one.
+  regexRule(
+    'curly-apostrophe',
+    'character',
+    'Curly apostrophe: house style asks for a straight apostrophe.',
+    /[\u2018\u2019]/gu,
+    () => "'",
+  ),
+  // The single Unicode ellipsis character becomes three ASCII dots.
+  regexRule(
+    'ellipsis-char',
+    'character',
+    'Single-character ellipsis: house style asks for three ASCII dots.',
+    /\u2026/gu,
+    () => '...',
+  ),
+  // A non-breaking space becomes an ordinary space.
+  regexRule(
+    'nbsp',
+    'character',
+    'Non-breaking space: house style asks for a plain space.',
+    /\u00A0/gu,
+    () => ' ',
+  ),
+];
+
+/**
+ * An en dash is only a house-style violation "between words" (house-style.ts:
+ * "en dashes between words"): a numeric range like "2019–2021" is ordinary
+ * usage and stays untouched. This needs to look at the nearest non-space
+ * neighbour on each side, which a single regex cannot express cleanly, so it
+ * is its own scan rather than `regexRule`.
+ */
+const EN_DASH_BETWEEN_WORDS: Rule = {
+  id: 'en-dash-between-words',
+  kind: 'character',
+  message: 'En dash between words: house style asks for a plain hyphen.',
+  scan(text) {
+    const out: Array<{ start: number; end: number; repair?: string }> = [];
+    const re = /\u2013/gu;
+    for (const m of text.matchAll(re)) {
+      const idx = m.index ?? 0;
+      let before = idx - 1;
+      while (before >= 0 && /\s/u.test(text[before])) before--;
+      let after = idx + 1;
+      while (after < text.length && /\s/u.test(text[after])) after++;
+      const beforeChar = before >= 0 ? text[before] : '';
+      const afterChar = after < text.length ? text[after] : '';
+      const beforeLetter = /\p{L}/u.test(beforeChar);
+      const afterLetter = /\p{L}/u.test(afterChar);
+      const beforeDigit = /\d/u.test(beforeChar);
+      const afterDigit = /\d/u.test(afterChar);
+      // Both sides are digits and neither is a letter: a numeric range, not
+      // "between words". Leave it alone.
+      if (beforeDigit && afterDigit && !beforeLetter && !afterLetter) continue;
+      out.push({ start: idx, end: idx + 1, repair: '-' });
+    }
+    return out;
+  },
+};
+CHARACTER_RULES.push(EN_DASH_BETWEEN_WORDS);
+
+// ---------------------------------------------------------------------------
+// Structural rules: constructions no character swap can fix. These name a
+// span for the round-trip rewrite instruction; `applyMechanicalRepairs`
+// never touches them.
+// ---------------------------------------------------------------------------
+
+/** house-style.ts's own opener list, checked only at the very start of the
+ * text (that is what makes them "openers" rather than ordinary phrases to
+ * avoid anywhere). */
+const FILLER_OPENERS = [
+  'Great question',
+  'Great post',
+  'Hope this finds you well',
+  'Thanks for sharing',
+  "You're absolutely right",
+];
+
+const FILLER_OPENER_RULE: Rule = {
+  id: 'filler-opener',
+  kind: 'structural',
+  message: 'Filler opener: house style bans starting a draft this way.',
+  scan(text) {
+    const leading = text.match(/^\s*/u)?.[0].length ?? 0;
+    const rest = text.slice(leading);
+    const lower = rest.toLowerCase();
+    for (const phrase of FILLER_OPENERS) {
+      if (lower.startsWith(phrase.toLowerCase())) {
+        return [{ start: leading, end: leading + phrase.length }];
+      }
+    }
+    return [];
+  },
+};
+
+/** house-style.ts's puffery list, minus "in today's fast-paced world" (its
+ * own rule below, since it is a phrase rather than a single word and worth
+ * naming on its own in a finding). */
+const PUFFERY_WORDS = [
+  'leverage',
+  'seamless',
+  'robust',
+  'comprehensive',
+  'delve',
+  'unlock',
+  'elevate',
+  'game-changer',
+];
+
+const PUFFERY_RULE: Rule = regexRule(
+  'puffery',
+  'structural',
+  'Puffery word: house style bans this as a corporate-speak tell.',
+  new RegExp(`\\b(?:${PUFFERY_WORDS.map(escapeRegExp).join('|')})\\b`, 'giu'),
+);
+
+const WRAPUP_CLOSERS = [
+  'hope this helps',
+  'at the end of the day',
+  'the bottom line is',
+  'happy to chat',
+  'let me know if you have any questions',
+];
+
+const WRAPUP_CLOSER_RULE = phraseRule(
+  'wrapup-closer',
+  'structural',
+  'Wrap-up closer: house style bans this as a machine-written tell.',
+  WRAPUP_CLOSERS,
+);
+
+/** house-style.ts's "not just X, but Y" / "it's not X, it's Y" constructions,
+ * bounded to one clause so the match cannot cross a sentence. */
+const NOT_X_BUT_Y_RULE = regexRule(
+  'not-x-but-y',
+  'structural',
+  '"Not just X but Y" construction: a listed LinkedIn tell.',
+  /\bnot\s+just\b[^.!?\n]{0,80}?\bbut\b|\bit'?s\s+not\b[^.!?\n]{0,80}?,\s*it'?s\b/giu,
+);
+
+/** A rhetorical question as the very first sentence ("Ever wondered why...?")
+ * - a classic LinkedIn opener. Only the opener is checked: a genuine question
+ * later in the text is ordinary writing. */
+const RHETORICAL_OPENER_RULE: Rule = {
+  id: 'rhetorical-question-opener',
+  kind: 'structural',
+  message: 'Rhetorical-question opener: a listed LinkedIn tell.',
+  scan(text) {
+    const leading = text.match(/^\s*/u)?.[0].length ?? 0;
+    const rest = text.slice(leading);
+    const m = rest.match(/^[^.!?\n]{1,140}\?/u);
+    if (!m) return [];
+    return [{ start: leading, end: leading + m[0].length }];
+  },
+};
+
+const FAST_PACED_RULE = regexRule(
+  'fast-paced-cliche',
+  'structural',
+  '"In today\'s fast-paced" cliche: a listed LinkedIn tell.',
+  /\bin\s+today'?s\s+fast-paced\b/giu,
+);
+
+/** Three or more hashtags in a row (a "hashtag stack"), separated only by
+ * whitespace or commas. */
+const HASHTAG_STACK_RULE = regexRule(
+  'hashtag-stack',
+  'structural',
+  'Hashtag stack: a listed LinkedIn tell.',
+  /#\w+(?:[\s,]+#\w+){2,}/gu,
+);
+
+/** A line whose first non-space character is an emoji, used as a bullet. */
+const EMOJI_BULLET_RULE = regexRule(
+  'emoji-bullet',
+  'structural',
+  'Emoji used as a bullet point: a listed LinkedIn tell.',
+  /^[ \t]*[\u{1F300}-\u{1FAFF}\u2600-\u27BF\u2B00-\u2BFF]\uFE0F?[ \t]+/gmu,
+);
+
+/**
+ * A tricolon: three short, comma-separated items closed with an Oxford
+ * comma before "and"/"or" ("faster, cheaper, and better"). Bounded to short
+ * items (at most four words each) and to one line, so an ordinary sentence
+ * that happens to list three things without this shape is not flagged - the
+ * counterexample test below is exactly that sentence.
+ */
+const TRICOLON_RULE = regexRule(
+  'tricolon',
+  'structural',
+  'Tricolon (rule-of-three list): a listed LinkedIn tell.',
+  /\b(?:\w[\w'-]*(?:\s+\w[\w'-]*){0,3}),\s*(?:\w[\w'-]*(?:\s+\w[\w'-]*){0,3}),\s*(?:and|or)\s+\w[\w'-]*(?:\s+\w[\w'-]*){0,3}\b/giu,
+);
+
+const STRUCTURAL_RULES: Rule[] = [
+  FILLER_OPENER_RULE,
+  PUFFERY_RULE,
+  WRAPUP_CLOSER_RULE,
+  NOT_X_BUT_Y_RULE,
+  RHETORICAL_OPENER_RULE,
+  FAST_PACED_RULE,
+  HASHTAG_STACK_RULE,
+  EMOJI_BULLET_RULE,
+  TRICOLON_RULE,
+];
+
+const ALL_RULES: Rule[] = [...CHARACTER_RULES, ...STRUCTURAL_RULES];
+
+/**
+ * Runs every rule against `text` and returns every finding, earliest span
+ * first. Unconditional: no argument here can turn a rule off, and no rule
+ * short-circuits because another one already matched.
+ */
+export function checkStyle(text: string): StyleFinding[] {
+  const findings: StyleFinding[] = [];
+  for (const rule of ALL_RULES) {
+    for (const { start, end, repair } of rule.scan(text)) {
+      findings.push({
+        ruleId: rule.id,
+        kind: rule.kind,
+        message: rule.message,
+        span: text.slice(start, end),
+        start,
+        end,
+        repair,
+      });
+    }
+  }
+  return findings.sort((a, b) => a.start - b.start);
+}
+
+/**
+ * Fixes every character-level finding mechanically - no model call, no
+ * judgement, one deterministic swap per banned code point. Structural
+ * findings are left exactly as they were; this function never rewrites a
+ * construction, only punctuation.
+ */
+export function applyMechanicalRepairs(text: string): string {
+  const findings = checkStyle(text).filter((f) => f.kind === 'character' && f.repair != null);
+  if (findings.length === 0) return text;
+  // Right-to-left so an earlier repair's length change never invalidates a
+  // later finding's offsets.
+  let out = text;
+  for (const f of [...findings].sort((a, b) => b.start - a.start)) {
+    out = out.slice(0, f.start) + f.repair + out.slice(f.end);
+  }
+  return out;
+}
+
+/** The line the round-trip rewrite instruction asks the model to answer
+ * after. Mirrors `shared/src/assist/envelope.ts`'s DRAFT_MARKER: the model is
+ * not trusted to reply with "nothing else", so the worst case of a marker
+ * never arriving is treated as a failed rewrite, not a rewrite that leaked a
+ * preamble into the draft. */
+export const REWRITE_MARKER = '---PITCHBOX-STYLE-REWRITE---';
+
+/**
+ * Builds the single targeted-rewrite instruction: the draft, the exact spans
+ * that still fail, and nothing else asked of the model. Sent at most once
+ * per draft (`enforceHouseStyle` never loops).
+ */
+export function buildRewriteInstruction(text: string, findings: StyleFinding[]): string {
+  const items = findings.map((f) => `- ${f.ruleId}: "${f.span}" - ${f.message}`).join('\n');
+  return [
+    'This draft fails a deterministic house-style check on exactly the points',
+    'listed below. Rewrite only what is needed to fix them. Every other word,',
+    'the language it is written in, and its length stay as they are.',
+    '',
+    'Draft:',
+    text,
+    '',
+    'Points to fix:',
+    items,
+    '',
+    `Reply with ${REWRITE_MARKER} alone on its own line, then the corrected`,
+    'draft and nothing else after it: no preamble, no quotes around it, no',
+    'notes.',
+  ].join('\n');
+}
+
+/** Extracts the corrected draft from a rewrite response. `null` on anything
+ * short of a clean match - a missing marker or an empty tail - so a
+ * non-compliant reply can never leak partial or reasoning text into a draft
+ * (same worst-case-is-nothing design as `splitSuggestion`). */
+export function extractRewrite(response: string): string | null {
+  const at = response.indexOf(REWRITE_MARKER);
+  if (at === -1) return null;
+  const rewritten = response.slice(at + REWRITE_MARKER.length).trim();
+  return rewritten.length > 0 ? rewritten : null;
+}
+
+export interface HouseStyleResult {
+  /** The best text `enforceHouseStyle` could produce: mechanically repaired,
+   * and rewritten once more if a rewrite function was given and needed. */
+  text: string;
+  /** Structural findings still present in `text`. Empty means the draft is
+   * clean. Never dropped silently: a caller with nowhere else to show these
+   * persists or displays them rather than accepting `text` as-is. */
+  findings: StyleFinding[];
+  /** True when a character-level rule actually changed the text. */
+  repaired: boolean;
+  /** True when a rewrite function was called (whether or not it left
+   * findings behind). */
+  rewriteAttempted: boolean;
+}
+
+/**
+ * Asks a caller-supplied function to run the targeted-rewrite instruction
+ * against a live model and hand back its raw reply, unparsed. Returning
+ * `null` (or throwing) is a failed round trip, handled the same way as no
+ * rewrite function at all. Extraction of the corrected draft from the reply
+ * happens inside `enforceHouseStyle`, not here: the same
+ * worst-case-is-nothing marker parsing every caller gets for free, instead
+ * of every caller re-implementing `extractRewrite` and one of them getting
+ * it wrong.
+ */
+export type RewriteFn = (text: string, findings: StyleFinding[]) => Promise<string | null>;
+
+/**
+ * The full repair pass, in the order #572 specifies:
+ *   1. check the produced draft;
+ *   2. fix every character-level finding mechanically;
+ *   3. if a structural finding remains, send it back to the model as a
+ *      targeted rewrite instruction, once, and check again;
+ *   4. if it still fails, return it with the finding attached rather than
+ *      silently accepting it.
+ *
+ * `rewrite` is optional because not every caller has a live model to round
+ * -trip against (`cli/src/commands/drafts.ts`'s batch insert runs after the
+ * agent turn that wrote the draft has already exited). Omitting it is not a
+ * way to skip the check: mechanical repair still runs, and any structural
+ * finding that would have gone to the model comes back in `findings`
+ * instead, unresolved but visible.
+ */
+export async function enforceHouseStyle(
+  text: string,
+  rewrite?: RewriteFn,
+): Promise<HouseStyleResult> {
+  const mechanical = applyMechanicalRepairs(text);
+  const repaired = mechanical !== text;
+  const structural = checkStyle(mechanical).filter((f) => f.kind === 'structural');
+
+  if (structural.length === 0) {
+    return { text: mechanical, findings: [], repaired, rewriteAttempted: false };
+  }
+  if (!rewrite) {
+    return { text: mechanical, findings: structural, repaired, rewriteAttempted: false };
+  }
+
+  let rawReply: string | null;
+  try {
+    rawReply = await rewrite(mechanical, structural);
+  } catch {
+    rawReply = null;
+  }
+  const rewritten = rawReply != null ? extractRewrite(rawReply) : null;
+  if (!rewritten) {
+    return { text: mechanical, findings: structural, repaired, rewriteAttempted: true };
+  }
+
+  // The rewrite is itself model output: run the same mechanical pass on it
+  // (a model asked to fix a tricolon can just as easily reintroduce an em
+  // dash) and check again before trusting it.
+  const rewrittenRepaired = applyMechanicalRepairs(rewritten);
+  const remaining = checkStyle(rewrittenRepaired).filter((f) => f.kind === 'structural');
+  return {
+    text: rewrittenRepaired,
+    findings: remaining,
+    repaired: repaired || rewrittenRepaired !== rewritten,
+    rewriteAttempted: true,
+  };
+}

--- a/shared/tests/style-check.test.ts
+++ b/shared/tests/style-check.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyMechanicalRepairs,
+  buildRewriteInstruction,
+  checkStyle,
+  enforceHouseStyle,
+  extractRewrite,
+  REWRITE_MARKER,
+  type StyleFinding,
+} from '../src/style-check.js';
+import { HOUSE_STYLE_SECTION } from '../src/house-style.js';
+
+function ruleIds(findings: StyleFinding[]): string[] {
+  return findings.map((f) => f.ruleId);
+}
+
+describe('checkStyle: character-level rules, one test per rule with a passing counterexample', () => {
+  it('flags an em dash and leaves an ordinary hyphenated word alone', () => {
+    expect(ruleIds(checkStyle('I built this\u2014it works.'))).toContain('em-dash');
+    // Counterexample: a plain ASCII hyphen is never a violation.
+    expect(ruleIds(checkStyle('A state-of-the-art tool.'))).not.toContain('em-dash');
+  });
+
+  it('flags an en dash between words but not a numeric range', () => {
+    expect(ruleIds(checkStyle('fast \u2013 but simple.'))).toContain('en-dash-between-words');
+    // Counterexample: "2019–2021" is a range, not "between words".
+    expect(ruleIds(checkStyle('Founded 2019\u20132021.'))).not.toContain('en-dash-between-words');
+  });
+
+  it('flags curly double quotes but not straight ones', () => {
+    expect(ruleIds(checkStyle('She said \u201Chello\u201D.'))).toContain('curly-quote');
+    expect(ruleIds(checkStyle('She said "hello".'))).not.toContain('curly-quote');
+  });
+
+  it('flags a curly apostrophe but not a straight one', () => {
+    expect(ruleIds(checkStyle('It\u2019s ready.'))).toContain('curly-apostrophe');
+    expect(ruleIds(checkStyle("It's ready."))).not.toContain('curly-apostrophe');
+  });
+
+  it('flags the single-character ellipsis but not three ASCII dots', () => {
+    expect(ruleIds(checkStyle('Wait\u2026 really?'))).toContain('ellipsis-char');
+    expect(ruleIds(checkStyle('Wait... really?'))).not.toContain('ellipsis-char');
+  });
+
+  it('flags a non-breaking space but not an ordinary space', () => {
+    expect(ruleIds(checkStyle('two\u00A0words'))).toContain('nbsp');
+    expect(ruleIds(checkStyle('two words'))).not.toContain('nbsp');
+  });
+});
+
+describe('checkStyle: structural rules, one test per rule with a passing counterexample', () => {
+  it('flags a filler opener only at the start of the draft', () => {
+    expect(ruleIds(checkStyle('Great question, thanks for asking.'))).toContain('filler-opener');
+    // Counterexample: the same words, not as an opener, are not flagged.
+    expect(
+      ruleIds(checkStyle('I looked into it and yes, that is a great question to raise.')),
+    ).not.toContain('filler-opener');
+  });
+
+  it('flags a puffery word but not an ordinary use of a similar word', () => {
+    expect(ruleIds(checkStyle('This will leverage our existing stack.'))).toContain('puffery');
+    // Counterexample: none of the banned words appear.
+    expect(ruleIds(checkStyle('This will use our existing stack.'))).not.toContain('puffery');
+  });
+
+  it('flags a wrap-up closer but not an ordinary sentence', () => {
+    expect(ruleIds(checkStyle('At the end of the day, it shipped.'))).toContain('wrapup-closer');
+    expect(ruleIds(checkStyle('It shipped on Tuesday.'))).not.toContain('wrapup-closer');
+  });
+
+  it('flags "not just X but Y" but not a plain contrast', () => {
+    expect(ruleIds(checkStyle('This is not just a bug, but a design flaw.'))).toContain(
+      'not-x-but-y',
+    );
+    expect(ruleIds(checkStyle('This is a bug, and it is a design flaw.'))).not.toContain(
+      'not-x-but-y',
+    );
+  });
+
+  it('flags a rhetorical-question opener but not a mid-text question', () => {
+    expect(ruleIds(checkStyle('Ever wondered why builds are slow?'))).toContain(
+      'rhetorical-question-opener',
+    );
+    expect(ruleIds(checkStyle('The build was slow. Why? A missing cache key.'))).not.toContain(
+      'rhetorical-question-opener',
+    );
+  });
+
+  it('flags the "today\'s fast-paced" cliche but not an ordinary mention of pace', () => {
+    expect(ruleIds(checkStyle("In today's fast-paced market, speed matters."))).toContain(
+      'fast-paced-cliche',
+    );
+    expect(ruleIds(checkStyle('The market moves fast these days.'))).not.toContain(
+      'fast-paced-cliche',
+    );
+  });
+
+  it('flags a hashtag stack but not a single hashtag', () => {
+    expect(ruleIds(checkStyle('Shipped it. #growth #sales #b2b'))).toContain('hashtag-stack');
+    expect(ruleIds(checkStyle('Shipped it. #shipping'))).not.toContain('hashtag-stack');
+  });
+
+  it('flags an emoji used as a bullet but not an emoji inside a sentence', () => {
+    expect(ruleIds(checkStyle('\uD83D\uDE80 Ship faster'))).toContain('emoji-bullet');
+    expect(ruleIds(checkStyle('We shipped it \uD83D\uDE80 today.'))).not.toContain('emoji-bullet');
+  });
+
+  it('flags a tricolon but not a plain two-item list', () => {
+    expect(ruleIds(checkStyle('It is faster, cheaper, and better.'))).toContain('tricolon');
+    // Counterexample: a rule-of-three needs the shape, not just three words
+    // anywhere in the sentence - a two-item list is ordinary writing.
+    expect(ruleIds(checkStyle('It is faster and cheaper.'))).not.toContain('tricolon');
+  });
+});
+
+describe('checkStyle: the check is not conditional', () => {
+  it('runs every rule regardless of draft length', () => {
+    // A one-character draft still gets checked; there is no length guard.
+    expect(checkStyle('\u2014')).toHaveLength(1);
+    expect(checkStyle('')).toEqual([]);
+  });
+
+  it('has no flag or option that turns any rule off', () => {
+    // checkStyle takes exactly one argument: the text. There is nothing to
+    // pass that could disable a rule.
+    expect(checkStyle.length).toBe(1);
+  });
+});
+
+describe('checkStyle: accents and diacritics are never touched', () => {
+  it('leaves Italian and French accented letters untouched by every rule', () => {
+    const text = "Il team più veloce c'è già, e il caffè è pronto. Voilà, ça y est déjà.";
+    expect(checkStyle(text)).toEqual([]);
+    expect(applyMechanicalRepairs(text)).toBe(text);
+  });
+
+  it('repairs banned punctuation next to accented text without altering the accents', () => {
+    const text = 'Il pi\u00F9 veloce \u2014 e gi\u00E0 pronto \u2014 \u00E8 qui.';
+    const repaired = applyMechanicalRepairs(text);
+    expect(repaired).toBe('Il pi\u00F9 veloce, e gi\u00E0 pronto, \u00E8 qui.');
+    // Every accented character survives byte-for-byte.
+    expect(repaired).toContain('pi\u00F9');
+    expect(repaired).toContain('gi\u00E0');
+    expect(repaired).toContain('\u00E8 qui');
+  });
+});
+
+describe('applyMechanicalRepairs: exact output, nothing else changed', () => {
+  it("turns a real draft's em dash into a comma and changes nothing else", () => {
+    const draft = 'We shipped the migration last week\u2014it ran clean on every table we tested.';
+    expect(applyMechanicalRepairs(draft)).toBe(
+      'We shipped the migration last week, it ran clean on every table we tested.',
+    );
+  });
+});
+
+describe('enforceHouseStyle: the repair pass, in order', () => {
+  it('proves the repair pass bites: a deliberately AI-sounding draft is caught rule by rule', async () => {
+    const aiSounding =
+      "Great question! In today's fast-paced world, this is not just a feature\u2014it's " +
+      'a game-changer, but a real one.\n' +
+      "It's faster, cheaper, and better.\n" +
+      '\uD83D\uDE80 Ship it today. #growth #sales #b2b\n' +
+      'At the end of the day, hope this helps.';
+    const result = await enforceHouseStyle(aiSounding);
+    const foundIds = ruleIds(result.findings);
+    expect(foundIds).toContain('filler-opener');
+    expect(foundIds).toContain('fast-paced-cliche');
+    expect(foundIds).toContain('not-x-but-y');
+    expect(foundIds).toContain('puffery'); // game-changer
+    expect(foundIds).toContain('tricolon');
+    expect(foundIds).toContain('emoji-bullet');
+    expect(foundIds).toContain('hashtag-stack');
+    expect(foundIds).toContain('wrapup-closer');
+    // The em dash is a character-level finding: mechanically repaired, so it
+    // is gone from the returned text and never appears in the leftover
+    // findings.
+    expect(result.text).not.toContain('\u2014');
+    expect(ruleIds(result.findings)).not.toContain('em-dash');
+    expect(result.repaired).toBe(true);
+  });
+
+  it('proves a clean human draft passes untouched', async () => {
+    const clean =
+      'I spent Tuesday afternoon on the migration and it broke twice before it worked. ' +
+      "Not glamorous, but it's done now.";
+    const result = await enforceHouseStyle(clean);
+    expect(result.text).toBe(clean);
+    expect(result.findings).toEqual([]);
+    expect(result.repaired).toBe(false);
+    expect(result.rewriteAttempted).toBe(false);
+  });
+
+  it('sends a structural finding back to the model exactly once and accepts a clean rewrite', async () => {
+    const original = 'Ever wondered why builds are slow? A missing cache key, mostly.';
+    let calls = 0;
+    const rewrite = async (text: string, findings: StyleFinding[]) => {
+      calls += 1;
+      expect(text).toBe(original);
+      expect(ruleIds(findings)).toEqual(['rhetorical-question-opener']);
+      return `${REWRITE_MARKER}\nBuilds were slow because of a missing cache key, mostly.`;
+    };
+    const result = await enforceHouseStyle(original, rewrite);
+    expect(calls).toBe(1);
+    expect(result.rewriteAttempted).toBe(true);
+    expect(result.findings).toEqual([]);
+    expect(result.text).toBe('Builds were slow because of a missing cache key, mostly.');
+  });
+
+  it('shows the finding rather than silently accepting a draft the rewrite could not fix', async () => {
+    const original = 'Ever wondered why builds are slow? Great question, honestly.';
+    // The rewrite fixes the rhetorical opener but still opens with a filler
+    // phrase - a rewrite that only partially complies.
+    const rewrite = async () =>
+      `${REWRITE_MARKER}\nGreat question, builds are slow because of a missing cache key.`;
+    const result = await enforceHouseStyle(original, rewrite);
+    expect(result.rewriteAttempted).toBe(true);
+    // The rewrite fixed one thing and reintroduced the other: the finding
+    // travels with the text instead of being dropped.
+    expect(ruleIds(result.findings)).toContain('filler-opener');
+    expect(ruleIds(result.findings)).not.toContain('rhetorical-question-opener');
+    expect(result.text).toBe('Great question, builds are slow because of a missing cache key.');
+  });
+
+  it('treats a non-compliant rewrite reply (no marker) as a failed rewrite, not a draft', async () => {
+    const original = 'Ever wondered why builds are slow?';
+    const rewrite = async () => 'Sure, here is the fix: Builds were slow.';
+    const result = await enforceHouseStyle(original, rewrite);
+    expect(result.rewriteAttempted).toBe(true);
+    // Falls back to the mechanically-repaired original, findings still shown.
+    expect(result.text).toBe(original);
+    expect(ruleIds(result.findings)).toContain('rhetorical-question-opener');
+  });
+
+  it('still runs the mechanical + structural check with no rewrite function at all', async () => {
+    const original = 'Great question\u2014ever wondered why?';
+    const result = await enforceHouseStyle(original);
+    expect(result.rewriteAttempted).toBe(false);
+    expect(result.repaired).toBe(true);
+    expect(result.text).not.toContain('\u2014');
+    const foundIds = ruleIds(result.findings);
+    expect(foundIds).toContain('filler-opener');
+    expect(foundIds).toContain('rhetorical-question-opener');
+  });
+});
+
+describe('buildRewriteInstruction / extractRewrite', () => {
+  it('names every remaining span once in the instruction', () => {
+    const findings = checkStyle('Ever wondered why? Great question.');
+    const instruction = buildRewriteInstruction('Ever wondered why? Great question.', findings);
+    for (const f of findings) {
+      expect(instruction).toContain(f.span);
+      expect(instruction).toContain(f.ruleId);
+    }
+    expect(instruction).toContain(REWRITE_MARKER);
+  });
+
+  it('extracts only the text after the marker', () => {
+    expect(extractRewrite(`blah blah\n${REWRITE_MARKER}\nThe fixed draft.`)).toBe(
+      'The fixed draft.',
+    );
+  });
+
+  it('returns null when the marker never arrives', () => {
+    expect(extractRewrite('The model just answered in prose.')).toBeNull();
+  });
+
+  it('returns null when the marker arrives with nothing after it', () => {
+    expect(extractRewrite(`some text\n${REWRITE_MARKER}\n   `)).toBeNull();
+  });
+});
+
+describe('house-style.ts stays in sync with the checker', () => {
+  // house-style.ts is the prompt-facing prose; these rule lists are the
+  // code-facing enforcement of the same rules. A phrase that exists in one
+  // and not the other is exactly the kind of drift the checker exists to
+  // prevent, so assert every phrase-based rule's vocabulary is still named
+  // in the prose.
+  const phrasesThatMustAppearInHouseStyle = [
+    'Great question',
+    'Hope this finds you well',
+    'leverage',
+    'game-changer',
+    'hope this helps',
+    'the bottom line is',
+    'not just X',
+  ];
+
+  it.each(phrasesThatMustAppearInHouseStyle)('house style prose still mentions "%s"', (phrase) => {
+    expect(HOUSE_STYLE_SECTION.toLowerCase()).toContain(phrase.toLowerCase());
+  });
+});

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -22,6 +22,12 @@ import type {
   VoiceProfileSummary,
 } from '@pitchbox/shared/assist/context';
 import type { AssistTone } from '@pitchbox/shared/assist/tone';
+import type { AgentRunner } from '@pitchbox/shared/agents';
+import {
+  buildRewriteInstruction,
+  enforceHouseStyle,
+  type StyleFinding,
+} from '@pitchbox/shared/style-check';
 
 /**
  * Runs one suggestion: a single-turn agent invocation with no playbook, no MCP
@@ -45,6 +51,12 @@ export interface SuggestionResult {
   /** The text the human may insert, or null when the model gave nothing to
    * insert - no marker, or an explicit skip (#382, envelope.ts). */
   draft: string | null;
+  /** House style findings (#572) the mechanical repair pass and one
+   * targeted-rewrite round trip could not resolve on `draft`. Empty or
+   * absent means the draft is clean; a non-empty list travels with the
+   * draft rather than being silently accepted - the caller shows it next
+   * to the draft instead of trusting it blind. */
+  styleFindings?: StyleFinding[];
   /** True when the model explicitly declined to write a draft. */
   skipped: boolean;
   ms: number;
@@ -113,6 +125,57 @@ export function resolveAssistRunnerConfig(
   const pinned = config.model?.trim();
   if (pinned) return config;
   return { ...config, model: functionModel?.trim() || ASSIST_DEFAULT_MODEL };
+}
+
+/**
+ * The single targeted-rewrite round trip #572 asks for: one more turn on the
+ * same runner that wrote the draft, naming the remaining structural
+ * findings once, no streaming and no MCP tools attached - the same shape as
+ * the suggestion turn itself, minus the parts a rewrite does not need.
+ *
+ * Returns the model's raw reply, unparsed, or `null` on a spawn failure or a
+ * cancel that landed mid-flight. `enforceHouseStyle` is what extracts and
+ * validates the reply (`extractRewrite`), exactly as suspiciously as the
+ * suggestion turn's own envelope is treated: a reply with no marker is a
+ * failed rewrite, never a draft.
+ */
+async function runStyleRewrite(
+  runner: AgentRunner,
+  text: string,
+  findings: StyleFinding[],
+  orgId: number | undefined,
+  isCancelled: () => boolean,
+  setCancelHandle: (cancel: () => void) => void,
+): Promise<string | null> {
+  const cwd = await mkdtemp(join(tmpdir(), 'pitchbox-style-rewrite-'));
+  if (isCancelled()) {
+    await rm(cwd, { recursive: true, force: true }).catch(() => {});
+    return null;
+  }
+  let rawText = '';
+  try {
+    const handle = runner.run({
+      prompt: buildRewriteInstruction(text, findings),
+      attachMcp: false,
+      slug: 'assist-style-rewrite',
+      env: {},
+      cwd,
+      timeoutMs: SUGGESTION_TIMEOUT_MS,
+      orgId,
+      onTextChunk: (chunk) => {
+        rawText += chunk;
+      },
+    });
+    setCancelHandle(handle.cancel);
+    if (isCancelled()) handle.cancel();
+    await handle.result;
+    if (isCancelled()) return null;
+    return rawText.trim() ? rawText : null;
+  } catch {
+    return null;
+  } finally {
+    await rm(cwd, { recursive: true, force: true }).catch(() => {});
+  }
 }
 
 export function runSuggestion(args: {
@@ -240,7 +303,17 @@ export function runSuggestion(args: {
         orgId: args.orgId,
         onTextChunk: (chunk) => {
           rawText += chunk;
-          args.onChunk?.(splitter.push(chunk));
+          // `args.onChunk?.(splitter.push(chunk))` looks equivalent but is
+          // not: optional-call short-circuiting skips evaluating its
+          // arguments too, so a caller with no `onChunk` (every direct
+          // caller of `runSuggestion` that isn't the SSE route - #572's own
+          // integration test is one) would never feed the splitter at all,
+          // and `envelope.draft` would always come back null regardless of
+          // what the model actually said. Pushing unconditionally keeps
+          // `onChunk`-less callers correct without changing anything for
+          // the streaming route, which always passes one.
+          const pushed = splitter.push(chunk);
+          args.onChunk?.(pushed);
         },
       });
       cancelHandle = handle.cancel;
@@ -260,9 +333,37 @@ export function runSuggestion(args: {
         );
       }
       const envelope = splitter.finish();
+
+      // #572: everything the human may insert is held to the same
+      // deterministic house-style check a campaign draft is. Only `draft`
+      // goes through it - `reasoning` is operator-facing and never posted,
+      // the same reason the assist plane never lets it near the composer
+      // (#382, envelope.ts). A cancel is checked before the round trip
+      // starts; once `runStyleRewrite` is under way it watches the same
+      // flag itself.
+      let draft = envelope.draft;
+      let styleFindings: StyleFinding[] = [];
+      if (draft != null && !cancelled) {
+        const enforcement = await enforceHouseStyle(draft, (rewriteText, findings) =>
+          runStyleRewrite(
+            runner,
+            rewriteText,
+            findings,
+            args.orgId,
+            () => cancelled,
+            (handle) => {
+              cancelHandle = handle;
+            },
+          ),
+        );
+        draft = enforcement.text;
+        styleFindings = enforcement.findings;
+      }
+
       return {
         reasoning: envelope.reasoning,
-        draft: envelope.draft,
+        draft,
+        styleFindings: styleFindings.length > 0 ? styleFindings : undefined,
         skipped: envelope.skipped,
         ms: Date.now() - started,
         model: resolvedConfig.model,

--- a/web/tests/suggest-style-check.test.ts
+++ b/web/tests/suggest-style-check.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getDb } from '@pitchbox/shared/db';
+import type { AgentRunHandle, AgentRunOptions, AgentRunner } from '@pitchbox/shared/agents';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+import { DRAFT_MARKER } from '@pitchbox/shared/assist/envelope';
+import { REWRITE_MARKER } from '@pitchbox/shared/style-check';
+
+/**
+ * #572: the assist plane's targeted-rewrite round trip. `enforceHouseStyle`
+ * itself is exercised directly against a mock rewrite function in
+ * `shared/tests/style-check.test.ts`; what these defend is that
+ * `runSuggestion` actually wires it in - a second turn on the same runner,
+ * naming the remaining finding, with the draft and findings the caller
+ * receives reflecting the outcome of that turn.
+ *
+ * The agent is faked exactly like `extension-suggest.test.ts` fakes it, but
+ * distinguishes the suggestion turn from the rewrite turn by `opts.slug`, so
+ * each can answer differently.
+ */
+
+const callSlugs: string[] = [];
+let secondTurnReply = '';
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'fake',
+    run(opts: AgentRunOptions): AgentRunHandle {
+      callSlugs.push(opts.slug);
+      if (opts.slug === 'assist-style-rewrite') {
+        opts.onTextChunk?.(secondTurnReply);
+      } else {
+        // An em dash (mechanically repairable) plus a rhetorical-question
+        // opener (structural: goes to the round trip).
+        opts.onTextChunk?.(
+          `Noticed the thing.\n${DRAFT_MARKER}\n` +
+            'Ever wondered why builds are slow\u2014ours got faster this week?',
+        );
+      }
+      return {
+        result: Promise.resolve({ exitCode: 0, logPath: '/dev/null' }),
+        cancel: () => {},
+      };
+    },
+  }),
+}));
+
+const { runSuggestion } = await import('../src/lib/server/suggest.js');
+
+async function reset() {
+  await getDb().execute(sql`TRUNCATE app_config RESTART IDENTITY CASCADE`);
+  callSlugs.length = 0;
+}
+
+function baseArgs() {
+  return {
+    kind: 'post_comment' as const,
+    post: { urn: 'urn:li:activity:1', authorName: 'A', text: 'hi' },
+    currentProject: { name: 'p', description: null },
+    persona: null,
+    voiceProfile: null,
+    projects: [],
+    repos: [],
+    projectId: 1,
+    runnerSlug: 'claude-code',
+  };
+}
+
+describe('runSuggestion: house-style enforcement round trip (#572)', () => {
+  it('mechanically repairs the em dash and accepts a clean single rewrite of the remaining finding', async () => {
+    await reset();
+    secondTurnReply = `${REWRITE_MARKER}\nBuilds were slow this week because of a missing cache key, now fixed.`;
+
+    const handle = runSuggestion(baseArgs());
+    const result = await handle.result;
+
+    // The suggestion turn, then exactly one rewrite turn - never more.
+    expect(callSlugs).toEqual(['assist-post_comment', 'assist-style-rewrite']);
+    expect(result.draft).toBe(
+      'Builds were slow this week because of a missing cache key, now fixed.',
+    );
+    expect(result.styleFindings ?? []).toEqual([]);
+  });
+
+  it('shows the finding rather than silently accepting a draft the rewrite could not fix', async () => {
+    await reset();
+    // No REWRITE_MARKER: a non-compliant reply, treated as a failed rewrite.
+    secondTurnReply = 'Sure, here is a rewrite of that sentence for you.';
+
+    const handle = runSuggestion(baseArgs());
+    const result = await handle.result;
+
+    expect(callSlugs).toEqual(['assist-post_comment', 'assist-style-rewrite']);
+    // The em dash is still mechanically repaired even though the rewrite
+    // failed - that half of the check never depends on the model at all.
+    expect(result.draft).toBe('Ever wondered why builds are slow, ours got faster this week?');
+    expect(result.styleFindings?.map((f) => f.ruleId)).toContain('rhetorical-question-opener');
+  });
+});


### PR DESCRIPTION
Closes #572

## What changed

The house style was a request in a prompt (`shared/src/house-style.ts`) and nothing checked what the model actually produced. This adds a deterministic checker and repair pass, and wires it into both places a draft is produced.

- `shared/src/style-check.ts` (new): `checkStyle(text)` runs every rule, unconditionally - no flag, no length guard, no retune exemption. Two kinds of finding:
  - **character**: em dash, en dash between words (not a numeric range), curly quotes/apostrophes, the single-character ellipsis, non-breaking space. `applyMechanicalRepairs` fixes these with no model involved.
  - **structural**: filler openers, puffery, wrap-up closers, "not just X but Y", rhetorical-question openers, "in today's fast-paced", hashtag stacks, emoji bullets, tricolons. These go back to the model as one targeted rewrite naming the remaining spans (`buildRewriteInstruction`/`extractRewrite`, marker-based extraction the same worst-case-is-nothing way `envelope.ts` already does it), checked again after.
  - `enforceHouseStyle(text, rewrite?)` runs the whole pass. A finding that survives the round trip - or that had no live model to round-trip against at all - travels with the text instead of being dropped.
- Accent and diacritic characters are never touched by any rule: every pattern targets a specific punctuation code point or ASCII phrase, never a letter class. Tested directly against Italian and French text.
- Campaign plane (`cli/src/commands/drafts.ts`, `drafts:create`): no live model exists here, the agent turn that wrote the draft has already exited by the time this runs, so `enforceHouseStyle` is called with no rewrite function. Mechanical repair still applies to `body` and `title`; any structural finding is stored in `metadata.styleFindings` rather than silently accepted.
- Assist plane (`web/src/lib/server/suggest.ts`): a live runner exists, so a real single rewrite round trip happens against the same runner and slug family (`assist-style-rewrite`), with its own temp cwd and cancellation wired through the existing `cancelHandle`. `SuggestionResult` gained an optional `styleFindings` field for whatever survives.

## A bug found while wiring the assist plane

`args.onChunk?.(splitter.push(chunk))` never actually called `splitter.push()` when `onChunk` was omitted, because optional-call short-circuiting (`?.()`) skips evaluating its arguments too, not just the call. Every production caller (the SSE route) always passes `onChunk`, so this never showed up before - but it meant `envelope.draft` came back `null` for any caller that didn't, including the round-trip logic this issue adds and its own test. Split into two statements so the splitter is always fed regardless. Existing `extension-suggest.test.ts` suite (26 tests) still passes unchanged.

## Verified

- `pnpm exec vitest run shared/tests/style-check.test.ts` - 37 tests: one test per rule with a passing counterexample, accents/diacritics never touched, the exact "em dash becomes a comma, nothing else changes" output, the full `enforceHouseStyle` round trip (accepted rewrite, failed/non-compliant rewrite shown not dropped, no-rewrite-function fallback), a deliberately AI-sounding draft caught rule by rule, a clean human draft passing untouched.
- `pnpm exec vitest run cli/tests/commands/drafts-create.test.ts` - 10 tests (9 pre-existing + 1 new): the new one proves the campaign path through `drafts:create` itself, not by calling the checker directly - asserts the persisted row's `body` and `metadata.styleFindings`.
- `pnpm exec vitest run web/tests/suggest-style-check.test.ts web/tests/extension-suggest.test.ts` - 28 tests (2 new + 26 pre-existing unaffected): the new pair mocks the agent registry to answer the suggestion turn and the rewrite turn differently, proving `runSuggestion` actually issues the second turn and applies its outcome.
- `npx eslint` / `npx prettier --check` on every changed file.
- `npx tsc --noEmit` on `shared`, `cli`, and `web` (pre-existing, unrelated `.svelte-kit` type errors in `web` untouched).

## Deliberately not done

- Enforcement stops at `body` and `title` on the campaign plane; `reasoning` is never checked, matching the assist plane's own existing reasoning/draft split (reasoning is operator-facing, never posted).
- Tricolon and rhetorical-question-opener detection are regex heuristics, not a parser. They will not catch every LinkedIn tell, and they are not meant to - the acceptance bar is a deterministic rule with a real counterexample, not perfect recall.
- Did not touch `extension-suggest.test.ts` itself, since another agent owns the suggest payload's zod schema this wave; the round trip is tested from a separate new file instead.
