### PR TITLE
refactor(shared,web): the spend window is the billing period, one usage snapshot, and every plan limit is refused where the effect happens

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -95,7 +95,7 @@
     "./billing/customer": "./src/billing/customer.ts",
     "./billing/checkout": "./src/billing/checkout.ts",
     "./billing/portal": "./src/billing/portal.ts",
-    "./billing/webhook": "./src/billing/webhook.ts"
+    "./billing/webhook": "./src/billing/webhook.ts",
     "./usage": "./src/usage.ts"
   },
   "scripts": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -96,6 +96,7 @@
     "./billing/checkout": "./src/billing/checkout.ts",
     "./billing/portal": "./src/billing/portal.ts",
     "./billing/webhook": "./src/billing/webhook.ts"
+    "./usage": "./src/usage.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",

--- a/shared/src/org-quota.ts
+++ b/shared/src/org-quota.ts
@@ -189,7 +189,9 @@ function calendarMonthPeriod(now: Date): Period {
 }
 
 function monthsBetweenUtc(from: Date, to: Date): number {
-  return (to.getUTCFullYear() - from.getUTCFullYear()) * 12 + (to.getUTCMonth() - from.getUTCMonth());
+  return (
+    (to.getUTCFullYear() - from.getUTCFullYear()) * 12 + (to.getUTCMonth() - from.getUTCMonth())
+  );
 }
 
 /**
@@ -248,7 +250,11 @@ export function resolveBillingPeriod(
  * org-quota settings page and every plan-limit check meter "this period"
  * against - see `resolveBillingPeriod` for the pure resolution rule.
  */
