### PR TITLE
feat(extension,web): the page hands over the whole visible thread, not just the post text

### DIFF
--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -17,9 +17,17 @@ import {
   detectPageKind,
   findCommentComposer,
   findFeedPosts,
+  findParentCommentId,
+  findPostComments,
   findPostComposerModal,
+  readCommentAuthor,
+  readCommentBody,
+  readCommentRelativeTime,
   readPostAuthor,
+  readPostCommentCount,
   readPostIdentifier,
+  readPostReactionCount,
+  readPostRelativeTime,
   readPostText,
   resetSelectorHealth,
   selectorHealthActivityEvents,
@@ -100,15 +108,100 @@ import CommentAssistPanel from './linkedin-comment-assist-panel.svelte';
 
 const COMMENT_KIND = 'post_comment';
 
+/** Mirrors shared/src/assist/suggest-prompt.ts's MAX_THREAD_COMMENTS,
+ * MAX_COMMENT_CHARS and MAX_THREAD_CHARS by hand - see api.ts's own note on
+ * why the extension has no dependency on @pitchbox/shared. Keep these three
+ * numbers in sync with that file if either changes; the server's own zod
+ * schema enforces them again regardless (AGENTS.md: a switch is enforced
+ * where the effect happens, not only where it is read). */
+const MAX_THREAD_COMMENTS = 30;
+const MAX_COMMENT_CHARS = 500;
+const MAX_THREAD_CHARS = 6000;
+
+/** One rendered comment or reply in `AssistPost.thread` (#568) - mirrors
+ * shared/src/assist/suggest-prompt.ts's `ObservedComment` by hand. */
+export type AssistComment = {
+  id?: string;
+  authorName?: string;
+  authorHandle?: string;
+  body: string;
+  relativeTime?: string;
+  parentId?: string;
+};
+
+/** The visible comment thread under a post, already clamped to the three
+ * caps above - see `buildAssistThread`'s doc comment for how, and
+ * shared/src/assist/suggest-prompt.ts's `ObservedThread` for what each
+ * field means. */
+export type AssistThread = {
+  comments: AssistComment[];
+  renderedCount: number;
+  truncated: boolean;
+};
+
+/**
+ * The visible comment thread under `post` (#568), clamped before it ever
+ * reaches the network - a post with hundreds of rendered comments must not
+ * turn into a multi-hundred-KB request. Reuses `findPostComments` and the
+ * other comment accessors from linkedin-dom.ts rather than a second set of
+ * selectors, so `getSelectorHealthReport` stays honest about what this
+ * script actually reads. `undefined` when the page rendered no comments at
+ * all (the SDUI feed, or a post nobody has replied to yet) - an absent
+ * thread, not an empty one with nothing to say.
+ */
+function buildAssistThread(post: Element, root: ParentNode): AssistThread | undefined {
+  const all = findPostComments(root).filter((el) => post.contains(el));
+  if (all.length === 0) return undefined;
+
+  const comments: AssistComment[] = [];
+  let totalChars = 0;
+  let truncated = false;
+
+  for (const el of all) {
+    if (comments.length >= MAX_THREAD_COMMENTS) {
+      truncated = true;
+      break;
+    }
+    let body = readCommentBody(el, root) ?? '';
+    if (body.length > MAX_COMMENT_CHARS) {
+      body = body.slice(0, MAX_COMMENT_CHARS);
+      truncated = true;
+    }
+    if (totalChars + body.length > MAX_THREAD_CHARS) {
+      truncated = true;
+      break;
+    }
+    totalChars += body.length;
+    const author = readCommentAuthor(el, root);
+    comments.push({
+      id: el.getAttribute('data-id') ?? undefined,
+      authorName: author.name ?? undefined,
+      authorHandle: author.handle ?? undefined,
+      body,
+      relativeTime: readCommentRelativeTime(el, root) ?? undefined,
+      parentId: findParentCommentId(el, root) ?? undefined,
+    });
+  }
+
+  return { comments, renderedCount: all.length, truncated };
+}
+
 /** The context a comment suggestion is requested for. `urn` is present only
  * on the classic post-detail frontend - a feed card has none (see the
- * module doc comment's "Two frontends, one identifier" note). */
+ * module doc comment's "Two frontends, one identifier" note). `relativeTime`,
+ * `reactionCount`, `commentCount` and `thread` are all classic-frontend-only
+ * too (#568): the SDUI feed exposes none of them (see linkedin-dom.ts's
+ * module header). */
 export type AssistPost = {
   urn?: string;
   authorHandle?: string;
   authorName?: string;
   text: string;
   url: string;
+  relativeTime?: string;
+  reactionCount?: string;
+  commentCount?: string;
+  thread?: AssistThread;
 };
 
 /**
@@ -132,6 +225,10 @@ export function readAssistPostFromCard(
     authorName: author.name ?? undefined,
     text,
     url: location.href,
+    relativeTime: readPostRelativeTime(post, root) ?? undefined,
+    reactionCount: readPostReactionCount(post, root) ?? undefined,
+    commentCount: readPostCommentCount(post, root) ?? undefined,
+    thread: buildAssistThread(post, root),
   };
 }
 
@@ -439,6 +536,10 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
           authorName: capturedPost.authorName,
           text: capturedPost.text,
           url: capturedPost.url,
+          relativeTime: capturedPost.relativeTime,
+          reactionCount: capturedPost.reactionCount,
+          commentCount: capturedPost.commentCount,
+          thread: capturedPost.thread,
         },
         retune,
       },

--- a/extension/src/content/shared/linkedin-dom.ts
+++ b/extension/src/content/shared/linkedin-dom.ts
@@ -126,7 +126,10 @@ export type LinkedInSelectorId =
   | 'ownProfileHeadline'
   | 'ownProfileAbout'
   | 'ownProfileExperience'
-  | 'ownPostTimestamp';
+  | 'ownPostTimestamp'
+  | 'postTimestamp'
+  | 'postReactionCount'
+  | 'postCommentCount';
 
 export type SelectorHealthEntry = {
   selector: LinkedInSelectorId;
@@ -640,6 +643,11 @@ export type LinkedInComment = {
   relativeTime: string | null;
 };
 
+/** Every comment/reply article's own selector on a classic post-detail page
+ * (see `LinkedInComment`'s doc comment) - one constant rather than four
+ * copies of the same string literal scattered across this module. */
+const COMMENT_ARTICLE_SELECTOR = 'article[data-id^="urn:li:comment:"]';
+
 /**
  * Every comment `article[data-id]` on a classic post-detail page, in
  * document order - both top-level comments and their nested replies (see
@@ -649,9 +657,7 @@ export type LinkedInComment = {
 export function findPostComments(root: ParentNode = document): Element[] {
   const pageKind = detectPageKind(root);
   const comments =
-    pageKind === 'post-detail-classic'
-      ? queryDeepAll<Element>('article[data-id^="urn:li:comment:"]', root)
-      : [];
+    pageKind === 'post-detail-classic' ? queryDeepAll<Element>(COMMENT_ARTICLE_SELECTOR, root) : [];
   if (pageKind !== 'unknown') record('postComments', pageKind, comments.length > 0);
   return comments;
 }
@@ -667,7 +673,7 @@ export function findPostComments(root: ParentNode = document): Element[] {
 export function findParentCommentId(comment: Element, root: ParentNode = document): string | null {
   let node = comment.parentElement;
   while (node && node !== root) {
-    if (node.matches('article[data-id^="urn:li:comment:"]')) {
+    if (node.matches(COMMENT_ARTICLE_SELECTOR)) {
       return node.getAttribute('data-id');
     }
     node = node.parentElement;
@@ -687,7 +693,7 @@ function ownCommentDescendant<T extends Element = Element>(
   selector: string,
 ): T | null {
   const matches = queryDeepAll<T>(selector, comment);
-  return matches.find((m) => m.closest('article[data-id^="urn:li:comment:"]') === comment) ?? null;
+  return matches.find((m) => m.closest(COMMENT_ARTICLE_SELECTOR) === comment) ?? null;
 }
 
 /**
@@ -763,6 +769,67 @@ export function readCommentRelativeTime(
   const timeEl = ownCommentDescendant<HTMLTimeElement>(comment, 'time');
   const text = timeEl?.textContent?.trim() || null;
   if (pageKind !== 'unknown') record('commentTimestamp', pageKind, text !== null);
+  return text;
+}
+
+/**
+ * The post's own rendered reaction count (#568) - e.g. "16" in the real
+ * capture, next to the reaction icons. LinkedIn renders the visible number
+ * in a `span[aria-hidden="true"]` sibling of the reaction summary's own
+ * `aria-label` (`"Paolo Greco e 15 altre persone"` in the capture - a name
+ * plus "and N others", not the count itself, and worded differently with no
+ * reactions at all), so a screen reader is not handed a bare digit. Every
+ * comment carries the identical shape for its own reaction count too
+ * (verified against the capture), which is why this skips any span whose
+ * `closest(COMMENT_ARTICLE_SELECTOR)` is non-null - the post's own reaction
+ * count is the only one that never sits inside a comment article. `null` on
+ * the SDUI feed, which renders none of this (see module header).
+ */
+export function readPostReactionCount(post: Element, root: ParentNode = document): string | null {
+  const pageKind = detectPageKind(root);
+  let text: string | null = null;
+  if (pageKind === 'post-detail-classic') {
+    for (const span of queryDeepAll<HTMLElement>('span[aria-hidden="true"]', post)) {
+      if (span.closest(COMMENT_ARTICLE_SELECTOR)) continue;
+      const own = span.textContent?.trim();
+      if (own && /^\d[\d.,\s]*$/.test(own)) {
+        text = own;
+        break;
+      }
+    }
+  }
+  if (pageKind !== 'unknown') record('postReactionCount', pageKind, text !== null);
+  return text;
+}
+
+/**
+ * The post's own rendered comment count (#568) - e.g. "31 commenti" in the
+ * real capture, LinkedIn's own total rather than what actually loaded (see
+ * `findPostComments`, and `ObservedThread.renderedCount` in
+ * shared/src/assist/suggest-prompt.ts for the distinction this exists for).
+ * Read the same way `readPostReactionCount` is - the count sits in a
+ * `span[aria-hidden="true"]` inside a `button[aria-label]`, scoped to the
+ * first one outside any comment article whose text is a digit run followed
+ * by more text (unlike the reaction count's span, which is nothing but
+ * digits - the property the two selectors use to tell each other apart).
+ */
+export function readPostCommentCount(post: Element, root: ParentNode = document): string | null {
+  const pageKind = detectPageKind(root);
+  let text: string | null = null;
+  if (pageKind === 'post-detail-classic') {
+    for (const span of queryDeepAll<HTMLElement>(
+      'button[aria-label] span[aria-hidden="true"]',
+      post,
+    )) {
+      if (span.closest(COMMENT_ARTICLE_SELECTOR)) continue;
+      const own = span.textContent?.trim();
+      if (own && /^\d[\d.,\s]*\D/.test(own)) {
+        text = own;
+        break;
+      }
+    }
+  }
+  if (pageKind !== 'unknown') record('postCommentCount', pageKind, text !== null);
   return text;
 }
 
@@ -1042,26 +1109,54 @@ export function readOwnProfile(root: Document = document): OwnProfileCapture | n
 }
 
 /**
+ * The first `[aria-hidden="true"]` element under `scope`, outside any
+ * anchor, in document order - the query behind both `readOwnPostRelativeTime`
+ * below (a post captured on the operator's own recent-activity page) and
+ * `readPostRelativeTime` (#568, any post-detail page): LinkedIn renders a
+ * classic-frontend byline's relative-time text the same way regardless of
+ * whose post it is, verified against both classic captures
+ * (`post-detail.html`: "6 giorni • Modificato •", `own-activity.html`: "3
+ * ore •"), in both cases before any comment content in document order. One
+ * query rather than two, so the two callers cannot drift apart.
+ */
+function firstAriaHiddenOutsideAnchor(scope: Element): string | null {
+  for (const el of queryDeepAll<Element>('[aria-hidden="true"]', scope)) {
+    if (el.closest('a')) continue;
+    const text = el.textContent?.trim();
+    if (text) return text;
+  }
+  return null;
+}
+
+/**
  * The signed-in member's own rendered relative-time text for `post`, read
  * the same way `readPostAuthor`'s classic branch reads the byline name: the
  * name, badge and headline all sit inside the byline's own `<a>`, and the
- * first `[aria-hidden="true"]` element *outside* any anchor is the
- * relative-time line LinkedIn renders next to it - verified against both
- * classic captures (`post-detail.html`: "6 giorni • Modificato •",
- * `own-activity.html`: "3 ore •"), in both cases before any comment content
- * in document order.
+ * first `[aria-hidden="true"]` element outside any anchor is the
+ * relative-time line LinkedIn renders next to it - see
+ * `firstAriaHiddenOutsideAnchor`'s own doc comment for the captures this is
+ * verified against.
  */
 function readOwnPostRelativeTime(post: Element): string | null {
-  let text: string | null = null;
-  for (const el of queryDeepAll<Element>('[aria-hidden="true"]', post)) {
-    if (el.closest('a')) continue;
-    const own = el.textContent?.trim();
-    if (own) {
-      text = own;
-      break;
-    }
-  }
+  const text = firstAriaHiddenOutsideAnchor(post);
   record('ownPostTimestamp', 'post-detail-classic', text !== null);
+  return text;
+}
+
+/**
+ * `post`'s own rendered relative-time text (#568) - when it was posted, not
+ * to be confused with a reply's own `readCommentRelativeTime`. Reuses
+ * `firstAriaHiddenOutsideAnchor`, the same selector `readOwnPostRelativeTime`
+ * above uses for the operator's own recent-activity posts, rather than a
+ * second one: LinkedIn renders any classic-frontend post's byline timestamp
+ * the same way regardless of whose post it is. `null` on the SDUI feed,
+ * which this module's header already documents as carrying none of this
+ * markup.
+ */
+export function readPostRelativeTime(post: Element, root: ParentNode = document): string | null {
+  const pageKind = detectPageKind(root);
+  const text = pageKind === 'post-detail-classic' ? firstAriaHiddenOutsideAnchor(post) : null;
+  if (pageKind !== 'unknown') record('postTimestamp', pageKind, text !== null);
   return text;
 }
 

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -64,17 +64,45 @@ export type ProjectSourceProfileOutput = {
 
 export type SuggestionKind = 'post_comment' | 'post';
 
+/** One rendered comment or reply in `SuggestPost.thread` (#568) - mirrors
+ * shared/src/assist/suggest-prompt.ts's `ObservedComment` by hand, same
+ * posture as every other shape on this file. */
+export type SuggestComment = {
+  id?: string;
+  authorName?: string;
+  authorHandle?: string;
+  body: string;
+  relativeTime?: string;
+  parentId?: string;
+};
+
+/** The visible comment thread under a post (#568), already clamped by the
+ * content script before this ever reaches `fetch` - mirrors
+ * shared/src/assist/suggest-prompt.ts's `ObservedThread` by hand. */
+export type SuggestThread = {
+  comments: SuggestComment[];
+  renderedCount: number;
+  truncated: boolean;
+};
+
 /** The observed post context /suggest drafts from. `urn` is absent for a
  * feed sighting - see linkedin-dom.ts's "Two frontends, one identifier".
  * `text` is optional because a `kind: 'post'` request carries nothing to
  * draft from at all - the server grounds that kind itself, in whatever the
- * observation buffer most recently saw (#315). */
+ * observation buffer most recently saw (#315). `relativeTime`,
+ * `reactionCount`, `commentCount` and `thread` are all #568: the visible
+ * comment thread and what the page cheaply says about the room, classic
+ * post-detail frontend only. */
 export type SuggestPost = {
   urn?: string;
   authorHandle?: string;
   authorName?: string;
   text?: string;
   url?: string;
+  relativeTime?: string;
+  reactionCount?: string;
+  commentCount?: string;
+  thread?: SuggestThread;
 };
 
 /** What /suggest/accept sends back: the same post context, minus `text` -

--- a/extension/tests/content/linkedin-comment-assist.test.ts
+++ b/extension/tests/content/linkedin-comment-assist.test.ts
@@ -798,6 +798,112 @@ describe('single-page navigation', () => {
   });
 });
 
+describe('the visible thread (#568)', () => {
+  /** A classic post-detail page with `count` synthetic comments, each
+   * `bodyLength` characters long - same shape `findPostComments` reads
+   * (`article[data-id^="urn:li:comment:"]`, `h3 span` for the byline,
+   * `section` for the body, `time` for the relative-time text), reused
+   * rather than invented, per the module's "reuse the existing accessors"
+   * posture. */
+  function renderThread(count: number, bodyLength: number): Element {
+    const comments = Array.from(
+      { length: count },
+      (_, i) => `
+        <article data-id="urn:li:comment:(activity:9999,${i})">
+          <h3><span>Commenter ${i}</span></h3>
+          <section>${'x'.repeat(bodyLength)}</section>
+          <time>1h</time>
+        </article>
+      `,
+    ).join('');
+    document.body.innerHTML = `
+      <div role="article" data-urn="urn:li:activity:9999">
+        <div class="update-components-text">Hostile post body text, long enough to draft from.</div>
+        ${comments}
+      </div>
+    `;
+    const [post] = findFeedPosts(document);
+    return post;
+  }
+
+  it('a hostile thread (many long comments) is clamped on every axis', () => {
+    // 50 comments at 2000 chars each - past every one of the three caps
+    // (30 comments, 500 chars/comment, 6000 chars total) at once.
+    const post = renderThread(50, 2000);
+    const captured = readAssistPostFromCard(post, document);
+    const thread = captured?.thread;
+    expect(thread).toBeDefined();
+    // The page really did render 50 - this is LinkedIn's own count, before
+    // any cap runs, and it must survive the clamp even though the comments
+    // array carrying them does not.
+    expect(thread!.renderedCount).toBe(50);
+    expect(thread!.truncated).toBe(true);
+    expect(thread!.comments.length).toBeLessThanOrEqual(30);
+    for (const c of thread!.comments) expect(c.body.length).toBeLessThanOrEqual(500);
+    const totalChars = thread!.comments.reduce((sum, c) => sum + c.body.length, 0);
+    expect(totalChars).toBeLessThanOrEqual(6000);
+  });
+
+  it('many short comments hit the count cap on their own, well under the char caps', () => {
+    // 50 comments at 50 chars each - 2500 chars total if every one made it
+    // through, comfortably under the 6000-char cap, so only the 30-comment
+    // count cap can be what stops this one.
+    const post = renderThread(50, 50);
+    const thread = readAssistPostFromCard(post, document)?.thread;
+    expect(thread?.renderedCount).toBe(50);
+    expect(thread?.comments).toHaveLength(30);
+    expect(thread?.truncated).toBe(true);
+  });
+
+  it('a single oversized comment is clamped on its own, well under the count and total caps', () => {
+    const post = renderThread(1, 2000);
+    const thread = readAssistPostFromCard(post, document)?.thread;
+    expect(thread?.renderedCount).toBe(1);
+    expect(thread?.comments).toHaveLength(1);
+    expect(thread?.comments[0]?.body.length).toBe(500);
+    expect(thread?.truncated).toBe(true);
+  });
+
+  it('an ordinary thread under every cap is carried whole, marked not truncated', () => {
+    const post = renderThread(3, 80);
+    const thread = readAssistPostFromCard(post, document)?.thread;
+    expect(thread?.renderedCount).toBe(3);
+    expect(thread?.comments).toHaveLength(3);
+    expect(thread?.truncated).toBe(false);
+  });
+
+  it('post-detail.html (real capture): the thread carries all 16 rendered comments, not truncated', () => {
+    renderPost();
+    const [post] = findFeedPosts(document);
+    const thread = readAssistPostFromCard(post, document)?.thread;
+    expect(thread?.renderedCount).toBe(16);
+    expect(thread?.comments).toHaveLength(16);
+    expect(thread?.truncated).toBe(false);
+    expect(thread?.comments[0]?.authorName).toBe('Marco Rossi');
+    expect(thread?.comments[0]?.parentId).toBeUndefined();
+  });
+
+  it('the suggest request carries the clamped thread, not the raw DOM read', async () => {
+    const post = renderThread(50, 2000);
+    const composer = document.createElement('div');
+    composer.setAttribute('contenteditable', 'true');
+    composer.setAttribute('role', 'textbox');
+    post.appendChild(composer);
+
+    wireCommentAssist(composer, post);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(suggest).toHaveBeenCalledTimes(1);
+    // vi.fn mock call built entirely by this test, not external input.
+    const call = suggest.mock.calls[0][0] as {
+      post: { thread?: { comments: Array<{ body: string }>; truncated: boolean } };
+    };
+    expect(call.post.thread?.truncated).toBe(true);
+    expect(call.post.thread?.comments.length).toBeLessThanOrEqual(30);
+  });
+});
+
 describe('per-card wiring on the feed (2026-09-07 overlay/feed rework)', () => {
   /** Appends a synthetic comment composer under `card` - the real anonymised
    * fixture carries none (LinkedIn renders one lazily, behind the human's

--- a/extension/tests/content/linkedin-comment-reading.test.ts
+++ b/extension/tests/content/linkedin-comment-reading.test.ts
@@ -1,15 +1,20 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
+  findFeedPosts,
   findPostComments,
   findParentCommentId,
   readCommentAuthor,
   readCommentBody,
   readCommentRelativeTime,
+  readPostCommentCount,
+  readPostReactionCount,
+  readPostRelativeTime,
   findMessageEvents,
   resetSelectorHealth,
 } from '../../src/content/shared/linkedin-dom.js';
 import POST_DETAIL_HTML from './fixtures/linkedin/post-detail.html?raw';
+import FEED_HTML from './fixtures/linkedin/feed.html?raw';
 
 // post-detail.html is the same anonymised, real, signed-in capture
 // linkedin-dom.test.ts already exercises (see that fixture's README): 8
@@ -90,6 +95,36 @@ describe('post-detail.html: comment/reply reading (#307, real capture)', () => {
     // the reason a caller must never treat this string as parseable in
     // general (see LinkedInComment.relativeTime's doc comment).
     expect(Number.isNaN(Date.parse(relativeTime!))).toBe(true);
+  });
+});
+
+describe("post-detail.html: the post's own relative time, reaction and comment counts (#568, real capture)", () => {
+  it("readPostRelativeTime reads the post's own byline timestamp, never a machine date", () => {
+    render(POST_DETAIL_HTML);
+    const [post] = findFeedPosts(document);
+    const relativeTime = readPostRelativeTime(post, document);
+    expect(relativeTime).toBeTruthy();
+    expect(Number.isNaN(Date.parse(relativeTime!))).toBe(true);
+  });
+
+  it("readPostReactionCount reads the visible reaction number, distinct from any comment's own", () => {
+    render(POST_DETAIL_HTML);
+    const [post] = findFeedPosts(document);
+    expect(readPostReactionCount(post, document)).toBe('16');
+  });
+
+  it("readPostCommentCount reads LinkedIn's own rendered total, as text", () => {
+    render(POST_DETAIL_HTML);
+    const [post] = findFeedPosts(document);
+    expect(readPostCommentCount(post, document)).toBe('31 commenti');
+  });
+
+  it('feed.html (SDUI): all three read null - the feed renders none of this markup', () => {
+    render(FEED_HTML);
+    const [post] = findFeedPosts(document);
+    expect(readPostRelativeTime(post, document)).toBeNull();
+    expect(readPostReactionCount(post, document)).toBeNull();
+    expect(readPostCommentCount(post, document)).toBeNull();
   });
 });
 

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -50,6 +50,60 @@ export interface ObservedPost {
   authorName?: string;
   text: string;
   url?: string;
+  /** LinkedIn's own rendered relative-time text for the post itself (#568),
+   * e.g. "6 giorni" - never a machine timestamp, the same posture
+   * `ObservedComment.relativeTime` documents below. */
+  relativeTime?: string;
+  /** LinkedIn's own rendered reaction count on the post, as text (#568) -
+   * e.g. "16". Left as the platform's own prose rather than parsed to a
+   * number: the source is locale-formatted, not a machine count. */
+  reactionCount?: string;
+  /** LinkedIn's own rendered comment count on the post, as text (#568) -
+   * e.g. "31 commenti". This is the platform's own total and can run ahead
+   * of `thread.renderedCount`, which is only what the page actually loaded
+   * - "300 comments already" and "two comments" call for different replies
+   * even when the page rendered the same handful either way. */
+  commentCount?: string;
+  /** The visible comment thread (#568), when the page had one to read - the
+   * SDUI feed never does (see linkedin-dom.ts's module header). */
+  thread?: ObservedThread;
+}
+
+/** One rendered comment or reply in `ObservedPost.thread` (#568), mirroring
+ * `LinkedInComment` in extension/src/content/shared/linkedin-dom.ts field
+ * for field - the extension has no dependency on `@pitchbox/shared`, so the
+ * two types cannot share a declaration, only a shape. */
+export interface ObservedComment {
+  id?: string;
+  authorName?: string;
+  authorHandle?: string;
+  body: string;
+  /** LinkedIn's own relative-time text, never a machine timestamp - see
+   * `LinkedInComment.relativeTime`'s doc comment in linkedin-dom.ts for why. */
+  relativeTime?: string;
+  /** The comment this one replies to, when nested; absent for a top-level
+   * comment, whose parent is the post itself. */
+  parentId?: string;
+}
+
+/** The visible comment thread under a post, as the page actually rendered
+ * it (#568) - not the platform's own total, which lives on `ObservedPost`
+ * as `commentCount` and can run ahead of what loaded. `comments` is already
+ * clamped to MAX_THREAD_COMMENTS entries, each body to MAX_COMMENT_CHARS,
+ * and the combined bodies to MAX_THREAD_CHARS by the extension before the
+ * request ever leaves the browser (a post with hundreds of comments must
+ * not become a multi-hundred-KB request) - the zod schema on
+ * `POST /api/extension/suggest` re-enforces the same three numbers rather
+ * than trusting that clamp, since a stale build or a crafted request could
+ * skip it. `truncated` is set the moment any cap actually cuts something,
+ * so a consumer knows the thread it received is partial rather than
+ * assuming it is complete. `renderedCount` is how many comment articles the
+ * page actually had on screen (`findPostComments(...).length` before any
+ * cap runs), never smaller than `comments.length`. */
+export interface ObservedThread {
+  comments: ObservedComment[];
+  renderedCount: number;
+  truncated: boolean;
 }
 
 /** The project the suggestion is filed under, described the way the old
@@ -65,6 +119,19 @@ export interface CurrentProject {
  * past this is either a pasted article or a hostile payload, and neither
  * improves the suggestion. */
 export const MAX_POST_CHARS = 4000;
+/** Ceilings on `ObservedThread` (#568), the same spirit as MAX_POST_CHARS: a
+ * post with hundreds of comments does not make a better suggestion by
+ * forwarding all of them, only a slower and more expensive one. Three
+ * separate caps because a thread can be hostile along any one axis alone -
+ * few but enormous comments, or many but short ones - and MAX_THREAD_CHARS
+ * is the one most likely to bind first on an ordinary long thread of
+ * merely-medium comments, each individually under MAX_COMMENT_CHARS. The
+ * extension clamps to these numbers before sending; the zod schema on
+ * `POST /api/extension/suggest` enforces them again rather than trusting
+ * that clamp. */
+export const MAX_THREAD_COMMENTS = 30;
+export const MAX_COMMENT_CHARS = 500;
+export const MAX_THREAD_CHARS = 6000;
 /** How many few-shot examples are worth carrying. More lengthens the prompt
  * without changing the voice, and the first token is what the human waits on. */
 export const MAX_EXAMPLES = 3;

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -10,7 +10,10 @@ import { loadActiveTemplates } from '@pitchbox/shared/templates';
 import { getAccountUsage, checkQuota, loadQuotaLimits } from '@pitchbox/shared/quota';
 import { mapDraftKindToQuotaKind } from '@pitchbox/shared/quota-types';
 import {
+  MAX_COMMENT_CHARS,
   MAX_POST_CHARS,
+  MAX_THREAD_CHARS,
+  MAX_THREAD_COMMENTS,
   RETUNE_DIRECTIONS,
   type ObservedPost,
   type SuggestionKind,
@@ -39,6 +42,25 @@ const perDevice = new RateLimiter(20, 60_000);
 // several legitimate devices still add up to something sane.
 const perOrg = new RateLimiter(60, 60_000);
 
+// #568: one comment/reply in the visible thread, capped per-body by
+// MAX_COMMENT_CHARS. The aggregate MAX_THREAD_CHARS cap (across every
+// comment's body combined) cannot be expressed as a single field
+// constraint, so it is checked in the `superRefine` below instead.
+const CommentSchema = z.object({
+  id: z.string().max(200).optional(),
+  authorName: z.string().max(200).optional(),
+  authorHandle: z.string().max(200).optional(),
+  body: z.string().max(MAX_COMMENT_CHARS),
+  relativeTime: z.string().max(200).optional(),
+  parentId: z.string().max(200).optional(),
+});
+
+const ThreadSchema = z.object({
+  comments: z.array(CommentSchema).max(MAX_THREAD_COMMENTS),
+  renderedCount: z.number().int().min(0),
+  truncated: z.boolean(),
+});
+
 const BodySchema = z
   .object({
     projectId: z.number().int().positive(),
@@ -52,6 +74,13 @@ const BodySchema = z
         .max(MAX_POST_CHARS * 2)
         .optional(),
       url: z.string().max(2000).optional(),
+      // #568: what the page cheaply says about the room, plus the visible
+      // thread itself - all classic-post-detail-only and all optional, the
+      // same posture as every other post field above.
+      relativeTime: z.string().max(200).optional(),
+      reactionCount: z.string().max(100).optional(),
+      commentCount: z.string().max(100).optional(),
+      thread: ThreadSchema.optional(),
     }),
     hint: z.string().max(500).optional(),
     // #409: a panel-level retune direction, never a setting - see the
@@ -73,6 +102,22 @@ const BodySchema = z
         message: 'post.text is required for kind "post_comment"',
         path: ['post', 'text'],
       });
