### PR TITLE
feat(web,shared): optional GitHub App so the companion can read private repos

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -14,6 +14,19 @@ ENCRYPTION_KEY=
 # Gateway with this key - no separate runner service, nothing else to point it at.
 AI_GATEWAY_API_KEY=
 
+# --- optional GitHub App (#390): private repositories in the companion ------
+# Optional. Unset, repositories are read anonymously (public only, 60
+# requests/hour per address). Set all three or none - a partial configuration
+# throws at load instead of quietly reading anonymously. The key is base64 so
+# a PEM survives an env file: base64 -w0 app.pem
+# These reach the web container through docker-compose.app.yml AND the
+# x-web-common anchor in docker-compose.bluegreen.yml (#583): a blue-green
+# deployment does not run the base `web` service, so a variable added only
+# there never reaches production.
+GITHUB_APP_ID=
+GITHUB_APP_SLUG=
+GITHUB_APP_PRIVATE_KEY_B64=
+
 # --- auth (login gate for the dashboard) ------------------------------------
 # When 'on', every route requires a logged-in user (see docs/orgs.md /
 # docs/permissions.md); when 'off' (default), the dashboard has no login at all.

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,19 @@ WEB_PORT=5180
 # default.
 # AI_GATEWAY_API_KEY=
 
+# Optional GitHub App (#390), which is what lets the companion read a PRIVATE
+# repository. With nothing set here, repositories are read anonymously: public
+# ones only, 60 requests/hour per address. That is the intended self-host
+# setup and needs no credential.
+#
+# Set all three or none: a partial configuration throws at load rather than
+# reading anonymously, because a private repo would otherwise be reported as
+# "not found" and nobody would know the credential was never used. The key is
+# base64 so a PEM's newlines survive an env file: base64 -w0 app.pem
+# GITHUB_APP_ID=
+# GITHUB_APP_SLUG=
+# GITHUB_APP_PRIVATE_KEY_B64=
+
 # Outbound email (#508). With nothing set below, the null transport is used:
 # nothing throws, and a send just logs what it would have sent - fine for a
 # self-host that never needed a reset/invite email to leave the box.

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -55,6 +55,14 @@ services:
       SMTP_SECURE: ${SMTP_SECURE:-}
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
+      # Optional GitHub App (#390): the credential that lets the companion read
+      # a private repository. Unset means anonymous reads, public repos only,
+      # which is a supported state and not an error. Enumerated here for the
+      # same reason the mail block above is: this file lists the environment
+      # rather than passing .env through.
+      GITHUB_APP_ID: ${GITHUB_APP_ID:-}
+      GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
+      GITHUB_APP_PRIVATE_KEY_B64: ${GITHUB_APP_PRIVATE_KEY_B64:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.bluegreen.yml
+++ b/docker-compose.bluegreen.yml
@@ -52,6 +52,13 @@ x-web-common: &web-common
     SMTP_SECURE: ${SMTP_SECURE:-}
     SMTP_USER: ${SMTP_USER:-}
     SMTP_PASS: ${SMTP_PASS:-}
+    # Optional GitHub App (#390), in this overlay for exactly the reason the
+    # mail block above records: this anchor replaces the base service's whole
+    # environment, so a credential added only to docker-compose.app.yml never
+    # reaches the container a blue-green deploy actually runs.
+    GITHUB_APP_ID: ${GITHUB_APP_ID:-}
+    GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
+    GITHUB_APP_PRIVATE_KEY_B64: ${GITHUB_APP_PRIVATE_KEY_B64:-}
   healthcheck:
     test:
       [

--- a/docs/platforms/linkedin.md
+++ b/docs/platforms/linkedin.md
@@ -75,8 +75,34 @@ Companion**:
 - **How you write**: the operator's own recent posts as voice samples,
   newest first. A sample can be excluded from prompts without deleting it,
   since a delete would just come back on the next capture.
-- **What you have shipped**: public GitHub repositories, added by URL with
-  no credential. Private repos need the (not yet built) GitHub App.
+- **What you have shipped**: GitHub repositories the companion may cite. A
+  public one needs nothing but its URL. A **private** one is readable once
+  the organization connects the optional GitHub App from that same card
+  (#390): the account chooses which repositories the app can see, the app
+  asks for read access to code and metadata and nothing else, and
+  disconnecting it here also uninstalls it from the account.
+
+The App is optional and per deployment. With no App configured, which is the
+self-host default, repositories are read anonymously: public ones only, and
+GitHub allows 60 requests an hour per address. With one configured, a read of
+a repository whose owner has installed it carries an installation token
+instead, which raises that to 5,000 an hour.
+
+Two operational details worth knowing before you debug a repo that will not
+load. Resolution is by **account login**: a token is only ever presented to
+the account that granted it, so a source under an owner nobody installed on
+is still read anonymously rather than with somebody else's credential. And an
+installation belongs to exactly one organization here: re-installing on an
+account another organization already connected is refused, not merged, since
+otherwise the second organization would read the first's private code.
+
+The credential itself is a **deployment secret** (`GITHUB_APP_ID`,
+`GITHUB_APP_SLUG`, `GITHUB_APP_PRIVATE_KEY_B64`, the last base64 because a
+PEM's newlines do not survive an env file). It is never an `app_config` value,
+never served to a client, and a partial configuration throws at load rather
+than falling back to anonymous reads - otherwise a private repository would be
+reported as "not found", which is the same thing GitHub says about a repo that
+never existed.
 
 An accepted suggestion that isn't written for a bound project - the operator
 writing as themselves, not as any one product - lands under the

--- a/shared/package.json
+++ b/shared/package.json
@@ -38,6 +38,7 @@
     "./operator-profile": "./src/operator-profile.ts",
     "./operator-voice-profile": "./src/operator-voice-profile.ts",
     "./github-sources": "./src/github-sources.ts",
+    "./github-app": "./src/github-app.ts",
     "./project-sources": "./src/project-sources.ts",
     "./project-source-sync": "./src/project-source-sync.ts",
     "./personal-project": "./src/personal-project.ts",

--- a/shared/src/db/migrations/0028_github_installations.sql
+++ b/shared/src/db/migrations/0028_github_installations.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "github_installations" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"organization_id" integer NOT NULL,
+	"installation_id" bigint NOT NULL,
+	"account_login" text NOT NULL,
+	"account_type" text DEFAULT 'User' NOT NULL,
+	"repository_selection" text DEFAULT 'selected' NOT NULL,
+	"permissions" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "github_installations" ADD CONSTRAINT "github_installations_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "github_installations_installation_unique" ON "github_installations" USING btree ("installation_id");--> statement-breakpoint
+CREATE INDEX "github_installations_org_idx" ON "github_installations" USING btree ("organization_id");

--- a/shared/src/db/migrations/meta/0028_snapshot.json
+++ b/shared/src/db/migrations/meta/0028_snapshot.json
@@ -1,0 +1,4946 @@
+{
+  "id": "c6abc8da-f99d-485a-a369-ca7c46ae48d8",
+  "prevId": "affcb36a-403e-4075-9783-5e2c4c9f1b84",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cookie_session": {
+          "name": "cookie_session",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_limit": {
+          "name": "weekly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_project_id_projects_id_fk": {
+          "name": "accounts_project_id_projects_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_platform_id_platforms_id_fk": {
+          "name": "accounts_platform_id_platforms_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assist_usage": {
+      "name": "assist_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assist_usage_org_created_idx": {
+          "name": "assist_usage_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assist_usage_project_created_idx": {
+          "name": "assist_usage_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assist_usage_organization_id_organizations_id_fk": {
+          "name": "assist_usage_organization_id_organizations_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_project_id_projects_id_fk": {
+          "name": "assist_usage_project_id_projects_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_device_id_extension_devices_id_fk": {
+          "name": "assist_usage_device_id_extension_devices_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "extension_devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assist_usage_platform_id_platforms_id_fk": {
+          "name": "assist_usage_platform_id_platforms_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_failures": {
+      "name": "auth_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login_attempt'"
+        }
+      },
+      "indexes": {
+        "auth_failures_identifier_idx": {
+          "name": "auth_failures_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist": {
+      "name": "blocklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocklist_platform_id_platforms_id_fk": {
+          "name": "blocklist_platform_id_platforms_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocklist_project_id_projects_id_fk": {
+          "name": "blocklist_project_id_projects_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_recommendations": {
+      "name": "campaign_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_slug": {
+          "name": "scenario_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_recommendations_project_idx": {
+          "name": "campaign_recommendations_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_recommendations_project_id_projects_id_fk": {
+          "name": "campaign_recommendations_project_id_projects_id_fk",
+          "tableFrom": "campaign_recommendations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_slug": {
+          "name": "skill_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_attempts": {
+          "name": "failure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_due_to_failures": {
+          "name": "paused_due_to_failures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_post": {
+          "name": "auto_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_platform_id_platforms_id_fk": {
+          "name": "campaigns_platform_id_platforms_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_history": {
+      "name": "contact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_handle": {
+          "name": "account_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_checked_at": {
+          "name": "reply_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_room_id": {
+          "name": "chat_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_context_url": {
+          "name": "platform_context_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uncontactable": {
+          "name": "uncontactable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uncontactable_reason": {
+          "name": "uncontactable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_history_target_idx": {
+          "name": "contact_history_target_idx",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_target_idx": {
+          "name": "messages_account_target_idx",
+          "columns": [
+            {
+              "expression": "account_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_org_idx": {
+          "name": "contact_history_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_contacted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_history_platform_id_platforms_id_fk": {
+          "name": "contact_history_platform_id_platforms_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contact_history_draft_id_drafts_id_fk": {
+          "name": "contact_history_draft_id_drafts_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_history_organization_id_organizations_id_fk": {
+          "name": "contact_history_organization_id_organizations_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_heartbeats": {
+      "name": "daemon_heartbeats",
+      "schema": "",
+      "columns": {
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tick_at": {
+          "name": "tick_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_events": {
+      "name": "draft_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_events_kind_created_idx": {
+          "name": "draft_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_events_draft_id_drafts_id_fk": {
+          "name": "draft_events_draft_id_drafts_id_fk",
+          "tableFrom": "draft_events",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_regeneration_hints": {
+      "name": "draft_regeneration_hints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint_text": {
+          "name": "hint_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_regeneration_hints_draft_id_drafts_id_fk": {
+          "name": "draft_regeneration_hints_draft_id_drafts_id_fk",
+          "tableFrom": "draft_regeneration_hints",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "fit_score": {
+          "name": "fit_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_url": {
+          "name": "compose_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_content": {
+          "name": "sent_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_comment_id": {
+          "name": "platform_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dedup_warning": {
+          "name": "dedup_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_edited": {
+          "name": "body_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_send_after": {
+          "name": "scheduled_send_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerating_run_id": {
+          "name": "regenerating_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drafting_run_id": {
+          "name": "drafting_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_reason": {
+          "name": "quality_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_model": {
+          "name": "quality_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_id": {
+          "name": "variant_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undeliverable_reason": {
+          "name": "undeliverable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drafts_state_idx": {
+          "name": "drafts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_project_idx": {
+          "name": "drafts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_run_idx": {
+          "name": "drafts_state_run_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_campaign_created_idx": {
+          "name": "drafts_state_campaign_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_variant_group_idx": {
+          "name": "drafts_variant_group_idx",
+          "columns": [
+            {
+              "expression": "variant_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_run_id_runs_id_fk": {
+          "name": "drafts_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_project_id_projects_id_fk": {
+          "name": "drafts_project_id_projects_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_platform_id_platforms_id_fk": {
+          "name": "drafts_platform_id_platforms_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_accounts_id_fk": {
+          "name": "drafts_account_id_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_regenerating_run_id_runs_id_fk": {
+          "name": "drafts_regenerating_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "regenerating_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drafts_drafting_run_id_runs_id_fk": {
+          "name": "drafts_drafting_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "drafting_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_verification_tokens_user_idx": {
+          "name": "email_verification_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_devices": {
+      "name": "extension_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unnamed device'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "extension_devices_token_hash_unique": {
+          "name": "extension_devices_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extension_devices_organization_id_organizations_id_fk": {
+          "name": "extension_devices_organization_id_organizations_id_fk",
+          "tableFrom": "extension_devices",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_pairings": {
+      "name": "extension_pairings",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extension_pairings_organization_id_organizations_id_fk": {
+          "name": "extension_pairings_organization_id_organizations_id_fk",
+          "tableFrom": "extension_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'User'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selected'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_unique": {
+          "name": "github_installations_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_organization_id_organizations_id_fk": {
+          "name": "github_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sources": {
+      "name": "github_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_language": {
+          "name": "primary_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readme_excerpt": {
+          "name": "readme_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_commits": {
+          "name": "recent_commits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_sources_org_repo_unique": {
+          "name": "github_sources_org_repo_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_sources_organization_id_organizations_id_fk": {
+          "name": "github_sources_organization_id_organizations_id_fk",
+          "tableFrom": "github_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_audit_log": {
+      "name": "instance_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_audit_log_created_idx": {
+          "name": "instance_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_watches": {
+      "name": "keyword_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_field": {
+          "name": "match_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keyword_watches_campaign_idx": {
+          "name": "keyword_watches_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_watches_project_idx": {
+          "name": "keyword_watches_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_watches_project_id_projects_id_fk": {
+          "name": "keyword_watches_project_id_projects_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keyword_watches_campaign_id_campaigns_id_fk": {
+          "name": "keyword_watches_campaign_id_campaigns_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_org_user_unique": {
+          "name": "memberships_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_from_us": {
+          "name": "is_from_us",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_platform": {
+          "name": "created_at_platform",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_contact_idx": {
+          "name": "messages_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_platform_message_unique": {
+          "name": "messages_platform_message_unique",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_contact_id_contact_history_id_fk": {
+          "name": "messages_contact_id_contact_history_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "contact_history",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_draft_id_drafts_id_fk": {
+          "name": "messages_draft_id_drafts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_platform_id_platforms_id_fk": {
+          "name": "messages_platform_id_platforms_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_unread_idx": {
+          "name": "notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_idx": {
+          "name": "notifications_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organization_id_organizations_id_fk": {
+          "name": "notifications_organization_id_organizations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observed_targets": {
+      "name": "observed_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_by_run_id": {
+          "name": "consumed_by_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "observed_targets_dedup_idx": {
+          "name": "observed_targets_dedup_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "observed_targets_project_unconsumed_idx": {
+          "name": "observed_targets_project_unconsumed_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_by_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "observed_targets_organization_id_organizations_id_fk": {
+          "name": "observed_targets_organization_id_organizations_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_project_id_projects_id_fk": {
+          "name": "observed_targets_project_id_projects_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_platform_id_platforms_id_fk": {
+          "name": "observed_targets_platform_id_platforms_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observed_targets_consumed_by_run_id_runs_id_fk": {
+          "name": "observed_targets_consumed_by_run_id_runs_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "consumed_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_profiles": {
+      "name": "operator_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiences": {
+          "name": "experiences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'linkedin_capture'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_profiles_org_unique": {
+          "name": "operator_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_profiles": {
+      "name": "operator_voice_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "openings": {
+          "name": "openings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "closings": {
+          "name": "closings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "common_words": {
+          "name": "common_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "words_per_sentence": {
+          "name": "words_per_sentence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'derived'"
+        },
+        "derived_at": {
+          "name": "derived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_profiles_org_unique": {
+          "name": "operator_voice_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_voice_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_samples": {
+      "name": "operator_voice_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_samples_org_external_unique": {
+          "name": "operator_voice_samples_org_external_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operator_voice_samples_org_idx": {
+          "name": "operator_voice_samples_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "excluded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_samples_organization_id_organizations_id_fk": {
+          "name": "operator_voice_samples_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_voice_samples_platform_id_platforms_id_fk": {
+          "name": "operator_voice_samples_platform_id_platforms_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invites": {
+      "name": "org_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_invites_org_idx": {
+          "name": "org_invites_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invites_organization_id_organizations_id_fk": {
+          "name": "org_invites_organization_id_organizations_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invites_created_by_user_id_users_id_fk": {
+          "name": "org_invites_created_by_user_id_users_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invites_token_unique": {
+          "name": "org_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_subscriptions": {
+      "name": "org_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "limit_runs": {
+          "name": "limit_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_suggestions": {
+          "name": "limit_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_projects": {
+          "name": "limit_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_seats": {
+          "name": "limit_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_devices": {
+          "name": "limit_devices",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrency": {
+          "name": "limit_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_budget_usd": {
+          "name": "limit_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_retention_days": {
+          "name": "limit_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_premium_models": {
+          "name": "limit_premium_models",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_org_unique": {
+          "name": "org_subscriptions_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_stripe_subscription_unique": {
+          "name": "org_subscriptions_stripe_subscription_unique",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_subscriptions_organization_id_organizations_id_fk": {
+          "name": "org_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "org_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_run_budget_usd": {
+          "name": "monthly_run_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_source": {
+          "name": "plan_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "plan_updated_at": {
+          "name": "plan_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_user_idx": {
+          "name": "password_reset_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platforms": {
+      "name": "platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platforms_slug_unique": {
+          "name": "platforms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playbooks": {
+      "name": "playbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playbooks_slug_unique": {
+          "name": "playbooks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_insights": {
+      "name": "project_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary_md": {
+          "name": "summary_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_insights_project_idx": {
+          "name": "project_insights_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_insights_project_id_projects_id_fk": {
+          "name": "project_insights_project_id_projects_id_fk",
+          "tableFrom": "project_insights",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_sources": {
+      "name": "project_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_runner": {
+          "name": "default_agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "voice_tone": {
+          "name": "voice_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_tone_notes": {
+          "name": "voice_tone_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_unique": {
+          "name": "projects_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_events_run_idx": {
+          "name": "run_events_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_events_kind_created_idx": {
+          "name": "run_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'campaign'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout_log_path": {
+          "name": "stdout_log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playbook_body": {
+          "name": "playbook_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_project_kind_idx": {
+          "name": "runs_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_campaign_id_campaigns_id_fk": {
+          "name": "runs_campaign_id_campaigns_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_scout_candidates": {
+      "name": "staging_scout_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staging_scout_candidates_run_id_runs_id_fk": {
+          "name": "staging_scout_candidates_run_id_runs_id_fk",
+          "tableFrom": "staging_scout_candidates",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_project_kind_idx": {
+          "name": "templates_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_project_id_projects_id_fk": {
+          "name": "templates_project_id_projects_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_instance_admin": {
+          "name": "is_instance_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recent_idx": {
+          "name": "webhook_deliveries_recent_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_org_idx": {
+          "name": "webhook_deliveries_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_organization_id_organizations_id_fk": {
+          "name": "webhook_deliveries_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1788960000014,
       "tag": "0027_org_plans",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1788960000015,
+      "tag": "0028_github_installations",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -1216,6 +1216,53 @@ export const githubSources = pgTable(
   }),
 );
 
+// The optional GitHub App's installations (#390). Only the public half of the
+// credential lives here: the installation id and which account granted it.
+// The private key is a deployment secret read from the environment
+// (`shared/src/github-app.ts`), never a row and never an `app_config` value.
+//
+// `installation_id` is unique across the whole table rather than per
+// organization, and that is a security property rather than tidiness: an
+// installation belongs to exactly one GitHub account, so letting two
+// organizations claim the same one would let the second read the first's
+// private repositories. A re-install onto an account another org already
+// holds is refused (`recordInstallation`), not merged.
+//
+// There is no `project_id` and no per-source link: resolution is by account
+// login (`installationTokenForOwner`), because that is what an installation
+// actually scopes.
+export const githubInstallations = pgTable(
+  'github_installations',
+  {
+    id: serial('id').primaryKey(),
+    organizationId: integer('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    /** GitHub's own installation id. `bigint` because GitHub's ids are already
+     * past what a 32-bit column holds (the two live ones are 160288218 and
+     * 160289335), with mode 'number' since the value stays far inside
+     * `Number.MAX_SAFE_INTEGER`. */
+    installationId: bigint('installation_id', { mode: 'number' }).notNull(),
+    /** The account that installed it: a user or an organization login. This is
+     * the join key for a repository's owner. */
+    accountLogin: text('account_login').notNull(),
+    accountType: text('account_type').notNull().default('User'),
+    /** `all` or `selected`, as GitHub reports it - worth showing an operator,
+     * since `selected` explains why a repo he just created is invisible. */
+    repositorySelection: text('repository_selection').notNull().default('selected'),
+    /** What the installation actually granted, as GitHub reports it. Stored so
+     * Settings can say "contents: read" rather than promising what the app
+     * registration asks for, which an account is free to narrow. */
+    permissions: jsonb('permissions').notNull().default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    byInstallation: uniqueIndex('github_installations_installation_unique').on(t.installationId),
+    byOrg: index('github_installations_org_idx').on(t.organizationId),
+  }),
+);
+
 // A project's set of sources (#431/#398): a project used to be described
 // from exactly one thing at a time, chosen fresh on every extraction run
 // (`cli/src/commands/project.ts`'s `folder` | `git` | `upload`, held only in

--- a/shared/src/github-app.ts
+++ b/shared/src/github-app.ts
@@ -1,0 +1,413 @@
+/**
+ * The optional GitHub App (issue #390), which is what lets the companion read
+ * a **private** repository. Without it `github-sources.ts` calls GitHub's
+ * anonymous REST API: public repos only, 60 requests/hour per IP.
+ *
+ * Deliberately an App and not a PAT or a CLI login. A user token is scoped to
+ * a person, expires in days, and refreshes only on the machine that minted it,
+ * which is the failure mode written down in the store-publishing runbook: a
+ * build that is green today and opaquely red next week. An App's credential is
+ * a private key that signs a short-lived JWT, which buys an installation token
+ * that expires in an hour and carries only the permissions and repositories
+ * the installing account chose.
+ *
+ * The credential is a **deployment secret**, read from the environment the
+ * same way `AI_GATEWAY_API_KEY` and the mail transport are
+ * (`shared/src/mail/env.ts` explains why `app_config` is the wrong home for
+ * one): never persisted to the database, never served to a client, never shown
+ * on a Settings page. What lives in the database is only the public half: the
+ * installation id and which account it belongs to.
+ *
+ * Two apps exist, one per deployment, because the setup URL GitHub redirects
+ * to after an install is a property of the app registration:
+ *   prod     Pitchbox Companion            app id 4883602
+ *   preview  Pitchbox Companion (preview)  app id 4883544
+ * Both ask for `contents: read` and `metadata: read` and nothing else, and
+ * both have their webhook and their user-authorization flow switched off:
+ * this feature reads repositories on demand and has no reason to receive
+ * events or to act as the person who installed it.
+ */
+
+import { createSign } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { schema, type Db } from './db/client.js';
+
+export type GithubAppEnv = {
+  appId: string;
+  /** The `pitchbox-companion` half of `https://github.com/apps/<slug>`, which
+   * is the only way to build an installation URL. */
+  slug: string;
+  /** PEM, decoded from `GITHUB_APP_PRIVATE_KEY_B64`. */
+  privateKey: string;
+};
+
+/**
+ * The private key is carried base64-encoded because a PEM's newlines do not
+ * survive an env file, a compose `environment:` list or a systemd unit. There
+ * is deliberately no raw-PEM fallback variable: two ways to supply one
+ * credential is how you end up with a deployment that holds a mangled key and
+ * only finds out when it signs.
+ *
+ * The name is a literal in the lookup below rather than read through this
+ * constant, and that is deliberate: `tests/docker-mail-env.test.ts` finds the
+ * variables a loader reads by scanning it for direct property reads off its
+ * `env` argument, so an indirect subscript would slip past the guard that
+ * proves the compose files pass the variable through. This constant is only
+ * used in the error messages.
+ */
+const PRIVATE_KEY_VAR = 'GITHUB_APP_PRIVATE_KEY_B64';
+
+/**
+ * Reads the app credential, or `null` when this deployment has no app - which
+ * is the ordinary case for a self-host and stays fully supported: public repos
+ * by URL, anonymously, exactly as before.
+ *
+ * A **partial** configuration throws instead of falling back. The mail
+ * transport takes the opposite route (warn and degrade to the null transport)
+ * because a deployment with no mail still works; here a half-set app is
+ * unambiguous operator error, and degrading silently would present private
+ * repositories as "not found" - the same string GitHub returns for a repo that
+ * really is gone. Failing at load is the only way that mistake is visible.
+ */
+export function loadGithubAppEnv(
+  env: Record<string, string | undefined> = process.env,
+): GithubAppEnv | null {
+  const appId = env.GITHUB_APP_ID?.trim();
+  const slug = env.GITHUB_APP_SLUG?.trim();
+  const keyB64 = env.GITHUB_APP_PRIVATE_KEY_B64?.trim();
+
+  const present = [appId, slug, keyB64].filter(Boolean).length;
+  if (present === 0) return null;
+  if (present < 3) {
+    const missing = [
+      appId ? null : 'GITHUB_APP_ID',
+      slug ? null : 'GITHUB_APP_SLUG',
+      keyB64 ? null : PRIVATE_KEY_VAR,
+    ].filter(Boolean);
+    throw new Error(
+      `[github-app] partially configured: ${missing.join(', ')} not set. Set all three or none.`,
+    );
+  }
+  if (!/^[0-9]+$/.test(appId!)) {
+    throw new Error(`[github-app] GITHUB_APP_ID must be numeric, got "${appId}"`);
+  }
+
+  const privateKey = Buffer.from(keyB64!, 'base64').toString('utf8');
+  if (!privateKey.includes('-----BEGIN') || !privateKey.includes('PRIVATE KEY-----')) {
+    throw new Error(
+      `[github-app] ${PRIVATE_KEY_VAR} did not decode to a PEM private key. It must be the .pem file base64-encoded, for example: base64 -w0 github-app.pem`,
+    );
+  }
+
+  return { appId: appId!, slug: slug!, privateKey };
+}
+
+/** GitHub rejects a JWT whose `exp` is more than 10 minutes out. Nine leaves
+ * room for clock skew in both directions without ever being refused. */
+const JWT_TTL_SECONDS = 9 * 60;
+/** GitHub's own advice for a fast clock on the calling machine: backdate
+ * `iat`, or the token is "issued in the future" and refused. */
+const JWT_BACKDATE_SECONDS = 30;
+
+const b64url = (input: string | Buffer): string =>
+  (typeof input === 'string' ? Buffer.from(input) : input).toString('base64url');
+
+/**
+ * A short-lived JWT identifying the **app** (not an installation). It can read
+ * `/app` and mint installation tokens, and it can read no repository content
+ * at all, so it is never the credential a fetch uses.
+ */
+export function mintAppJwt(app: GithubAppEnv, now: Date = new Date()): string {
+  const iat = Math.floor(now.getTime() / 1000) - JWT_BACKDATE_SECONDS;
+  const header = b64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = b64url(
+    JSON.stringify({ iat, exp: iat + JWT_TTL_SECONDS + JWT_BACKDATE_SECONDS, iss: app.appId }),
+  );
+  const signature = createSign('RSA-SHA256').update(`${header}.${payload}`).sign(app.privateKey);
+  return `${header}.${payload}.${b64url(signature)}`;
+}
+
+/** Same narrow shape `github-sources.ts` uses, for the same reason: a test
+ * double that only accepts a string URL is a valid substitute, while
+ * `typeof fetch` would demand the `Request`/`URL` overloads this code never
+ * calls. POST is needed here, so the init carries a method. */
+export type GithubFetch = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+) => Promise<Response>;
+
+const GITHUB_API_BASE = 'https://api.github.com';
+const API_HEADERS = { Accept: 'application/vnd.github+json' };
+
+export type InstallationTokenResult =
+  { ok: true; token: string; expiresAt: Date } | { ok: false; reason: string; status?: number };
+
+/**
+ * Installation tokens last an hour and GitHub rate-limits minting them, so
+ * they are cached in process and reused. Refreshed early (`SKEW_MS` before
+ * expiry) so a token never expires mid-request. The cache is keyed by app id
+ * as well as installation id: preview and prod are different apps, and a
+ * process only ever holds one, but keying on both means a test that swaps the
+ * app env is not served a stale token.
+ */
+const tokenCache = new Map<string, { token: string; expiresAt: Date }>();
+const TOKEN_REFRESH_SKEW_MS = 5 * 60 * 1000;
+
+/** Test seam. Nothing in production calls this. */
+export function clearInstallationTokenCache(): void {
+  tokenCache.clear();
+}
+
+export async function getInstallationToken(
+  app: GithubAppEnv,
+  installationId: number,
+  opts: { fetchImpl?: GithubFetch; now?: Date } = {},
+): Promise<InstallationTokenResult> {
+  const fetchImpl = opts.fetchImpl ?? (fetch as GithubFetch);
+  const now = opts.now ?? new Date();
+  const key = `${app.appId}:${installationId}`;
+
+  const cached = tokenCache.get(key);
+  if (cached && cached.expiresAt.getTime() - now.getTime() > TOKEN_REFRESH_SKEW_MS) {
+    return { ok: true, token: cached.token, expiresAt: cached.expiresAt };
+  }
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${GITHUB_API_BASE}/app/installations/${installationId}/access_tokens`, {
+      method: 'POST',
+      headers: { ...API_HEADERS, Authorization: `Bearer ${mintAppJwt(app, now)}` },
+    });
+  } catch (err) {
+    return { ok: false, reason: `network error: ${(err as Error).message}` };
+  }
+
+  if (!res.ok) {
+    // 404 here means the installation is gone: somebody uninstalled the app
+    // from the account. That is a normal end of life for a row, not an error
+    // worth throwing - the caller drops back to anonymous reads.
+    tokenCache.delete(key);
+    return {
+      ok: false,
+      status: res.status,
+      reason:
+        res.status === 404
+          ? 'installation no longer exists (uninstalled on GitHub)'
+          : `GitHub refused to mint an installation token (${res.status})`,
+    };
+  }
+
+  const body = (await res.json()) as { token?: string; expires_at?: string };
+  if (!body.token || !body.expires_at) {
+    return { ok: false, reason: 'GitHub returned a token response with no token' };
+  }
+  const expiresAt = new Date(body.expires_at);
+  tokenCache.set(key, { token: body.token, expiresAt });
+  return { ok: true, token: body.token, expiresAt };
+}
+
+export type InstallationDetails = {
+  installationId: number;
+  accountLogin: string;
+  accountType: string;
+  repositorySelection: string;
+  permissions: Record<string, string>;
+};
+
+/**
+ * Reads an installation from GitHub with the app JWT. This is what makes the
+ * setup callback trustworthy: the `installation_id` in that redirect is a
+ * query parameter anybody can forge, so it is never stored on the strength of
+ * the request. An installation belonging to a different app answers 404 here.
+ */
+export async function fetchInstallation(
+  app: GithubAppEnv,
+  installationId: number,
+  opts: { fetchImpl?: GithubFetch; now?: Date } = {},
+): Promise<{ ok: true; details: InstallationDetails } | { ok: false; reason: string }> {
+  const fetchImpl = opts.fetchImpl ?? (fetch as GithubFetch);
+  let res: Response;
+  try {
+    res = await fetchImpl(`${GITHUB_API_BASE}/app/installations/${installationId}`, {
+      headers: { ...API_HEADERS, Authorization: `Bearer ${mintAppJwt(app, opts.now)}` },
+    });
+  } catch (err) {
+    return { ok: false, reason: `network error: ${(err as Error).message}` };
+  }
+  if (!res.ok) {
+    return {
+      ok: false,
+      reason:
+        res.status === 404
+          ? 'no such installation for this app'
+          : `GitHub returned ${res.status} for that installation`,
+    };
+  }
+  const body = (await res.json()) as {
+    id?: number;
+    account?: { login?: string; type?: string };
+    repository_selection?: string;
+    permissions?: Record<string, string>;
+  };
+  if (!body.id || !body.account?.login) {
+    return { ok: false, reason: 'GitHub returned an installation with no account' };
+  }
+  return {
+    ok: true,
+    details: {
+      installationId: body.id,
+      accountLogin: body.account.login,
+      accountType: body.account.type ?? 'User',
+      repositorySelection: body.repository_selection ?? 'selected',
+      permissions: body.permissions ?? {},
+    },
+  };
+}
+
+/** Uninstalls the app from the account. Called when an operator disconnects an
+ * installation here, so the account's GitHub settings do not keep listing an
+ * app nothing uses. A 404 is success: it is already gone. */
+export async function deleteInstallation(
+  app: GithubAppEnv,
+  installationId: number,
+  opts: { fetchImpl?: GithubFetch; now?: Date } = {},
+): Promise<{ ok: boolean; reason?: string }> {
+  const fetchImpl = opts.fetchImpl ?? (fetch as GithubFetch);
+  try {
+    const res = await fetchImpl(`${GITHUB_API_BASE}/app/installations/${installationId}`, {
+      method: 'DELETE',
+      headers: { ...API_HEADERS, Authorization: `Bearer ${mintAppJwt(app, opts.now)}` },
+    });
+    clearInstallationTokenCache();
+    if (res.ok || res.status === 404) return { ok: true };
+    return { ok: false, reason: `GitHub returned ${res.status}` };
+  } catch (err) {
+    return { ok: false, reason: `network error: ${(err as Error).message}` };
+  }
+}
+
+export type GithubInstallationRow = typeof schema.githubInstallations.$inferSelect;
+
+/** Every installation an organization has connected, oldest first. An org may
+ * hold more than one: a person's own account and an organization account are
+ * separate installations, and a source can live under either. */
+export async function listInstallations(
+  db: Db,
+  organizationId: number,
+): Promise<GithubInstallationRow[]> {
+  return db
+    .select()
+    .from(schema.githubInstallations)
+    .where(eq(schema.githubInstallations.organizationId, organizationId))
+    .orderBy(schema.githubInstallations.id);
+}
+
+/**
+ * Records (or refreshes) an installation for an organization. Keyed on the
+ * installation id alone, not on `(org, installation)`: an installation belongs
+ * to exactly one GitHub account, and letting two organizations claim the same
+ * one would let a second tenant read the first tenant's private repositories.
+ * A re-install onto an account that a different org already holds is therefore
+ * a refusal, not an upsert.
+ */
+export async function recordInstallation(
+  db: Db,
+  organizationId: number,
+  details: InstallationDetails,
+): Promise<{ ok: true; row: GithubInstallationRow } | { ok: false; code: 'claimed_by_other_org' }> {
+  const [existing] = await db
+    .select()
+    .from(schema.githubInstallations)
+    .where(eq(schema.githubInstallations.installationId, details.installationId));
+
+  if (existing && existing.organizationId !== organizationId) {
+    return { ok: false, code: 'claimed_by_other_org' };
+  }
+
+  const values = {
+    organizationId,
+    installationId: details.installationId,
+    accountLogin: details.accountLogin,
+    accountType: details.accountType,
+    repositorySelection: details.repositorySelection,
+    permissions: details.permissions,
+    updatedAt: new Date(),
+  };
+
+  if (existing) {
+    const [row] = await db
+      .update(schema.githubInstallations)
+      .set(values)
+      .where(eq(schema.githubInstallations.id, existing.id))
+      .returning();
+    return { ok: true, row };
+  }
+
+  const [row] = await db.insert(schema.githubInstallations).values(values).returning();
+  return { ok: true, row };
+}
+
+/** Forgets an installation, scoped to the caller's organization. Returns false
+ * when the id does not exist or belongs to another org, which the caller turns
+ * into a 404 and never a 403, so a probe learns nothing - the same rule
+ * `removeGithubSource` follows. */
+export async function forgetInstallation(
+  db: Db,
+  organizationId: number,
+  id: number,
+): Promise<GithubInstallationRow | null> {
+  const [row] = await db
+    .delete(schema.githubInstallations)
+    .where(
+      and(
+        eq(schema.githubInstallations.id, id),
+        eq(schema.githubInstallations.organizationId, organizationId),
+      ),
+    )
+    .returning();
+  return row ?? null;
+}
+
+/**
+ * The credential a read of `owner/repo` should use, or `null` for "read it
+ * anonymously, as before".
+ *
+ * Resolution is by **account login**, because that is what an installation
+ * actually is: the account installs the app, and the repositories it exposes
+ * all belong to that account. Matching case-insensitively, since GitHub logins
+ * are compared that way. When an org has no installation for that owner the
+ * answer is `null` rather than "try them all": presenting one account's token
+ * on another account's repository would only ever produce a 404, and trying
+ * every installation would burn the rate limit to learn that.
+ */
+export async function installationTokenForOwner(
+  db: Db,
+  organizationId: number,
+  owner: string,
+  opts: { app?: GithubAppEnv | null; fetchImpl?: GithubFetch; now?: Date } = {},
+): Promise<{ token: string; installationId: number } | null> {
+  const app = opts.app === undefined ? loadGithubAppEnv() : opts.app;
+  if (!app) return null;
+
+  const rows = await listInstallations(db, organizationId);
+  const match = rows.find((r) => r.accountLogin.toLowerCase() === owner.toLowerCase());
+  if (!match) return null;
+
+  const token = await getInstallationToken(app, match.installationId, opts);
+  if (!token.ok) {
+    console.warn(
+      `[github-app] installation ${match.installationId} (${match.accountLogin}): ${token.reason}`,
+    );
+    return null;
+  }
+  return { token: token.token, installationId: match.installationId };
+}
+
+/**
+ * Where GitHub sends somebody to install the app. `state` is ours and comes
+ * back on the setup redirect, which is how the callback knows which
+ * organization asked - see `web/src/lib/server/github-install-state.ts`.
+ */
+export function installationUrl(app: GithubAppEnv, state: string): string {
+  return `https://github.com/apps/${encodeURIComponent(app.slug)}/installations/new?state=${encodeURIComponent(state)}`;
+}

--- a/shared/src/github-sources.ts
+++ b/shared/src/github-sources.ts
@@ -14,6 +14,7 @@
 
 import { and, asc, eq, isNull, lt, or } from 'drizzle-orm';
 import { schema, type Db } from './db/client.js';
+import { installationTokenForOwner, type GithubAppEnv } from './github-app.js';
 
 export type GithubSourceRow = typeof schema.githubSources.$inferSelect;
 
@@ -138,6 +139,14 @@ type RefreshOptions = {
    * this never actually reaches GitHub. */
   fetchImpl?: GithubFetch;
   ttlMs?: number;
+  /**
+   * The GitHub App credential to authenticate with when the source's owner is
+   * an account that installed it (#390). `undefined` reads the deployment
+   * environment, `null` forces the anonymous path, which is what most tests
+   * want. Resolution, and why it is by account login, is in
+   * `shared/src/github-app.ts`.
+   */
+  app?: GithubAppEnv | null;
 };
 
 async function recordFetchError(db: Db, id: number, message: string): Promise<void> {
@@ -172,7 +181,19 @@ export async function refreshGithubSource(
   if (row.fetchedAt && Date.now() - row.fetchedAt.getTime() < ttlMs) return;
 
   const base = `${GITHUB_API_BASE}/repos/${encodeURIComponent(row.owner)}/${encodeURIComponent(row.repo)}`;
-  const headers = { Accept: 'application/vnd.github+json' };
+
+  // A private repository is invisible to the anonymous API, and GitHub answers
+  // 404 rather than 403 for one, so without a credential this module cannot
+  // tell "does not exist" from "not yours to see". When the organization has
+  // installed the app on that owner's account, every call below carries an
+  // installation token instead, which also lifts the 60/hour anonymous cap to
+  // 5,000.
+  const installation = await installationTokenForOwner(db, row.organizationId, row.owner, {
+    app: opts.app,
+    fetchImpl: opts.fetchImpl,
+  });
+  const headers: Record<string, string> = { Accept: 'application/vnd.github+json' };
+  if (installation) headers.Authorization = `token ${installation.token}`;
 
   let repoRes: Response;
   try {
@@ -183,7 +204,18 @@ export async function refreshGithubSource(
   }
 
   if (repoRes.status === 404) {
-    await recordFetchError(db, id, 'repository not found (private or deleted)');
+    // The message differs by credential on purpose. Anonymously, 404 is
+    // ambiguous and the operator's fix is to install the app. Authenticated,
+    // it is not ambiguous at all: the installation exists but this repository
+    // is not in what the account selected, which is a different fix and a
+    // different sentence.
+    await recordFetchError(
+      db,
+      id,
+      installation
+        ? "not in this installation's selected repositories (add it on GitHub, or install the app on all repositories)"
+        : 'repository not found (private or deleted; a private repo needs the GitHub App)',
+    );
     return;
   }
   if (repoRes.status === 403) {

--- a/shared/tests/github-app.test.ts
+++ b/shared/tests/github-app.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { createVerify, generateKeyPairSync } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import {
+  clearInstallationTokenCache,
+  deleteInstallation,
+  fetchInstallation,
+  forgetInstallation,
+  getInstallationToken,
+  installationTokenForOwner,
+  installationUrl,
+  listInstallations,
+  loadGithubAppEnv,
+  mintAppJwt,
+  recordInstallation,
+  type GithubAppEnv,
+} from '@pitchbox/shared/github-app';
+
+// The optional GitHub App (#390). What is worth defending here is not that the
+// module can format a JWT, it is the three things that decide whether a
+// private repository is read safely: a half-configured credential is refused
+// rather than degraded, an installation cannot be claimed by a second
+// organization, and a token is only ever presented to the account that
+// granted it.
+
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const PEM = privateKey.export({ type: 'pkcs1', format: 'pem' }).toString();
+const APP: GithubAppEnv = { appId: '4883602', slug: 'pitchbox-companion', privateKey: PEM };
+
+function envFor(overrides: Record<string, string | undefined> = {}) {
+  return {
+    GITHUB_APP_ID: '4883602',
+    GITHUB_APP_SLUG: 'pitchbox-companion',
+    GITHUB_APP_PRIVATE_KEY_B64: Buffer.from(PEM).toString('base64'),
+    ...overrides,
+  };
+}
+
+/** A fetch double that records what it was called with, so a test can assert
+ * on the Authorization header rather than on a return value. */
+function fakeFetch(
+  handler: (url: string, init?: { method?: string; headers?: Record<string, string> }) => Response,
+) {
+  const calls: Array<{ url: string; method: string; auth: string | undefined }> = [];
+  const impl = async (
+    url: string,
+    init?: { method?: string; headers?: Record<string, string> },
+  ) => {
+    calls.push({ url, method: init?.method ?? 'GET', auth: init?.headers?.Authorization });
+    return handler(url, init);
+  };
+  return { impl, calls };
+}
+
+const jsonRes = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+describe('loadGithubAppEnv', () => {
+  it('returns null when no app is configured, which is the self-host default', () => {
+    expect(loadGithubAppEnv({})).toBeNull();
+  });
+
+  it('refuses a half-configured app instead of silently reading anonymously', () => {
+    // The failure this prevents: with only two of the three set, a private
+    // repository would be reported as "not found", the same string GitHub
+    // returns for a repo that really is gone, and nobody would know the
+    // credential was never used.
+    expect(() => loadGithubAppEnv({ GITHUB_APP_ID: '1', GITHUB_APP_SLUG: 'x' })).toThrow(
+      /GITHUB_APP_PRIVATE_KEY_B64 not set/,
+    );
+    expect(() => loadGithubAppEnv(envFor({ GITHUB_APP_SLUG: undefined }))).toThrow(
+      /GITHUB_APP_SLUG not set/,
+    );
+  });
+
+  it('refuses a key that is not a base64 PEM, naming how to encode one', () => {
+    expect(() =>
+      loadGithubAppEnv(envFor({ GITHUB_APP_PRIVATE_KEY_B64: Buffer.from(PEM).toString('utf8') })),
+    ).toThrow(/base64 -w0/);
+  });
+
+  it('refuses a non-numeric app id', () => {
+    expect(() => loadGithubAppEnv(envFor({ GITHUB_APP_ID: 'pitchbox-companion' }))).toThrow(
+      /must be numeric/,
+    );
+  });
+
+  it('decodes the key so the app id and slug are usable', () => {
+    const app = loadGithubAppEnv(envFor());
+    expect(app?.appId).toBe('4883602');
+    expect(app?.privateKey).toContain('-----BEGIN');
+    expect(installationUrl(app!, 'st.ate')).toBe(
+      'https://github.com/apps/pitchbox-companion/installations/new?state=st.ate',
+    );
+  });
+});
+
+describe('mintAppJwt', () => {
+  it('signs a token GitHub will accept: RS256, backdated iat, exp inside ten minutes', () => {
+    const now = new Date('2026-09-09T12:00:00Z');
+    const [header, payload, signature] = mintAppJwt(APP, now).split('.');
+
+    const verified = createVerify('RSA-SHA256')
+      .update(`${header}.${payload}`)
+      .verify(publicKey, Buffer.from(signature, 'base64url'));
+    expect(verified).toBe(true);
+
+    expect(JSON.parse(Buffer.from(header, 'base64url').toString())).toEqual({
+      alg: 'RS256',
+      typ: 'JWT',
+    });
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString()) as {
+      iat: number;
+      exp: number;
+      iss: string;
+    };
+    const seconds = Math.floor(now.getTime() / 1000);
+    expect(claims.iss).toBe('4883602');
+    // Backdated, because GitHub refuses a token issued in the future when the
+    // calling machine's clock runs fast.
+    expect(claims.iat).toBeLessThan(seconds);
+    // GitHub refuses an exp more than 600s out.
+    expect(claims.exp - seconds).toBeLessThan(600);
+    expect(claims.exp).toBeGreaterThan(seconds);
+  });
+});
+
+describe('getInstallationToken', () => {
+  beforeEach(clearInstallationTokenCache);
+  afterEach(clearInstallationTokenCache);
+
+  it('mints once and reuses the token until it is close to expiring', async () => {
+    const expires = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const f = fakeFetch(() => jsonRes({ token: 'ghs_first', expires_at: expires }));
+
+    const a = await getInstallationToken(APP, 160289335, { fetchImpl: f.impl });
+    const b = await getInstallationToken(APP, 160289335, { fetchImpl: f.impl });
+
+    expect(a).toMatchObject({ ok: true, token: 'ghs_first' });
+    expect(b).toMatchObject({ ok: true, token: 'ghs_first' });
+    // One network call for two reads: minting is rate-limited, and a
+    // suggestion can build a prompt from several sources at once.
+    expect(f.calls).toHaveLength(1);
+    expect(f.calls[0].method).toBe('POST');
+    expect(f.calls[0].auth).toMatch(/^Bearer /);
+  });
+
+  it('refreshes rather than handing back a token about to expire mid-request', async () => {
+    let n = 0;
+    const f = fakeFetch(() =>
+      jsonRes({
+        token: `ghs_${++n}`,
+        // Two minutes left, which is inside the refresh skew.
+        expires_at: new Date(Date.now() + 2 * 60 * 1000).toISOString(),
+      }),
+    );
+    await getInstallationToken(APP, 1, { fetchImpl: f.impl });
+    const second = await getInstallationToken(APP, 1, { fetchImpl: f.impl });
+    expect(second).toMatchObject({ token: 'ghs_2' });
+  });
+
+  it('reports an uninstalled app as such rather than throwing', async () => {
+    const f = fakeFetch(() => jsonRes({ message: 'Not Found' }, 404));
+    const res = await getInstallationToken(APP, 999, { fetchImpl: f.impl });
+    expect(res).toMatchObject({ ok: false, status: 404 });
+    expect(res.ok === false && res.reason).toMatch(/uninstalled on GitHub/);
+  });
+});
+
+describe('fetchInstallation', () => {
+  it('is what makes the setup callback trustworthy: an unknown installation is refused', async () => {
+    // The attack this closes: `installation_id` arrives as a query parameter
+    // on a GET, so anybody can put a stranger's id there. An id belonging to
+    // another app answers 404 against our JWT.
+    const f = fakeFetch(() => jsonRes({ message: 'Not Found' }, 404));
+    const res = await fetchInstallation(APP, 160289335, { fetchImpl: f.impl });
+    expect(res).toMatchObject({ ok: false, reason: 'no such installation for this app' });
+  });
+
+  it('reads the account and the repository selection GitHub reports', async () => {
+    const f = fakeFetch(() =>
+      jsonRes({
+        id: 160289335,
+        account: { login: 'fiorelorenzo', type: 'User' },
+        repository_selection: 'selected',
+        permissions: { contents: 'read', metadata: 'read' },
+      }),
+    );
+    const res = await fetchInstallation(APP, 160289335, { fetchImpl: f.impl });
+    expect(res.ok && res.details).toEqual({
+      installationId: 160289335,
+      accountLogin: 'fiorelorenzo',
+      accountType: 'User',
+      repositorySelection: 'selected',
+      permissions: { contents: 'read', metadata: 'read' },
+    });
+  });
+});
+
+describe('installations in the database', () => {
+  let orgA: number;
+  let orgB: number;
+
+  beforeEach(async () => {
+    clearInstallationTokenCache();
+    const db = getDb();
+    await db.execute(sql`TRUNCATE github_installations RESTART IDENTITY CASCADE`);
+    await db.execute(sql`DELETE FROM organizations WHERE slug LIKE 'ghapp-%'`);
+    const [a] = await db
+      .insert(schema.organizations)
+      .values({ slug: 'ghapp-a', name: 'ghapp-a' })
+      .returning();
+    const [b] = await db
+      .insert(schema.organizations)
+      .values({ slug: 'ghapp-b', name: 'ghapp-b' })
+      .returning();
+    orgA = a.id;
+    orgB = b.id;
+  });
+
+  const details = (overrides: Record<string, unknown> = {}) => ({
+    installationId: 160289335,
+    accountLogin: 'fiorelorenzo',
+    accountType: 'User',
+    repositorySelection: 'selected',
+    permissions: { contents: 'read', metadata: 'read' },
+    ...overrides,
+  });
+
+  it('refuses to let a second organization claim the same installation', async () => {
+    // This is the cross-tenant hole the unique index exists for: an
+    // installation is one GitHub account, so two orgs holding it would mean
+    // the second reading the first's private repositories.
+    expect(await recordInstallation(getDb(), orgA, details())).toMatchObject({ ok: true });
+    expect(await recordInstallation(getDb(), orgB, details())).toEqual({
+      ok: false,
+      code: 'claimed_by_other_org',
+    });
+    expect(await listInstallations(getDb(), orgB)).toHaveLength(0);
+  });
+
+  it('refreshes an existing row when the account changes its selection', async () => {
+    await recordInstallation(getDb(), orgA, details());
+    await recordInstallation(getDb(), orgA, details({ repositorySelection: 'all' }));
+    const rows = await listInstallations(getDb(), orgA);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].repositorySelection).toBe('all');
+  });
+
+  it('scopes forgetting to the caller organization', async () => {
+    await recordInstallation(getDb(), orgA, details());
+    const [row] = await listInstallations(getDb(), orgA);
+    // Another org's id is indistinguishable from a nonexistent one, which is
+    // what lets the route answer 404 and never 403.
+    expect(await forgetInstallation(getDb(), orgB, row.id)).toBeNull();
+    expect(await forgetInstallation(getDb(), orgA, row.id)).toMatchObject({ id: row.id });
+    expect(await listInstallations(getDb(), orgA)).toHaveLength(0);
+  });
+
+  it('presents a token only to the account that granted it', async () => {
+    await recordInstallation(getDb(), orgA, details({ accountLogin: 'fiorelorenzo' }));
+    const f = fakeFetch(() =>
+      jsonRes({ token: 'ghs_x', expires_at: new Date(Date.now() + 3600_000).toISOString() }),
+    );
+
+    // Case-insensitive, because GitHub compares logins that way.
+    expect(
+      await installationTokenForOwner(getDb(), orgA, 'FioreLorenzo', {
+        app: APP,
+        fetchImpl: f.impl,
+      }),
+    ).toMatchObject({ token: 'ghs_x', installationId: 160289335 });
+
+    // A different account gets nothing rather than being handed this token:
+    // presenting it there would only ever 404, and trying every installation
+    // would burn the rate limit to learn that.
+    expect(
+      await installationTokenForOwner(getDb(), orgA, 'someone-else', {
+        app: APP,
+        fetchImpl: f.impl,
+      }),
+    ).toBeNull();
+
+    // And another organization gets nothing at all.
+    expect(
+      await installationTokenForOwner(getDb(), orgB, 'fiorelorenzo', {
+        app: APP,
+        fetchImpl: f.impl,
+      }),
+    ).toBeNull();
+  });
+
+  it('reads anonymously when the deployment has no app', async () => {
+    await recordInstallation(getDb(), orgA, details());
+    expect(
+      await installationTokenForOwner(getDb(), orgA, 'fiorelorenzo', { app: null }),
+    ).toBeNull();
+  });
+});
+
+describe('deleteInstallation', () => {
+  it('treats an already-gone installation as success', async () => {
+    const f = fakeFetch(() => new Response(null, { status: 404 }));
+    expect(await deleteInstallation(APP, 1, { fetchImpl: f.impl })).toEqual({ ok: true });
+    expect(f.calls[0].method).toBe('DELETE');
+  });
+
+  it('reports a refusal rather than claiming the app was uninstalled', async () => {
+    const f = fakeFetch(() => new Response(null, { status: 500 }));
+    expect(await deleteInstallation(APP, 1, { fetchImpl: f.impl })).toEqual({
+      ok: false,
+      reason: 'GitHub returned 500',
+    });
+  });
+});

--- a/shared/tests/github-sources-private.test.ts
+++ b/shared/tests/github-sources-private.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+import { eq, sql } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { refreshGithubSource } from '@pitchbox/shared/github-sources';
+import {
+  clearInstallationTokenCache,
+  recordInstallation,
+  type GithubAppEnv,
+} from '@pitchbox/shared/github-app';
+
+// The point of #390: a private repository is only readable with an
+// installation token. What this file defends is that the token actually
+// reaches the request, that it is not presented to an account that never
+// granted it, and that the two 404s (invisible versus not selected) are told
+// apart, because they have different fixes.
+
+const PEM = generateKeyPairSync('rsa', { modulusLength: 2048 })
+  .privateKey.export({ type: 'pkcs1', format: 'pem' })
+  .toString();
+const APP: GithubAppEnv = { appId: '4883602', slug: 'pitchbox-companion', privateKey: PEM };
+
+const jsonRes = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+type Call = { url: string; auth: string | undefined };
+
+function githubDouble(opts: { repoStatus?: number } = {}) {
+  const calls: Call[] = [];
+  const impl = async (
+    url: string,
+    init?: { method?: string; headers?: Record<string, string> },
+  ) => {
+    calls.push({ url, auth: init?.headers?.Authorization });
+    if (url.endsWith('/access_tokens')) {
+      return jsonRes({
+        token: 'ghs_installation',
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+      });
+    }
+    if (url.endsWith('/readme')) {
+      return jsonRes({
+        encoding: 'base64',
+        content: Buffer.from('# Private\n\nA repo.').toString('base64'),
+      });
+    }
+    if (url.includes('/commits')) {
+      return jsonRes([
+        {
+          sha: 'abc123',
+          commit: {
+            message: 'feat: something\n\nbody',
+            committer: { date: '2026-09-01T00:00:00Z' },
+          },
+        },
+      ]);
+    }
+    if (opts.repoStatus && opts.repoStatus !== 200) {
+      return jsonRes({ message: 'Not Found' }, opts.repoStatus);
+    }
+    return jsonRes({ description: 'A private repo', language: 'TypeScript' });
+  };
+  return { impl, calls };
+}
+
+async function seedOrgAndSource(slug: string, owner: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [source] = await db
+    .insert(schema.githubSources)
+    .values({
+      organizationId: org.id,
+      owner,
+      repo: 'private-thing',
+      url: `https://github.com/${owner}/private-thing`,
+    })
+    .returning();
+  return { orgId: org.id, sourceId: source.id };
+}
+
+describe('refreshGithubSource with a GitHub App installation', () => {
+  beforeEach(async () => {
+    clearInstallationTokenCache();
+    const db = getDb();
+    await db.execute(sql`TRUNCATE github_installations, github_sources RESTART IDENTITY CASCADE`);
+    await db.execute(sql`DELETE FROM organizations WHERE slug LIKE 'ghsrc-%'`);
+  });
+
+  it('reads a private repository with the installation token on every call', async () => {
+    const { orgId, sourceId } = await seedOrgAndSource('ghsrc-a', 'fiorelorenzo');
+    await recordInstallation(getDb(), orgId, {
+      installationId: 160289335,
+      accountLogin: 'fiorelorenzo',
+      accountType: 'User',
+      repositorySelection: 'selected',
+      permissions: { contents: 'read', metadata: 'read' },
+    });
+
+    const gh = githubDouble();
+    await refreshGithubSource(getDb(), sourceId, { fetchImpl: gh.impl, app: APP });
+
+    // The repo, README and commit calls all carry the token: a private repo
+    // 404s on any one of them without it, so a half-authenticated refresh
+    // would silently store metadata with no README.
+    const repoCalls = gh.calls.filter((c) => !c.url.endsWith('/access_tokens'));
+    expect(repoCalls).toHaveLength(3);
+    for (const call of repoCalls) expect(call.auth).toBe('token ghs_installation');
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.githubSources)
+      .where(eq(schema.githubSources.id, sourceId));
+    expect(row.description).toBe('A private repo');
+    expect(row.readmeExcerpt).toContain('A repo.');
+    expect(row.recentCommits).toEqual([
+      { sha: 'abc123', message: 'feat: something', committedAt: '2026-09-01T00:00:00Z' },
+    ]);
+    expect(row.fetchError).toBeNull();
+  });
+
+  it('reads anonymously when the owner is not an account this org installed on', async () => {
+    const { orgId, sourceId } = await seedOrgAndSource('ghsrc-b', 'someone-else');
+    await recordInstallation(getDb(), orgId, {
+      installationId: 160288218,
+      accountLogin: 'fiorelorenzo',
+      accountType: 'User',
+      repositorySelection: 'selected',
+      permissions: { contents: 'read' },
+    });
+
+    const gh = githubDouble();
+    await refreshGithubSource(getDb(), sourceId, { fetchImpl: gh.impl, app: APP });
+
+    expect(gh.calls.some((c) => c.url.endsWith('/access_tokens'))).toBe(false);
+    for (const call of gh.calls) expect(call.auth).toBeUndefined();
+  });
+
+  it('says which 404 it is, because the two have different fixes', async () => {
+    const anon = await seedOrgAndSource('ghsrc-c', 'stranger');
+    const gh1 = githubDouble({ repoStatus: 404 });
+    await refreshGithubSource(getDb(), anon.sourceId, { fetchImpl: gh1.impl, app: APP });
+    const [anonRow] = await getDb()
+      .select()
+      .from(schema.githubSources)
+      .where(eq(schema.githubSources.id, anon.sourceId));
+    expect(anonRow.fetchError).toMatch(/needs the GitHub App/);
+
+    const auth = await seedOrgAndSource('ghsrc-d', 'fiorelorenzo');
+    await recordInstallation(getDb(), auth.orgId, {
+      installationId: 160289336,
+      accountLogin: 'fiorelorenzo',
+      accountType: 'User',
+      repositorySelection: 'selected',
+      permissions: { contents: 'read' },
+    });
+    const gh2 = githubDouble({ repoStatus: 404 });
+    await refreshGithubSource(getDb(), auth.sourceId, { fetchImpl: gh2.impl, app: APP });
+    const [authRow] = await getDb()
+      .select()
+      .from(schema.githubSources)
+      .where(eq(schema.githubSources.id, auth.sourceId));
+    expect(authRow.fetchError).toMatch(/selected repositories/);
+  });
+});

--- a/tests/docker-mail-env.test.ts
+++ b/tests/docker-mail-env.test.ts
@@ -19,11 +19,26 @@ import { join } from 'node:path';
  */
 const root = join(import.meta.dirname, '..');
 
-function mailEnvVarsReadByTheLoader(): string[] {
-  const src = readFileSync(join(root, 'shared/src/mail/env.ts'), 'utf8');
+function envVarsReadBy(loaderPath: string): string[] {
+  const src = readFileSync(join(root, loaderPath), 'utf8');
   const names = new Set<string>();
   for (const m of src.matchAll(/\benv\.([A-Z][A-Z0-9_]*)/g)) names.add(m[1]);
   return [...names].sort();
+}
+
+function mailEnvVarsReadByTheLoader(): string[] {
+  return envVarsReadBy('shared/src/mail/env.ts');
+}
+
+/** The optional GitHub App's credential (#390), read the same way and with
+ * the same failure shape: a variable the loader reads and the compose files
+ * do not pass produces a deployment that reads repositories anonymously while
+ * its `.env` holds a perfectly good key. `loadGithubAppEnv` throws on a
+ * partial configuration, so a missing one here is worse than silent - it
+ * takes the route down - which is another reason to check it in CI rather
+ * than in production. */
+function githubAppEnvVarsReadByTheLoader(): string[] {
+  return envVarsReadBy('shared/src/github-app.ts');
 }
 
 /** The `web:` service's own block, cut at the next service at the same indent. */
@@ -50,6 +65,29 @@ function blueGreenCommonBlock(): string {
   const next = rest.search(/\nservices:\n/);
   return next < 0 ? rest : rest.slice(0, next);
 }
+
+describe('the deployed app receives the GitHub App credential it reads', () => {
+  it('finds the variables to check, rather than passing on an empty set', () => {
+    expect(githubAppEnvVarsReadByTheLoader()).toEqual([
+      'GITHUB_APP_ID',
+      'GITHUB_APP_PRIVATE_KEY_B64',
+      'GITHUB_APP_SLUG',
+    ]);
+  });
+
+  it.each(githubAppEnvVarsReadByTheLoader())('passes %s into the base web service', (name) => {
+    expect(webServiceBlock()).toMatch(new RegExp(`^\\s+${name}: \\$\\{${name}(:-[^}]*)?\\}$`, 'm'));
+  });
+
+  it.each(githubAppEnvVarsReadByTheLoader())(
+    'passes %s into the blue-green web containers, which are what production runs',
+    (name) => {
+      expect(blueGreenCommonBlock()).toMatch(
+        new RegExp(`^\\s+${name}: \\$\\{${name}(:-[^}]*)?\\}$`, 'm'),
+      );
+    },
+  );
+});
 
 describe('the deployed app receives the mail configuration it reads', () => {
   it('finds the variables to check, rather than passing on an empty set', () => {

--- a/web/src/lib/server/github-install-state.ts
+++ b/web/src/lib/server/github-install-state.ts
@@ -1,0 +1,90 @@
+/**
+ * The `state` parameter carried through a GitHub App installation (#390).
+ *
+ * GitHub redirects to the app's setup URL after an install with
+ * `?installation_id=<n>&setup_action=install`, and it round-trips whatever
+ * `state` the install URL carried. Neither value is trustworthy on arrival:
+ * both are query parameters on a GET anybody can construct, so the callback
+ * verifies the installation against GitHub with the app JWT
+ * (`fetchInstallation`) and verifies this state's signature before it writes a
+ * row.
+ *
+ * What the state buys, given the callback also requires a session: it pins the
+ * install to the **organization that started it**. Without it, a person who
+ * belongs to two organizations could start an install while acting for one and
+ * land the row on whichever org their session happens to have active by the
+ * time GitHub redirects back, which is a cross-tenant write nobody would ever
+ * notice.
+ *
+ * Signed with `ENCRYPTION_KEY`, the deployment secret that already exists,
+ * through an HMAC rather than the reversible `encrypt`/`decrypt` in
+ * `shared/src/crypto.ts`: nothing here is secret (an org id and a nonce), only
+ * unforgeable. Compared in constant time, and short-lived, because a state is
+ * only ever in flight for as long as somebody takes to click Install.
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+/** Long enough for the GitHub flow, including choosing repositories on a
+ * slow page, short enough that a link left in a browser history is useless. */
+export const INSTALL_STATE_TTL_MS = 30 * 60 * 1000;
+
+type StatePayload = { orgId: number; userId: number; nonce: string; exp: number };
+
+function hmacKey(): string {
+  const key = process.env.ENCRYPTION_KEY?.trim();
+  if (!key) {
+    // The app refuses to boot without ENCRYPTION_KEY elsewhere too; failing
+    // loudly here beats signing with an empty key.
+    throw new Error('[github-install] ENCRYPTION_KEY is not set, cannot sign an install state');
+  }
+  return key;
+}
+
+function sign(body: string): string {
+  return createHmac('sha256', hmacKey()).update(body).digest('base64url');
+}
+
+export function encodeInstallState(orgId: number, userId: number, now: Date = new Date()): string {
+  const payload: StatePayload = {
+    orgId,
+    userId,
+    nonce: randomBytes(12).toString('base64url'),
+    exp: now.getTime() + INSTALL_STATE_TTL_MS,
+  };
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${body}.${sign(body)}`;
+}
+
+export type DecodedInstallState =
+  | { ok: true; orgId: number; userId: number }
+  | { ok: false; reason: 'malformed' | 'bad_signature' | 'expired' };
+
+export function decodeInstallState(
+  state: string | null,
+  now: Date = new Date(),
+): DecodedInstallState {
+  if (!state) return { ok: false, reason: 'malformed' };
+  const [body, signature] = state.split('.');
+  if (!body || !signature) return { ok: false, reason: 'malformed' };
+
+  const expected = Buffer.from(sign(body));
+  const given = Buffer.from(signature);
+  if (expected.length !== given.length || !timingSafeEqual(expected, given)) {
+    return { ok: false, reason: 'bad_signature' };
+  }
+
+  let payload: StatePayload;
+  try {
+    payload = JSON.parse(Buffer.from(body, 'base64url').toString('utf8')) as StatePayload;
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+  if (typeof payload.orgId !== 'number' || typeof payload.userId !== 'number') {
+    return { ok: false, reason: 'malformed' };
+  }
+  if (!Number.isFinite(payload.exp) || payload.exp < now.getTime()) {
+    return { ok: false, reason: 'expired' };
+  }
+  return { ok: true, orgId: payload.orgId, userId: payload.userId };
+}

--- a/web/src/routes/api/integrations/github/install/+server.ts
+++ b/web/src/routes/api/integrations/github/install/+server.ts
@@ -1,0 +1,30 @@
+import { error, redirect, type RequestEvent } from '@sveltejs/kit';
+import { installationUrl, loadGithubAppEnv } from '@pitchbox/shared/github-app';
+import { requireOrgId, requireRole } from '$lib/server/auth.js';
+import { encodeInstallState } from '$lib/server/github-install-state.js';
+
+// Where "Connect GitHub" in Settings -> Companion sends the operator (#390).
+// A redirect rather than a link with the URL baked into the page, for two
+// reasons: the app slug is a deployment secret's neighbour in `.env` and does
+// not belong in a client bundle, and the `state` has to be minted per request
+// so the callback can pin the install to the organization that started it.
+//
+// Admin-gated like the rest of Settings' structural configuration
+// (docs/permissions.md): an installation grants the whole org read access to
+// somebody's repositories, which is not a member-level decision.
+export async function GET(event: RequestEvent) {
+  const orgId = await requireOrgId(event);
+  requireRole(event, 'admin');
+
+  const app = loadGithubAppEnv();
+  if (!app) {
+    // No app registered for this deployment, which is the ordinary self-host
+    // case. 501 rather than 404: the route exists, the capability is not
+    // configured, and the difference is what tells an operator to read
+    // docs/platforms/linkedin.md instead of filing a bug.
+    throw error(501, 'github_app_not_configured');
+  }
+
+  const userId = event.locals.user?.id ?? 0;
+  throw redirect(302, installationUrl(app, encodeInstallState(orgId, userId)));
+}

--- a/web/src/routes/api/integrations/github/setup/+server.ts
+++ b/web/src/routes/api/integrations/github/setup/+server.ts
@@ -1,0 +1,80 @@
+import { redirect, type RequestEvent } from '@sveltejs/kit';
+import {
+  fetchInstallation,
+  loadGithubAppEnv,
+  recordInstallation,
+} from '@pitchbox/shared/github-app';
+import { getDb } from '$lib/server/db.js';
+import { resolveOrgId, requireRole } from '$lib/server/auth.js';
+import { decodeInstallState } from '$lib/server/github-install-state.js';
+
+// The GitHub App's setup URL (#390): where GitHub sends the browser after
+// somebody installs or updates the app. Registered on both apps as
+// `https://<host>/api/integrations/github/setup` with "redirect on update"
+// on, so a repository-selection change also lands here and refreshes the row.
+//
+// Everything in this request is attacker-supplied, so nothing is believed:
+//
+//   - `installation_id` is read back from GitHub with the app JWT. An id that
+//     belongs to another app, or to nothing, answers 404 there and is refused.
+//     That is what stops somebody pasting a stranger's installation id into
+//     this URL and attaching it to their own organization.
+//   - `state` is HMAC-signed by us and pins the organization that started the
+//     flow (see github-install-state.ts).
+//   - The session still has to exist and still has to be an admin of that
+//     organization. A signed state is not an authentication.
+//
+// This is a browser redirect target, not an API: it never returns JSON, it
+// always lands the operator back on the page he started from with a result in
+// the query string, so a failure is something he can read rather than a
+// stack trace.
+const BACK = '/settings/companion';
+
+function back(result: string, detail?: string): never {
+  const params = new URLSearchParams({ github: result });
+  if (detail) params.set('detail', detail);
+  throw redirect(303, `${BACK}?${params.toString()}`);
+}
+
+export async function GET(event: RequestEvent) {
+  const url = event.url;
+  const setupAction = url.searchParams.get('setup_action');
+  const installationIdRaw = url.searchParams.get('installation_id');
+
+  const app = loadGithubAppEnv();
+  if (!app) back('not_configured');
+
+  // GitHub sends `setup_action=request` when somebody without permission on
+  // the account asked an owner to approve the install. Nothing exists yet, so
+  // there is nothing to store and saying so is the whole job.
+  if (setupAction === 'request') back('requested');
+
+  const installationId = Number(installationIdRaw);
+  if (!Number.isInteger(installationId) || installationId <= 0) back('bad_request');
+
+  const state = decodeInstallState(url.searchParams.get('state'));
+  if (!state.ok) {
+    // An install started from GitHub's own directory rather than from
+    // Settings carries no state at all. That is a real path, not an attack,
+    // and the honest answer is to tell the operator to start it from the app
+    // rather than to guess which organization he meant.
+    back('no_state', state.reason);
+  }
+
+  const sessionOrgId = await resolveOrgId(event);
+  if (sessionOrgId == null) back('unauthenticated');
+  if (sessionOrgId !== state.orgId) back('wrong_org');
+  try {
+    requireRole(event, 'admin');
+  } catch {
+    back('forbidden');
+  }
+
+  const details = await fetchInstallation(app, installationId);
+  if (!details.ok) back('unverified', details.reason);
+
+  const recorded = await recordInstallation(getDb(), state.orgId, details.details);
+  if (!recorded.ok) back('claimed_by_other_org');
+
+  back('installed', details.details.accountLogin);
+}

--- a/web/src/routes/api/settings/github-installations/+server.ts
+++ b/web/src/routes/api/settings/github-installations/+server.ts
@@ -1,0 +1,35 @@
+import { json, type RequestEvent } from '@sveltejs/kit';
+import { listInstallations, loadGithubAppEnv } from '@pitchbox/shared/github-app';
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId } from '$lib/server/auth.js';
+
+// What Settings -> Companion renders for the GitHub App (#390). Member-level
+// read, matching the other read-only settings lists (docs/permissions.md);
+// the mutations (install, disconnect) are admin-gated in their own routes.
+//
+// `configured` is the deployment's own state, not the org's: it says whether
+// this install has an app at all, which is what decides between offering a
+// Connect button and explaining that a self-host needs no credential for
+// public repositories. The app id and the slug are safe to expose (both are
+// public halves of the registration, readable on the app's GitHub page); the
+// private key never leaves the server, and is not read here.
+export async function GET(event: RequestEvent) {
+  const orgId = await requireOrgId(event);
+  const app = loadGithubAppEnv();
+  const installations = app ? await listInstallations(getDb(), orgId) : [];
+
+  return json({
+    configured: Boolean(app),
+    slug: app?.slug ?? null,
+    installations: installations.map((row) => ({
+      id: row.id,
+      installationId: row.installationId,
+      accountLogin: row.accountLogin,
+      accountType: row.accountType,
+      repositorySelection: row.repositorySelection,
+      permissions: row.permissions,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    })),
+  });
+}

--- a/web/src/routes/api/settings/github-installations/[id]/+server.ts
+++ b/web/src/routes/api/settings/github-installations/[id]/+server.ts
@@ -1,0 +1,38 @@
+import { error, json, type RequestEvent } from '@sveltejs/kit';
+import {
+  deleteInstallation,
+  forgetInstallation,
+  loadGithubAppEnv,
+} from '@pitchbox/shared/github-app';
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId, requireRole } from '$lib/server/auth.js';
+
+// Disconnecting an installation (#390). Two things happen, in this order:
+// the row goes first, so the org stops using the credential even if GitHub is
+// unreachable, and then the app is uninstalled from the account so its GitHub
+// settings do not keep listing an app nothing reads.
+//
+// A GitHub failure on the second step is reported and not rolled back: the
+// operator asked to stop using it, and leaving our row behind because GitHub
+// timed out would be the wrong half to keep. The response says so, so he can
+// finish the uninstall by hand.
+//
+// An id that does not exist, or belongs to another organization, is a 404 and
+// never a 403 - the same rule `removeGithubSource` follows, so a probe against
+// another org's id learns nothing.
+export async function DELETE(event: RequestEvent) {
+  const orgId = await requireOrgId(event);
+  requireRole(event, 'admin');
+
+  const id = Number(event.params.id);
+  if (!Number.isInteger(id)) throw error(400, 'invalid id');
+
+  const row = await forgetInstallation(getDb(), orgId, id);
+  if (!row) throw error(404, 'not_found');
+
+  const app = loadGithubAppEnv();
+  if (!app) return json({ ok: true, uninstalled: false, reason: 'github_app_not_configured' });
+
+  const removed = await deleteInstallation(app, row.installationId);
+  return json({ ok: true, uninstalled: removed.ok, reason: removed.reason ?? null });
+}

--- a/web/src/routes/settings/companion/+page.svelte
+++ b/web/src/routes/settings/companion/+page.svelte
@@ -6,7 +6,7 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Checkbox } from '$lib/components/ui/checkbox';
-	import { Info, TriangleAlert, Plus, Trash2, UserRound, Mic, FolderGit2, RefreshCw, RotateCcw } from '@lucide/svelte';
+	import { Info, TriangleAlert, Plus, Trash2, UserRound, Mic, FolderGit2, RefreshCw, RotateCcw, KeyRound } from '@lucide/svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import Seo from '$lib/components/Seo.svelte';
 	import PageContainer from '$lib/components/PageContainer.svelte';
@@ -196,6 +196,103 @@
 			toast.error('Could not add that repository');
 		} finally {
 			addingRepo = false;
+		}
+	}
+
+	// --- The optional GitHub App (#390) -------------------------------------
+	// `configured` is the deployment's own state (does an app exist at all),
+	// `installations` is this org's. A self-host with no app is not an error
+	// and gets a sentence rather than a warning: public repos by URL keep
+	// working exactly as they did.
+
+	type GithubInstallation = {
+		id: number;
+		installationId: number;
+		accountLogin: string;
+		accountType: string;
+		repositorySelection: string;
+		permissions: Record<string, string>;
+		updatedAt: string;
+	};
+
+	let appConfigured = $state(false);
+	let installations = $state<GithubInstallation[]>([]);
+	let loadingInstallations = $state(true);
+	let disconnectingId = $state<number | null>(null);
+
+	async function loadInstallations() {
+		loadingInstallations = true;
+		try {
+			const res = await fetch('/api/settings/github-installations');
+			if (!res.ok) return;
+			const body = (await res.json()) as {
+				configured: boolean;
+				installations: GithubInstallation[];
+			};
+			appConfigured = body.configured;
+			installations = body.installations;
+		} catch {
+			// Leave the card in its "not configured" shape rather than shouting:
+			// nothing here is required for the companion to work.
+		} finally {
+			loadingInstallations = false;
+		}
+	}
+	onMount(loadInstallations);
+
+	// The install and setup round trip reports back in the query string
+	// (web/src/routes/api/integrations/github/setup/+server.ts), so the result
+	// of a redirect the operator just came back from is said out loud once.
+	onMount(() => {
+		const params = new URLSearchParams(window.location.search);
+		const result = params.get('github');
+		if (!result) return;
+		const detail = params.get('detail');
+		const messages: Record<string, string> = {
+			installed: `GitHub connected${detail ? ` for ${detail}` : ''}`,
+			requested: 'Install requested. An owner of that account has to approve it.',
+			not_configured: 'This deployment has no GitHub App configured.',
+			no_state: 'Start the install from this page, so it lands on the right organization.',
+			wrong_org: 'That install was started for a different organization.',
+			forbidden: 'You need admin access to connect GitHub.',
+			unauthenticated: 'Sign in again and retry the install.',
+			claimed_by_other_org: 'That GitHub account is already connected to another organization.',
+			unverified: `GitHub would not confirm that installation${detail ? `: ${detail}` : ''}`,
+			bad_request: 'GitHub sent back an install with no installation id.',
+		};
+		if (result === 'installed' || result === 'requested') {
+			toast.success(messages[result]);
+		} else {
+			toast.error(messages[result] ?? 'The GitHub install did not complete');
+		}
+		// Strip the params so a refresh does not repeat the toast.
+		window.history.replaceState({}, '', window.location.pathname);
+	});
+
+	async function disconnectInstallation(id: number) {
+		if (disconnectingId) return;
+		disconnectingId = id;
+		try {
+			const res = await fetch(`/api/settings/github-installations/${id}`, { method: 'DELETE' });
+			if (res.ok) {
+				const body = (await res.json()) as { uninstalled: boolean; reason: string | null };
+				if (body.uninstalled) {
+					toast.success('GitHub disconnected and the app uninstalled');
+				} else {
+					// The row is gone either way, so the org has already stopped
+					// using the credential. Say what is left to do by hand.
+					toast.warning(
+						'Disconnected here, but GitHub did not confirm the uninstall. Remove it from the account settings on GitHub.',
+					);
+				}
+				await Promise.all([loadInstallations(), loadRepos()]);
+			} else if (res.status === 403) {
+				toast.error('You need admin access for that');
+			} else {
+				toast.error('Could not disconnect that installation');
+			}
+		} finally {
+			disconnectingId = null;
 		}
 	}
 
@@ -523,11 +620,78 @@
 			<Card.Header>
 				<Card.Title class="flex items-center gap-2"><FolderGit2 class="size-4" /> What you have shipped</Card.Title>
 				<Card.Description>
-					Public repositories the companion can mention. Public repos only, added by URL with no
-					credential - a private repo needs the GitHub App, which doesn't exist yet.
+					Repositories the companion can mention. A public repo needs nothing but its URL. A
+					private one is only readable once this organization connects the GitHub App below, and
+					only for the repositories the account selects.
 				</Card.Description>
 			</Card.Header>
 			<Card.Content class="flex flex-col gap-4">
+				<!-- The GitHub App (#390). Above the add form on purpose: whether a
+				     private URL will work at all is decided here. -->
+				{#if !loadingInstallations}
+					<div class="rounded-md border border-border bg-muted/30 p-4">
+						{#if !appConfigured}
+							<p class="text-xs text-muted-foreground">
+								No GitHub App is configured on this deployment, so repositories are read
+								anonymously: public ones only, and GitHub allows 60 requests an hour per
+								address. That is the intended self-host setup and needs no credential.
+							</p>
+						{:else if installations.length === 0}
+							<div class="flex flex-wrap items-center justify-between gap-3">
+								<p class="text-xs text-muted-foreground">
+									Connect the GitHub App to read private repositories. You choose which
+									repositories it can see, it asks for read access to code and metadata and
+									nothing else, and you can disconnect it here at any time.
+								</p>
+								<Button href="/api/integrations/github/install" data-sveltekit-reload>
+									<KeyRound class="size-4" /> Connect GitHub
+								</Button>
+							</div>
+						{:else}
+							<div class="flex flex-col gap-3">
+								{#each installations as install (install.id)}
+									<div class="flex flex-wrap items-center justify-between gap-3">
+										<div class="min-w-0">
+											<p class="text-sm font-medium text-foreground">
+												{install.accountLogin}
+												<Badge variant="outline" class="ml-1 align-middle">
+													{install.repositorySelection === 'all'
+														? 'all repositories'
+														: 'selected repositories'}
+												</Badge>
+											</p>
+											<p class="mt-0.5 text-xs text-muted-foreground">
+												{Object.entries(install.permissions)
+													.map(([name, level]) => `${name}: ${level}`)
+													.join(', ') || 'no permissions reported'}
+											</p>
+										</div>
+										<div class="flex items-center gap-2">
+											<Button
+												href="/api/integrations/github/install"
+												variant="outline"
+												size="sm"
+												data-sveltekit-reload
+											>
+												Change repositories
+											</Button>
+											<Button
+												type="button"
+												variant="ghost"
+												size="sm"
+												disabled={disconnectingId === install.id}
+												onclick={() => disconnectInstallation(install.id)}
+											>
+												Disconnect
+											</Button>
+										</div>
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/if}
+
 				<form onsubmit={addRepo} class="flex gap-2">
 					<Input
 						bind:value={newRepoUrl}

--- a/web/tests/github-install-flow.test.ts
+++ b/web/tests/github-install-flow.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { listInstallations, recordInstallation } from '@pitchbox/shared/github-app';
+import {
+  decodeInstallState,
+  encodeInstallState,
+  INSTALL_STATE_TTL_MS,
+} from '../src/lib/server/github-install-state.js';
+import { GET as setupGET } from '../src/routes/api/integrations/github/setup/+server.js';
+import { GET as installGET } from '../src/routes/api/integrations/github/install/+server.js';
+
+// The GitHub App install round trip (#390). Everything arriving at the setup
+// callback is attacker-supplied: it is a GET with two query parameters. So
+// what this file defends is every refusal on the way in, and it defends them
+// by asserting that no row was written, not just that a redirect said no.
+
+const PEM = generateKeyPairSync('rsa', { modulusLength: 2048 })
+  .privateKey.export({ type: 'pkcs1', format: 'pem' })
+  .toString();
+
+const APP_ENV = {
+  GITHUB_APP_ID: '4883602',
+  GITHUB_APP_SLUG: 'pitchbox-companion',
+  GITHUB_APP_PRIVATE_KEY_B64: Buffer.from(PEM).toString('base64'),
+};
+
+const saved: Record<string, string | undefined> = {};
+function setEnv(vars: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(vars)) {
+    if (!(k in saved)) saved[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+type SetupEvent = Parameters<typeof setupGET>[0];
+
+function setupEvent(
+  orgId: number | null,
+  role: string,
+  params: Record<string, string>,
+): SetupEvent {
+  const url = new URL('http://x/api/integrations/github/setup');
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return {
+    url,
+    locals: orgId == null ? {} : { org: { id: orgId, slug: 'x', role }, user: { id: 1 } },
+    request: new Request(url),
+  } as unknown as SetupEvent;
+}
+
+/** The routes call GitHub through the shared module's default fetch, so the
+ * global is what a test has to substitute. Only `/app/installations/<id>` is
+ * ever reached from the setup route. */
+function stubGithub(handler: (url: string) => Response) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: unknown) => handler(String(input))) as typeof globalThis.fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+const installationJson = (login: string) =>
+  new Response(
+    JSON.stringify({
+      id: 160289335,
+      account: { login, type: 'User' },
+      repository_selection: 'selected',
+      permissions: { contents: 'read', metadata: 'read' },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+
+/** A redirect leaves a route as a thrown `Redirect`, so the assertion has to
+ * catch it. Returns the `github=` result the operator will see. */
+async function resultOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (thrown) {
+    const location = (thrown as { location?: string }).location;
+    if (!location) throw thrown;
+    return new URL(location, 'http://x').searchParams.get('github') ?? '';
+  }
+  throw new Error('expected a redirect');
+}
+
+describe('install state', () => {
+  beforeEach(() => setEnv({ ENCRYPTION_KEY: 'a'.repeat(64) }));
+
+  it('round-trips the organization that started the install', () => {
+    const state = encodeInstallState(7, 3);
+    expect(decodeInstallState(state)).toEqual({ ok: true, orgId: 7, userId: 3 });
+  });
+
+  it('refuses a tampered payload, which is the point of signing it', () => {
+    const signature = encodeInstallState(7, 3).split('.')[1];
+    const forged = Buffer.from(
+      JSON.stringify({ orgId: 999, userId: 3, nonce: 'x', exp: Date.now() + 1000 }),
+    ).toString('base64url');
+    expect(decodeInstallState(`${forged}.${signature}`)).toEqual({
+      ok: false,
+      reason: 'bad_signature',
+    });
+  });
+
+  it('expires, so a state left in a browser history is useless', () => {
+    const state = encodeInstallState(7, 3, new Date(Date.now() - INSTALL_STATE_TTL_MS - 1000));
+    expect(decodeInstallState(state)).toEqual({ ok: false, reason: 'expired' });
+  });
+});
+
+describe('the install redirect', () => {
+  afterEach(() => setEnv(saved));
+
+  it('is a 501 rather than a 404 when the deployment has no app', async () => {
+    setEnv({
+      GITHUB_APP_ID: undefined,
+      GITHUB_APP_SLUG: undefined,
+      GITHUB_APP_PRIVATE_KEY_B64: undefined,
+    });
+    const event = setupEvent(1, 'admin', {});
+    await expect(
+      installGET(event as unknown as Parameters<typeof installGET>[0]),
+    ).rejects.toMatchObject({
+      status: 501,
+    });
+  });
+
+  it('sends an admin to the app with a signed state', async () => {
+    setEnv({ ...APP_ENV, ENCRYPTION_KEY: 'a'.repeat(64) });
+    let location = '';
+    try {
+      await installGET(setupEvent(1, 'admin', {}) as unknown as Parameters<typeof installGET>[0]);
+    } catch (thrown) {
+      location = (thrown as { location: string }).location;
+    }
+    const url = new URL(location);
+    expect(url.pathname).toBe('/apps/pitchbox-companion/installations/new');
+    expect(decodeInstallState(url.searchParams.get('state'))).toMatchObject({ ok: true, orgId: 1 });
+  });
+
+  it('refuses a member', async () => {
+    setEnv({ ...APP_ENV, ENCRYPTION_KEY: 'a'.repeat(64) });
+    await expect(
+      installGET(setupEvent(1, 'member', {}) as unknown as Parameters<typeof installGET>[0]),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe('the setup callback', () => {
+  let orgA: number;
+  let orgB: number;
+  let restoreFetch: (() => void) | null = null;
+
+  beforeEach(async () => {
+    setEnv({ ...APP_ENV, ENCRYPTION_KEY: 'a'.repeat(64) });
+    const db = getDb();
+    await db.execute(sql`TRUNCATE github_installations RESTART IDENTITY CASCADE`);
+    await db.execute(sql`DELETE FROM organizations WHERE slug LIKE 'ghflow-%'`);
+    const [a] = await db
+      .insert(schema.organizations)
+      .values({ slug: 'ghflow-a', name: 'a' })
+      .returning();
+    const [b] = await db
+      .insert(schema.organizations)
+      .values({ slug: 'ghflow-b', name: 'b' })
+      .returning();
+    orgA = a.id;
+    orgB = b.id;
+  });
+
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = null;
+    setEnv(saved);
+  });
+
+  it('records the installation after verifying it against GitHub', async () => {
+    restoreFetch = stubGithub(() => installationJson('fiorelorenzo'));
+    const state = encodeInstallState(orgA, 1);
+    const result = await resultOf(
+      setupGET(
+        setupEvent(orgA, 'admin', { installation_id: '160289335', setup_action: 'install', state }),
+      ),
+    );
+    expect(result).toBe('installed');
+    const rows = await listInstallations(getDb(), orgA);
+    expect(rows).toMatchObject([{ accountLogin: 'fiorelorenzo', installationId: 160289335 }]);
+  });
+
+  it('refuses an installation id GitHub will not confirm, and writes nothing', async () => {
+    // The forged-id case: `installation_id` is a query parameter, so somebody
+    // can paste a stranger's. It is checked with the app JWT, where an
+    // installation of another app answers 404.
+    restoreFetch = stubGithub(() => new Response('{}', { status: 404 }));
+    const state = encodeInstallState(orgA, 1);
+    const result = await resultOf(
+      setupGET(setupEvent(orgA, 'admin', { installation_id: '160289335', state })),
+    );
+    expect(result).toBe('unverified');
+    expect(await listInstallations(getDb(), orgA)).toHaveLength(0);
+  });
+
+  it('refuses a state minted for another organization', async () => {
+    restoreFetch = stubGithub(() => installationJson('fiorelorenzo'));
+    const state = encodeInstallState(orgB, 1);
+    const result = await resultOf(
+      setupGET(setupEvent(orgA, 'admin', { installation_id: '160289335', state })),
+    );
+    expect(result).toBe('wrong_org');
+    expect(await listInstallations(getDb(), orgA)).toHaveLength(0);
+    expect(await listInstallations(getDb(), orgB)).toHaveLength(0);
+  });
+
+  it('refuses an unsigned state, which is what an install from GitHub\u0027s directory looks like', async () => {
+    restoreFetch = stubGithub(() => installationJson('fiorelorenzo'));
+    const result = await resultOf(
+      setupGET(setupEvent(orgA, 'admin', { installation_id: '160289335' })),
+    );
+    expect(result).toBe('no_state');
+    expect(await listInstallations(getDb(), orgA)).toHaveLength(0);
+  });
+
+  it('refuses a member even with a valid state', async () => {
+    restoreFetch = stubGithub(() => installationJson('fiorelorenzo'));
+    const state = encodeInstallState(orgA, 1);
+    const result = await resultOf(
+      setupGET(setupEvent(orgA, 'member', { installation_id: '160289335', state })),
+    );
+    expect(result).toBe('forbidden');
+    expect(await listInstallations(getDb(), orgA)).toHaveLength(0);
+  });
+
+  it('refuses an installation another organization already holds', async () => {
+    await recordInstallation(getDb(), orgB, {
+      installationId: 160289335,
+      accountLogin: 'fiorelorenzo',
+      accountType: 'User',
+      repositorySelection: 'selected',
+      permissions: { contents: 'read' },
+    });
+    restoreFetch = stubGithub(() => installationJson('fiorelorenzo'));
+    const state = encodeInstallState(orgA, 1);
+    const result = await resultOf(
+      setupGET(setupEvent(orgA, 'admin', { installation_id: '160289335', state })),
+    );
+    expect(result).toBe('claimed_by_other_org');
+    expect(await listInstallations(getDb(), orgA)).toHaveLength(0);
+    expect(await listInstallations(getDb(), orgB)).toHaveLength(1);
+  });
+
+  it('says so when an install needs an owner to approve it', async () => {
+    const state = encodeInstallState(orgA, 1);
+    const result = await resultOf(
+      setupGET(setupEvent(orgA, 'admin', { setup_action: 'request', installation_id: '0', state })),
+    );
+    expect(result).toBe('requested');
+  });
+});


### PR DESCRIPTION
Closes #390.

The companion could only read public repositories, by URL, anonymously. That was the right first version (nothing to store, nothing to rotate) but it left out most of what I actually work on, and the anonymous API allows 60 requests an hour per address. This adds the optional GitHub App as the credential for a private repo, and nothing else changes: with no App configured, which stays the self-host default, every read happens exactly as it did before.

Both Apps already exist and are installed: `Pitchbox Companion` (app id 4883602, public, so a client org can install it, which is what the cloud edition needs) and `Pitchbox Companion (preview)` (4883544, private to this account). Each asks for `contents: read` and `metadata: read` and nothing else, with the webhook and the user-authorization flow off. The credentials are already in both deployed environments as deployment secrets; the issue carries the verification I ran against the API with a JWT signed by each key.

### What is here

- `shared/src/github-app.ts`: load the credential from the environment, sign the app JWT, mint and cache installation tokens, read an installation back from GitHub, and resolve which credential a given repository owner should be read with, plus the DB helpers for the new `github_installations` table.
- `web/src/routes/api/integrations/github/install`: mints a signed `state` and redirects to the App. Admin only.
- `web/src/routes/api/integrations/github/setup`: the App's registered setup URL, where GitHub lands the browser after an install or a repository-selection change.
- `web/src/routes/api/settings/github-installations`: what Settings renders, and the disconnect, which also uninstalls the App from the account.
- Settings -> Companion now tells the truth. Its description used to say "a private repo needs the GitHub App, which doesn't exist yet".

### The decisions worth reviewing

**A partial configuration throws instead of degrading.** The mail transport does the opposite (warn, fall back to the null transport) because a deployment with no mail still works. Here, degrading would report a private repository as `not found`, the same string GitHub returns for a repo that never existed, so nobody would discover the credential was unused. Failing at load is the only version of this that is visible.

**An installation is unique across the whole table, not per organization.** An installation belongs to exactly one GitHub account, so two organizations holding the same one would mean the second reading the first's private code. A re-install onto an account another org already connected is refused rather than merged.

**A token is resolved by account login and never tried against another account.** Presenting one account's token on another's repository can only 404, and trying every installation would spend the rate limit to learn that.

**Nothing in the setup callback is believed.** `installation_id` arrives as a query parameter on a GET, so it is read back from GitHub with the app JWT before anything is written, and `state` is HMAC-signed with `ENCRYPTION_KEY` so the install lands on the organization that started it rather than on whichever org the session happens to have active. The session still has to be an admin of that org: a signed state is not an authentication.

**The 404 message now differs by credential**, because the fixes differ: anonymously it means install the App, authenticated it means the account did not select this repository.

### Verified

- 68 tests across five files, all passing: `pnpm exec vitest run shared/tests/github-app.test.ts shared/tests/github-sources-private.test.ts web/tests/github-install-flow.test.ts shared/tests/migration-audit.test.ts tests/docker-mail-env.test.ts`.
- Both new guards proven to bite by breaking the code under them and watching the right test fail, then restoring: removing the cross-org refusal fails `refuses to let a second organization claim the same installation`, and dropping the `Authorization` header fails `reads a private repository with the installation token on every call`.
- The refusal tests assert that **no row was written**, not just that a redirect said no.
- `tests/docker-mail-env.test.ts` is extended to cover this credential, and the compose files carry it in the base `web` service **and** in `docker-compose.bluegreen.yml`'s `x-web-common` anchor, which is the #580/#583 trap: a variable added only to the base never reaches what a blue-green deploy runs. Proven by deleting `GITHUB_APP_SLUG` from the overlay and watching that assertion fail. While extending the guard I found that it scans a loader for direct `env.NAME` reads, so an indirect `env[SOME_CONST]` would slip past it. The key lookup is a literal for that reason, with a comment saying why.
- The migration `0028_github_installations` applies on a fresh database (`migrations applied (28 in journal, all present)`, table and both indexes present). `migrate:generate` produced a journal `when` of `1788952711862`, **lower** than `0027_org_plans`'s `1788960000014` (the artificial timestamp from #538's chain), so I pushed it to `1788960000015`. I checked that this mattered rather than assuming: on a database already at `0027`, the generated timestamp makes `pnpm run migrate` exit 1 with `github_installations` absent, and the corrected one applies it.
- `pnpm -F @pitchbox/shared typecheck` clean, `pnpm -F web check` 0 errors and 0 warnings, eslint and prettier clean on every changed file.

### Not done here

No private repository is in either installation yet, so the private path is proven against a fake GitHub in tests and against the real API only for a public repo. Adding one is two clicks and a decision about which repositories an assistant may read, so I left it out. The App is also not a `project_sources` kind: this is authentication for the existing `github_sources` cache, exactly as the issue framed it.