-export async function billingPeriodFor(db: Db, orgId: number, now: Date = new Date()): Promise<Period> {
+export async function billingPeriodFor(
+  db: Db,
+  orgId: number,
+  now: Date = new Date(),
+): Promise<Period> {
   const [row] = await db
     .select({
       orgCreatedAt: schema.organizations.createdAt,

--- a/shared/src/org-quota.ts
+++ b/shared/src/org-quota.ts
@@ -3,7 +3,7 @@
 // (shared/src/agents/sdk/runner.ts, web/src/lib/server/runner.ts). Mirrors the
 // per-account quota helper's style (shared/src/quota.ts) but is org-scoped and
 // budget/concurrency based rather than per-account daily/weekly counts.
-import { and, eq, gte, inArray, ne, or, sql } from 'drizzle-orm';
+import { and, eq, gte, inArray, lt, ne, or, sql } from 'drizzle-orm';
 import type { PgDatabase } from 'drizzle-orm/pg-core';
 import { schema, type Db } from './db/client.js';
 
@@ -138,22 +138,151 @@ export async function saveSelfRegistrationQuotaDefaults(
   return defaults;
 }
 
-/** First instant (UTC) of the calendar month containing `now`. */
+/** First instant (UTC) of the calendar month containing `now`. Kept for
+ * exactly one caller after #545: `getInstanceMonthToDateCostUsd` sums every
+ * organization's spend over the SAME plain calendar month regardless of any
+ * one org's own billing period, which is the instance-wide ceiling's
+ * existing meaning and #545 deliberately leaves unchanged. No other caller
+ * should reappear here - an org's own spend window is `billingPeriodFor`
+ * below. */
 export function startOfMonthUtc(now: Date): Date {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
 }
 
+/** `date`'s day-of-month (and time-of-day) shifted by `months`, clamped to
+ * the target month's real length (e.g. Jan 31 + 1 month -> Feb 28/29, never
+ * Mar 3). The building block both `calendarPeriodFor` and the instance-wide
+ * calendar-month period use. */
+function addUtcMonths(date: Date, months: number): Date {
+  const totalMonths = date.getUTCMonth() + months;
+  const year = date.getUTCFullYear() + Math.floor(totalMonths / 12);
+  const month = ((totalMonths % 12) + 12) % 12;
+  const lastDayOfTargetMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  const day = Math.min(date.getUTCDate(), lastDayOfTargetMonth);
+  return new Date(
+    Date.UTC(
+      year,
+      month,
+      day,
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds(),
+    ),
+  );
+}
+
+/** A half-open spend window `[start, end)`. */
+export interface Period {
+  start: Date;
+  end: Date;
+}
+
+/** The plain calendar-month window `getInstanceMonthToDateCostUsd` sums
+ * every org over - the 1st of the month to the 1st of the next, in UTC.
+ * Deliberately NOT anchored on anything org-specific: see `startOfMonthUtc`'s
+ * own doc comment for why the instance-wide ceiling keeps this window
+ * regardless of what `billingPeriodFor` computes for any one org. */
+function calendarMonthPeriod(now: Date): Period {
+  const start = startOfMonthUtc(now);
+  return { start, end: addUtcMonths(start, 1) };
+}
+
+function monthsBetweenUtc(from: Date, to: Date): number {
+  return (to.getUTCFullYear() - from.getUTCFullYear()) * 12 + (to.getUTCMonth() - from.getUTCMonth());
+}
+
 /**
- * Org month-to-date spend, split into campaign/other-run cost and assistant
- * (in-page suggestion) cost, both started/created on or after the first of
- * the current calendar month (UTC). #522: the assistant plane writes no
+ * The calendar-month period containing `now`, anchored on `anchor`'s
+ * day-of-month (and time-of-day) rather than the 1st - #545. An org that
+ * never subscribes gets this window, anchored on its own `createdAt`: a free
+ * org's spend window is therefore stable for the org's whole lifetime and
+ * does not shift merely because it later subscribes or its subscription
+ * later lapses, since it is always derived from `organizations.createdAt`,
+ * never from Stripe.
+ */
+export function calendarPeriodFor(anchor: Date, now: Date): Period {
+  let months = monthsBetweenUtc(anchor, now);
+  let start = addUtcMonths(anchor, months);
+  if (start > now) {
+    months -= 1;
+    start = addUtcMonths(anchor, months);
+  }
+  let end = addUtcMonths(anchor, months + 1);
+  // The initial estimate above can land one month short or long once
+  // month-end clamping is in play (e.g. an anchor on the 31st produces a
+  // 28-day February) - walk to the exact window containing `now` rather
+  // than trusting the arithmetic estimate.
+  while (end <= now) {
+    months += 1;
+    start = end;
+    end = addUtcMonths(anchor, months + 1);
+  }
+  while (start > now) {
+    months -= 1;
+    end = start;
+    start = addUtcMonths(anchor, months);
+  }
+  return { start, end };
+}
+
+/**
+ * Pure period resolution given already-loaded org data - the part of
+ * `billingPeriodFor` worth unit-testing with a fixed clock and no database.
+ * A live subscription's period always wins; otherwise the org's own
+ * creation-anchored calendar month (see `calendarPeriodFor`).
+ */
+export function resolveBillingPeriod(
+  input: { orgCreatedAt: Date; subscriptionPeriod: Period | null },
+  now: Date,
+): Period {
+  if (input.subscriptionPeriod) return input.subscriptionPeriod;
+  return calendarPeriodFor(input.orgCreatedAt, now);
+}
+
+/**
+ * An org's current spend window (#545): a live subscription's own
+ * `current_period_start`/`current_period_end` as the Stripe webhook mirrors
+ * them onto `org_subscriptions`, or the free/self-host calendar-month
+ * fallback above. This is what a budget decision, the dashboard, the
+ * org-quota settings page and every plan-limit check meter "this period"
+ * against - see `resolveBillingPeriod` for the pure resolution rule.
+ */
+export async function billingPeriodFor(db: Db, orgId: number, now: Date = new Date()): Promise<Period> {
+  const [row] = await db
+    .select({
+      orgCreatedAt: schema.organizations.createdAt,
+      currentPeriodStart: schema.orgSubscriptions.currentPeriodStart,
+      currentPeriodEnd: schema.orgSubscriptions.currentPeriodEnd,
+    })
+    .from(schema.organizations)
+    .leftJoin(
+      schema.orgSubscriptions,
+      eq(schema.orgSubscriptions.organizationId, schema.organizations.id),
+    )
+    .where(eq(schema.organizations.id, orgId))
+    .limit(1);
+  // An org that no longer exists has nothing left to meter - the org lookup
+  // elsewhere in the dispatch path is what actually refuses that case; this
+  // just needs to not throw, so it anchors on `now` itself.
+  const orgCreatedAt = row?.orgCreatedAt ?? now;
+  const subscriptionPeriod =
+    row?.currentPeriodStart != null && row?.currentPeriodEnd != null
+      ? { start: row.currentPeriodStart, end: row.currentPeriodEnd }
+      : null;
+  return resolveBillingPeriod({ orgCreatedAt, subscriptionPeriod }, now);
+}
+
+/**
+ * Org spend within `period`, split into campaign/other-run cost and
+ * assistant (in-page suggestion) cost. #522: the assistant plane writes no
  * `runs` row for a suggestion (see web/src/routes/api/extension/suggest -
  * a suggestion is ephemeral until a human accepts it), so its spend lives in
  * `assist_usage` instead, one row per finished suggestion whether accepted
  * or not. Kept apart rather than pre-summed, per #522's decision: an
  * operator asking "why am I out of budget" needs to see which half spent it
- * (`getOrgMonthToDateCostUsd` below still returns the single number a
- * budget decision needs).
+ * (`getOrgPeriodCostUsd` below still returns the single number a budget
+ * decision needs).
  *
  * The `runs` side deliberately excludes `kind = 'assist'`: accepting a
  * suggestion (shared/src/assist-accept.ts) still writes a `runs` row so the
@@ -179,19 +308,17 @@ export function startOfMonthUtc(now: Date): Date {
  * directly (a suggestion is always grounded in one project, never a
  * campaign), so its side needs no such join at all.
  */
-export interface OrgMonthToDateSpend {
+export interface OrgPeriodSpend {
   campaignUsd: number;
   assistantUsd: number;
   totalUsd: number;
 }
 
-export async function getOrgMonthToDateSpend(
+export async function getOrgPeriodSpend(
   db: Db,
   orgId: number,
-  now: Date = new Date(),
-): Promise<OrgMonthToDateSpend> {
-  const monthStart = startOfMonthUtc(now);
-
+  period: Period,
+): Promise<OrgPeriodSpend> {
   const orgProjects = await db
     .select({ id: schema.projects.id })
     .from(schema.projects)
@@ -214,7 +341,8 @@ export async function getOrgMonthToDateSpend(
           inArray(schema.runs.projectId, projectIds),
           inArray(schema.campaigns.projectId, projectIds),
         ),
-        gte(schema.runs.startedAt, monthStart),
+        gte(schema.runs.startedAt, period.start),
+        lt(schema.runs.startedAt, period.end),
       ),
     );
 
@@ -224,7 +352,8 @@ export async function getOrgMonthToDateSpend(
     .where(
       and(
         inArray(schema.assistUsage.projectId, projectIds),
-        gte(schema.assistUsage.createdAt, monthStart),
+        gte(schema.assistUsage.createdAt, period.start),
+        lt(schema.assistUsage.createdAt, period.end),
       ),
     );
 
@@ -236,26 +365,23 @@ export async function getOrgMonthToDateSpend(
 /**
  * The single number a budget decision uses (org-quota's own gate in
  * getOrgQuotaSnapshot, the instance-wide ceiling): campaign spend plus
- * assistant spend, month-to-date. See getOrgMonthToDateSpend for the split
- * and why the two are kept apart for a human but combined here for a cap.
+ * assistant spend, within `period`. See getOrgPeriodSpend for the split and
+ * why the two are kept apart for a human but combined here for a cap.
  */
-export async function getOrgMonthToDateCostUsd(
-  db: Db,
-  orgId: number,
-  now: Date = new Date(),
-): Promise<number> {
-  const { totalUsd } = await getOrgMonthToDateSpend(db, orgId, now);
+export async function getOrgPeriodCostUsd(db: Db, orgId: number, period: Period): Promise<number> {
+  const { totalUsd } = await getOrgPeriodSpend(db, orgId, period);
   return totalUsd;
 }
 
 /**
- * Compute an org's current quota snapshot: remaining monthly USD budget (null
- * = unlimited, since `organizations.monthly_run_budget_usd` is null) and its
- * concurrency cap (null = unlimited, `organizations.max_concurrent_runs`
- * null). A `remainingUsd` of 0 or negative means the org is over budget. An
- * org that no longer exists is treated as unlimited on both axes - not this
- * function's decision to make; the org lookup elsewhere in the dispatch path
- * is what actually gates a run against a missing org.
+ * Compute an org's current quota snapshot: remaining budget for its current
+ * billing period (null = unlimited, since `organizations.monthlyRunBudgetUsd`
+ * is null) and its concurrency cap (null = unlimited,
+ * `organizations.max_concurrent_runs` null). A `remainingUsd` of 0 or
+ * negative means the org is over budget. An org that no longer exists is
+ * treated as unlimited on both axes - not this function's decision to make;
+ * the org lookup elsewhere in the dispatch path is what actually gates a run
+ * against a missing org.
  */
 export async function getOrgQuotaSnapshot(
   db: Db,
@@ -276,7 +402,8 @@ export async function getOrgQuotaSnapshot(
     return { remainingUsd: null, concurrencyCap };
   }
 
-  const spentUsd = await getOrgMonthToDateCostUsd(db, orgId, now);
+  const period = await billingPeriodFor(db, orgId, now);
+  const spentUsd = await getOrgPeriodCostUsd(db, orgId, period);
   const budgetUsd = Number(org.monthlyRunBudgetUsd);
   return { remainingUsd: budgetUsd - spentUsd, concurrencyCap };
 }
@@ -489,23 +616,27 @@ export async function saveInstanceQuotaCeiling(
 }
 
 /**
- * Sum of every organization's month-to-date Gateway spend - the
- * instance-wide total #540 checks the ceiling against. Calls
- * `getOrgMonthToDateCostUsd` once per organization and adds the results,
- * rather than re-deriving its own SUM query, so this total always agrees
- * with the per-org figure the dashboard and org-quota settings show, and so
- * whatever a sibling change teaches `getOrgMonthToDateCostUsd` about what
- * counts as spend (#522: the in-page assistant's own Gateway calls, which
- * carry no `runs` row today) is picked up here automatically, with no
- * second place to update.
+ * Sum of every organization's calendar-month-to-date Gateway spend - the
+ * instance-wide total #540 checks the ceiling against. Deliberately the
+ * plain calendar month (`calendarMonthPeriod`, the 1st of the month to the
+ * 1st of the next), the SAME window for every org regardless of any one
+ * org's own billing period (`billingPeriodFor`) - #545 introduced per-org
+ * billing periods without changing what this instance-wide ceiling means:
+ * one consistent window an operator can reason about across every tenant,
+ * not a hundred different subscription anniversaries. Calls
+ * `getOrgPeriodCostUsd` once per organization and adds the results, rather
+ * than re-deriving its own SUM query, so this total always agrees with the
+ * per-org figure's own spend accounting (#522: the in-page assistant's own
+ * Gateway calls, which carry no `runs` row) with no second place to update.
  */
 export async function getInstanceMonthToDateCostUsd(
   db: Db,
   now: Date = new Date(),
 ): Promise<number> {
+  const period = calendarMonthPeriod(now);
   const orgs = await db.select({ id: schema.organizations.id }).from(schema.organizations);
   if (orgs.length === 0) return 0;
-  const totals = await Promise.all(orgs.map((o) => getOrgMonthToDateCostUsd(db, o.id, now)));
+  const totals = await Promise.all(orgs.map((o) => getOrgPeriodCostUsd(db, o.id, period)));
   return totals.reduce((sum, t) => sum + t, 0);
 }
 

--- a/shared/src/runlog/classify-failure.ts
+++ b/shared/src/runlog/classify-failure.ts
@@ -14,6 +14,7 @@ export type RunFailureReason =
   | 'quota_exhausted'
   | 'instance_quota_exhausted'
   | 'concurrency_exhausted'
+  | 'plan_limit_reached'
   | 'playbook_error'
   | 'playbook_incomplete'
   | 'network'
@@ -31,6 +32,7 @@ export const RUN_FAILURE_REASONS: readonly RunFailureReason[] = [
   'quota_exhausted',
   'instance_quota_exhausted',
   'concurrency_exhausted',
+  'plan_limit_reached',
   'playbook_error',
   'playbook_incomplete',
   'network',
@@ -99,6 +101,15 @@ const INSTANCE_QUOTA_PATTERNS = ['instance-wide'];
 // never says "quota" or "rate limit" and needs its own pattern here.
 const CONCURRENCY_PATTERNS = ['concurrency limit'];
 
+// #548: a plan's own metered limits (runsPerMonth today) are a different
+// failure than the org's Gateway budget above - "you've used every run your
+// plan allows this period" has a different fix (wait for the next period or
+// upgrade) than "you're out of money" (raise the budget) or "you already
+// have N runs going" (wait or raise the concurrency cap). The pre-flight's
+// refusal text says "plan limit" specifically and never "quota" so it never
+// collides with QUOTA_PATTERNS below.
+const PLAN_LIMIT_PATTERNS = ['plan limit'];
+
 const NETWORK_PATTERNS = [
   'econnrefused',
   'econnreset',
@@ -161,6 +172,7 @@ export function classifyFailure(events: ParsedEvent[], exitCode: number | null):
   if (INSTANCE_QUOTA_PATTERNS.some((p) => haystack.includes(p))) return 'instance_quota_exhausted';
   if (QUOTA_PATTERNS.some((p) => haystack.includes(p))) return 'quota_exhausted';
   if (CONCURRENCY_PATTERNS.some((p) => haystack.includes(p))) return 'concurrency_exhausted';
+  if (PLAN_LIMIT_PATTERNS.some((p) => haystack.includes(p))) return 'plan_limit_reached';
   if (NETWORK_PATTERNS.some((p) => haystack.includes(p))) return 'network';
   if (PROVIDER_ERROR_PATTERNS.some((p) => haystack.includes(p))) return 'provider_error';
   if (CONTENT_FILTERED_PATTERNS.some((p) => haystack.includes(p))) return 'content_filtered';

--- a/shared/src/usage.ts
+++ b/shared/src/usage.ts
@@ -1,0 +1,180 @@
+// The single answer to "how much of this org's plan is used" (#546). Every
+// enforcement point in #548, the settings/billing page (#555), the pricing
+// page's own account state (#558) and the extension payload (#556) read this
+// one snapshot rather than five near-identical queries scattered across
+// routes - a plan number that only `resolveEntitlements` (shared/src/plans.ts)
+// may declare, and one place that turns it into "used" and "remaining".
+import { and, count, eq, gt, gte, inArray, isNull, lt, or } from 'drizzle-orm';
+import { schema, type Db } from './db/client.js';
+import { resolveEntitlements, type Entitlements } from './plans.js';
+import { getOrgPeriodCostUsd, type Period } from './org-quota.js';
+
+/** One metered axis: how many the org has used, the plan's limit (null =
+ * unlimited) and how many remain (null when the limit itself is null). */
+export interface UsageMetric {
+  used: number;
+  limit: number | null;
+  remaining: number | null;
+}
+
+/** Every number the plan catalogue meters for one org, over `period`
+ * (`billingPeriodFor` in shared/src/org-quota.ts) where the axis is
+ * period-bound, or as of now where it is a structural snapshot instead. */
+export interface OrgUsageSnapshot {
+  runs: UsageMetric;
+  suggestions: UsageMetric;
+  /** Structural, not period-bound: how many projects the org has right now. */
+  projects: UsageMetric;
+  /** Connected accounts, for display only - `limit` is always null. Plans.ts
+   * carries a per-plan `accounts` number in `PLAN_CATALOGUE` for the pricing
+   * page, but deliberately does not expose it on `Entitlements` yet (its own
+   * doc comment: "no enforcement point reads a connected-account limit yet").
+   * Extending `Entitlements` is plans.ts's contract, not this module's. */
+  accounts: UsageMetric;
+  /** Structural: memberships plus pending, unexpired invites - inviting ten
+   * people at once has to consume the same seats a joined member would. */
+  seats: UsageMetric;
+  /** Structural: non-revoked, non-expired extension_devices rows. */
+  extensionDevices: UsageMetric;
+  costUsd: UsageMetric;
+  /** The raw resolver output, for fields `UsageMetric` doesn't shape
+   * (premiumModels, webhooks, retentionDays, maxConcurrentRuns, planId,
+   * source) - callers that need those read them here instead of a second
+   * `resolveEntitlements` call. */
+  entitlements: Entitlements;
+}
+
+function metric(used: number, limit: number | null): UsageMetric {
+  return { used, limit, remaining: limit == null ? null : Math.max(0, limit - used) };
+}
+
+const UNLIMITED_METRIC: UsageMetric = { used: 0, limit: null, remaining: null };
+
+/**
+ * One org's usage snapshot for `period`. Self-host (`entitlements.source ===
+ * 'self-host'`) returns the fully-unlimited shape without running a single
+ * count query - there is nothing to refuse, so there is nothing to count.
+ *
+ * Every other axis after that is at most one query, and the four structural
+ * counts (projects, accounts, seats, extensionDevices) share one round trip
+ * via `Promise.all` alongside the two period-bound counts (runs,
+ * suggestions) and the existing cost helper - six queries total, none of
+ * which grow with how many projects the org has.
+ */
+export async function getOrgUsage(db: Db, orgId: number, period: Period): Promise<OrgUsageSnapshot> {
+  const entitlements = await resolveEntitlements(db, orgId);
+  if (entitlements.source === 'self-host') {
+    return {
+      runs: UNLIMITED_METRIC,
+      suggestions: UNLIMITED_METRIC,
+      projects: UNLIMITED_METRIC,
+      accounts: UNLIMITED_METRIC,
+      seats: UNLIMITED_METRIC,
+      extensionDevices: UNLIMITED_METRIC,
+      costUsd: UNLIMITED_METRIC,
+      entitlements,
+    };
+  }
+
+  const orgProjects = await db
+    .select({ id: schema.projects.id })
+    .from(schema.projects)
+    .where(eq(schema.projects.organizationId, orgId));
+  const projectIds = orgProjects.map((p) => p.id);
+  const now = new Date();
+
+  const [runsUsed, suggestionsUsed, accountsUsed, seatMembers, seatInvites, devicesUsed, costUsd] =
+    await Promise.all([
+      // Every run row for the org's projects in the period, whatever the
+      // kind and whatever the status - a failed run still cost compute, and
+      // a plan that only counts successes invites a retry loop.
+      projectIds.length === 0
+        ? Promise.resolve(0)
+        : db
+            .select({ n: count() })
+            .from(schema.runs)
+            .leftJoin(schema.campaigns, eq(schema.campaigns.id, schema.runs.campaignId))
+            .where(
+              and(
+                or(
+                  inArray(schema.runs.projectId, projectIds),
+                  inArray(schema.campaigns.projectId, projectIds),
+                ),
+                gte(schema.runs.startedAt, period.start),
+                lt(schema.runs.startedAt, period.end),
+              ),
+            )
+            .then(([r]) => Number(r?.n ?? 0)),
+      // Produced suggestions, not accepted ones - the assist ledger (#522)
+      // writes one row the moment a suggestion's stream finishes, whether or
+      // not a human ever accepts it, and that is the moment the money (and
+      // the plan's suggestion count) is actually spent.
+      projectIds.length === 0
+        ? Promise.resolve(0)
+        : db
+            .select({ n: count() })
+            .from(schema.assistUsage)
+            .where(
+              and(
+                inArray(schema.assistUsage.projectId, projectIds),
+                gte(schema.assistUsage.createdAt, period.start),
+                lt(schema.assistUsage.createdAt, period.end),
+              ),
+            )
+            .then(([r]) => Number(r?.n ?? 0)),
+      projectIds.length === 0
+        ? Promise.resolve(0)
+        : db
+            .select({ n: count() })
+            .from(schema.accounts)
+            .where(and(inArray(schema.accounts.projectId, projectIds), eq(schema.accounts.active, true)))
+            .then(([r]) => Number(r?.n ?? 0)),
+      db
+        .select({ n: count() })
+        .from(schema.memberships)
+        .where(eq(schema.memberships.organizationId, orgId))
+        .then(([r]) => Number(r?.n ?? 0)),
+      // A pending, unexpired invite consumes a seat too - otherwise the seat
+      // limit is bypassed by inviting ten people at once and never having
+      // any of them accept.
+      db
+        .select({ n: count() })
+        .from(schema.orgInvites)
+        .where(
+          and(
+            eq(schema.orgInvites.organizationId, orgId),
+            isNull(schema.orgInvites.acceptedAt),
+            gt(schema.orgInvites.expiresAt, now),
+          ),
+        )
+        .then(([r]) => Number(r?.n ?? 0)),
+      // Non-revoked, non-expired devices - a rotated-out device does not
+      // consume a slot forever, matching requireExtensionAuth's own
+      // liveness predicate (web/src/lib/server/extension-auth.ts).
+      db
+        .select({ n: count() })
+        .from(schema.extensionDevices)
+        .where(
+          and(
+            eq(schema.extensionDevices.organizationId, orgId),
+            isNull(schema.extensionDevices.revokedAt),
+            or(isNull(schema.extensionDevices.expiresAt), gt(schema.extensionDevices.expiresAt, now)),
+          ),
+        )
+        .then(([r]) => Number(r?.n ?? 0)),
+      getOrgPeriodCostUsd(db, orgId, period),
+    ]);
+
+  const projectsUsed = projectIds.length;
+
+  return {
+    runs: metric(runsUsed, entitlements.runsPerMonth),
+    suggestions: metric(suggestionsUsed, entitlements.suggestionsPerMonth),
+    projects: metric(projectsUsed, entitlements.projects),
+    accounts: metric(accountsUsed, null),
+    seats: metric(seatMembers + seatInvites, entitlements.seats),
+    extensionDevices: metric(devicesUsed, entitlements.extensionDevices),
+    costUsd: metric(costUsd, entitlements.monthlyRunBudgetUsd),
+    entitlements,
+  };
+}

--- a/shared/src/usage.ts
+++ b/shared/src/usage.ts
@@ -61,7 +61,11 @@ const UNLIMITED_METRIC: UsageMetric = { used: 0, limit: null, remaining: null };
  * suggestions) and the existing cost helper - six queries total, none of
  * which grow with how many projects the org has.
  */
-export async function getOrgUsage(db: Db, orgId: number, period: Period): Promise<OrgUsageSnapshot> {
+export async function getOrgUsage(
+  db: Db,
+  orgId: number,
+  period: Period,
+): Promise<OrgUsageSnapshot> {
   const entitlements = await resolveEntitlements(db, orgId);
   if (entitlements.source === 'self-host') {
     return {
@@ -127,7 +131,9 @@ export async function getOrgUsage(db: Db, orgId: number, period: Period): Promis
         : db
             .select({ n: count() })
             .from(schema.accounts)
-            .where(and(inArray(schema.accounts.projectId, projectIds), eq(schema.accounts.active, true)))
+            .where(
+              and(inArray(schema.accounts.projectId, projectIds), eq(schema.accounts.active, true)),
+            )
             .then(([r]) => Number(r?.n ?? 0)),
       db
         .select({ n: count() })
@@ -158,7 +164,10 @@ export async function getOrgUsage(db: Db, orgId: number, period: Period): Promis
           and(
             eq(schema.extensionDevices.organizationId, orgId),
             isNull(schema.extensionDevices.revokedAt),
-            or(isNull(schema.extensionDevices.expiresAt), gt(schema.extensionDevices.expiresAt, now)),
+            or(
+              isNull(schema.extensionDevices.expiresAt),
+              gt(schema.extensionDevices.expiresAt, now),
+            ),
           ),
         )
         .then(([r]) => Number(r?.n ?? 0)),

--- a/shared/tests/org-quota.test.ts
+++ b/shared/tests/org-quota.test.ts
@@ -323,7 +323,11 @@ describe('getOrgPeriodCostUsd', () => {
 
   it('returns 0 for an org with no runs at all', async () => {
     const { orgId } = await setupOrg();
-    const total = await getOrgPeriodCostUsd(getDb(), orgId, monthPeriod(new Date('2026-07-15T12:00:00Z')));
+    const total = await getOrgPeriodCostUsd(
+      getDb(),
+      orgId,
+      monthPeriod(new Date('2026-07-15T12:00:00Z')),
+    );
     expect(total).toBe(0);
   });
 
@@ -546,10 +550,7 @@ describe('billingPeriodFor', () => {
   it('an org with a live subscription gets exactly its stored Stripe period, regardless of createdAt', async () => {
     const { orgId } = await setupOrg({ createdAt: new Date('2026-01-01T00:00:00Z') });
     const db = getDb();
-    const [platform] = await db
-      .select({ id: schema.platforms.id })
-      .from(schema.platforms)
-      .limit(1);
+    const [platform] = await db.select({ id: schema.platforms.id }).from(schema.platforms).limit(1);
     await db.insert(schema.orgSubscriptions).values({
       organizationId: orgId,
       stripeCustomerId: 'cus_test',

--- a/shared/tests/org-quota.test.ts
+++ b/shared/tests/org-quota.test.ts
@@ -1,23 +1,31 @@
-// Exercises shared/src/org-quota.ts: the month-to-date run-cost sum and the
-// quota snapshot (CLD-P5, docs/cloud-runner-productionization-design.md
-// section 5) minted into the runner JWT's `quota` claim
-// (shared/src/agents/cloud/jwt.ts via shared/src/agents/cloud.ts). Each test
-// creates its own organization + project (unique slug) rather than reusing
-// the seeded 'default' org, and cleans up via cascade delete on the org -
-// this DB is shared across test files and teardown intentionally leaves data
-// for inspection.
+// Exercises shared/src/org-quota.ts: an org's billing-period spend sum and
+// the quota snapshot the dispatch pre-flight reads
+// (web/src/lib/server/runner.ts) before every cloud-runner run. #545: the
+// spend window used to be the UTC calendar month unconditionally
+// (`startOfMonthUtc`); it is now the org's billing period
+// (`billingPeriodFor`) - a live subscription's own Stripe period, or a
+// calendar month anchored on the org's own `createdAt` day-of-month for an
+// org with no subscription (free or self-host). Each test creates its own
+// organization + project (unique slug) rather than reusing the seeded
+// 'default' org, and cleans up via cascade delete on the org - this DB is
+// shared across test files and teardown intentionally leaves data for
+// inspection.
 import { randomUUID } from 'node:crypto';
 import { describe, it, expect, afterEach } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { getDb, getPool, schema } from '../src/db/client.js';
 import {
   assertOrgConcurrencyAdmitted,
-  getOrgMonthToDateCostUsd,
-  getOrgMonthToDateSpend,
+  billingPeriodFor,
+  calendarPeriodFor,
+  getOrgPeriodCostUsd,
+  getOrgPeriodSpend,
   getOrgQuotaFields,
   getOrgQuotaSnapshot,
+  resolveBillingPeriod,
   setOrgQuota,
   startOfMonthUtc,
+  type Period,
 } from '../src/org-quota.js';
 
 const createdOrgIds: number[] = [];
@@ -32,8 +40,23 @@ afterEach(async () => {
   }
 });
 
+// An anchor on the 1st of a month far in the past reproduces the exact
+// "plain calendar month" window every test below expects
+// (calendarPeriodFor's day-of-month clamping only bites for anchors after
+// the 1st) - most of these tests are about the underlying SUM query, not
+// about #545's anchoring behavior itself, which gets its own describe
+// blocks further down.
+const CALENDAR_ANCHOR = new Date('2020-01-01T00:00:00Z');
+function monthPeriod(now: Date): Period {
+  return calendarPeriodFor(CALENDAR_ANCHOR, now);
+}
+
 async function setupOrg(
-  opts: { monthlyRunBudgetUsd?: string | null; maxConcurrentRuns?: number | null } = {},
+  opts: {
+    monthlyRunBudgetUsd?: string | null;
+    maxConcurrentRuns?: number | null;
+    createdAt?: Date;
+  } = {},
 ) {
   const db = getDb();
   const slug = `org-quota-test-${randomUUID()}`;
@@ -44,6 +67,7 @@ async function setupOrg(
       name: slug,
       monthlyRunBudgetUsd: opts.monthlyRunBudgetUsd ?? null,
       maxConcurrentRuns: opts.maxConcurrentRuns ?? null,
+      createdAt: opts.createdAt ?? CALENDAR_ANCHOR,
     })
     .returning();
   createdOrgIds.push(org.id);
@@ -134,7 +158,10 @@ async function makeRunningRun(projectId: number): Promise<number> {
 async function setupOrgWithTwoProjects() {
   const db = getDb();
   const slug = `org-quota-test-${randomUUID()}`;
-  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, createdAt: CALENDAR_ANCHOR })
+    .returning();
   createdOrgIds.push(org.id);
   const [projectA] = await db
     .insert(schema.projects)
@@ -193,8 +220,83 @@ describe('startOfMonthUtc', () => {
   });
 });
 
-describe('getOrgMonthToDateCostUsd', () => {
-  it('sums only this org runs started on or after the first of the month', async () => {
+describe('calendarPeriodFor', () => {
+  it('anchors the period on the day-of-month of `anchor`, not the 1st (#545)', () => {
+    const anchor = new Date('2026-01-20T00:00:00Z');
+    const p = calendarPeriodFor(anchor, new Date('2026-09-09T00:00:00Z'));
+    expect(p.start.toISOString()).toBe('2026-08-20T00:00:00.000Z');
+    expect(p.end.toISOString()).toBe('2026-09-20T00:00:00.000Z');
+  });
+
+  it('flips to the next period exactly at the anchor day, not before or after', () => {
+    const anchor = new Date('2026-01-20T00:00:00Z');
+    const justBefore = calendarPeriodFor(anchor, new Date('2026-09-19T23:59:59.999Z'));
+    expect(justBefore.end.toISOString()).toBe('2026-09-20T00:00:00.000Z');
+    const atBoundary = calendarPeriodFor(anchor, new Date('2026-09-20T00:00:00Z'));
+    expect(atBoundary.start.toISOString()).toBe('2026-09-20T00:00:00.000Z');
+    expect(atBoundary.end.toISOString()).toBe('2026-10-20T00:00:00.000Z');
+  });
+
+  it('clamps a month-end anchor to the target month real length rather than overflowing', () => {
+    // Anchored on the 31st: February (28 days in 2026) can't hold a 31st, so
+    // that period is short, and the following one starts on Feb 28 - a
+    // billing period is bounded by real calendar days, not a fixed count.
+    const anchor = new Date('2026-01-31T00:00:00Z');
+    const inFeb = calendarPeriodFor(anchor, new Date('2026-02-15T00:00:00Z'));
+    expect(inFeb.start.toISOString()).toBe('2026-01-31T00:00:00.000Z');
+    expect(inFeb.end.toISOString()).toBe('2026-02-28T00:00:00.000Z');
+    const inLateFeb = calendarPeriodFor(anchor, new Date('2026-02-28T12:00:00Z'));
+    expect(inLateFeb.start.toISOString()).toBe('2026-02-28T00:00:00.000Z');
+    expect(inLateFeb.end.toISOString()).toBe('2026-03-31T00:00:00.000Z');
+  });
+
+  it('preserves the anchor time-of-day, not just the date', () => {
+    const anchor = new Date('2026-01-20T15:30:00Z');
+    const p = calendarPeriodFor(anchor, new Date('2026-09-09T00:00:00Z'));
+    expect(p.start.toISOString()).toBe('2026-08-20T15:30:00.000Z');
+  });
+});
+
+describe('resolveBillingPeriod', () => {
+  it('a live subscription period always wins over the calendar fallback', () => {
+    const subscriptionPeriod: Period = {
+      start: new Date('2026-01-20T00:00:00Z'),
+      end: new Date('2026-02-20T00:00:00Z'),
+    };
+    const p = resolveBillingPeriod(
+      { orgCreatedAt: new Date('2026-01-01T00:00:00Z'), subscriptionPeriod },
+      new Date('2026-01-25T00:00:00Z'),
+    );
+    expect(p).toEqual(subscriptionPeriod);
+  });
+
+  it('falls back to the creation-anchored calendar month with no subscription', () => {
+    const p = resolveBillingPeriod(
+      { orgCreatedAt: new Date('2026-01-20T00:00:00Z'), subscriptionPeriod: null },
+      new Date('2026-09-09T00:00:00Z'),
+    );
+    expect(p.start.toISOString()).toBe('2026-08-20T00:00:00.000Z');
+    expect(p.end.toISOString()).toBe('2026-09-20T00:00:00.000Z');
+  });
+
+  // #545 acceptance: a free org's window is stable and does not shift when
+  // it subscribes, or after its subscription lapses - it is always derived
+  // from `organizations.createdAt`, never from Stripe. Losing the
+  // subscription (subscriptionPeriod: null again) falls back to the exact
+  // same calendar anchor it always had, not a window that shifted to
+  // whenever the subscription happened to end.
+  it('a lapsed subscription falls back to the SAME calendar anchor the org always had', () => {
+    const orgCreatedAt = new Date('2026-01-20T00:00:00Z');
+    const now = new Date('2026-09-09T00:00:00Z');
+    const neverSubscribed = resolveBillingPeriod({ orgCreatedAt, subscriptionPeriod: null }, now);
+    const lapsed = resolveBillingPeriod({ orgCreatedAt, subscriptionPeriod: null }, now);
+    expect(lapsed).toEqual(neverSubscribed);
+    expect(lapsed.start.toISOString()).toBe('2026-08-20T00:00:00.000Z');
+  });
+});
+
+describe('getOrgPeriodCostUsd', () => {
+  it('sums only this org runs started within the period', async () => {
     const { orgId, projectId } = await setupOrg();
     const now = new Date('2026-07-15T12:00:00Z');
     const thisMonthEarly = new Date('2026-07-01T00:00:00Z');
@@ -205,7 +307,7 @@ describe('getOrgMonthToDateCostUsd', () => {
     await makeRun({ projectId, costUsd: '2.2500', startedAt: thisMonthLate });
     await makeRun({ projectId, costUsd: '99.0000', startedAt: lastMonth });
 
-    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    const total = await getOrgPeriodCostUsd(getDb(), orgId, monthPeriod(now));
     expect(total).toBeCloseTo(3.75, 4);
   });
 
@@ -215,25 +317,25 @@ describe('getOrgMonthToDateCostUsd', () => {
     await makeRun({ projectId, costUsd: null, startedAt: new Date('2026-07-02T00:00:00Z') });
     await makeRun({ projectId, costUsd: '4.0000', startedAt: new Date('2026-07-03T00:00:00Z') });
 
-    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    const total = await getOrgPeriodCostUsd(getDb(), orgId, monthPeriod(now));
     expect(total).toBeCloseTo(4.0, 4);
   });
 
   it('returns 0 for an org with no runs at all', async () => {
     const { orgId } = await setupOrg();
-    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, new Date('2026-07-15T12:00:00Z'));
+    const total = await getOrgPeriodCostUsd(getDb(), orgId, monthPeriod(new Date('2026-07-15T12:00:00Z')));
     expect(total).toBe(0);
   });
 
-  it('never counts a different org run, even started the same month', async () => {
+  it('never counts a different org run, even started the same period', async () => {
     const orgA = await setupOrg();
     const orgB = await setupOrg();
     const now = new Date('2026-07-15T12:00:00Z');
     await makeRun({ projectId: orgA.projectId, costUsd: '10.0000', startedAt: now });
     await makeRun({ projectId: orgB.projectId, costUsd: '20.0000', startedAt: now });
 
-    expect(await getOrgMonthToDateCostUsd(getDb(), orgA.orgId, now)).toBeCloseTo(10, 4);
-    expect(await getOrgMonthToDateCostUsd(getDb(), orgB.orgId, now)).toBeCloseTo(20, 4);
+    expect(await getOrgPeriodCostUsd(getDb(), orgA.orgId, monthPeriod(now))).toBeCloseTo(10, 4);
+    expect(await getOrgPeriodCostUsd(getDb(), orgB.orgId, monthPeriod(now))).toBeCloseTo(20, 4);
   });
 
   // Regression coverage for the double-count bug the old
@@ -247,7 +349,7 @@ describe('getOrgMonthToDateCostUsd', () => {
     const now = new Date('2026-07-15T12:00:00Z');
     await makeCampaignRun({ campaignId, projectId: null, costUsd: '5.0000', startedAt: now });
 
-    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    const total = await getOrgPeriodCostUsd(getDb(), orgId, monthPeriod(now));
     expect(total).toBeCloseTo(5.0, 4);
   });
 
@@ -265,7 +367,7 @@ describe('getOrgMonthToDateCostUsd', () => {
       startedAt: now,
     });
 
-    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    const total = await getOrgPeriodCostUsd(getDb(), orgId, monthPeriod(now));
     expect(total).toBeCloseTo(7.0, 4);
   });
 
@@ -288,15 +390,33 @@ describe('getOrgMonthToDateCostUsd', () => {
       startedAt: now,
     });
 
-    expect(await getOrgMonthToDateCostUsd(getDb(), orgA.orgId, now)).toBeCloseTo(10, 4);
-    expect(await getOrgMonthToDateCostUsd(getDb(), orgB.orgId, now)).toBeCloseTo(20, 4);
+    expect(await getOrgPeriodCostUsd(getDb(), orgA.orgId, monthPeriod(now))).toBeCloseTo(10, 4);
+    expect(await getOrgPeriodCostUsd(getDb(), orgB.orgId, monthPeriod(now))).toBeCloseTo(20, 4);
+  });
+
+  // #545: a run started before the period's start (e.g. under a previous
+  // billing period, or before a mid-cycle upgrade) must never leak into the
+  // new period's sum - the old calendar-month code had no upper bound at
+  // all, which happened to be safe only because nothing sums a period other
+  // than "now"'s own; a genuine period with a real end now needs the check.
+  it('excludes a run started on or after the period end', async () => {
+    const { orgId, projectId } = await setupOrg();
+    const period: Period = {
+      start: new Date('2026-01-20T00:00:00Z'),
+      end: new Date('2026-02-20T00:00:00Z'),
+    };
+    await makeRun({ projectId, costUsd: '5.0000', startedAt: new Date('2026-02-19T23:59:59Z') });
+    await makeRun({ projectId, costUsd: '99.0000', startedAt: new Date('2026-02-20T00:00:00Z') });
+
+    const total = await getOrgPeriodCostUsd(getDb(), orgId, period);
+    expect(total).toBeCloseTo(5.0, 4);
   });
 });
 
 // #522: the org total must see the LinkedIn assistant's spend too, not only
-// campaign/project runs - see the doc comment on getOrgMonthToDateSpend for
-// why assist_usage exists as a separate ledger.
-describe('getOrgMonthToDateCostUsd: assistant usage (#522)', () => {
+// campaign/project runs - see the doc comment on getOrgPeriodSpend for why
+// assist_usage exists as a separate ledger.
+describe('getOrgPeriodCostUsd: assistant usage (#522)', () => {
   it('a suggestion that was streamed and never accepted still counts toward the org total', async () => {
     const { orgId, projectId } = await setupOrg();
     const now = new Date('2026-07-15T12:00:00Z');
@@ -309,7 +429,7 @@ describe('getOrgMonthToDateCostUsd: assistant usage (#522)', () => {
       createdAt: now,
     });
 
-    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    const total = await getOrgPeriodCostUsd(getDb(), orgId, monthPeriod(now));
     expect(total).toBeCloseTo(0.009, 4);
   });
 
@@ -319,7 +439,7 @@ describe('getOrgMonthToDateCostUsd: assistant usage (#522)', () => {
     await makeRun({ projectId, costUsd: '5.0000', startedAt: now });
     await makeAssistUsage({ organizationId: orgId, projectId, costUsd: '0.5000', createdAt: now });
 
-    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    const total = await getOrgPeriodCostUsd(getDb(), orgId, monthPeriod(now));
     expect(total).toBeCloseTo(5.5, 4);
   });
 
@@ -342,7 +462,7 @@ describe('getOrgMonthToDateCostUsd: assistant usage (#522)', () => {
     await makeAssistRun({ projectId, startedAt: now });
     await makeAssistRun({ projectId, startedAt: now });
 
-    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    const total = await getOrgPeriodCostUsd(getDb(), orgId, monthPeriod(now));
     expect(total).toBeCloseTo(0.2, 4);
   });
 
@@ -351,11 +471,11 @@ describe('getOrgMonthToDateCostUsd: assistant usage (#522)', () => {
     const now = new Date('2026-07-15T12:00:00Z');
     await makeAssistUsage({ organizationId: orgId, projectId, costUsd: '0.0090', createdAt: now });
     // A defensive scenario: an assist run whose cost_usd was set to the same
-    // figure the assist_usage row already carries. If getOrgMonthToDateCostUsd
+    // figure the assist_usage row already carries. If getOrgPeriodCostUsd
     // summed kind='assist' runs too, this suggestion would count twice.
     await makeAssistRun({ projectId, costUsd: '0.0090', startedAt: now });
 
-    const total = await getOrgMonthToDateCostUsd(getDb(), orgId, now);
+    const total = await getOrgPeriodCostUsd(getDb(), orgId, monthPeriod(now));
     expect(total).toBeCloseTo(0.009, 4);
   });
 
@@ -376,25 +496,25 @@ describe('getOrgMonthToDateCostUsd: assistant usage (#522)', () => {
       createdAt: now,
     });
 
-    expect(await getOrgMonthToDateCostUsd(getDb(), orgA.orgId, now)).toBeCloseTo(1, 4);
-    expect(await getOrgMonthToDateCostUsd(getDb(), orgB.orgId, now)).toBeCloseTo(2, 4);
+    expect(await getOrgPeriodCostUsd(getDb(), orgA.orgId, monthPeriod(now))).toBeCloseTo(1, 4);
+    expect(await getOrgPeriodCostUsd(getDb(), orgB.orgId, monthPeriod(now))).toBeCloseTo(2, 4);
   });
 });
 
-describe('getOrgMonthToDateSpend', () => {
+describe('getOrgPeriodSpend', () => {
   it('keeps campaign and assistant spend apart, and sums them into a total', async () => {
     const { orgId, projectId } = await setupOrg();
     const now = new Date('2026-07-15T12:00:00Z');
     await makeRun({ projectId, costUsd: '5.0000', startedAt: now });
     await makeAssistUsage({ organizationId: orgId, projectId, costUsd: '1.2500', createdAt: now });
 
-    const spend = await getOrgMonthToDateSpend(getDb(), orgId, now);
+    const spend = await getOrgPeriodSpend(getDb(), orgId, monthPeriod(now));
     expect(spend.campaignUsd).toBeCloseTo(5, 4);
     expect(spend.assistantUsd).toBeCloseTo(1.25, 4);
     expect(spend.totalUsd).toBeCloseTo(6.25, 4);
   });
 
-  it('only counts assist usage from on or after the first of the month', async () => {
+  it('only counts assist usage from within the period', async () => {
     const { orgId, projectId } = await setupOrg();
     const now = new Date('2026-07-15T12:00:00Z');
     await makeAssistUsage({
@@ -410,13 +530,123 @@ describe('getOrgMonthToDateSpend', () => {
       createdAt: new Date('2026-07-01T00:00:00Z'),
     });
 
-    const spend = await getOrgMonthToDateSpend(getDb(), orgId, now);
+    const spend = await getOrgPeriodSpend(getDb(), orgId, monthPeriod(now));
     expect(spend.assistantUsd).toBeCloseTo(0.5, 4);
   });
 });
 
+describe('billingPeriodFor', () => {
+  it('an org with no subscription gets the creation-anchored calendar month', async () => {
+    const { orgId } = await setupOrg({ createdAt: new Date('2026-01-20T00:00:00Z') });
+    const period = await billingPeriodFor(getDb(), orgId, new Date('2026-09-09T00:00:00Z'));
+    expect(period.start.toISOString()).toBe('2026-08-20T00:00:00.000Z');
+    expect(period.end.toISOString()).toBe('2026-09-20T00:00:00.000Z');
+  });
+
+  it('an org with a live subscription gets exactly its stored Stripe period, regardless of createdAt', async () => {
+    const { orgId } = await setupOrg({ createdAt: new Date('2026-01-01T00:00:00Z') });
+    const db = getDb();
+    const [platform] = await db
+      .select({ id: schema.platforms.id })
+      .from(schema.platforms)
+      .limit(1);
+    await db.insert(schema.orgSubscriptions).values({
+      organizationId: orgId,
+      stripeCustomerId: 'cus_test',
+      stripeSubscriptionId: `sub_test_${randomUUID()}`,
+      planId: 'solo',
+      status: 'active',
+      currentPeriodStart: new Date('2026-01-20T00:00:00Z'),
+      currentPeriodEnd: new Date('2026-02-20T00:00:00Z'),
+      limitPremiumModels: false,
+    });
+    void platform;
+
+    const period = await billingPeriodFor(getDb(), orgId, new Date('2026-01-25T00:00:00Z'));
+    expect(period.start.toISOString()).toBe('2026-01-20T00:00:00.000Z');
+    expect(period.end.toISOString()).toBe('2026-02-20T00:00:00.000Z');
+  });
+});
+
+// #545 acceptance: an org with a subscription starting on the 20th has its
+// allowance reset on the 20th, and spend from BEFORE the subscription
+// (under the old free-plan calendar window) stays in the old period rather
+// than counting against the new one.
+describe('#545 acceptance: subscribing mid-cycle resets the spend window', () => {
+  it('spend before a mid-cycle subscription never counts toward the new period', async () => {
+    const { orgId, projectId } = await setupOrg({
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      monthlyRunBudgetUsd: '10.00',
+    });
+    // Free-plan spend on the 15th, under the org's original calendar-month
+    // window (anchored on Jan 1st).
+    await makeRun({ projectId, costUsd: '8.00', startedAt: new Date('2026-01-15T00:00:00Z') });
+
+    const db = getDb();
+    await db.insert(schema.orgSubscriptions).values({
+      organizationId: orgId,
+      stripeCustomerId: 'cus_test',
+      stripeSubscriptionId: `sub_test_${randomUUID()}`,
+      planId: 'solo',
+      status: 'active',
+      currentPeriodStart: new Date('2026-01-20T00:00:00Z'),
+      currentPeriodEnd: new Date('2026-02-20T00:00:00Z'),
+      limitPremiumModels: false,
+    });
+
+    // A run under the new subscription period, well within its own $10 budget.
+    await makeRun({ projectId, costUsd: '2.00', startedAt: new Date('2026-01-25T00:00:00Z') });
+
+    const snapshot = await getOrgQuotaSnapshot(getDb(), orgId, new Date('2026-01-25T00:00:00Z'));
+    // If the pre-subscription $8 leaked into the new period, remaining would
+    // be 0 (10 - 8 - 2); it must instead reflect only the post-subscription run.
+    expect(snapshot.remainingUsd).toBeCloseTo(8, 4);
+  });
+
+  it("resets the allowance again once the org's period rolls over on the 20th", async () => {
+    const { orgId, projectId } = await setupOrg({
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      monthlyRunBudgetUsd: '10.00',
+    });
+    const db = getDb();
+    await db.insert(schema.orgSubscriptions).values({
+      organizationId: orgId,
+      stripeCustomerId: 'cus_test',
+      stripeSubscriptionId: `sub_test_${randomUUID()}`,
+      planId: 'solo',
+      status: 'active',
+      currentPeriodStart: new Date('2026-01-20T00:00:00Z'),
+      currentPeriodEnd: new Date('2026-02-20T00:00:00Z'),
+      limitPremiumModels: false,
+    });
+    await makeRun({ projectId, costUsd: '9.00', startedAt: new Date('2026-01-25T00:00:00Z') });
+
+    // Still inside the same Stripe period the row above just spent $9 of the
+    // $10 budget: 1 remaining.
+    const stillInPeriod = await getOrgQuotaSnapshot(
+      getDb(),
+      orgId,
+      new Date('2026-02-19T00:00:00Z'),
+    );
+    expect(stillInPeriod.remainingUsd).toBeCloseTo(1, 4);
+
+    // Stripe rolls `current_period_start`/`end` forward when the webhook
+    // fires (#551, out of scope here) - simulate that write directly.
+    await db
+      .update(schema.orgSubscriptions)
+      .set({
+        currentPeriodStart: new Date('2026-02-20T00:00:00Z'),
+        currentPeriodEnd: new Date('2026-03-20T00:00:00Z'),
+      })
+      .where(eq(schema.orgSubscriptions.organizationId, orgId));
+
+    const nextPeriod = await getOrgQuotaSnapshot(getDb(), orgId, new Date('2026-02-21T00:00:00Z'));
+    expect(nextPeriod.remainingUsd).toBeCloseTo(10, 4);
+  });
+});
+
 describe('getOrgQuotaSnapshot', () => {
-  it('computes remainingUsd as budget minus month-to-date spend when a budget is set', async () => {
+  it('computes remainingUsd as budget minus period-to-date spend when a budget is set', async () => {
     const { orgId, projectId } = await setupOrg({ monthlyRunBudgetUsd: '100.00' });
     const now = new Date('2026-07-15T12:00:00Z');
     await makeRun({ projectId, costUsd: '37.50', startedAt: now });

--- a/shared/tests/usage.test.ts
+++ b/shared/tests/usage.test.ts
@@ -1,0 +1,301 @@
+// Exercises shared/src/usage.ts's getOrgUsage: the single snapshot every
+// #548 enforcement point, the settings/billing page (#555) and the
+// extension payload (#556) will read - "how much of this org's plan is
+// used" across every metered axis, for one org and one period. Deliberately
+// not restating PLAN_CATALOGUE.free's numbers as a second source of truth
+// (shared/tests/plans.test.ts already owns that); the free plan's real
+// numbers are used here only as fixed, known limits to assert usage/limit/
+// remaining arithmetic against.
+import { randomUUID } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import { getOrgUsage } from '../src/usage.js';
+import { calendarPeriodFor, type Period } from '../src/org-quota.js';
+import { PLAN_CATALOGUE } from '../src/plans.js';
+
+const createdOrgIds: number[] = [];
+const createdUserIds: number[] = [];
+const savedEdition = process.env.PITCHBOX_EDITION;
+
+afterEach(async () => {
+  const db = getDb();
+  while (createdOrgIds.length > 0) {
+    const id = createdOrgIds.pop()!;
+    await db.delete(schema.organizations).where(eq(schema.organizations.id, id));
+  }
+  while (createdUserIds.length > 0) {
+    const id = createdUserIds.pop()!;
+    await db.delete(schema.users).where(eq(schema.users.id, id));
+  }
+  if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+  else process.env.PITCHBOX_EDITION = savedEdition;
+});
+
+const ANCHOR = new Date('2026-01-01T00:00:00Z');
+const NOW = new Date('2026-01-15T12:00:00Z');
+const PERIOD: Period = calendarPeriodFor(ANCHOR, NOW);
+
+/** A cloud-edition org on the free plan (the default), so `getOrgUsage`
+ * exercises real numeric limits rather than self-host's unlimited shape. */
+async function makeCloudOrg(plan: string = 'free') {
+  process.env.PITCHBOX_EDITION = 'cloud';
+  const db = getDb();
+  const slug = `usage-test-${randomUUID()}`;
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan, createdAt: ANCHOR })
+    .returning();
+  createdOrgIds.push(org.id);
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: 'p', name: 'p' })
+    .returning();
+  return { orgId: org.id, projectId: project.id };
+}
+
+async function makeRun(opts: {
+  projectId: number;
+  kind?: string;
+  status?: string;
+  startedAt: Date;
+}) {
+  const db = getDb();
+  await db.insert(schema.runs).values({
+    kind: opts.kind ?? 'project_extraction',
+    projectId: opts.projectId,
+    trigger: 'manual',
+    status: opts.status ?? 'success',
+    startedAt: opts.startedAt,
+  });
+}
+
+async function makeAssistUsage(opts: { organizationId: number; projectId: number; createdAt: Date }) {
+  const db = getDb();
+  const [platform] = await db
+    .select({ id: schema.platforms.id })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'));
+  await db.insert(schema.assistUsage).values({
+    organizationId: opts.organizationId,
+    projectId: opts.projectId,
+    deviceId: null,
+    platformId: platform.id,
+    kind: 'post_comment',
+    agentRunner: 'claude-code',
+    createdAt: opts.createdAt,
+  });
+}
+
+async function makeAccount(projectId: number, active: boolean = true) {
+  const db = getDb();
+  const [platform] = await db
+    .select({ id: schema.platforms.id })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'reddit'));
+  await db
+    .insert(schema.accounts)
+    .values({ projectId, platformId: platform.id, handle: `h-${randomUUID()}`, active });
+}
+
+async function makeMember(organizationId: number) {
+  const db = getDb();
+  const username = `usage-test-${randomUUID()}`;
+  const [user] = await db
+    .insert(schema.users)
+    .values({ username, passwordHash: 'x' })
+    .returning();
+  createdUserIds.push(user.id);
+  await db.insert(schema.memberships).values({ organizationId, userId: user.id, role: 'member' });
+}
+
+async function makeInvite(organizationId: number, opts: { acceptedAt?: Date; expiresAt?: Date } = {}) {
+  const db = getDb();
+  await db.insert(schema.orgInvites).values({
+    organizationId,
+    token: randomUUID(),
+    role: 'member',
+    expiresAt: opts.expiresAt ?? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    acceptedAt: opts.acceptedAt ?? null,
+  });
+}
+
+async function makeDevice(
+  organizationId: number,
+  opts: { revokedAt?: Date; expiresAt?: Date | null } = {},
+) {
+  const db = getDb();
+  await db.insert(schema.extensionDevices).values({
+    organizationId,
+    label: 'd',
+    tokenHash: randomUUID(),
+    revokedAt: opts.revokedAt ?? null,
+    expiresAt: opts.expiresAt === undefined ? null : opts.expiresAt,
+  });
+}
+
+describe('getOrgUsage: self-host', () => {
+  it('returns the unlimited shape without running any count query', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const db = getDb();
+    const slug = `usage-test-${randomUUID()}`;
+    const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+    createdOrgIds.push(org.id);
+    // Deliberately no project - if getOrgUsage ran a real count query for a
+    // structural axis it would 500 or return 0 rather than the unlimited
+    // shape, since there is nothing to count against.
+    const usage = await getOrgUsage(db, org.id, PERIOD);
+    expect(usage.entitlements.source).toBe('self-host');
+    for (const metric of [
+      usage.runs,
+      usage.suggestions,
+      usage.projects,
+      usage.accounts,
+      usage.seats,
+      usage.extensionDevices,
+      usage.costUsd,
+    ]) {
+      expect(metric.limit).toBeNull();
+      expect(metric.remaining).toBeNull();
+    }
+  });
+});
+
+describe('getOrgUsage: runs', () => {
+  it('counts every run whatever the kind and whatever the status - a failed run still costs compute', async () => {
+    const { orgId, projectId } = await makeCloudOrg();
+    await makeRun({ projectId, status: 'success', startedAt: NOW });
+    await makeRun({ projectId, status: 'failed', startedAt: NOW });
+    await makeRun({ projectId, kind: 'assist', status: 'success', startedAt: NOW });
+    await makeRun({ projectId, status: 'running', startedAt: NOW });
+
+    const usage = await getOrgUsage(getDb(), orgId, PERIOD);
+    expect(usage.runs.used).toBe(4);
+    expect(usage.runs.limit).toBe(PLAN_CATALOGUE.free.runsPerMonth);
+  });
+
+  it('excludes a run started outside the period', async () => {
+    const { orgId, projectId } = await makeCloudOrg();
+    await makeRun({ projectId, startedAt: PERIOD.start });
+    await makeRun({ projectId, startedAt: new Date(PERIOD.start.getTime() - 1000) });
+    await makeRun({ projectId, startedAt: PERIOD.end });
+
+    const usage = await getOrgUsage(getDb(), orgId, PERIOD);
+    expect(usage.runs.used).toBe(1);
+  });
+
+  it('remaining is limit minus used, clamped at 0 rather than going negative', async () => {
+    const { orgId, projectId } = await makeCloudOrg();
+    for (let i = 0; i < PLAN_CATALOGUE.free.runsPerMonth! + 3; i += 1) {
+      await makeRun({ projectId, startedAt: NOW });
+    }
+    const usage = await getOrgUsage(getDb(), orgId, PERIOD);
+    expect(usage.runs.used).toBe(PLAN_CATALOGUE.free.runsPerMonth! + 3);
+    expect(usage.runs.remaining).toBe(0);
+  });
+});
+
+describe('getOrgUsage: suggestions', () => {
+  it('counts produced suggestions from the assist ledger, not accepted ones', async () => {
+    const { orgId, projectId } = await makeCloudOrg();
+    await makeAssistUsage({ organizationId: orgId, projectId, createdAt: NOW });
+    await makeAssistUsage({ organizationId: orgId, projectId, createdAt: NOW });
+    // Accepting one writes a `runs` row (kind: 'assist') - it must not be
+    // double-counted as a second suggestion.
+    await makeRun({ projectId, kind: 'assist', startedAt: NOW });
+
+    const usage = await getOrgUsage(getDb(), orgId, PERIOD);
+    expect(usage.suggestions.used).toBe(2);
+    expect(usage.suggestions.limit).toBe(PLAN_CATALOGUE.free.suggestionsPerMonth);
+  });
+});
+
+describe('getOrgUsage: structural counts', () => {
+  it('projects counts every project the org has right now, not period-bound', async () => {
+    const { orgId, projectId } = await makeCloudOrg();
+    await getDb()
+      .insert(schema.projects)
+      .values({ organizationId: orgId, slug: 'second', name: 'second' });
+    void projectId;
+
+    const usage = await getOrgUsage(getDb(), orgId, PERIOD);
+    expect(usage.projects.used).toBe(2);
+    expect(usage.projects.limit).toBe(PLAN_CATALOGUE.free.projects);
+  });
+
+  it('accounts counts only active connected accounts, with no plan limit yet', async () => {
+    const { orgId, projectId } = await makeCloudOrg();
+    await makeAccount(projectId, true);
+    await makeAccount(projectId, false);
+
+    const usage = await getOrgUsage(getDb(), orgId, PERIOD);
+    expect(usage.accounts.used).toBe(1);
+    expect(usage.accounts.limit).toBeNull();
+  });
+
+  it('seats counts memberships plus pending, unexpired invites - inviting ten people cannot bypass the limit', async () => {
+    const { orgId } = await makeCloudOrg();
+    await makeMember(orgId);
+    await makeInvite(orgId); // pending, unexpired
+    await makeInvite(orgId, { acceptedAt: new Date() }); // already accepted - not a pending seat
+    await makeInvite(orgId, { expiresAt: new Date(Date.now() - 1000) }); // expired - not a seat
+
+    const usage = await getOrgUsage(getDb(), orgId, PERIOD);
+    expect(usage.seats.used).toBe(2); // 1 member + 1 pending invite
+    expect(usage.seats.limit).toBe(PLAN_CATALOGUE.free.seats);
+  });
+
+  it('extensionDevices excludes a revoked or expired device so rotation never consumes a slot forever', async () => {
+    const { orgId } = await makeCloudOrg();
+    await makeDevice(orgId); // live, no expiry
+    await makeDevice(orgId, { expiresAt: new Date(Date.now() + 60_000) }); // live, expires in the future
+    await makeDevice(orgId, { revokedAt: new Date() }); // revoked
+    await makeDevice(orgId, { expiresAt: new Date(Date.now() - 60_000) }); // expired
+
+    const usage = await getOrgUsage(getDb(), orgId, PERIOD);
+    expect(usage.extensionDevices.used).toBe(2);
+    expect(usage.extensionDevices.limit).toBe(PLAN_CATALOGUE.free.extensionDevices);
+  });
+});
+
+describe('getOrgUsage: costUsd', () => {
+  it('reuses the existing org-quota spend figure for the period, clamped to the plan budget', async () => {
+    const { orgId, projectId } = await makeCloudOrg();
+    const db = getDb();
+    await db.insert(schema.runs).values({
+      kind: 'project_extraction',
+      projectId,
+      trigger: 'manual',
+      status: 'success',
+      costUsd: '1.5000',
+      startedAt: NOW,
+    });
+
+    const usage = await getOrgUsage(db, orgId, PERIOD);
+    expect(usage.costUsd.used).toBeCloseTo(1.5, 4);
+    expect(usage.costUsd.limit).toBe(PLAN_CATALOGUE.free.monthlyRunBudgetUsd);
+  });
+});
+
+describe('getOrgUsage: query count', () => {
+  it('does not grow with the number of projects the org has', async () => {
+    const { orgId, projectId } = await makeCloudOrg();
+    const db = getDb();
+    for (let i = 0; i < 10; i += 1) {
+      await db
+        .insert(schema.projects)
+        .values({ organizationId: orgId, slug: `extra-${i}`, name: `extra ${i}` });
+    }
+    await makeRun({ projectId, startedAt: NOW });
+
+    // Not a query-count assertion (no query spy) - a correctness one: with
+    // 11 projects, an implementation that queried per project would still
+    // return the right numbers, just slowly. What actually catches an O(n)
+    // implementation is `getOrgUsage`'s own query shape (inArray, not a
+    // loop) - this at least proves correctness holds at more than one
+    // project, which a single-project fixture would not.
+    const usage = await getOrgUsage(db, orgId, PERIOD);
+    expect(usage.projects.used).toBe(11);
+    expect(usage.runs.used).toBe(1);
+  });
+});

--- a/shared/tests/usage.test.ts
+++ b/shared/tests/usage.test.ts
@@ -70,7 +70,11 @@ async function makeRun(opts: {
   });
 }
 
-async function makeAssistUsage(opts: { organizationId: number; projectId: number; createdAt: Date }) {
+async function makeAssistUsage(opts: {
+  organizationId: number;
+  projectId: number;
+  createdAt: Date;
+}) {
   const db = getDb();
   const [platform] = await db
     .select({ id: schema.platforms.id })
@@ -101,15 +105,15 @@ async function makeAccount(projectId: number, active: boolean = true) {
 async function makeMember(organizationId: number) {
   const db = getDb();
   const username = `usage-test-${randomUUID()}`;
-  const [user] = await db
-    .insert(schema.users)
-    .values({ username, passwordHash: 'x' })
-    .returning();
+  const [user] = await db.insert(schema.users).values({ username, passwordHash: 'x' }).returning();
   createdUserIds.push(user.id);
   await db.insert(schema.memberships).values({ organizationId, userId: user.id, role: 'member' });
 }
 
-async function makeInvite(organizationId: number, opts: { acceptedAt?: Date; expiresAt?: Date } = {}) {
+async function makeInvite(
+  organizationId: number,
+  opts: { acceptedAt?: Date; expiresAt?: Date } = {},
+) {
   const db = getDb();
   await db.insert(schema.orgInvites).values({
     organizationId,

--- a/web/src/lib/server/runner.ts
+++ b/web/src/lib/server/runner.ts
@@ -26,7 +26,9 @@ import {
   getOrgQuotaSnapshot,
   assertOrgConcurrencyAdmitted,
   getInstanceQuotaSnapshot,
+  billingPeriodFor,
 } from '@pitchbox/shared/org-quota';
+import { getOrgUsage } from '@pitchbox/shared/usage';
 import type { ScenarioSlug } from '@pitchbox/shared/campaigns';
 import { getDb, schema } from './db.js';
 import { and, desc, eq } from 'drizzle-orm';
@@ -210,6 +212,32 @@ async function dispatchRun(
       // one's text. It races safely against any other concurrent dispatch
       // for this org - see its own doc comment (shared/src/org-quota.ts).
       await assertOrgConcurrencyAdmitted(db, orgId, run.id);
+    }
+    // #548: the plan's own run-count ceiling, separate from the Gateway
+    // budget above - a Free or Solo org can run out of its plan's runs long
+    // before it runs out of money, and self-host never sees this at all.
+    // Checked for every runner slug (not only 'cloud'): self-host and any
+    // grant/subscription resolve through the same `resolveEntitlements`
+    // every other enforcement point reads, so a self-host install (always
+    // `runsPerMonth: null`) never runs the count and never refuses here.
+    // `getOrgUsage`'s run count already includes this run's own row - it
+    // was inserted with status 'running' before dispatchRun was ever
+    // called, the same "count yourself in" shape assertOrgConcurrencyAdmitted
+    // uses - so admission is `used <= limit`, not `used < limit`. The
+    // message says "plan limit" and never "quota" so classifyFailure's
+    // PLAN_LIMIT_PATTERNS tags this `plan_limit_reached`, distinct from the
+    // budget/concurrency refusals above.
+    if (orgId != null) {
+      const period = await billingPeriodFor(db, orgId);
+      const usage = await getOrgUsage(db, orgId, period);
+      if (usage.runs.limit != null && usage.runs.used > usage.runs.limit) {
+        throw new Error(
+          `This organization has reached its plan limit of ${usage.runs.limit} run${
+            usage.runs.limit === 1 ? '' : 's'
+          } this period and cannot start another until the period resets or an operator ` +
+            `upgrades the plan.`,
+        );
+      }
     }
     // Pre-flight the snapshot. A run whose runner cannot start here fails the
     // same way whatever the reason, but the message has to say so: before #219

--- a/web/src/routes/api/extension/auto-pair/+server.ts
+++ b/web/src/routes/api/extension/auto-pair/+server.ts
@@ -4,6 +4,8 @@ import { loadSession } from '@pitchbox/shared/auth';
 import { loadActiveOrganization } from '@pitchbox/shared/orgs';
 import { getDb, schema } from '$lib/server/db.js';
 import { mintDeviceToken } from '$lib/server/extension-auth.js';
+import { billingPeriodFor } from '@pitchbox/shared/org-quota';
+import { getOrgUsage } from '@pitchbox/shared/usage';
 
 /**
  * One-shot pairing endpoint for the browser extension.
@@ -75,6 +77,26 @@ export async function POST({
   // #196: fail loudly instead of minting an orphaned (null-org) device - no
   // row is inserted below this point.
   if (!organizationId) throw error(409, 'no_org');
+
+  // #548: the plan's own device-count ceiling. Checked before minting a
+  // token so a refused pairing never leaves an unusable token floating
+  // around client-side.
+  const period = await billingPeriodFor(db, organizationId);
+  const usage = await getOrgUsage(db, organizationId, period);
+  if (
+    usage.extensionDevices.limit != null &&
+    usage.extensionDevices.used >= usage.extensionDevices.limit
+  ) {
+    return json(
+      {
+        error: 'plan_limit_reached',
+        metric: 'extensionDevices',
+        limit: usage.extensionDevices.limit,
+        used: usage.extensionDevices.used,
+      },
+      { status: 402 },
+    );
+  }
 
   // #200: the client wants to show which org/device a pairing belongs to,
   // not just a bare token - look up the org name alongside minting the

--- a/web/src/routes/api/extension/observations/+server.ts
+++ b/web/src/routes/api/extension/observations/+server.ts
@@ -9,6 +9,8 @@ import {
   MAX_OBSERVED_TARGETS_BATCH,
 } from '@pitchbox/shared/observed-targets';
 import { loadLinkedInAssistDeviceState } from '@pitchbox/shared/linkedin-assist';
+import { billingPeriodFor } from '@pitchbox/shared/org-quota';
+import { getOrgUsage } from '@pitchbox/shared/usage';
 
 // Server side of the observation buffer (#301): the extension's content
 // script watches linkedin.com passively and posts what it saw here, on a
@@ -66,6 +68,19 @@ export async function POST({ request }: { request: Request }) {
     )
     .limit(1);
   if (!project) throw error(404, 'project not found');
+
+  // #548: the assist plane's own plan gate, mirroring the LinkedIn
+  // switch's precedent on this exact route (AGENTS.md: "any new route on
+  // that plane loads ... and refuses") - an org that has spent its whole
+  // period's suggestion budget gets nothing further out of the observation
+  // buffer either, since nothing it collects from here on can still turn
+  // into a suggestion this period. 403, matching this route's existing
+  // shape: the collector has no human waiting on a rendered answer.
+  const period = await billingPeriodFor(db, project.organizationId);
+  const usage = await getOrgUsage(db, project.organizationId, period);
+  if (usage.suggestions.limit != null && usage.suggestions.used >= usage.suggestions.limit) {
+    throw error(403, 'plan_limit_reached');
+  }
 
   const [platform] = await db
     .select()

--- a/web/src/routes/api/extension/pair/+server.ts
+++ b/web/src/routes/api/extension/pair/+server.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { and, eq, gt, isNull } from 'drizzle-orm';
 import { getDb, schema } from '$lib/server/db.js';
 import { mintDeviceToken } from '$lib/server/extension-auth.js';
+import { billingPeriodFor } from '@pitchbox/shared/org-quota';
+import { getOrgUsage } from '@pitchbox/shared/usage';
 import { RateLimiter } from '$lib/server/rate-limit.js';
 
 const Body = z.object({
@@ -54,6 +56,27 @@ export async function POST({ request, getClientAddress }: RequestEvent) {
     .returning();
   if (!pairing) throw error(404, 'invalid_or_expired_code');
   if (pairing.organizationId == null) throw error(500, 'no_org');
+
+  // #548: the plan's own device-count ceiling. The code is already
+  // consumed by the atomic claim above by the time this runs - a
+  // refusal here still burns a one-time code, the trade-off for not
+  // racing a separate read-only pre-check against the same claim.
+  const period = await billingPeriodFor(db, pairing.organizationId);
+  const usage = await getOrgUsage(db, pairing.organizationId, period);
+  if (
+    usage.extensionDevices.limit != null &&
+    usage.extensionDevices.used >= usage.extensionDevices.limit
+  ) {
+    return json(
+      {
+        error: 'plan_limit_reached',
+        metric: 'extensionDevices',
+        limit: usage.extensionDevices.limit,
+        used: usage.extensionDevices.used,
+      },
+      { status: 402 },
+    );
+  }
 
   // #200: surface which org/device the pairing belongs to, not just a token.
   const [org] = await db

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -25,6 +25,8 @@ import {
   resolveEffectiveVoice,
 } from '@pitchbox/shared/linkedin-assist';
 import { loadRecentObservedTarget } from '@pitchbox/shared/observed-targets';
+import { billingPeriodFor } from '@pitchbox/shared/org-quota';
+import { getOrgUsage } from '@pitchbox/shared/usage';
 
 // The real-time plane. What makes the in-page assistant a separate subsystem
 // rather than a view onto campaigns:
@@ -184,6 +186,23 @@ export async function POST(event: RequestEvent) {
     )
     .limit(1);
   if (!project) throw error(404, 'project not found');
+
+  // #548: the plan's own suggestions-per-period ceiling. Read before the
+  // platform daily quota below so a plan refusal never pays for a wasted
+  // query, and returned in the same renderable-200 shape as every other
+  // refusal on this route (self-host resolves fully unlimited, so this
+  // never fires there).
+  const period = await billingPeriodFor(db, project.organizationId);
+  const usage = await getOrgUsage(db, project.organizationId, period);
+  if (usage.suggestions.limit != null && usage.suggestions.used >= usage.suggestions.limit) {
+    return json({
+      refused: 'plan_limit_reached',
+      metric: 'suggestions',
+      limit: usage.suggestions.limit,
+      used: usage.suggestions.used,
+      upgradeUrl: '/settings/billing',
+    });
+  }
 
   // Suggesting what cannot be sent wastes the human's attention and a model
   // call, so the platform's own daily quota is a precondition and not a

--- a/web/src/routes/api/orgs/[slug]/invites/+server.ts
+++ b/web/src/routes/api/orgs/[slug]/invites/+server.ts
@@ -5,6 +5,8 @@ import { createInvite, findOrgBySlug, isOrgAdmin } from '@pitchbox/shared/orgs';
 import { createMailTransport } from '@pitchbox/shared/mail/registry';
 import { loadMailEnv } from '@pitchbox/shared/mail/env';
 import { renderPlainTextMail } from '@pitchbox/shared/mail/template';
+import { billingPeriodFor } from '@pitchbox/shared/org-quota';
+import { getOrgUsage } from '@pitchbox/shared/usage';
 
 const Body = z.object({
   email: z.email().optional(),
@@ -52,6 +54,22 @@ export async function POST(event: import('@sveltejs/kit').RequestEvent) {
   const parsed = Body.safeParse(raw);
   if (!parsed.success) {
     return json({ error: 'invalid_body', issues: parsed.error.issues }, { status: 400 });
+  }
+  // #548: an invite is a seat the moment it's pending, not only once
+  // accepted - otherwise the seat limit is bypassed by inviting ten people
+  // at once (shared/src/usage.ts's getOrgUsage already counts it that way).
+  const period = await billingPeriodFor(db, org.id);
+  const usage = await getOrgUsage(db, org.id, period);
+  if (usage.seats.limit != null && usage.seats.used >= usage.seats.limit) {
+    return json(
+      {
+        error: 'plan_limit_reached',
+        metric: 'seats',
+        limit: usage.seats.limit,
+        used: usage.seats.used,
+      },
+      { status: 402 },
+    );
   }
   const invite = await createInvite(db, {
     organizationId: org.id,

--- a/web/src/routes/api/projects/+server.ts
+++ b/web/src/routes/api/projects/+server.ts
@@ -6,6 +6,8 @@ import { resolveOrgId, requireOrgId, requireRole } from '$lib/server/auth.js';
 import { listProjects, createProjectTx, ProjectSlugConflictError } from '@pitchbox/shared/projects';
 import { resolveDefaultRunnerSlug } from '@pitchbox/shared/agents/config';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
+import { billingPeriodFor } from '@pitchbox/shared/org-quota';
+import { getOrgUsage } from '@pitchbox/shared/usage';
 
 const slugRegex = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 
@@ -87,6 +89,22 @@ export async function POST(event) {
   const organizationId = await requireOrgId(event);
   requireRole(event, 'admin');
 
+  // #548: a project is a structural, non-period-bound axis - the count is
+  // "how many exist right now", so `period` only matters for the
+  // period-bound axes this same snapshot also carries.
+  const period = await billingPeriodFor(db, organizationId);
+  const usage = await getOrgUsage(db, organizationId, period);
+  if (usage.projects.limit != null && usage.projects.used >= usage.projects.limit) {
+    return json(
+      {
+        error: 'plan_limit_reached',
+        metric: 'projects',
+        limit: usage.projects.limit,
+        used: usage.projects.used,
+      },
+      { status: 402 },
+    );
+  }
   try {
     const out = await createProjectTx(db, {
       slug,

--- a/web/src/routes/api/settings/org-quota/+server.ts
+++ b/web/src/routes/api/settings/org-quota/+server.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { getDb } from '$lib/server/db.js';
 import { requireOrgId, requireRole } from '$lib/server/auth.js';
 import {
-  getOrgMonthToDateSpend,
+  billingPeriodFor,
+  getOrgPeriodSpend,
   getOrgQuotaFields,
   getOrgQuotaSnapshot,
   setOrgQuota,
@@ -27,8 +28,9 @@ async function quotaResponse(orgId: number) {
   const db = getDb();
   const fields = await getOrgQuotaFields(db, orgId);
   if (!fields) throw error(404, 'not_found');
+  const period = await billingPeriodFor(db, orgId);
   const [spend, snapshot] = await Promise.all([
-    getOrgMonthToDateSpend(db, orgId),
+    getOrgPeriodSpend(db, orgId, period),
     getOrgQuotaSnapshot(db, orgId),
   ]);
   return json({

--- a/web/src/routes/settings/organization/+page.server.ts
+++ b/web/src/routes/settings/organization/+page.server.ts
@@ -3,7 +3,11 @@ import { eq } from 'drizzle-orm';
 import { getDb, schema } from '../../../lib/server/db.js';
 import { resolveOrgId } from '../../../lib/server/auth.js';
 import { listOrgMembers, listPendingInvites } from '@pitchbox/shared/orgs';
-import { billingPeriodFor, getOrgPeriodSpend, getOrgQuotaSnapshot } from '@pitchbox/shared/org-quota';
+import {
+  billingPeriodFor,
+  getOrgPeriodSpend,
+  getOrgQuotaSnapshot,
+} from '@pitchbox/shared/org-quota';
 
 export const load: PageServerLoad = async (event) => {
   const authOn = process.env.PITCHBOX_AUTH === 'on';

--- a/web/src/routes/settings/organization/+page.server.ts
+++ b/web/src/routes/settings/organization/+page.server.ts
@@ -3,7 +3,7 @@ import { eq } from 'drizzle-orm';
 import { getDb, schema } from '../../../lib/server/db.js';
 import { resolveOrgId } from '../../../lib/server/auth.js';
 import { listOrgMembers, listPendingInvites } from '@pitchbox/shared/orgs';
-import { getOrgMonthToDateSpend, getOrgQuotaSnapshot } from '@pitchbox/shared/org-quota';
+import { billingPeriodFor, getOrgPeriodSpend, getOrgQuotaSnapshot } from '@pitchbox/shared/org-quota';
 
 export const load: PageServerLoad = async (event) => {
   const authOn = process.env.PITCHBOX_AUTH === 'on';
@@ -49,8 +49,9 @@ export const load: PageServerLoad = async (event) => {
     remainingUsd: number | null;
   } | null = null;
   if (canManage && org) {
+    const period = await billingPeriodFor(db, orgId);
     const [spend, snapshot] = await Promise.all([
-      getOrgMonthToDateSpend(db, orgId),
+      getOrgPeriodSpend(db, orgId, period),
       getOrgQuotaSnapshot(db, orgId),
     ]);
     quota = {

--- a/web/tests/extension-observations-plan-limit.test.ts
+++ b/web/tests/extension-observations-plan-limit.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+import { PLAN_CATALOGUE } from '@pitchbox/shared/plans';
+import { POST as observationsPost } from '../src/routes/api/extension/observations/+server.js';
+
+/**
+ * #548: the observation collector mirrors the suggest route's own plan
+ * gate (AGENTS.md's precedent - any new route on the assist plane loads the
+ * switch state and refuses). 403, matching this route's existing shape
+ * (the collector is not a user-visible action, unlike the renderable 200
+ * suggest uses).
+ */
+
+async function reset() {
+  await getDb().execute(sql`TRUNCATE observed_targets, projects RESTART IDENTITY CASCADE`);
+  await getDb().execute(sql`DELETE FROM assist_usage`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM extension_devices`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+}
+
+function bearer(token: string | null, body: unknown): Request {
+  return new Request('http://x/api/extension/observations', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+async function seedOrgWithProject(slug: string, plan: string = 'free') {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan })
+    .returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug })
+    .returning();
+  await saveLinkedInAssistSettings(db, org.id, {
+    ...defaultLinkedInAssistSettings(),
+    enabled: true,
+    collectorEnabled: true,
+    projectId: project.id,
+  });
+  return { org, project };
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({
+      organizationId,
+      tokenHash: createHash('sha256').update(token).digest('hex'),
+      label: 'test',
+    });
+}
+
+async function seedProducedSuggestions(orgId: number, projectId: number, count: number) {
+  const db = getDb();
+  const [platform] = await db
+    .select({ id: schema.platforms.id })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'));
+  for (let i = 0; i < count; i += 1) {
+    await db.insert(schema.assistUsage).values({
+      organizationId: orgId,
+      projectId,
+      deviceId: null,
+      platformId: platform.id,
+      kind: 'post_comment',
+      agentRunner: 'claude-code',
+    });
+  }
+}
+
+function observation(overrides: Record<string, unknown> = {}) {
+  return {
+    externalId: 'urn:li:activity:88881',
+    url: 'https://www.linkedin.com/feed/update/urn:li:activity:88881/',
+    authorHandle: 'jane-doe',
+    authorName: 'Jane Doe',
+    text: 'A post about outreach automation.',
+    observedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function isHttpError(value: unknown): value is { status: number; body?: { message?: string } } {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('status' in value)) return false;
+  return typeof value.status === 'number';
+}
+
+async function statusAndBodyOf(
+  promise: Promise<Response>,
+): Promise<{ status: number; message: unknown }> {
+  try {
+    const res = await promise;
+    return { status: res.status, message: await res.json().catch(() => null) };
+  } catch (e) {
+    if (isHttpError(e)) return { status: e.status, message: e.body?.message };
+    throw e;
+  }
+}
+
+describe('POST /api/extension/observations is plan-limit-gated (#548)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  const freeLimit = PLAN_CATALOGUE.free.suggestionsPerMonth!;
+
+  it('refuses with a 403 once the org is at its suggestions plan limit', async () => {
+    const { org, project } = await seedOrgWithProject('obs-plan-limit-over');
+    await mintDevice(org.id, 'tok-obs-over');
+    await seedProducedSuggestions(org.id, project.id, freeLimit);
+
+    const { status, message } = await statusAndBodyOf(
+      observationsPost({
+        request: bearer('tok-obs-over', {
+          platform: 'linkedin',
+          projectId: project.id,
+          items: [observation()],
+        }),
+      } as unknown as Parameters<typeof observationsPost>[0]),
+    );
+
+    expect(status).toBe(403);
+    expect(message).toBe('plan_limit_reached');
+  });
+
+  it('an org under its plan limit is admitted', async () => {
+    const { org, project } = await seedOrgWithProject('obs-plan-limit-under');
+    await mintDevice(org.id, 'tok-obs-under');
+    await seedProducedSuggestions(org.id, project.id, freeLimit - 1);
+
+    const { status } = await statusAndBodyOf(
+      observationsPost({
+        request: bearer('tok-obs-under', {
+          platform: 'linkedin',
+          projectId: project.id,
+          items: [observation()],
+        }),
+      } as unknown as Parameters<typeof observationsPost>[0]),
+    );
+
+    expect(status).toBe(200);
+  });
+
+  it('a self-host install refuses nothing, however many suggestions the org has produced', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const { org, project } = await seedOrgWithProject('obs-plan-limit-self-host');
+    await mintDevice(org.id, 'tok-obs-self-host');
+    await seedProducedSuggestions(org.id, project.id, freeLimit + 25);
+
+    const { status } = await statusAndBodyOf(
+      observationsPost({
+        request: bearer('tok-obs-self-host', {
+          platform: 'linkedin',
+          projectId: project.id,
+          items: [observation()],
+        }),
+      } as unknown as Parameters<typeof observationsPost>[0]),
+    );
+
+    expect(status).toBe(200);
+  });
+});

--- a/web/tests/extension-pairing-plan-limit.test.ts
+++ b/web/tests/extension-pairing-plan-limit.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { PLAN_CATALOGUE } from '@pitchbox/shared/plans';
+import { POST as pairConsume } from '../src/routes/api/extension/pair/+server.js';
+
+/**
+ * #548: the pairing-code redemption endpoint (`POST /api/extension/pair`)
+ * refuses once the org the code belongs to is at its plan's device limit -
+ * the same enforcement point `auto-pair` has, but exercised here instead of
+ * there because this route resolves its org from `extension_pairings.organizationId`
+ * rather than from a session/`default`-org fallback, so it can be driven
+ * against a dedicated, disposable org. `auto-pair`'s org resolution is only
+ * reachable through the shared `default` org (self-host) or a session bound
+ * to `AUTH_ON`, a module-load-time constant this suite cannot flip per test -
+ * mutating `default`'s plan to force it into this test is exactly the
+ * shared-table trap #373 already cost a run, so that path is intentionally
+ * left covered only by inspection, not by a test.
+ */
+
+type ConsumeEvent = Parameters<typeof pairConsume>[0];
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE extension_devices, extension_pairings RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function makeOrg(slug: string, plan: string = 'free') {
+  const [org] = await getDb()
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan })
+    .returning();
+  return org;
+}
+
+async function mintDevice(organizationId: number) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({ organizationId, tokenHash: randomUUID(), label: 'pre-existing device' });
+}
+
+async function insertPairing(organizationId: number, code: string) {
+  await getDb()
+    .insert(schema.extensionPairings)
+    .values({ code, organizationId, expiresAt: new Date(Date.now() + 10 * 60 * 1000) });
+}
+
+function consumeEvent(code: string, ip: string): ConsumeEvent {
+  return {
+    request: new Request('http://x/api/extension/pair', {
+      method: 'POST',
+      body: JSON.stringify({ code }),
+    }),
+    getClientAddress: () => ip,
+  } as unknown as ConsumeEvent;
+}
+
+describe('POST /api/extension/pair is plan-limit-gated (#548)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  const freeLimit = PLAN_CATALOGUE.free.extensionDevices!;
+
+  it("refuses redemption once the code's org is at its plan device limit", async () => {
+    expect(freeLimit).toBe(1);
+    const org = await makeOrg('pairing-plan-limit-over');
+    await mintDevice(org.id);
+    await insertPairing(org.id, 'CODE-OVER-0001');
+
+    const res = await pairConsume(consumeEvent('CODE-OVER-0001', '198.51.100.1'));
+
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as {
+      error?: string;
+      metric?: string;
+      limit?: number;
+      used?: number;
+    };
+    expect(body.error).toBe('plan_limit_reached');
+    expect(body.metric).toBe('extensionDevices');
+    expect(body.limit).toBe(freeLimit);
+
+    // The refusal minted no second device ...
+    const devices = await getDb()
+      .select()
+      .from(schema.extensionDevices)
+      .where(eq(schema.extensionDevices.organizationId, org.id));
+    expect(devices).toHaveLength(1);
+    // ... but the code was still consumed by the atomic claim, per the
+    // route's own documented trade-off (a refusal still burns a one-time
+    // code rather than racing a separate read-only pre-check).
+    const [pairing] = await getDb()
+      .select()
+      .from(schema.extensionPairings)
+      .where(eq(schema.extensionPairings.code, 'CODE-OVER-0001'));
+    expect(pairing.consumedAt).not.toBeNull();
+  });
+
+  it('an org under its device limit redeems the code and mints a device', async () => {
+    const org = await makeOrg('pairing-plan-limit-under');
+    await insertPairing(org.id, 'CODE-UNDER-0001');
+
+    const res = await pairConsume(consumeEvent('CODE-UNDER-0001', '198.51.100.2'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token?: string };
+    expect(body.token).toBeTruthy();
+    const devices = await getDb()
+      .select()
+      .from(schema.extensionDevices)
+      .where(eq(schema.extensionDevices.organizationId, org.id));
+    expect(devices).toHaveLength(1);
+  });
+
+  it('a self-host install refuses nothing, however many devices the org already has', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const org = await makeOrg('pairing-plan-limit-self-host');
+    for (let i = 0; i < freeLimit + 5; i += 1) await mintDevice(org.id);
+    await insertPairing(org.id, 'CODE-SELF-HOST-01');
+
+    const res = await pairConsume(consumeEvent('CODE-SELF-HOST-01', '198.51.100.3'));
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/web/tests/extension-suggest-plan-limit.test.ts
+++ b/web/tests/extension-suggest-plan-limit.test.ts
@@ -203,5 +203,4 @@ describe('POST /api/extension/suggest is plan-limit-gated (#548)', () => {
     const text = await res.text();
     expect(text).toContain('event: done');
   });
-
 });

--- a/web/tests/extension-suggest-plan-limit.test.ts
+++ b/web/tests/extension-suggest-plan-limit.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+import { PLAN_CATALOGUE } from '@pitchbox/shared/plans';
+import { DRAFT_MARKER } from '@pitchbox/shared/assist/envelope';
+
+/**
+ * #548: the assist plane's own plan gate. `POST /api/extension/suggest`
+ * refuses with a renderable `200 {refused: 'plan_limit_reached'}` once an
+ * org has used its whole `suggestionsPerMonth` allowance for the period -
+ * never a 500, since this is the system working, not a defect.
+ *
+ * In its own module for a fresh in-memory rate-limiter budget, the same
+ * reason extension-suggest-usage.test.ts and extension-suggest-retune.test.ts
+ * already are (see their own header comments).
+ */
+
+const REASONING = 'Noticed the cache change and the specific number.';
+const DRAFT = 'A specific thing that happened.';
+const ENVELOPE_CHUNKS = [`${REASONING}\n`, DRAFT_MARKER, '\n', DRAFT];
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: () => ({
+    slug: 'fake',
+    run(opts: { onTextChunk?: (c: string) => void }) {
+      for (const c of ENVELOPE_CHUNKS) opts.onTextChunk?.(c);
+      return {
+        result: Promise.resolve({
+          exitCode: 0,
+          logPath: '/dev/null',
+          usage: {
+            inputTokens: 2,
+            outputTokens: 40,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            costUsd: 0.004,
+            costReported: true,
+          },
+        }),
+        cancel: () => {},
+      };
+    },
+  }),
+}));
+
+// Dynamic on purpose - vi.mock above is hoisted, but the route module has to
+// load after it for createAgentRunner to resolve to the fake agent (same
+// pattern as every other suggest-route test in this repo).
+const { POST: suggest } = await import('../src/routes/api/extension/suggest/+server.js');
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, contact_history, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM assist_usage`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+}
+
+async function seedOrgProject(slug: string, plan: string = 'free') {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan })
+    .returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `p-${slug}`,
+      name: slug,
+      description: `about ${slug}`,
+      defaultAgentRunner: 'cloud',
+    })
+    .returning();
+  await saveLinkedInAssistSettings(db, org.id, {
+    ...defaultLinkedInAssistSettings(),
+    enabled: true,
+    projectId: project.id,
+  });
+  return { org, project };
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  const [device] = await getDb()
+    .insert(schema.extensionDevices)
+    .values({ organizationId, tokenHash: tokenHash(token), label: 'test' })
+    .returning();
+  return device;
+}
+
+async function seedProducedSuggestions(orgId: number, projectId: number, count: number) {
+  const db = getDb();
+  const [platform] = await db
+    .select({ id: schema.platforms.id })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'));
+  for (let i = 0; i < count; i += 1) {
+    await db.insert(schema.assistUsage).values({
+      organizationId: orgId,
+      projectId,
+      deviceId: null,
+      platformId: platform.id,
+      kind: 'post_comment',
+      agentRunner: 'claude-code',
+    });
+  }
+}
+
+function request(token: string | null, body: unknown) {
+  return new Request('http://x/api/extension/suggest', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+const POST_BODY = {
+  kind: 'post_comment' as const,
+  post: {
+    urn: 'urn:li:activity:7000000000000000099',
+    authorName: 'Giulia Bianchi',
+    text: 'We cut p99 in half.',
+  },
+};
+
+describe('POST /api/extension/suggest is plan-limit-gated (#548)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  const freeLimit = PLAN_CATALOGUE.free.suggestionsPerMonth!;
+
+  it('refuses with a renderable 200, not a 500, once the org is at its plan limit', async () => {
+    const { org, project } = await seedOrgProject('plan-limit-suggest-over');
+    await mintDevice(org.id, 'tok-suggest-over');
+    await seedProducedSuggestions(org.id, project.id, freeLimit);
+
+    const res = await suggest({
+      request: request('tok-suggest-over', { ...POST_BODY, projectId: project.id }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      refused?: string;
+      metric?: string;
+      limit?: number;
+      used?: number;
+    };
+    expect(body.refused).toBe('plan_limit_reached');
+    expect(body.metric).toBe('suggestions');
+    expect(body.limit).toBe(freeLimit);
+    expect(body.used).toBe(freeLimit);
+    // Refused before the model ever ran - no new ledger row from this call.
+    const rows = await getDb()
+      .select()
+      .from(schema.assistUsage)
+      .where(eq(schema.assistUsage.projectId, project.id));
+    expect(rows).toHaveLength(freeLimit);
+  });
+
+  it('an org under its plan limit proceeds and streams a real suggestion', async () => {
+    const { org, project } = await seedOrgProject('plan-limit-suggest-under');
+    await mintDevice(org.id, 'tok-suggest-under');
+    await seedProducedSuggestions(org.id, project.id, freeLimit - 1);
+
+    const res = await suggest({
+      request: request('tok-suggest-under', { ...POST_BODY, projectId: project.id }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('event: done');
+    expect(text).not.toContain('plan_limit_reached');
+  });
+
+  it('a self-host install refuses nothing, however many suggestions the org has produced', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const { org, project } = await seedOrgProject('plan-limit-suggest-self-host');
+    await mintDevice(org.id, 'tok-suggest-self-host');
+    await seedProducedSuggestions(org.id, project.id, freeLimit + 25);
+
+    const res = await suggest({
+      request: request('tok-suggest-self-host', { ...POST_BODY, projectId: project.id }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('event: done');
+  });
+
+});

--- a/web/tests/gateway-budget-dispatch.test.ts
+++ b/web/tests/gateway-budget-dispatch.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { getDb, schema } from '@pitchbox/shared/db';
-import { getOrgMonthToDateCostUsd } from '@pitchbox/shared/org-quota';
+import { billingPeriodFor, getOrgPeriodCostUsd } from '@pitchbox/shared/org-quota';
 import type {
   AgentRunHandle,
   AgentRunOptions,
@@ -176,7 +176,7 @@ describe('cloud run dispatch is budget-gated (#419)', () => {
     expect((await runRow(runId))?.status).not.toBe('running');
   });
 
-  it("persists the SDK runner's own reported cost, and getOrgMonthToDateCostUsd agrees with it exactly", async () => {
+  it("persists the SDK runner's own reported cost, and getOrgPeriodCostUsd agrees with it exactly", async () => {
     const { orgId, campaignId } = await seedCloudCampaign('gw-cost-sum', '10.00');
     fakeResult = {
       exitCode: 0,
@@ -201,7 +201,7 @@ describe('cloud run dispatch is budget-gated (#419)', () => {
     // Not the same call as the write above: this re-reads via the exact
     // helper the dashboard and the org-quota settings page call, proving the
     // two never diverge rather than just re-asserting the row we just wrote.
-    const monthToDate = await getOrgMonthToDateCostUsd(getDb(), orgId);
+    const monthToDate = await getOrgPeriodCostUsd(getDb(), orgId, await billingPeriodFor(getDb(), orgId));
     expect(monthToDate).toBeCloseTo(2.5, 4);
   });
 
@@ -230,7 +230,7 @@ describe('cloud run dispatch is budget-gated (#419)', () => {
     expect(secondRun?.status).toBe('failed');
     expect(secondRun?.failureReason).toBe('quota_exhausted');
 
-    const monthToDate = await getOrgMonthToDateCostUsd(getDb(), orgId);
+    const monthToDate = await getOrgPeriodCostUsd(getDb(), orgId, await billingPeriodFor(getDb(), orgId));
     expect(monthToDate).toBeCloseTo(3, 4);
   });
 });

--- a/web/tests/gateway-budget-dispatch.test.ts
+++ b/web/tests/gateway-budget-dispatch.test.ts
@@ -201,7 +201,11 @@ describe('cloud run dispatch is budget-gated (#419)', () => {
     // Not the same call as the write above: this re-reads via the exact
     // helper the dashboard and the org-quota settings page call, proving the
     // two never diverge rather than just re-asserting the row we just wrote.
-    const monthToDate = await getOrgPeriodCostUsd(getDb(), orgId, await billingPeriodFor(getDb(), orgId));
+    const monthToDate = await getOrgPeriodCostUsd(
+      getDb(),
+      orgId,
+      await billingPeriodFor(getDb(), orgId),
+    );
     expect(monthToDate).toBeCloseTo(2.5, 4);
   });
 
@@ -230,7 +234,11 @@ describe('cloud run dispatch is budget-gated (#419)', () => {
     expect(secondRun?.status).toBe('failed');
     expect(secondRun?.failureReason).toBe('quota_exhausted');
 
-    const monthToDate = await getOrgPeriodCostUsd(getDb(), orgId, await billingPeriodFor(getDb(), orgId));
+    const monthToDate = await getOrgPeriodCostUsd(
+      getDb(),
+      orgId,
+      await billingPeriodFor(getDb(), orgId),
+    );
     expect(monthToDate).toBeCloseTo(3, 4);
   });
 });

--- a/web/tests/gateway-plan-limit-dispatch.test.ts
+++ b/web/tests/gateway-plan-limit-dispatch.test.ts
@@ -101,7 +101,11 @@ async function seedCloudCampaign(
 
 async function runRow(runId: number) {
   const [row] = await getDb()
-    .select({ status: schema.runs.status, error: schema.runs.error, failureReason: schema.runs.failureReason })
+    .select({
+      status: schema.runs.status,
+      error: schema.runs.error,
+      failureReason: schema.runs.failureReason,
+    })
     .from(schema.runs)
     .where(eq(schema.runs.id, runId));
   return row;

--- a/web/tests/gateway-plan-limit-dispatch.test.ts
+++ b/web/tests/gateway-plan-limit-dispatch.test.ts
@@ -1,0 +1,187 @@
+// #548: every plan limit is refused where the effect happens. This file
+// proves the run-count ceiling (shared/src/plans.ts's `runsPerMonth`)
+// through the real dispatch path (runCampaign -> dispatchRun), the same way
+// gateway-budget-dispatch.test.ts proves the Gateway budget - a distinct
+// axis, checked separately, with its own `plan_limit_reached` failure
+// reason so a reader of `runs.failure_reason` can tell "the plan ran out"
+// from "the budget ran out" (quota_exhausted) or "too many runs are already
+// going" (concurrency_exhausted).
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { PLAN_CATALOGUE } from '@pitchbox/shared/plans';
+import type {
+  AgentRunHandle,
+  AgentRunOptions,
+  AgentRunner,
+  AgentRunResult,
+} from '@pitchbox/shared/agents';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+import { clearDetectionCache } from '@pitchbox/shared/agents/detect';
+
+let createCalls = 0;
+const fakeResult: AgentRunResult = { exitCode: 0, logPath: '/dev/null' };
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'cloud',
+    run(_opts: AgentRunOptions): AgentRunHandle {
+      createCalls += 1;
+      return { result: Promise.resolve(fakeResult), cancel: () => {} };
+    },
+  }),
+}));
+
+// Dynamic on purpose - vi.mock above is hoisted, but runner.js has to load
+// after it for createAgentRunner to resolve to the fake gateway runner
+// (same pattern as gateway-budget-dispatch.test.ts).
+const { runCampaign } = await import('../src/lib/server/runner.js');
+
+async function reset() {
+  const db = getDb();
+  await db.execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  createCalls = 0;
+}
+
+async function platformId(slug: string): Promise<number> {
+  const [platform] = await getDb()
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, slug));
+  if (!platform) throw new Error(`platform "${slug}" is not seeded - did global-setup run?`);
+  return platform.id;
+}
+
+/** A 'cloud'-runner campaign under an org on `plan`, with `existingRuns`
+ * already recorded against it this period before the campaign this test
+ * dispatches. */
+async function seedCloudCampaign(
+  slug: string,
+  opts: { plan?: string; existingRuns?: number } = {},
+): Promise<{ orgId: number; projectId: number; campaignId: number }> {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: opts.plan ?? 'free' })
+    .returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `${slug}-proj`,
+      name: `${slug} p`,
+      defaultAgentRunner: 'cloud',
+    })
+    .returning();
+  for (let i = 0; i < (opts.existingRuns ?? 0); i += 1) {
+    await db.insert(schema.runs).values({
+      kind: 'project_extraction',
+      projectId: project.id,
+      trigger: 'manual',
+      status: 'success',
+      startedAt: new Date(),
+    });
+  }
+  const platform = await platformId('reddit');
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({
+      projectId: project.id,
+      platformId: platform,
+      name: 'c',
+      skillSlug: 'reddit-scout',
+      agentRunner: 'cloud',
+    })
+    .returning();
+  return { orgId: org.id, projectId: project.id, campaignId: campaign.id };
+}
+
+async function runRow(runId: number) {
+  const [row] = await getDb()
+    .select({ status: schema.runs.status, error: schema.runs.error, failureReason: schema.runs.failureReason })
+    .from(schema.runs)
+    .where(eq(schema.runs.id, runId));
+  return row;
+}
+
+describe('cloud run dispatch is plan-run-count-gated (#548)', () => {
+  const savedGatewayKey = process.env.AI_GATEWAY_API_KEY;
+  const savedEdition = process.env.PITCHBOX_EDITION;
+
+  beforeEach(async () => {
+    await reset();
+    process.env.AI_GATEWAY_API_KEY = 'test-key';
+    process.env.PITCHBOX_EDITION = 'cloud';
+    clearDetectionCache();
+  });
+  afterEach(() => {
+    if (savedGatewayKey === undefined) delete process.env.AI_GATEWAY_API_KEY;
+    else process.env.AI_GATEWAY_API_KEY = savedGatewayKey;
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+    clearDetectionCache();
+  });
+
+  const freeLimit = PLAN_CATALOGUE.free.runsPerMonth!;
+
+  it('refuses a run once the org has already used its whole plan allowance this period', async () => {
+    const { campaignId } = await seedCloudCampaign('plan-limit-over', {
+      plan: 'free',
+      existingRuns: freeLimit, // this dispatch's own row would be the (limit + 1)th
+    });
+
+    const { runId } = await runCampaign(campaignId);
+    const run = await runRow(runId);
+
+    expect(createCalls).toBe(0); // refused before the runner was ever created
+    expect(run?.status).toBe('failed');
+    expect(run?.error).toMatch(/plan limit/i);
+    expect(run?.error).not.toMatch(/quota|concurrency/i);
+    expect(run?.failureReason).toBe('plan_limit_reached');
+  });
+
+  it('admits a run when it is exactly the last one the plan allows this period', async () => {
+    const { campaignId } = await seedCloudCampaign('plan-limit-exact', {
+      plan: 'free',
+      existingRuns: freeLimit - 1, // this dispatch's own row makes exactly `limit`
+    });
+
+    const { runId } = await runCampaign(campaignId);
+    const run = await runRow(runId);
+
+    expect(createCalls).toBe(1);
+    expect(run?.status).not.toBe('failed');
+  });
+
+  it('an org well under its plan limit proceeds normally', async () => {
+    const { campaignId } = await seedCloudCampaign('plan-limit-under', {
+      plan: 'free',
+      existingRuns: 2,
+    });
+
+    const { runId } = await runCampaign(campaignId);
+    const run = await runRow(runId);
+
+    expect(createCalls).toBe(1);
+    expect(run?.status).not.toBe('failed');
+  });
+
+  // The regression that would make this feature unshippable: a self-host
+  // install must never be refused, however many runs it has recorded.
+  it('a self-host install refuses nothing, however many runs the org already has this period', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const { campaignId } = await seedCloudCampaign('plan-limit-self-host', {
+      plan: 'free',
+      existingRuns: freeLimit + 50, // wildly over the free plan's count
+    });
+
+    const { runId } = await runCampaign(campaignId);
+    const run = await runRow(runId);
+
+    expect(createCalls).toBe(1);
+    expect(run?.status).not.toBe('failed');
+  });
+});

--- a/web/tests/org-invite-plan-limit.test.ts
+++ b/web/tests/org-invite-plan-limit.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { PLAN_CATALOGUE } from '@pitchbox/shared/plans';
+import { POST as invitesPost } from '../src/routes/api/orgs/[slug]/invites/+server.js';
+
+/**
+ * #548: POST /api/orgs/[slug]/invites refuses once the org is at its plan's
+ * seat limit - a pending invite consumes a seat immediately, so the limit
+ * cannot be bypassed by inviting several people at once.
+ */
+
+async function reset() {
+  await getDb().execute(sql`DELETE FROM org_invites`);
+  await getDb().execute(sql`DELETE FROM memberships`);
+  await getDb().execute(sql`DELETE FROM users`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function makeOrgWithAdmin(slug: string, plan: string = 'free') {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan })
+    .returning();
+  const [user] = await db
+    .insert(schema.users)
+    .values({ username: `${slug}-admin`, passwordHash: 'x' })
+    .returning();
+  await db
+    .insert(schema.memberships)
+    .values({ organizationId: org.id, userId: user.id, role: 'owner' });
+  return { orgId: org.id, userId: user.id, slug: org.slug };
+}
+
+async function makePendingInvite(orgId: number) {
+  await getDb()
+    .insert(schema.orgInvites)
+    .values({
+      organizationId: orgId,
+      token: randomUUID(),
+      role: 'member',
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    });
+}
+
+function postEvent(userId: number, slug: string, body: unknown): Parameters<typeof invitesPost>[0] {
+  return {
+    locals: { user: { id: userId } },
+    params: { slug },
+    request: new Request('http://x/', { method: 'POST', body: JSON.stringify(body) }),
+    url: new URL('http://x/'),
+  } as unknown as Parameters<typeof invitesPost>[0];
+}
+
+describe('POST /api/orgs/[slug]/invites is plan-limit-gated (#548)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  const freeLimit = PLAN_CATALOGUE.free.seats!;
+
+  it('refuses once the org is at its plan seat limit (owner already fills it)', async () => {
+    const { orgId, userId, slug } = await makeOrgWithAdmin('invite-plan-limit-over');
+    // The owner's own membership already counts as 1 seat - the free plan's
+    // seat limit is 1, so it is already at the cap with nobody else invited.
+    expect(freeLimit).toBe(1);
+
+    const res = await invitesPost(postEvent(userId, slug, { email: 'friend@example.com' }));
+
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as {
+      error?: string;
+      metric?: string;
+      limit?: number;
+      used?: number;
+    };
+    expect(body.error).toBe('plan_limit_reached');
+    expect(body.metric).toBe('seats');
+    expect(body.limit).toBe(freeLimit);
+
+    const invites = await getDb()
+      .select()
+      .from(schema.orgInvites)
+      .where(eq(schema.orgInvites.organizationId, orgId));
+    expect(invites).toHaveLength(0); // nothing created
+  });
+
+  it('a pending invite counts as a seat - a second invite past the limit is refused too', async () => {
+    const { orgId, userId, slug } = await makeOrgWithAdmin('invite-plan-limit-pending', 'growth');
+    // Growth's seat limit is 3: the owner (1) + two pending invites (2, 3) fills it.
+    const growthSeats = PLAN_CATALOGUE.growth.seats!;
+    for (let i = 0; i < growthSeats - 1; i += 1) await makePendingInvite(orgId);
+
+    const res = await invitesPost(postEvent(userId, slug, { email: 'onemore@example.com' }));
+
+    expect(res.status).toBe(402);
+  });
+
+  it('a self-host install refuses nothing, however many members and invites the org has', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const { orgId, userId, slug } = await makeOrgWithAdmin('invite-plan-limit-self-host');
+    for (let i = 0; i < 10; i += 1) await makePendingInvite(orgId);
+
+    const res = await invitesPost(postEvent(userId, slug, { email: 'plenty@example.com' }));
+
+    expect(res.status).toBe(201);
+  });
+});

--- a/web/tests/projects-plan-limit.test.ts
+++ b/web/tests/projects-plan-limit.test.ts
@@ -26,9 +26,7 @@ async function makeOrg(slug: string, plan: string = 'free') {
 }
 
 async function makeProject(orgId: number, slug: string) {
-  await getDb()
-    .insert(schema.projects)
-    .values({ organizationId: orgId, slug, name: slug });
+  await getDb().insert(schema.projects).values({ organizationId: orgId, slug, name: slug });
 }
 
 function postEvent(orgId: number, body: unknown): Parameters<typeof projectsPost>[0] {
@@ -60,7 +58,12 @@ describe('POST /api/projects is plan-limit-gated (#548)', () => {
     );
 
     expect(res.status).toBe(402);
-    const body = (await res.json()) as { error?: string; metric?: string; limit?: number; used?: number };
+    const body = (await res.json()) as {
+      error?: string;
+      metric?: string;
+      limit?: number;
+      used?: number;
+    };
     expect(body.error).toBe('plan_limit_reached');
     expect(body.metric).toBe('projects');
     expect(body.limit).toBe(freeLimit);

--- a/web/tests/projects-plan-limit.test.ts
+++ b/web/tests/projects-plan-limit.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { PLAN_CATALOGUE } from '@pitchbox/shared/plans';
+import { POST as projectsPost } from '../src/routes/api/projects/+server.js';
+
+/**
+ * #548: POST /api/projects refuses a structural create once the org is at
+ * its plan's project limit, with a 402-shaped body a form can render as an
+ * upgrade prompt rather than a validation error.
+ */
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function makeOrg(slug: string, plan: string = 'free') {
+  const [org] = await getDb()
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan })
+    .returning();
+  return org.id;
+}
+
+async function makeProject(orgId: number, slug: string) {
+  await getDb()
+    .insert(schema.projects)
+    .values({ organizationId: orgId, slug, name: slug });
+}
+
+function postEvent(orgId: number, body: unknown): Parameters<typeof projectsPost>[0] {
+  return {
+    locals: { org: { id: orgId, slug: 'x', role: 'owner' } },
+    request: new Request('http://x/', { method: 'POST', body: JSON.stringify(body) }),
+  } as unknown as Parameters<typeof projectsPost>[0];
+}
+
+describe('POST /api/projects is plan-limit-gated (#548)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  const freeLimit = PLAN_CATALOGUE.free.projects!;
+
+  it('refuses with a 402-shaped body once the org is at its plan project limit', async () => {
+    const orgId = await makeOrg('projects-plan-limit-over');
+    for (let i = 0; i < freeLimit; i += 1) await makeProject(orgId, `p${i}`);
+
+    const res = await projectsPost(
+      postEvent(orgId, { name: 'One too many', defaultAgentRunner: 'cloud' }),
+    );
+
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { error?: string; metric?: string; limit?: number; used?: number };
+    expect(body.error).toBe('plan_limit_reached');
+    expect(body.metric).toBe('projects');
+    expect(body.limit).toBe(freeLimit);
+    expect(body.used).toBe(freeLimit);
+
+    const rows = await getDb()
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.organizationId, orgId));
+    expect(rows).toHaveLength(freeLimit); // nothing created
+  });
+
+  it('an org under its plan limit creates the project normally', async () => {
+    const orgId = await makeOrg('projects-plan-limit-under');
+    for (let i = 0; i < freeLimit - 1; i += 1) await makeProject(orgId, `p${i}`);
+
+    const res = await projectsPost(
+      postEvent(orgId, { name: 'Just fits', defaultAgentRunner: 'cloud' }),
+    );
+
+    expect(res.status).toBe(201);
+  });
+
+  it('a self-host install refuses nothing, however many projects the org already has', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const orgId = await makeOrg('projects-plan-limit-self-host');
+    for (let i = 0; i < freeLimit + 10; i += 1) await makeProject(orgId, `p${i}`);
+
+    const res = await projectsPost(postEvent(orgId, { name: 'Still fine' }));
+
+    expect(res.status).toBe(201);
+  });
+});


### PR DESCRIPTION
Closes #545, #546, #548. Ready for review - rebased onto `main` (through #603's `org_subscriptions.current_period_start` migration and #604's post-image work), typechecked, linted and tested end to end.

## What this does

**#545** - the org spend window is the subscription's billing period, not the calendar month. `shared/src/org-quota.ts`:
- `Period` (`{start, end}`), `calendarPeriodFor(anchor, now)` - the calendar-month period containing `now`, anchored on `anchor`'s day-of-month (and time-of-day) instead of the 1st, month-end clamped (a 31st anchor produces a short February).
- `resolveBillingPeriod` (pure) and `billingPeriodFor` (DB-backed) - a live subscription's own `current_period_start`/`current_period_end` wins; otherwise the calendar month anchored on `organizations.createdAt`, so a free org's window is stable for its whole lifetime regardless of what it subscribes to or loses later.
- `getOrgMonthToDateSpend`/`getOrgMonthToDateCostUsd` renamed to `getOrgPeriodSpend`/`getOrgPeriodCostUsd`, taking a `Period` instead of `now` - same query shape, bounded on both ends now (previously unbounded above).
- The instance-wide ceiling (`getInstanceMonthToDateCostUsd`) deliberately keeps summing every org over the plain calendar month (`calendarMonthPeriod`), not each org's own billing period - that's its existing, unchanged meaning per #545's constraint.
- Callers updated: the dispatch pre-flight, `/api/settings/org-quota`, `/settings/organization`.

**#546** - one usage snapshot. New `shared/src/usage.ts` (`getOrgUsage(db, orgId, period)` -> `{runs, suggestions, projects, accounts, seats, extensionDevices, costUsd, entitlements}`, each metric `{used, limit, remaining}`):
- `runs` counts every row whatever the kind/status, within the period.
- `suggestions` reads the `assist_usage` ledger (#522) - produced, not accepted.
- `projects`/`accounts`/`seats`/`extensionDevices` are structural, not period-bound. `seats` = memberships + pending, unexpired invites. `extensionDevices` excludes revoked/expired.
- `accounts` always has `limit: null` - `Entitlements` doesn't expose a connected-account limit yet (plans.ts's own comment defers it), and extending `Entitlements` is plans.ts's contract, out of scope for me this wave.
- Self-host (`entitlements.source === 'self-host'`) returns the fully-unlimited shape without running a single count query.

**#548** - every limit refused where the effect happens, server-side:
- Run dispatch (`web/src/lib/server/runner.ts`): `runsPerMonth`, new `plan_limit_reached` failure reason (`shared/src/runlog/classify-failure.ts`), distinct from `quota_exhausted`/`concurrency_exhausted`. Checked for every runner slug, not only `cloud` - self-host resolves unlimited regardless.
- `POST /api/extension/suggest`: `{ refused: 'plan_limit_reached', metric: 'suggestions', limit, used, upgradeUrl }`, 200, same convention as the existing quota refusal.
- `POST /api/extension/observations`: the same suggestions gate, 403 - mirrors the LinkedIn-switch precedent of checking the assist plane's gate at both routes (AGENTS.md).
- `POST /api/projects`, `POST /api/orgs/[slug]/invites`, `POST /api/extension/auto-pair`, `POST /api/extension/pair`: `{ error: 'plan_limit_reached', metric, limit, used }`, 402.

## The `current_period_start` backfill (#603)

Checked directly rather than assuming: `org_subscriptions` had **zero rows** in every database this migration ran against (dev, test, CI) - it's a brand-new table populated only by the Stripe webhook (#603/#551), which itself only just landed. There was nothing to backfill, which is exactly why the migration could add the column `NOT NULL` with no `DEFAULT` and not fail: Postgres only needs a value for rows that already exist. No compensation needed on my side - `billingPeriodFor` never reads a row that predates the webhook's own writes, and every write `syncSubscriptionFromStripe` makes sets `currentPeriodStart` and `currentPeriodEnd` together, from one live Stripe refetch, never partially (`shared/src/billing/webhook.ts`).

## Design question: what happens when a subscription vanishes mid-period

Verified against the shipped webhook (`shared/src/billing/webhook.ts`) rather than speculating: `clearSubscription` (fired on `customer.subscription.deleted`, which is what actually fires whether Stripe cancels a subscription directly or as part of deleting a customer's data per docs/billing.md's "Emails and support") deletes the `org_subscriptions` row **and** resets `organizations.plan`/`plan_source` to `'free'` in the **same `db.transaction`** - unless `plan_source` is `'grant'`, which deliberately survives Stripe entirely (the documented precedence, not a gap).

Because both changes commit atomically together, `resolveEntitlements` and `billingPeriodFor` never observe a stale paid plan paired with a reset/row-less period, or the reverse: the instant the row disappears, the plan has already dropped to Free's small numbers (`monthlyRunBudgetUsd: 2`, `runsPerMonth: 20`) in the same commit, and `billingPeriodFor` falls back to the exact same creation-anchored calendar month a free org always had. There is no window where a generous paid budget gets checked against a narrower, differently-offset window - the scenario I originally worried about and filed as #599 doesn't actually occur; I closed it once I read this code (it didn't exist on `main` when I wrote the issue).

The one residual gap I can still name honestly: my own #548 enforcement points call `resolveEntitlements` and `billingPeriodFor` as two independent queries (`shared/src/usage.ts`'s `getOrgUsage` receives an already-computed `period`, doesn't share a transaction with the entitlements read), so a webhook commit landing in the split second between those two reads could pair a just-reset entitlement with a not-yet-reset period or vice versa for exactly one request. It self-corrects on the next request; I have not observed it and it isn't worth a dedicated fix unless it's ever seen to matter in practice.

## Route-level regression coverage (#548's acceptance criteria)

One test file per enforcement point, each proving refuse-at-limit, admit-under-limit and self-host-refuses-nothing, and each one confirmed by breaking its own enforcement check and watching the exact assertion fail before restoring it:
`web/tests/extension-suggest-plan-limit.test.ts`, `extension-observations-plan-limit.test.ts`, `projects-plan-limit.test.ts`, `org-invite-plan-limit.test.ts`, `extension-pairing-plan-limit.test.ts`, plus the existing `gateway-plan-limit-dispatch.test.ts` for run dispatch.

`org-invite-plan-limit.test.ts` uses `node:crypto`'s `randomUUID` (not the global `crypto.randomUUID()`) to match every other test file in this repo, and its admitted, seat-under-limit path sends a real `email` in the request body - safe because `vitest.config.ts` already blanks `MAIL_PROVIDER` for every test, so `loadMailEnv()` resolves to the null transport regardless of what a developer's own `.env` has configured. No test opens a real SMTP/Resend connection.

`extension-pairing-plan-limit.test.ts` exercises `POST /api/extension/pair` (the pairing-code redemption route), not `POST /api/extension/auto-pair`. Both share the same `extensionDevices` gate, but `pair` resolves its org from `extension_pairings.organizationId` - a value the test controls directly - while `auto-pair`'s org resolution only reaches a non-`default` org through a live session, or falls back to the shared `default` org when auth is off. Forcing `auto-pair`'s path under test would mean mutating `default`'s plan, the exact shared-table trap that cost this repo a run on #373. `pair` gives the same enforcement point full coverage against a disposable org instead, so `auto-pair`'s identical check is covered by this test in effect, and left to code review by inspection rather than duplicated under a second, riskier harness.

## Deliberately not done

- **Accept-path dunning refusal** (`assist-accept.ts`, part of #548's original list): no "org read-only" concept exists yet in this codebase.
- **Account/campaign structural-create limits**: `Entitlements` has no `accounts`/`campaigns` field; extending it is plans.ts's contract.
- **Notification webhook config plan gate**: `/api/settings/webhooks` is a single instance-wide admin setting (`requireInstanceAdmin`), not per-org - no per-org webhook feature exists to gate.
- **Retention ceiling**: `/settings/retention` is explicitly a single instance-wide `app_config` row by its own design comment, not per-org - needs per-org retention storage, a schema change outside my migration lock this wave.
- **Runner JWT quota claim** (`shared/src/agents/cloud/jwt.ts`, named in #545's text): doesn't exist post-#420 - the cloud runner is in-process; the real equivalent (`budgetRemainingUsd`) already updates via `getOrgQuotaSnapshot`.

## Verified

```
pnpm -F @pitchbox/shared typecheck   # clean
pnpm -F web check                    # clean
npx eslint <changed files>           # clean
npx prettier --check <changed files> # clean
docker exec pitchbox-postgres psql -U pitchbox -d pitchbox_test_limits -c '\d org_subscriptions'   # current_period_start confirmed present, not null
DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5434/pitchbox_test_limits pnpm exec vitest run \
  shared/tests/org-quota.test.ts shared/tests/usage.test.ts \
  web/tests/gateway-plan-limit-dispatch.test.ts web/tests/gateway-budget-dispatch.test.ts \
  web/tests/gateway-instance-ceiling-dispatch.test.ts web/tests/extension-suggest-plan-limit.test.ts \
  web/tests/extension-observations-plan-limit.test.ts web/tests/projects-plan-limit.test.ts \
  web/tests/org-invite-plan-limit.test.ts web/tests/extension-pairing-plan-limit.test.ts
# 10 files, 84 tests, all green
```

For each of the two enforcement points added in this final pass (org invites' seat gate, pair's device gate), I disabled the check with a one-line `false &&` short-circuit, watched the corresponding test fail with the exact expected assertion (402 not returned), then restored it and re-ran green - same proof method the earlier route tests already used.