+    }
+    // #568: the one thread cap `z.array().max()`/`z.string().max()` above
+    // cannot express - the combined body length across every comment,
+    // rather than any single one. The schema is the enforcement boundary
+    // (AGENTS.md), so this rejects rather than silently re-truncating what
+    // the extension already clamped.
+    const thread = val.post.thread;
+    if (thread) {
+      const totalChars = thread.comments.reduce((sum, c) => sum + c.body.length, 0);
+      if (totalChars > MAX_THREAD_CHARS) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `post.thread.comments combined body length exceeds ${MAX_THREAD_CHARS}`,
+          path: ['post', 'thread', 'comments'],
+        });
+      }
     }
   });
 

--- a/web/tests/extension-suggest-thread.test.ts
+++ b/web/tests/extension-suggest-thread.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type { AgentRunHandle, AgentRunOptions, AgentRunner } from '@pitchbox/shared/agents';
+import { type RunnerConfig } from '@pitchbox/shared/agents/config';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+import { DRAFT_MARKER } from '@pitchbox/shared/assist/envelope';
+import {
+  MAX_COMMENT_CHARS,
+  MAX_THREAD_CHARS,
+  MAX_THREAD_COMMENTS,
+} from '@pitchbox/shared/assist/suggest-prompt';
+
+/**
+ * #568: the zod schema on POST /api/extension/suggest is the enforcement
+ * boundary for the visible thread, not the extension's own clamp - a stale
+ * build or a crafted request must not reach the model with more than the
+ * three caps allow. Kept in its own file rather than folded into
+ * extension-suggest.test.ts because that file's `perDevice` rate limiter
+ * (20/60s) is a module-level singleton shared by every test in the process
+ * that imports it, and its own tests already run it close to the cap (see
+ * the comment on its last describe block) - a fresh file gets a fresh
+ * import and a fresh limiter.
+ */
+
+const REASONING = 'Noticed the cache change and the specific number.';
+const DRAFT = 'A specific thing that happened.';
+const ENVELOPE_CHUNKS = [`${REASONING}\n`, DRAFT_MARKER, '\n', DRAFT];
+let responseChunks: string[] = ENVELOPE_CHUNKS;
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'fake',
+    run(opts: AgentRunOptions): AgentRunHandle {
+      for (const c of responseChunks) opts.onTextChunk?.(c);
+      return {
+        result: Promise.resolve({ exitCode: 0, logPath: '/dev/null' }),
+        cancel: () => {},
+      };
+    },
+  }),
+}));
+
+// Dynamic on purpose: `vi.mock` above is hoisted, but the route module (and
+// the `suggest.ts` it imports) has to load *after* that mock is registered
+// for `createAgentRunner` to resolve to the fake - a static import here
+// would race the hoisted mock. Same pattern as extension-suggest.test.ts.
+const { POST: suggest } = await import('../src/routes/api/extension/suggest/+server.js');
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, contact_history, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+  responseChunks = ENVELOPE_CHUNKS;
+}
+
+async function seedOrgProject(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug, description: `about ${slug}` })
+    .returning();
+  await saveLinkedInAssistSettings(db, org.id, {
+    ...defaultLinkedInAssistSettings(),
+    enabled: true,
+    projectId: project.id,
+  });
+  return { org, project };
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({ organizationId, tokenHash: tokenHash(token), label: 'test' });
+}
+
+function request(token: string | null, body: unknown): Request {
+  return new Request('http://x/api/extension/suggest', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+const POST_BODY = {
+  kind: 'post_comment' as const,
+  post: {
+    urn: 'urn:li:activity:7000000000000000001',
+    authorName: 'Giulia Bianchi',
+    text: 'We cut p99 in half.',
+  },
+};
+
+function threadOf(count: number, bodyLength: number) {
+  return {
+    comments: Array.from({ length: count }, (_, i) => ({
+      id: `urn:li:comment:(activity:1,${i})`,
+      authorName: `Commenter ${i}`,
+      body: 'x'.repeat(bodyLength),
+    })),
+    renderedCount: count,
+    truncated: false,
+  };
+}
+
+describe('the visible thread (#568): the schema rejects what the caps forbid', () => {
+  beforeEach(reset);
+
+  it('accepts a thread within every cap and streams normally', async () => {
+    const { org, project } = await seedOrgProject('org-thread-ok');
+    await mintDevice(org.id, 'tok-thread-ok');
+
+    const res = await suggest({
+      request: request('tok-thread-ok', {
+        ...POST_BODY,
+        projectId: project.id,
+        post: { ...POST_BODY.post, thread: threadOf(3, 80) },
+      }),
+    } as never);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+  });
+
+  it('rejects more comments than MAX_THREAD_COMMENTS', async () => {
+    const { org, project } = await seedOrgProject('org-thread-count');
+    await mintDevice(org.id, 'tok-thread-count');
+
+    await expect(
+      suggest({
+        request: request('tok-thread-count', {
+          ...POST_BODY,
+          projectId: project.id,
+          post: { ...POST_BODY.post, thread: threadOf(MAX_THREAD_COMMENTS + 1, 20) },
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects a single comment body longer than MAX_COMMENT_CHARS', async () => {
+    const { org, project } = await seedOrgProject('org-thread-body');
+    await mintDevice(org.id, 'tok-thread-body');
+
+    await expect(
+      suggest({
+        request: request('tok-thread-body', {
+          ...POST_BODY,
+          projectId: project.id,
+          post: { ...POST_BODY.post, thread: threadOf(1, MAX_COMMENT_CHARS + 1) },
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects a combined comment-body length past MAX_THREAD_CHARS even though the count and each body individually stay within their own caps', async () => {
+    const { org, project } = await seedOrgProject('org-thread-total');
+    await mintDevice(org.id, 'tok-thread-total');
+
+    // 20 comments (under MAX_THREAD_COMMENTS) at 400 chars each (under
+    // MAX_COMMENT_CHARS) - 8000 combined, past MAX_THREAD_CHARS (6000).
+    const perComment = 400;
+    const count = 20;
+    expect(count).toBeLessThan(MAX_THREAD_COMMENTS);
+    expect(perComment).toBeLessThan(MAX_COMMENT_CHARS);
+    expect(count * perComment).toBeGreaterThan(MAX_THREAD_CHARS);
+
+    await expect(
+      suggest({
+        request: request('tok-thread-total', {
+          ...POST_BODY,
+          projectId: project.id,
+          post: { ...POST_BODY.post, thread: threadOf(count, perComment) },
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});


### PR DESCRIPTION
## What changed

The suggest payload for a `post_comment` request now carries the visible comment thread, not just the post text:

- Each comment: author name/handle, body, relative time, parent id (nested reply resolution), in document order. Built from `findPostComments`/`readCommentAuthor`/`readCommentBody`/`readCommentRelativeTime`/`findParentCommentId` (`linkedin-dom.ts`) - no second selectors, so `getSelectorHealthReport` stays honest.
- The post's own `relativeTime`, `reactionCount` and `commentCount`, read the same way: `readPostRelativeTime` reuses the exact aria-hidden query `readOwnPostRelativeTime` already used for the operator's own recent-activity posts (extracted into a shared `firstAriaHiddenOutsideAnchor` helper rather than duplicated), and the two new count readers exclude anything `closest()`-matching a comment article so a post's own reaction/comment count is never confused with a comment's identically-shaped one.
- Three caps in `shared/src/assist/suggest-prompt.ts` (`MAX_THREAD_COMMENTS = 30`, `MAX_COMMENT_CHARS = 500`, `MAX_THREAD_CHARS = 6000`), same spirit as the existing `MAX_POST_CHARS`. The extension clamps before the request ever leaves the browser - a `truncated` flag is set the moment any cap actually cuts something - and the zod schema on `POST /api/extension/suggest` enforces the same three numbers again (array `.max()`, string `.max()`, and a `superRefine` for the one cap - the combined body total - that a single field constraint can't express) and rejects a request that violates them rather than trusting the client's own clamp.

## What this does not do

- Does not wire the thread into the prompt the model actually sees. That's #566 (the multi-step agent loop with tools - "read the thread" becomes a tool call there); this issue is the transport and the enforcement boundary.
- Does not expand the thread. No click, no request toward linkedin.com/licdn from this code - `pnpm run test:linkedin-compliance` is green with every rule intact, including rule 3 (no synthetic click/submit on a `linkedin-dom.ts` node).
- Does not touch `kind: 'post'` suggestions (composing a fresh post) - that path sends an empty `post: {}` today and still does.

## Verified

- `pnpm exec vitest run extension/tests/content/linkedin-comment-reading.test.ts extension/tests/content/linkedin-comment-assist.test.ts web/tests/extension-suggest-thread.test.ts web/tests/extension-suggest.test.ts tests/extension-packaged-build.test.ts` - 89 passed. New coverage: `readPostRelativeTime`/`readPostReactionCount`/`readPostCommentCount` against the real `post-detail.html` capture (and `null` on `feed.html`, the SDUI frontend); a hostile synthetic fixture (50 comments x 2000 chars) proving all three caps clamp simultaneously, plus three narrower fixtures isolating each cap individually; the schema's own rejection of each cap violation in isolation, in a fresh test file (`extension-suggest-thread.test.ts`) rather than folded into `extension-suggest.test.ts`, whose module-level rate limiter is already run close to its cap by that file's own tests (same pattern `extension-suggest-voice.test.ts` uses).
- `pnpm run test:linkedin-compliance` - 15 passed.
- `pnpm run build:extension`, then confirmed `extension/dist/src/content/linkedin-comment-assist.js` exists with zero top-level `import`/`export` lines (grep) and contains the new selector logic.
- `pnpm -F @pitchbox/shared typecheck`, `pnpm -F web check`, `pnpm -F @pitchbox/extension check` - all clean.
- **Driven against a real LinkedIn post**, not just the fixture: loaded the built `extension/dist` unpacked via `Extensions.loadUnpacked` over raw CDP into a cloned, logged-in profile (`omp-chrome up personal-b`), navigated from the real feed into a real post's permalink (`.../posts/golfetto-elia_.../`, 4 top-level comments, no nested replies on this one), and evaluated the exact selector logic this PR adds against the live DOM: `reactionCount` read `"5"`, `commentCount` read `"4 commenti"`, `relativeTime` read `"1 ora • Modificato •"`, and all 4 comments resolved with correct author name, body and relative time. Also confirmed live, matching the module's own documented claim: the SDUI feed (including an inline-expanded comment view that visually looks identical to post-detail) carries zero `article[data-id^="urn:li:comment:"]` elements - the thread feature is correctly a no-op there.

## Deliberately not verified

The full network round trip (panel -> `fetch` -> `POST /api/extension/suggest`) could not be exercised against a real LinkedIn page pointed at a local backend: this is a pre-existing, documented Chrome Private Network Access restriction (AGENTS.md, "Design and UI" - a public HTTPS page's `fetch` to a loopback address needs a PNA preflight `web/src/lib/server/extension-cors.ts` doesn't answer yet), not something this change introduces or is in scope to fix.

Closes #568
