### PR TITLE
feat(shared,cli): the assist tool surface - thread, image, author history, voice, project knowledge

### DIFF
--- a/bin/pitchbox-assist-mcp
+++ b/bin/pitchbox-assist-mcp
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Pitchbox assist MCP server wrapper - forwards to the tsx-executed assist MCP
+# server source (cli/src/mcp/assist-server.ts). Exposes only the seven
+# read-only in-page-assistant tools (shared/src/assist/tools.ts) to the ACP
+# path's agent loop, bound to one organization and one project rather than to
+# a run - the campaign MCP server's 26 tools (bin/pitchbox-mcp) stay a
+# separate plane and are never reachable from here.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+exec "$REPO_ROOT/node_modules/.bin/tsx" "$REPO_ROOT/cli/src/mcp/assist-index.ts" "$@"

--- a/cli/src/mcp/assist-index.ts
+++ b/cli/src/mcp/assist-index.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { config } from 'dotenv';
+import { resolve } from 'node:path';
+// mcp/ is one level deeper than the CLI entry, so reach the repo root with three ascents.
+config({ path: resolve(import.meta.dirname ?? '.', '..', '..', '..', '.env') });
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createAssistMcpServer } from './assist-server.js';
+
+async function main() {
+  const server = createAssistMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(JSON.stringify({ ok: false, error: String(err?.message ?? err) }) + '\n');
+  process.exit(1);
+});

--- a/cli/src/mcp/assist-server.ts
+++ b/cli/src/mcp/assist-server.ts
@@ -1,0 +1,142 @@
+// cli/src/mcp/assist-server.ts (#567)
+//
+// The assist MCP server: exposes exactly the seven read-only tools declared
+// in `shared/src/assist/tools.ts` to the ACP path's agent loop
+// (docs/design/in-page-agent.md, section 1). A sibling of
+// `cli/src/mcp/server.ts`, the campaign MCP server - deliberately not built
+// on top of it or importing any of its tool registrations, because the two
+// planes carry different privileges (26 tools, most of them writers, bound
+// to a `runs` row, vs seven read-only tools bound to an org and a project).
+// Handing the assistant `drafts_create` or `run_finish` because they happen
+// to share a process would undo the isolation #520 exists for.
+//
+// This server's session binds to an organization and a bound project rather
+// than a run, campaign or `PITCHBOX_RUN_ID`/`PITCHBOX_CAMPAIGN_ID` - there is
+// no run row on this plane (`web/src/lib/server/suggest.ts` spawns no `runs`
+// row for a suggestion). The observed target (the post, its thread, its
+// image crop) and the operator persona are both too large and too
+// structured to carry as scalar env vars the way `PITCHBOX_PROJECT_ID` does,
+// so they travel as a JSON file the caller writes into the run's temp cwd
+// before spawning this process (mirrors `web/src/lib/server/suggest.ts`'s
+// existing `mkdtemp`/`rm` temp-dir lifecycle) - `PITCHBOX_ASSIST_CONTEXT_FILE`
+// names it. This server only ever reads that file; it never writes one.
+
+import { readFile } from 'node:fs/promises';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getDb } from '@pitchbox/shared/db';
+import {
+  ASSIST_TOOLS,
+  type AssistObservedTarget,
+  type AssistToolContext,
+} from '@pitchbox/shared/assist/tools';
+import type { OperatorPersona } from '@pitchbox/shared/assist/context';
+
+/**
+ * Session binding for the assist MCP tools. An explicit context (the SDK
+ * side, if it ever reused this server in-process) wins over the session env
+ * a spawned subprocess reads, the same precedence `PitchboxMcpContext`
+ * (./server.ts) follows.
+ */
+export interface AssistMcpContext {
+  organizationId?: number;
+  boundProjectId?: number;
+  /** Path to the JSON context file, shaped `AssistRequestPayload` below. */
+  contextFile?: string;
+}
+
+/** What the context file carries: everything server-resolved before the
+ * loop starts, that a tool handler needs but cannot re-derive from
+ * `organizationId`/`boundProjectId` alone. */
+export interface AssistRequestPayload {
+  observedTarget: AssistObservedTarget | null;
+  operator: OperatorPersona | null;
+}
+
+/**
+ * Builds the assist MCP server. Registers `ASSIST_TOOLS` (`shared/src/
+ * assist/tools.ts`) one for one under their own names, with no extra tool
+ * and no renaming - a test asserts the exposed set is exactly those seven
+ * and none of the campaign server's.
+ */
+export function createAssistMcpServer(ctx: AssistMcpContext = {}): McpServer {
+  const server = new McpServer({ name: 'pitchbox-assist', version: '0.1.0' });
+
+  const rawOrgId = Number(process.env.PITCHBOX_ASSIST_ORG_ID);
+  const organizationId =
+    ctx.organizationId ?? (Number.isInteger(rawOrgId) && rawOrgId > 0 ? rawOrgId : undefined);
+  const rawProjectId = Number(process.env.PITCHBOX_ASSIST_PROJECT_ID);
+  const boundProjectId =
+    ctx.boundProjectId ??
+    (Number.isInteger(rawProjectId) && rawProjectId > 0 ? rawProjectId : undefined);
+  const contextFile = ctx.contextFile ?? process.env.PITCHBOX_ASSIST_CONTEXT_FILE;
+
+  // Read once per server instance (a fresh process per suggestion, same
+  // lifetime as the campaign server's own per-run spawn) and memoized -
+  // every tool call in this session reads the same observed target.
+  let payloadPromise: Promise<AssistRequestPayload> | null = null;
+  const loadPayload = (): Promise<AssistRequestPayload> => {
+    if (!payloadPromise) {
+      payloadPromise = (async () => {
+        if (!contextFile) return { observedTarget: null, operator: null };
+        try {
+          const raw = await readFile(contextFile, 'utf8');
+          const parsed = JSON.parse(raw) as Partial<AssistRequestPayload>;
+          return {
+            observedTarget: parsed.observedTarget ?? null,
+            operator: parsed.operator ?? null,
+          };
+        } catch {
+          // A missing or unreadable context file degrades to "nothing was
+          // captured", the same explicit-nothing every tool already
+          // handles for a real empty observation - never a thrown error
+          // that would fail every tool call in the session.
+          return { observedTarget: null, operator: null };
+        }
+      })();
+    }
+    return payloadPromise;
+  };
+
+  for (const tool of ASSIST_TOOLS) {
+    server.registerTool(
+      tool.name,
+      { title: tool.name, description: tool.description, inputSchema: tool.schema },
+      async (args: Record<string, unknown>, extra: { signal?: AbortSignal }) => {
+        if (organizationId == null || boundProjectId == null) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text:
+                  'this assist MCP session has no bound organization/project - PITCHBOX_ASSIST_ORG_ID and ' +
+                  'PITCHBOX_ASSIST_PROJECT_ID must both be set before a tool call',
+              },
+            ],
+          };
+        }
+        const { observedTarget, operator } = await loadPayload();
+        const toolCtx: AssistToolContext = {
+          db: getDb(),
+          orgId: organizationId,
+          boundProjectId,
+          observedTarget,
+          operator,
+        };
+        try {
+          const answer = await tool.handler(toolCtx, args, extra?.signal);
+          return { content: [{ type: 'text' as const, text: JSON.stringify(answer) }] };
+        } catch (err) {
+          return {
+            isError: true,
+            content: [
+              { type: 'text' as const, text: String(err instanceof Error ? err.message : err) },
+            ],
+          };
+        }
+      },
+    );
+  }
+
+  return server;
+}

--- a/cli/tests/mcp/assist-server.test.ts
+++ b/cli/tests/mcp/assist-server.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, beforeEach, afterAll } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getDb, getPool, schema } from '@pitchbox/shared/db';
+import { eq, sql } from 'drizzle-orm';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createAssistMcpServer } from '../../src/mcp/assist-server.js';
+import { createPitchboxMcpServer } from '../../src/mcp/server.js';
+
+// #567: the assist MCP entry point. What matters here, beyond `shared/tests/
+// assist-tools.test.ts`'s coverage of the handlers themselves, is the
+// transport contract: exactly the seven assist tools are advertised, none of
+// the campaign server's, and the session-bound org/project plus the context
+// file actually reach a handler through this server rather than only
+// through a direct function call.
+
+type CallResult = { content: { type: string; text?: string }[]; isError?: boolean };
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`TRUNCATE contact_history, projects RESTART IDENTITY CASCADE`);
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function defaultOrgId(): Promise<number> {
+  const [org] = await getDb()
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.slug, 'default'));
+  return org!.id;
+}
+
+async function connectAssistClient(
+  ctx: Parameters<typeof createAssistMcpServer>[0] = {},
+): Promise<Client> {
+  const server = createAssistMcpServer(ctx);
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverT);
+  const client = new Client({ name: 'test-assist-client', version: '0.0.0' });
+  await client.connect(clientT);
+  return client;
+}
+
+async function call(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<CallResult> {
+  return (await client.callTool({ name, arguments: args })) as unknown as CallResult;
+}
+
+function parse(res: CallResult): unknown {
+  return JSON.parse(res.content[0]?.text ?? 'null');
+}
+
+describe('cli/src/mcp/assist-server', () => {
+  beforeEach(reset);
+
+  it('advertises exactly the seven assist tools and none of the campaign server\u2019s', async () => {
+    const orgId = await defaultOrgId();
+    const assistClient = await connectAssistClient({ organizationId: orgId, boundProjectId: 1 });
+    const { tools } = await assistClient.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      'author_history',
+      'check_style',
+      'look_at_image',
+      'my_prior_takes',
+      'operator_voice',
+      'project_knowledge',
+      'read_thread',
+    ]);
+
+    const campaignServer = createPitchboxMcpServer();
+    const [campaignClientT, campaignServerT] = InMemoryTransport.createLinkedPair();
+    await campaignServer.connect(campaignServerT);
+    const campaignClient = new Client({ name: 'test-campaign-client', version: '0.0.0' });
+    await campaignClient.connect(campaignClientT);
+    const { tools: campaignTools } = await campaignClient.listTools();
+    const campaignNames = new Set(campaignTools.map((t) => t.name));
+    expect(campaignTools.length).toBe(26);
+    for (const name of names) expect(campaignNames.has(name)).toBe(false);
+  });
+
+  it('refuses every tool call when the session has no bound organization/project', async () => {
+    const client = await connectAssistClient({});
+    const res = await call(client, 'check_style', { text: 'A clean sentence.' });
+    expect(res.isError).toBe(true);
+  });
+
+  it('runs check_style end to end with no session binding required beyond org/project', async () => {
+    const orgId = await defaultOrgId();
+    const client = await connectAssistClient({ organizationId: orgId, boundProjectId: 1 });
+    const res = await call(client, 'check_style', { text: 'This is great \u2014 really great.' });
+    expect(res.isError).toBeFalsy();
+    const answer = parse(res) as { ok: boolean; data?: { findings: unknown[] } };
+    expect(answer.ok).toBe(true);
+    expect((answer.data?.findings ?? []).length).toBeGreaterThan(0);
+  });
+
+  it('reads the observed target from the context file for read_thread', async () => {
+    const orgId = await defaultOrgId();
+    const dir = mkdtempSync(join(tmpdir(), 'pitchbox-assist-mcp-test-'));
+    const contextFile = join(dir, 'context.json');
+    try {
+      writeFileSync(
+        contextFile,
+        JSON.stringify({
+          observedTarget: { text: 'A post read through the context file.', authorHandle: 'jdoe' },
+          operator: null,
+        }),
+      );
+      const client = await connectAssistClient({
+        organizationId: orgId,
+        boundProjectId: 1,
+        contextFile,
+      });
+      const res = await call(client, 'read_thread', {});
+      expect(res.isError).toBeFalsy();
+      const answer = parse(res) as { ok: boolean; data?: { post: { text: string } } };
+      expect(answer.ok).toBe(true);
+      expect(answer.data?.post.text).toBe('A post read through the context file.');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('answers read_thread with an explicit refusal when no context file was given', async () => {
+    const orgId = await defaultOrgId();
+    const client = await connectAssistClient({ organizationId: orgId, boundProjectId: 1 });
+    const res = await call(client, 'read_thread', {});
+    expect(res.isError).toBeFalsy();
+    const answer = parse(res) as { ok: boolean; reason?: string };
+    expect(answer.ok).toBe(false);
+  });
+});
+
+afterAll(async () => {
+  await getPool().end();
+});

--- a/shared/package.json
+++ b/shared/package.json
@@ -36,6 +36,8 @@
     "./assist/register": "./src/assist/register.ts",
     "./assist/tone": "./src/assist/tone.ts",
     "./assist/voice-profile": "./src/assist/voice-profile.ts",
+    "./assist/tools": "./src/assist/tools.ts",
+    "./assist/budget": "./src/assist/budget.ts",
     "./operator-profile": "./src/operator-profile.ts",
     "./operator-voice-profile": "./src/operator-voice-profile.ts",
     "./github-sources": "./src/github-sources.ts",

--- a/shared/src/ai/model-functions.ts
+++ b/shared/src/ai/model-functions.ts
@@ -19,6 +19,7 @@ import { loadGatewayCatalogue } from './gateway-catalogue.js';
 export const MODEL_FUNCTIONS = [
   'campaign_draft',
   'assist_suggest',
+  'assist_vision',
   'project_extract',
   'project_insights',
   'skill_generate',
@@ -56,6 +57,13 @@ export const MODEL_FUNCTION_META: readonly ModelFunctionMeta[] = [
     label: 'Answering in the panel',
     description:
       'The in-page companion suggesting a comment or a post while somebody waits for it. The only path here with a human watching an empty panel, so first-token latency is the constraint that matters.',
+    defaultModelId: FAST_DEFAULT,
+  },
+  {
+    fn: 'assist_vision',
+    label: 'Looking at an image in the panel',
+    description:
+      'The in-page companion reading the pixels of a post\u2019s image, chart or slide before suggesting a comment on it. Skipped entirely on a text-only post, so this only runs when the crop the extension captured is actually present.',
     defaultModelId: FAST_DEFAULT,
   },
   {

--- a/shared/src/assist/budget.ts
+++ b/shared/src/assist/budget.ts
@@ -1,0 +1,38 @@
+// shared/src/assist/budget.ts
+//
+// Every number the in-page assistant's agent loop is allowed to spend,
+// named once so nothing re-declares it - docs/design/in-page-agent.md,
+// "The step and budget contract", is the argument for each value below.
+// #574 is the only issue allowed to move one, and it edits that document in
+// the same PR.
+//
+// A human is watching an empty panel, so these are product decisions, not
+// safety valves: past ASSIST_SOFT_BUDGET_MS the agent is told to answer with
+// what it has, and at ASSIST_HARD_TIMEOUT_MS whatever draft text already
+// streamed is what the operator gets. A partial suggestion beats an error.
+
+/** Five tool steps plus the writing turn - the heaviest realistic plan is
+ * thread, image, author history, voice, prior takes, then write. */
+export const ASSIST_MAX_STEPS = 6;
+
+/** Past this the agent is told to answer with what it has. Two model turns
+ * plus parallel DB reads fit inside it with room: one turn measures 10 to
+ * 13s (design doc, "Where we are starting from"). */
+export const ASSIST_SOFT_BUDGET_MS = 35_000;
+
+/** The ceiling, not the target. Unchanged from today's `SUGGESTION_TIMEOUT_MS`
+ * (`web/src/lib/server/suggest.ts`). */
+export const ASSIST_HARD_TIMEOUT_MS = 90_000;
+
+/** A DB-backed tool that cannot answer in 4s is broken, and the loop must not
+ * wait on it. Applies to every tool below except `look_at_image`. */
+export const ASSIST_TOOL_TIMEOUT_MS = 4_000;
+
+/** `look_at_image` is a real model call and the only tool that spends
+ * tokens, so it gets its own, longer budget. */
+export const ASSIST_VISION_TIMEOUT_MS = 12_000;
+
+/** Accumulated input tokens across every step. Past it, no further tool
+ * result is admitted into the context and the agent is told to answer. #574
+ * owns replacing this with a measured number and a per-plan ceiling. */
+export const ASSIST_TOKEN_BUDGET = 60_000;

--- a/shared/src/assist/tools.ts
+++ b/shared/src/assist/tools.ts
@@ -1,0 +1,966 @@
+// shared/src/assist/tools.ts (#567)
+//
+// The seven tools the in-page assistant's agent loop may call
+// (docs/design/in-page-agent.md, "What the agent may know and do"): declared
+// once here, executed server-side, and driven by two transports that share
+// these exact handler functions - native tools on `SdkRunner`
+// (`shared/src/agents/sdk/`) and the assist MCP entry point
+// (`cli/src/mcp/assist-server.ts`) for the ACP path. #566 owns wiring the
+// loop that calls these; this file owns what each tool is allowed to know
+// and refuse.
+//
+// Every tool takes its authority from `AssistToolContext`, never from a
+// model-supplied argument: the org id, the bound project id, the observed
+// target and the operator persona are all resolved server-side before the
+// loop ever starts. `project_knowledge`'s `projectId` is the one exception,
+// and it is validated against the binding rather than trusted (see its
+// handler below) - an org id or a project id accepted from the model would
+// be a cross-tenant hole one hallucination wide.
+//
+// A tool that has nothing to say returns `{ ok: false, reason }` - an
+// explicit nothing, never `{ ok: true, data: <empty> }` - because "no prior
+// contact with this person" is information a suggestion needs, and an empty
+// result only teaches the model to retry. `check_style` is the one
+// exception: it is deterministic and never refuses, so a clean draft
+// legitimately gets back an empty findings list.
+//
+// No tool writes anything. Not a draft, not an observation, not a run row -
+// the accept path stays the single place the assist plane touches durable
+// state (#520/#521).
+
+import { z } from 'zod';
+import { and, desc, eq, ilike, isNotNull, or, type Column, type SQL } from 'drizzle-orm';
+import { generateText } from 'ai';
+import { createGateway } from '@ai-sdk/gateway';
+import { schema, type Db } from '../db/client.js';
+import { isBlocklisted } from '../blocklist.js';
+import { loadVoiceProfile } from '../operator-voice-profile.js';
+import { resolveEntitlements } from '../plans.js';
+import { resolveFunctionModel, gateModelForPlan } from '../ai/model-functions.js';
+import { checkStyle, type StyleFinding } from '../style-check.js';
+import { PERSONAL_PROJECT_SLUG } from '../personal-project.js';
+import {
+  MAX_COMMENT_CHARS,
+  MAX_POST_CHARS,
+  MAX_THREAD_CHARS,
+  MAX_THREAD_COMMENTS,
+  VOICE_PROFILE_MAX,
+  type ObservedPost,
+} from './suggest-prompt.js';
+import type { OperatorPersona } from './context.js';
+import { MIN_ITEMS_TO_DERIVE } from './voice-profile.js';
+
+// ---------------------------------------------------------------------------
+// The observed target and its image, and the context every handler reads.
+// ---------------------------------------------------------------------------
+
+/**
+ * The image crop captured with the observed target (#569). Declared locally
+ * rather than as a change to `ObservedPost` in this file: #569 lands the
+ * real field (`ObservedPost.image?: ObservedImage`) on its own branch in
+ * parallel, and this shape is structurally identical to what was agreed
+ * with that issue over `hub` - once it lands, `ObservedPost & { image?:
+ * ObservedImage }` below is simply redundant with the base type, never in
+ * conflict with it.
+ */
+export interface ObservedImage {
+  /** `data:<mediaType>;base64,<...>` of the downscaled, capped crop.
+   * Absent when the post has media but no pixels reached the server (not
+   * visible on screen, capture permission not granted). */
+  dataUrl?: string;
+  /** LinkedIn's own alt text, present independently of `dataUrl`. */
+  alt?: string;
+  kind: 'image' | 'video_frame' | 'carousel_page' | 'document_page';
+  /** True for one page of a multi-page carousel or document post - the
+   * description must not overclaim it is the whole post. */
+  partial?: boolean;
+}
+
+/** What `read_thread` and `look_at_image` read: the post `runSuggestion`
+ * already grounded before the loop starts (the request body for a
+ * `post_comment`, or the DB-loaded recent observation for a `post` - see
+ * `web/src/lib/server/suggest.ts`'s `groundedPost`), plus the image crop. */
+export type AssistObservedTarget = ObservedPost & { image?: ObservedImage };
+
+export interface AssistToolContext {
+  db: Db;
+  /** The organization this suggestion belongs to. Every query below filters
+   * on this - never on anything a tool argument could name. */
+  orgId: number;
+  /** The project this suggestion is filed under: the device's bound
+   * project, or the org's `personal` project (see `personal-project.ts`). */
+  boundProjectId: number;
+  /** Null when nothing was captured for this device (a fresh binding, nothing
+   * scrolled since the collector was last on) - every tool that reads it
+   * refuses explicitly rather than fabricating a post. */
+  observedTarget: AssistObservedTarget | null;
+  /** The operator's own persona, loaded once by the caller
+   * (`assist/context.ts`'s `loadCompanionContext`) so `operator_voice`
+   * never re-queries `operator_profiles` itself. */
+  operator: OperatorPersona | null;
+}
+
+/** A tool's answer is either real data or an explicit refusal - never an
+ * empty success, per the module header. */
+export type AssistToolAnswer<T> = { ok: true; data: T } | { ok: false; reason: string };
+
+export interface AssistTool<TArgs = Record<string, never>, TResult = unknown> {
+  name: string;
+  description: string;
+  /** A zod raw shape (not `z.object(...)`), so the same declaration wraps
+   * as-is into both `tool({ inputSchema: z.object(shape) })` for the SDK
+   * path and `registerTool({ inputSchema: shape })` for the assist MCP
+   * server. */
+  schema: z.ZodRawShape;
+  /** `signal` is provided by the loop's cancellation wrapper (#566) and is
+   * optional so the six DB-backed tools can ignore it; `look_at_image` is
+   * the one handler that threads it into a real network call, so a
+   * cancelled suggestion actually stops paying for it rather than merely
+   * being ignored by the caller. */
+  handler: (
+    ctx: AssistToolContext,
+    args: TArgs,
+    signal?: AbortSignal,
+  ) => Promise<AssistToolAnswer<TResult>>;
+}
+
+// ---------------------------------------------------------------------------
+// Shared clamping. Every payload below is bounded the same way the prompt
+// builder already bounds one (suggest-prompt.ts's own `clamp`), and every
+// clamp is marked on the result rather than applied silently.
+// ---------------------------------------------------------------------------
+
+function clampText(text: string, max: number): { text: string; truncated: boolean } {
+  if (text.length <= max) return { text, truncated: false };
+  return { text: text.slice(0, max), truncated: true };
+}
+
+async function resolveLinkedinPlatformId(db: Db): Promise<number | null> {
+  const [row] = await db
+    .select({ id: schema.platforms.id })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'))
+    .limit(1);
+  return row?.id ?? null;
+}
+
+/** The org's `personal` project id, read-only. Unlike
+ * `personal-project.ts`'s `ensurePersonalProject`, this never creates the
+ * row - `project_knowledge` only reads, per the module header ("no tool
+ * writes anything"), and a project every org gets at creation time is not
+ * expected to be missing outside a pre-migration organization. */
+async function resolvePersonalProjectId(db: Db, orgId: number): Promise<number | null> {
+  const [row] = await db
+    .select({ id: schema.projects.id })
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.organizationId, orgId),
+        eq(schema.projects.slug, PERSONAL_PROJECT_SLUG),
+      ),
+    )
+    .limit(1);
+  return row?.id ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// read_thread
+// ---------------------------------------------------------------------------
+
+export interface ReadThreadResult {
+  post: {
+    author: { handle?: string; name?: string };
+    text: string;
+    url?: string;
+    relativeTime?: string;
+    reactionCount?: string;
+    commentCount?: string;
+  };
+  comments: Array<{
+    id?: string;
+    author: { handle?: string; name?: string };
+    body: string;
+    relativeTime?: string;
+    parentId?: string;
+  }>;
+  /** How many comment articles the page actually rendered, per
+   * `ObservedThread.renderedCount` - can run ahead of `comments.length`
+   * once either cap below bites. */
+  renderedCommentCount: number;
+  clamp: { textTruncated: boolean; commentsTruncated: boolean };
+}
+
+const readThread: AssistTool<Record<string, never>, ReadThreadResult> = {
+  name: 'read_thread',
+  description:
+    "The post plus the visible comment thread the human's own browser had rendered for this suggestion: author, text, comment bodies with their authors, relative times and parent relationships. Read this before writing anything specific, so the suggestion says something the thread does not already say.",
+  schema: {},
+  async handler(ctx) {
+    const post = ctx.observedTarget;
+    if (!post) {
+      return {
+        ok: false,
+        reason: 'no thread was captured for this device - nothing rendered to read',
+      };
+    }
+    const { text, truncated: textTruncated } = clampText(post.text ?? '', MAX_POST_CHARS);
+
+    const rawComments = post.thread?.comments ?? [];
+    const cappedComments = rawComments.slice(0, MAX_THREAD_COMMENTS);
+    const comments: ReadThreadResult['comments'] = [];
+    let usedChars = 0;
+    let charsCapped = false;
+    for (const c of cappedComments) {
+      const { text: body } = clampText(c.body ?? '', MAX_COMMENT_CHARS);
+      if (usedChars + body.length > MAX_THREAD_CHARS) {
+        charsCapped = true;
+        break;
+      }
+      usedChars += body.length;
+      comments.push({
+        id: c.id,
+        author: { handle: c.authorHandle, name: c.authorName },
+        body,
+        relativeTime: c.relativeTime,
+        parentId: c.parentId,
+      });
+    }
+
+    return {
+      ok: true,
+      data: {
+        post: {
+          author: { handle: post.authorHandle, name: post.authorName },
+          text,
+          url: post.url,
+          relativeTime: post.relativeTime,
+          reactionCount: post.reactionCount,
+          commentCount: post.commentCount,
+        },
+        comments,
+        renderedCommentCount: post.thread?.renderedCount ?? comments.length,
+        clamp: {
+          textTruncated,
+          commentsTruncated:
+            charsCapped || comments.length < rawComments.length || !!post.thread?.truncated,
+        },
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// look_at_image
+// ---------------------------------------------------------------------------
+
+const LOOK_AT_IMAGE_DESCRIPTION_MAX = 800;
+const VISION_DESCRIPTION_MARKER = 'DESCRIPTION:';
+const VISION_TEXT_MARKER = 'TEXT_IN_IMAGE:';
+
+export interface LookAtImageResult {
+  description: string;
+  /** Text found inside the image, verbatim; null when there was none. */
+  textInImage: string | null;
+  source: 'vision' | 'alt_text';
+  kind: ObservedImage['kind'];
+  partial: boolean;
+  /** Present only when a real vision call ran - the only tool whose result
+   * carries a spend the loop's total usage has to fold in (design doc,
+   * "look_at_image is a real model call and the only tool that spends
+   * tokens"). */
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
+  };
+  clamp: { descriptionTruncated: boolean };
+}
+
+function parseDataUrl(dataUrl: string): { mediaType: string; base64: string } | null {
+  const match = /^data:([-\w.]+\/[-\w.+]+);base64,(.+)$/su.exec(dataUrl.trim());
+  if (!match) return null;
+  return { mediaType: match[1], base64: match[2] };
+}
+
+function imageKindLabel(kind: ObservedImage['kind'], partial: boolean | undefined): string {
+  const base =
+    kind === 'video_frame'
+      ? 'a single frame of a video'
+      : kind === 'carousel_page'
+        ? 'one page of a carousel'
+        : kind === 'document_page'
+          ? 'one page of a document'
+          : 'an image';
+  return partial
+    ? `${base} (only one part of a multi-part post - do not describe it as the whole post)`
+    : base;
+}
+
+/** Extracts the description and any in-image text from the vision model's
+ * reply. A non-compliant reply (no markers) falls back to the raw text as
+ * the description rather than losing it - the same worst-case-is-never-
+ * blank posture `style-check.ts`'s `extractRewrite` and `envelope.ts`
+ * already follow. */
+function splitVisionResponse(raw: string): { description: string; textInImage: string | null } {
+  const descIdx = raw.indexOf(VISION_DESCRIPTION_MARKER);
+  const textIdx = raw.indexOf(VISION_TEXT_MARKER);
+  if (descIdx === -1 || textIdx === -1 || textIdx < descIdx) {
+    const fallback = raw.trim();
+    return { description: fallback || 'the model returned no description', textInImage: null };
+  }
+  const description = raw.slice(descIdx + VISION_DESCRIPTION_MARKER.length, textIdx).trim();
+  const textPart = raw.slice(textIdx + VISION_TEXT_MARKER.length).trim();
+  const textInImage = textPart.length === 0 || /^none$/iu.test(textPart) ? null : textPart;
+  return { description: description || 'the model returned no description', textInImage };
+}
+
+const lookAtImage: AssistTool<Record<string, never>, LookAtImageResult> = {
+  name: 'look_at_image',
+  description:
+    'Looks at the crop of the post\u2019s image, chart or slide that the extension captured from the rendered tab, and returns a short description plus any text found in it. Never fetches a remote asset - the pixels are only ever what the human\u2019s own browser already rendered. Skip this tool entirely on a text-only post.',
+  schema: {},
+  async handler(ctx, _args, signal) {
+    const image = ctx.observedTarget?.image;
+    if (!image) {
+      return { ok: false, reason: 'this post has no image - nothing to look at' };
+    }
+    if (!image.dataUrl && !image.alt) {
+      return {
+        ok: false,
+        reason:
+          'there is an image on this post that could not be captured (not visible on screen, or capture unavailable) - do not guess or invent what it shows',
+      };
+    }
+    if (!image.dataUrl) {
+      const { text, truncated } = clampText(image.alt!, LOOK_AT_IMAGE_DESCRIPTION_MAX);
+      return {
+        ok: true,
+        data: {
+          description: text,
+          textInImage: null,
+          source: 'alt_text',
+          kind: image.kind,
+          partial: image.partial ?? false,
+          clamp: { descriptionTruncated: truncated },
+        },
+      };
+    }
+
+    // No provider API key on a self-host running the ACP backend (the
+    // design doc's "authentication model" argument, section 1) - this one
+    // tool degrades to an explicit nothing rather than failing the whole
+    // loop, the same posture as every other refusal here.
+    const apiKey = process.env.AI_GATEWAY_API_KEY;
+    if (!apiKey) {
+      return {
+        ok: false,
+        reason:
+          'vision is not available on this deployment (no Gateway key configured) - describe only what the post text says',
+      };
+    }
+    const parsed = parseDataUrl(image.dataUrl);
+    if (!parsed) {
+      return { ok: false, reason: 'the captured image could not be decoded' };
+    }
+
+    try {
+      const modelId = await resolveFunctionModel(ctx.db, 'assist_vision');
+      const entitlements = await resolveEntitlements(ctx.db, ctx.orgId);
+      const gatedModelId = await gateModelForPlan(
+        'assist_vision',
+        modelId,
+        entitlements.premiumModels,
+      );
+      const gateway = createGateway({ apiKey });
+
+      const result = await generateText({
+        model: gateway(gatedModelId),
+        abortSignal: signal,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text:
+                  `Describe ${imageKindLabel(image.kind, image.partial)} from a LinkedIn post in two or three ` +
+                  'sentences - only the image itself, not the post text around it. Then transcribe any text ' +
+                  'visible inside the image verbatim, or say "none" if there is none. Answer in exactly this ' +
+                  `shape, nothing before or after it:\n${VISION_DESCRIPTION_MARKER} <two or three sentences>\n` +
+                  `${VISION_TEXT_MARKER} <verbatim text, or none>`,
+              },
+              { type: 'file', mediaType: parsed.mediaType, data: parsed.base64 },
+            ],
+          },
+        ],
+      });
+
+      const { description, textInImage } = splitVisionResponse(result.text);
+      const { text: clampedDescription, truncated } = clampText(
+        description,
+        LOOK_AT_IMAGE_DESCRIPTION_MAX,
+      );
+      return {
+        ok: true,
+        data: {
+          description: clampedDescription,
+          textInImage,
+          source: 'vision',
+          kind: image.kind,
+          partial: image.partial ?? false,
+          usage: {
+            inputTokens: result.usage.inputTokens,
+            outputTokens: result.usage.outputTokens,
+            cacheReadTokens: result.usage.inputTokenDetails?.cacheReadTokens,
+            cacheCreationTokens: result.usage.inputTokenDetails?.cacheWriteTokens,
+          },
+          clamp: { descriptionTruncated: truncated },
+        },
+      };
+    } catch (err) {
+      // A slow or failing vision provider must not fail the whole
+      // suggestion (design doc, "a partial suggestion beats an error") -
+      // it degrades to the same explicit nothing as every other refusal.
+      return {
+        ok: false,
+        reason: `the vision call failed or timed out (${err instanceof Error ? err.message : String(err)}) - describe only what the post text says`,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// author_history
+// ---------------------------------------------------------------------------
+
+const AUTHOR_HISTORY_MAX_ITEMS = 5;
+const AUTHOR_HISTORY_EXCERPT_MAX = 300;
+
+export interface AuthorHistoryResult {
+  handle: string;
+  blocked: boolean;
+  blockedReason: string | null;
+  contactedBefore: boolean;
+  lastContactedAt: string | null;
+  repliedAt: string | null;
+  uncontactable: boolean;
+  uncontactableReason: string | null;
+  priorOutreach: Array<{
+    id: number;
+    kind: string;
+    state: string;
+    /** True for a draft created through an accepted suggestion (a `runs`
+     * row of kind `'assist'`) rather than a campaign. */
+    viaAssist: boolean;
+    excerpt: string;
+    createdAt: string;
+  }>;
+  priorMessages: Array<{ id: number; isFromUs: boolean; excerpt: string; at: string }>;
+  clamp: { outreachTruncated: boolean; messagesTruncated: boolean };
+}
+
+const authorHistory: AssistTool<Record<string, never>, AuthorHistoryResult> = {
+  name: 'author_history',
+  description:
+    "What this organization already knows about the post's author: contact history, prior drafts and sent messages, prior accepted suggestions, and whether they are blocklisted. Prevents greeting somebody as a stranger after three exchanges, and pitching somebody who asked not to be pitched.",
+  schema: {},
+  async handler(ctx) {
+    const authorHandle = ctx.observedTarget?.authorHandle?.trim();
+    if (!authorHandle) {
+      return { ok: false, reason: 'the captured post has no author handle to look up' };
+    }
+    const platformId = await resolveLinkedinPlatformId(ctx.db);
+    if (platformId == null) {
+      return { ok: false, reason: 'the linkedin platform is not configured on this instance' };
+    }
+
+    const [blocklistResult, contactRows, draftRows, messageRows] = await Promise.all([
+      isBlocklisted(ctx.db, {
+        platformId,
+        projectId: ctx.boundProjectId,
+        targetUser: authorHandle,
+      }),
+      ctx.db
+        .select({
+          lastContactedAt: schema.contactHistory.lastContactedAt,
+          repliedAt: schema.contactHistory.repliedAt,
+          uncontactable: schema.contactHistory.uncontactable,
+          uncontactableReason: schema.contactHistory.uncontactableReason,
+        })
+        .from(schema.contactHistory)
+        .where(
+          and(
+            eq(schema.contactHistory.organizationId, ctx.orgId),
+            eq(schema.contactHistory.platformId, platformId),
+            eq(schema.contactHistory.targetUser, authorHandle),
+          ),
+        )
+        .orderBy(desc(schema.contactHistory.lastContactedAt))
+        .limit(1),
+      ctx.db
+        .select({
+          id: schema.drafts.id,
+          kind: schema.drafts.kind,
+          state: schema.drafts.state,
+          body: schema.drafts.body,
+          sentContent: schema.drafts.sentContent,
+          createdAt: schema.drafts.createdAt,
+          runKind: schema.runs.kind,
+        })
+        .from(schema.drafts)
+        .innerJoin(schema.runs, eq(schema.runs.id, schema.drafts.runId))
+        .innerJoin(schema.projects, eq(schema.projects.id, schema.drafts.projectId))
+        .where(
+          and(
+            eq(schema.projects.organizationId, ctx.orgId),
+            eq(schema.drafts.platformId, platformId),
+            eq(schema.drafts.targetUser, authorHandle),
+          ),
+        )
+        .orderBy(desc(schema.drafts.createdAt))
+        .limit(AUTHOR_HISTORY_MAX_ITEMS),
+      ctx.db
+        .select({
+          id: schema.messages.id,
+          isFromUs: schema.messages.isFromUs,
+          body: schema.messages.body,
+          createdAtPlatform: schema.messages.createdAtPlatform,
+        })
+        .from(schema.messages)
+        .innerJoin(schema.contactHistory, eq(schema.contactHistory.id, schema.messages.contactId))
+        .where(
+          and(
+            eq(schema.contactHistory.organizationId, ctx.orgId),
+            eq(schema.contactHistory.platformId, platformId),
+            eq(schema.contactHistory.targetUser, authorHandle),
+          ),
+        )
+        .orderBy(desc(schema.messages.createdAtPlatform))
+        .limit(AUTHOR_HISTORY_MAX_ITEMS),
+    ]);
+
+    const contact = contactRows[0] ?? null;
+    const hasAnySignal =
+      blocklistResult.blocked || !!contact || draftRows.length > 0 || messageRows.length > 0;
+    if (!hasAnySignal) {
+      return {
+        ok: false,
+        reason: `no prior contact with ${authorHandle} - nothing on file for this organization`,
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        handle: authorHandle,
+        blocked: blocklistResult.blocked,
+        blockedReason: blocklistResult.reason,
+        contactedBefore: !!contact,
+        lastContactedAt: contact?.lastContactedAt?.toISOString() ?? null,
+        repliedAt: contact?.repliedAt?.toISOString() ?? null,
+        uncontactable: contact?.uncontactable ?? false,
+        uncontactableReason: contact?.uncontactableReason ?? null,
+        priorOutreach: draftRows.map((d) => ({
+          id: d.id,
+          kind: d.kind,
+          state: d.state,
+          viaAssist: d.runKind === 'assist',
+          excerpt: clampText(d.sentContent ?? d.body, AUTHOR_HISTORY_EXCERPT_MAX).text,
+          createdAt: d.createdAt.toISOString(),
+        })),
+        priorMessages: messageRows.map((m) => ({
+          id: m.id,
+          isFromUs: m.isFromUs,
+          excerpt: clampText(m.body, AUTHOR_HISTORY_EXCERPT_MAX).text,
+          at: m.createdAtPlatform.toISOString(),
+        })),
+        clamp: {
+          outreachTruncated: draftRows.length >= AUTHOR_HISTORY_MAX_ITEMS,
+          messagesTruncated: messageRows.length >= AUTHOR_HISTORY_MAX_ITEMS,
+        },
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// operator_voice
+// ---------------------------------------------------------------------------
+
+/** Mirrors `suggest-prompt.ts`'s private `PERSONA_ABOUT_MAX` (also 1200) -
+ * not exported there, so restated here rather than reached across a module
+ * boundary that does not expose it. */
+const OPERATOR_ABOUT_MAX = 1200;
+
+const DEFAULT_VOICE_NOTE =
+  'No measured voice on file yet for this organization - too few voice samples, sent messages or drafts to say anything honest about how this person writes. Write in a clear, direct, first-person register without presuming a habit that has not been observed.';
+
+export interface OperatorVoiceResult {
+  persona: {
+    displayName: string | null;
+    headline: string | null;
+    about: string | null;
+    notes: string | null;
+  } | null;
+  voice: {
+    status: 'measured' | 'default';
+    summary: string;
+    itemCount: number;
+    derivedAt: string | null;
+  };
+  clamp: { aboutTruncated: boolean; summaryTruncated: boolean };
+}
+
+const operatorVoice: AssistTool<Record<string, never>, OperatorVoiceResult> = {
+  name: 'operator_voice',
+  description:
+    "The operator's own persona and derived writing voice for this organization: who is typing, and how they actually write when they have written enough for that to mean anything. Never invents a voice from a thin corpus - a thin corpus gets an honest default instead.",
+  schema: {},
+  async handler(ctx) {
+    const voiceRow = await loadVoiceProfile(ctx.db, ctx.orgId);
+    const measured =
+      !!voiceRow && voiceRow.itemCount >= MIN_ITEMS_TO_DERIVE && voiceRow.summary.trim().length > 0;
+    const persona = ctx.operator;
+    const about = persona?.about ? clampText(persona.about, OPERATOR_ABOUT_MAX) : null;
+    const summary = measured ? clampText(voiceRow!.summary, VOICE_PROFILE_MAX) : null;
+
+    return {
+      ok: true,
+      data: {
+        persona: persona
+          ? {
+              displayName: persona.displayName ?? null,
+              headline: persona.headline ?? null,
+              about: about?.text ?? null,
+              notes: persona.notes ?? null,
+            }
+          : null,
+        voice: {
+          status: measured ? 'measured' : 'default',
+          summary: measured ? summary!.text : DEFAULT_VOICE_NOTE,
+          itemCount: voiceRow?.itemCount ?? 0,
+          derivedAt: voiceRow?.derivedAt?.toISOString() ?? null,
+        },
+        clamp: {
+          aboutTruncated: about?.truncated ?? false,
+          summaryTruncated: summary?.truncated ?? false,
+        },
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// project_knowledge
+// ---------------------------------------------------------------------------
+
+const PROJECT_KNOWLEDGE_REPOS_MAX = 4;
+const PROJECT_KNOWLEDGE_README_MAX = 400;
+const PROJECT_KNOWLEDGE_DESCRIPTION_MAX = 800;
+const PROJECT_KNOWLEDGE_INSIGHTS_MAX = 2;
+const PROJECT_KNOWLEDGE_INSIGHT_CHARS = 1200;
+
+export interface ProjectKnowledgeResult {
+  project: { id: number; name: string; description: string | null };
+  repos: Array<{
+    owner: string;
+    repo: string;
+    url: string;
+    description: string | null;
+    primaryLanguage: string | null;
+    readmeExcerpt: string | null;
+    recentCommits: Array<{ message: string; committedAt?: string | null }>;
+  }>;
+  insights: Array<{ summary: string; generatedAt: string }>;
+  clamp: { descriptionTruncated: boolean; reposTruncated: boolean; insightsTruncated: boolean };
+}
+
+const projectKnowledge: AssistTool<{ projectId: number }, ProjectKnowledgeResult> = {
+  name: 'project_knowledge',
+  description:
+    "The named project's brief, the organization's public repos and their recent commits, and that project's insights. Only usable for the project this suggestion is filed under, or the organization's personal project - fetch this when the post is actually about the product, skip it otherwise.",
+  schema: { projectId: z.number().int().positive() },
+  async handler(ctx, args) {
+    const personalProjectId = await resolvePersonalProjectId(ctx.db, ctx.orgId);
+    if (args.projectId !== ctx.boundProjectId && args.projectId !== personalProjectId) {
+      return {
+        ok: false,
+        reason: `project ${args.projectId} is neither the project this suggestion is filed under nor this organization's personal project`,
+      };
+    }
+
+    const [projectRow] = await ctx.db
+      .select({
+        id: schema.projects.id,
+        name: schema.projects.name,
+        description: schema.projects.description,
+      })
+      .from(schema.projects)
+      .where(
+        and(eq(schema.projects.id, args.projectId), eq(schema.projects.organizationId, ctx.orgId)),
+      )
+      .limit(1);
+    if (!projectRow) {
+      return { ok: false, reason: `project ${args.projectId} does not exist in this organization` };
+    }
+
+    const [repoRows, insightRows] = await Promise.all([
+      ctx.db
+        .select()
+        .from(schema.githubSources)
+        .where(
+          and(
+            eq(schema.githubSources.organizationId, ctx.orgId),
+            eq(schema.githubSources.active, true),
+          ),
+        )
+        .orderBy(desc(schema.githubSources.fetchedAt))
+        .limit(PROJECT_KNOWLEDGE_REPOS_MAX),
+      ctx.db
+        .select({
+          summaryMd: schema.projectInsights.summaryMd,
+          generatedAt: schema.projectInsights.generatedAt,
+        })
+        .from(schema.projectInsights)
+        .where(eq(schema.projectInsights.projectId, args.projectId))
+        .orderBy(desc(schema.projectInsights.generatedAt))
+        .limit(PROJECT_KNOWLEDGE_INSIGHTS_MAX),
+    ]);
+
+    const repos = repoRows
+      .filter((r) => r.readmeExcerpt || r.description || (r.recentCommits as unknown[])?.length)
+      .map((r) => ({
+        owner: r.owner,
+        repo: r.repo,
+        url: r.url,
+        description: r.description,
+        primaryLanguage: r.primaryLanguage,
+        readmeExcerpt: r.readmeExcerpt
+          ? clampText(r.readmeExcerpt, PROJECT_KNOWLEDGE_README_MAX).text
+          : null,
+        recentCommits:
+          (r.recentCommits as Array<{ message: string; committedAt?: string | null }>) ?? [],
+      }));
+    const insights = insightRows.map((i) => ({
+      summary: clampText(i.summaryMd, PROJECT_KNOWLEDGE_INSIGHT_CHARS).text,
+      generatedAt: i.generatedAt.toISOString(),
+    }));
+    const description = projectRow.description
+      ? clampText(projectRow.description, PROJECT_KNOWLEDGE_DESCRIPTION_MAX)
+      : null;
+
+    if (!description && repos.length === 0 && insights.length === 0) {
+      return {
+        ok: false,
+        reason: `project "${projectRow.name}" has no description, repos or insights on file yet`,
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        project: {
+          id: projectRow.id,
+          name: projectRow.name,
+          description: description?.text ?? null,
+        },
+        repos,
+        insights,
+        clamp: {
+          descriptionTruncated: description?.truncated ?? false,
+          reposTruncated: repoRows.length >= PROJECT_KNOWLEDGE_REPOS_MAX,
+          insightsTruncated: insightRows.length >= PROJECT_KNOWLEDGE_INSIGHTS_MAX,
+        },
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// my_prior_takes
+// ---------------------------------------------------------------------------
+
+const PRIOR_TAKES_MAX_MATCHES = 5;
+const PRIOR_TAKES_EXCERPT_MAX = 400;
+const PRIOR_TAKES_MAX_WORDS = 6;
+
+// A short stopword list, English and Italian - the same split
+// `assist/voice-profile.ts`'s own STOPWORDS carries, for the same reason:
+// Lorenzo's feed is half Italian. Only used to keep a lexical match from
+// firing on grammar rather than subject matter; it does not need to be
+// exhaustive.
+const PRIOR_TAKES_STOPWORDS: Record<string, true> = {
+  the: true, and: true, for: true, with: true, that: true, this: true, have: true, from: true, about: true, your: true, you: true,
+  are: true, was: true, were: true, been: true, they: true, their: true, what: true, when: true, where: true, which: true,
+  into: true, over: true, than: true, then: true, also: true, just: true, like: true, more: true, some: true,
+  della: true, delle: true, degli: true, questo: true, questa: true, queste: true, questi: true, anche: true, come: true,
+  sono: true, stato: true, stati: true, state: true, perche: true, quando: true, dove: true, quale: true, quali: true,
+}; // prettier-ignore
+
+function significantWords(query: string): string[] {
+  const words = query.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const word of words) {
+    if (word.length < 4 || PRIOR_TAKES_STOPWORDS[word] || seen.has(word)) continue;
+    seen.add(word);
+    out.push(word);
+    if (out.length >= PRIOR_TAKES_MAX_WORDS) break;
+  }
+  return out;
+}
+
+function wordMatchClause(column: Column, words: string[]): SQL {
+  return or(...words.map((w) => ilike(column, `%${w}%`)))!;
+}
+
+export type PriorTakeSource = 'voice_sample' | 'message' | 'sent_draft' | 'template';
+
+export interface MyPriorTakesResult {
+  matches: Array<{ source: PriorTakeSource; excerpt: string; at: string | null }>;
+  clamp: { truncatedToTop: boolean };
+}
+
+const myPriorTakes: AssistTool<{ query: string }, MyPriorTakesResult> = {
+  name: 'my_prior_takes',
+  description:
+    "What the operator has already written on a subject - their own voice samples, sent messages, sent drafts and project templates, matched lexically against the query - so a suggestion does not repeat a line used last week. Pass the post's own subject, not the whole post text.",
+  schema: { query: z.string().min(1).max(300) },
+  async handler(ctx, args) {
+    const words = significantWords(args.query);
+    if (words.length === 0) {
+      return { ok: false, reason: 'no searchable words in that query' };
+    }
+
+    const [sampleRows, messageRows, draftRows, templateRows] = await Promise.all([
+      ctx.db
+        .select({
+          text: schema.operatorVoiceSamples.text,
+          at: schema.operatorVoiceSamples.capturedAt,
+        })
+        .from(schema.operatorVoiceSamples)
+        .where(
+          and(
+            eq(schema.operatorVoiceSamples.organizationId, ctx.orgId),
+            eq(schema.operatorVoiceSamples.excluded, false),
+            wordMatchClause(schema.operatorVoiceSamples.text, words),
+          ),
+        )
+        .orderBy(desc(schema.operatorVoiceSamples.capturedAt))
+        .limit(PRIOR_TAKES_MAX_MATCHES),
+      ctx.db
+        .select({ text: schema.messages.body, at: schema.messages.createdAtPlatform })
+        .from(schema.messages)
+        .innerJoin(schema.contactHistory, eq(schema.contactHistory.id, schema.messages.contactId))
+        .where(
+          and(
+            eq(schema.contactHistory.organizationId, ctx.orgId),
+            eq(schema.messages.isFromUs, true),
+            wordMatchClause(schema.messages.body, words),
+          ),
+        )
+        .orderBy(desc(schema.messages.createdAtPlatform))
+        .limit(PRIOR_TAKES_MAX_MATCHES),
+      ctx.db
+        .select({
+          body: schema.drafts.body,
+          sentContent: schema.drafts.sentContent,
+          at: schema.drafts.sentAt,
+        })
+        .from(schema.drafts)
+        .innerJoin(schema.projects, eq(schema.projects.id, schema.drafts.projectId))
+        .where(
+          and(
+            eq(schema.projects.organizationId, ctx.orgId),
+            isNotNull(schema.drafts.sentAt),
+            wordMatchClause(schema.drafts.body, words),
+          ),
+        )
+        .orderBy(desc(schema.drafts.sentAt))
+        .limit(PRIOR_TAKES_MAX_MATCHES),
+      ctx.db
+        .select({ text: schema.templates.body, at: schema.templates.updatedAt })
+        .from(schema.templates)
+        .innerJoin(schema.projects, eq(schema.projects.id, schema.templates.projectId))
+        .where(
+          and(
+            eq(schema.projects.organizationId, ctx.orgId),
+            wordMatchClause(schema.templates.body, words),
+          ),
+        )
+        .orderBy(desc(schema.templates.updatedAt))
+        .limit(PRIOR_TAKES_MAX_MATCHES),
+    ]);
+
+    const matches = [
+      ...sampleRows.map((r) => ({
+        source: 'voice_sample' as const,
+        excerpt: clampText(r.text, PRIOR_TAKES_EXCERPT_MAX).text,
+        at: r.at?.toISOString() ?? null,
+      })),
+      ...messageRows.map((r) => ({
+        source: 'message' as const,
+        excerpt: clampText(r.text, PRIOR_TAKES_EXCERPT_MAX).text,
+        at: r.at?.toISOString() ?? null,
+      })),
+      ...draftRows.map((r) => ({
+        source: 'sent_draft' as const,
+        excerpt: clampText(r.sentContent ?? r.body, PRIOR_TAKES_EXCERPT_MAX).text,
+        at: r.at?.toISOString() ?? null,
+      })),
+      ...templateRows.map((r) => ({
+        source: 'template' as const,
+        excerpt: clampText(r.text, PRIOR_TAKES_EXCERPT_MAX).text,
+        at: r.at?.toISOString() ?? null,
+      })),
+    ]
+      .sort((a, b) => (b.at ?? '').localeCompare(a.at ?? ''))
+      .slice(0, PRIOR_TAKES_MAX_MATCHES);
+
+    if (matches.length === 0) {
+      return { ok: false, reason: `no prior writing on file matches "${args.query}"` };
+    }
+    const totalFound =
+      sampleRows.length + messageRows.length + draftRows.length + templateRows.length;
+    return { ok: true, data: { matches, clamp: { truncatedToTop: totalFound > matches.length } } };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// check_style
+// ---------------------------------------------------------------------------
+
+export interface CheckStyleResult {
+  findings: StyleFinding[];
+}
+
+const checkStyleTool: AssistTool<{ text: string }, CheckStyleResult> = {
+  name: 'check_style',
+  description:
+    'Runs the deterministic house-style checker against a draft and returns every finding - a banned character, a filler opener, a tricolon, a LinkedIn tell - so the model can fix its own tells before answering. Never refuses (an empty findings list is a real, clean answer). Not a substitute for the server-side enforcement that runs on every draft regardless.',
+  schema: { text: z.string().min(1).max(20_000) },
+  async handler(_ctx, args) {
+    return { ok: true, data: { findings: checkStyle(args.text) } };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// The seven tools.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const ASSIST_TOOLS: Array<AssistTool<any, any>> = [
+  readThread,
+  lookAtImage,
+  authorHistory,
+  operatorVoice,
+  projectKnowledge,
+  myPriorTakes,
+  checkStyleTool,
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const ASSIST_TOOLS_BY_NAME: Record<string, AssistTool<any, any>> = Object.fromEntries(
+  ASSIST_TOOLS.map((t) => [t.name, t]),
+);

--- a/shared/tests/assist-tools.test.ts
+++ b/shared/tests/assist-tools.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import {
+  ASSIST_TOOLS,
+  ASSIST_TOOLS_BY_NAME,
+  type AssistToolContext,
+  type AssistObservedTarget,
+} from '../src/assist/tools.js';
+import { ensurePersonalProject } from '../src/personal-project.js';
+import { recordVoiceSamples } from '../src/operator-profile.js';
+
+// #567: the seven assist tool handlers. What matters here is what a pure
+// unit test cannot check on its own - real org-scoped queries against real
+// tables - and the refusal contract every tool follows: an explicit nothing
+// (`{ ok: false, reason }`), never an empty success, when there is nothing
+// to say.
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE operator_voice_profiles, operator_voice_samples, operator_profiles,
+      messages, contact_history, drafts, runs, campaigns, templates, accounts,
+      project_insights, github_sources, blocklist, projects
+      RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function ensureOrg(slug: string): Promise<number> {
+  const db = getDb();
+  await db.insert(schema.organizations).values({ slug, name: slug }).onConflictDoNothing();
+  const [org] = await db
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.slug, slug));
+  return org!.id;
+}
+
+async function platformId(slug: string): Promise<number> {
+  const [p] = await getDb().select().from(schema.platforms).where(eq(schema.platforms.slug, slug));
+  return p!.id;
+}
+
+async function makeProject(orgId: number, slug: string, description?: string): Promise<number> {
+  const [p] = await getDb()
+    .insert(schema.projects)
+    .values({ organizationId: orgId, slug, name: slug, description })
+    .returning({ id: schema.projects.id });
+  return p!.id;
+}
+
+function baseCtx(
+  overrides: Partial<AssistToolContext> & { orgId: number; boundProjectId: number },
+): AssistToolContext {
+  return { db: getDb(), observedTarget: null, operator: null, ...overrides };
+}
+
+describe('shared/src/assist/tools', () => {
+  beforeEach(reset);
+
+  describe('read_thread', () => {
+    it('refuses with an explicit nothing when no thread was captured', async () => {
+      const ctx = baseCtx({ orgId: 1, boundProjectId: 1, observedTarget: null });
+      const result = await ASSIST_TOOLS_BY_NAME.read_thread.handler(ctx, {});
+      expect(result.ok).toBe(false);
+    });
+
+    it('returns the post and the visible comment thread, clamp marked false when nothing was cut', async () => {
+      const observedTarget: AssistObservedTarget = {
+        authorHandle: 'jdoe',
+        authorName: 'Jane Doe',
+        text: 'Hello world',
+        thread: {
+          comments: [
+            {
+              id: 'c1',
+              authorHandle: 'bob',
+              authorName: 'Bob',
+              body: 'nice post',
+              relativeTime: '2h',
+            },
+          ],
+          renderedCount: 1,
+          truncated: false,
+        },
+      };
+      const ctx = baseCtx({ orgId: 1, boundProjectId: 1, observedTarget });
+      const result = await ASSIST_TOOLS_BY_NAME.read_thread.handler(ctx, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.post.text).toBe('Hello world');
+      expect(result.data.post.author.handle).toBe('jdoe');
+      expect(result.data.comments).toHaveLength(1);
+      expect(result.data.comments[0].body).toBe('nice post');
+      expect(result.data.clamp).toEqual({ textTruncated: false, commentsTruncated: false });
+    });
+
+    it('marks the clamp when the extension-reported thread was already truncated', async () => {
+      const observedTarget: AssistObservedTarget = {
+        text: 'Hello world',
+        thread: { comments: [], renderedCount: 40, truncated: true },
+      };
+      const ctx = baseCtx({ orgId: 1, boundProjectId: 1, observedTarget });
+      const result = await ASSIST_TOOLS_BY_NAME.read_thread.handler(ctx, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.clamp.commentsTruncated).toBe(true);
+    });
+  });
+
+  describe('look_at_image', () => {
+    it('refuses with an explicit nothing when the post has no image at all', async () => {
+      const ctx = baseCtx({
+        orgId: 1,
+        boundProjectId: 1,
+        observedTarget: { text: 'no image here' },
+      });
+      const result = await ASSIST_TOOLS_BY_NAME.look_at_image.handler(ctx, {});
+      expect(result.ok).toBe(false);
+    });
+
+    it('refuses with an explicit nothing when the image exists but nothing was captured', async () => {
+      const ctx = baseCtx({
+        orgId: 1,
+        boundProjectId: 1,
+        observedTarget: { text: 'x', image: { kind: 'image' } },
+      });
+      const result = await ASSIST_TOOLS_BY_NAME.look_at_image.handler(ctx, {});
+      expect(result.ok).toBe(false);
+    });
+
+    it('describes from alt text with no model call when only alt text is present', async () => {
+      const ctx = baseCtx({
+        orgId: 1,
+        boundProjectId: 1,
+        observedTarget: {
+          text: 'x',
+          image: { kind: 'image', alt: 'A bar chart showing quarterly growth' },
+        },
+      });
+      const result = await ASSIST_TOOLS_BY_NAME.look_at_image.handler(ctx, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.source).toBe('alt_text');
+      expect(result.data.description).toContain('bar chart');
+      expect(result.data.usage).toBeUndefined();
+    });
+
+    it('refuses with an explicit nothing rather than throwing when no Gateway key is configured', async () => {
+      const previous = process.env.AI_GATEWAY_API_KEY;
+      delete process.env.AI_GATEWAY_API_KEY;
+      try {
+        const ctx = baseCtx({
+          orgId: 1,
+          boundProjectId: 1,
+          observedTarget: {
+            text: 'x',
+            image: { kind: 'image', dataUrl: 'data:image/png;base64,AAAA' },
+          },
+        });
+        const result = await ASSIST_TOOLS_BY_NAME.look_at_image.handler(ctx, {});
+        expect(result.ok).toBe(false);
+      } finally {
+        if (previous !== undefined) process.env.AI_GATEWAY_API_KEY = previous;
+      }
+    });
+  });
+
+  describe('author_history', () => {
+    it("never returns another organization's contact rows - org scoping", async () => {
+      const orgA = await ensureOrg('at-org-a');
+      const orgB = await ensureOrg('at-org-b');
+      const linkedin = await platformId('linkedin');
+      await getDb()
+        .insert(schema.contactHistory)
+        .values({
+          platformId: linkedin,
+          accountHandle: 'acct-a',
+          targetUser: 'shared-handle',
+          organizationId: orgA,
+          repliedAt: new Date('2026-01-01T00:00:00Z'),
+        });
+      await getDb()
+        .insert(schema.contactHistory)
+        .values({
+          platformId: linkedin,
+          accountHandle: 'acct-b',
+          targetUser: 'shared-handle',
+          organizationId: orgB,
+          repliedAt: new Date('2026-06-01T00:00:00Z'),
+          uncontactable: true,
+          uncontactableReason: "org B's own private fact",
+        });
+      const projA = await makeProject(orgA, 'at-proj-a');
+      const ctx = baseCtx({
+        orgId: orgA,
+        boundProjectId: projA,
+        observedTarget: { authorHandle: 'shared-handle', text: 'x' },
+      });
+      const result = await ASSIST_TOOLS_BY_NAME.author_history.handler(ctx, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.repliedAt).toBe(new Date('2026-01-01T00:00:00Z').toISOString());
+      expect(result.data.uncontactable).toBe(false);
+      expect(result.data.uncontactableReason).toBeNull();
+    });
+
+    it('refuses with an explicit nothing when there is no prior contact', async () => {
+      const orgA = await ensureOrg('at-org-empty');
+      const projA = await makeProject(orgA, 'at-proj-empty');
+      const ctx = baseCtx({
+        orgId: orgA,
+        boundProjectId: projA,
+        observedTarget: { authorHandle: 'nobody-seen-before', text: 'x' },
+      });
+      const result = await ASSIST_TOOLS_BY_NAME.author_history.handler(ctx, {});
+      expect(result.ok).toBe(false);
+    });
+
+    it('surfaces a blocklisted handle even with no contact history on file', async () => {
+      const orgA = await ensureOrg('at-org-blocked');
+      const projA = await makeProject(orgA, 'at-proj-blocked');
+      const linkedin = await platformId('linkedin');
+      await getDb().insert(schema.blocklist).values({
+        platformId: linkedin,
+        kind: 'user',
+        value: 'spammer',
+        scope: 'global',
+        reason: 'asked not to be pitched',
+      });
+      const ctx = baseCtx({
+        orgId: orgA,
+        boundProjectId: projA,
+        observedTarget: { authorHandle: 'spammer', text: 'x' },
+      });
+      const result = await ASSIST_TOOLS_BY_NAME.author_history.handler(ctx, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.blocked).toBe(true);
+      expect(result.data.blockedReason).toBe('asked not to be pitched');
+      expect(result.data.contactedBefore).toBe(false);
+    });
+
+    it('refuses with an explicit nothing when the captured post has no author handle', async () => {
+      const ctx = baseCtx({
+        orgId: 1,
+        boundProjectId: 1,
+        observedTarget: { text: 'no author here' },
+      });
+      const result = await ASSIST_TOOLS_BY_NAME.author_history.handler(ctx, {});
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('operator_voice', () => {
+    it('reports an honest default, never an invented voice, when the corpus is thin', async () => {
+      const orgA = await ensureOrg('ov-org-thin');
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: 1 });
+      const result = await ASSIST_TOOLS_BY_NAME.operator_voice.handler(ctx, {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.voice.status).toBe('default');
+      expect(result.data.voice.itemCount).toBe(0);
+      expect(result.data.persona).toBeNull();
+    });
+
+    it('always answers - never refuses, even with nothing on file', async () => {
+      const orgA = await ensureOrg('ov-org-never-refuses');
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: 1 });
+      const result = await ASSIST_TOOLS_BY_NAME.operator_voice.handler(ctx, {});
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('project_knowledge', () => {
+    it('refuses a project id that is neither the bound project nor the personal project', async () => {
+      const orgA = await ensureOrg('pk-org-a');
+      const projBound = await makeProject(orgA, 'pk-bound');
+      const projOther = await makeProject(orgA, 'pk-other');
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBound });
+      const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
+        projectId: projOther,
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it("refuses another organization's project id even though it is a valid row", async () => {
+      const orgA = await ensureOrg('pk-org-x');
+      const orgB = await ensureOrg('pk-org-y');
+      const projBoundA = await makeProject(orgA, 'pk-bound-a');
+      const projB = await makeProject(orgB, 'pk-proj-b', "org B's own product");
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBoundA });
+      const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
+        projectId: projB,
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('answers for the bound project with its description', async () => {
+      const orgA = await ensureOrg('pk-org-b');
+      const projBound = await makeProject(orgA, 'pk-bound2', 'A product that does X');
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBound });
+      const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
+        projectId: projBound,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.project.description).toBe('A product that does X');
+    });
+
+    it('answers for the personal project even when it is not the bound project', async () => {
+      const orgA = await ensureOrg('pk-org-c');
+      const projBound = await makeProject(orgA, 'pk-bound3', 'Bound product');
+      const personalId = await ensurePersonalProject(getDb(), orgA);
+      await getDb()
+        .update(schema.projects)
+        .set({ description: 'The operator, not a product' })
+        .where(eq(schema.projects.id, personalId));
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBound });
+      const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
+        projectId: personalId,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.project.description).toBe('The operator, not a product');
+    });
+
+    it('refuses with an explicit nothing when the project has no description, repos or insights', async () => {
+      const orgA = await ensureOrg('pk-org-empty');
+      const projBound = await makeProject(orgA, 'pk-bound-empty');
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBound });
+      const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
+        projectId: projBound,
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it("never returns another organization's github repos - org scoping", async () => {
+      const orgA = await ensureOrg('pk-org-repo-a');
+      const orgB = await ensureOrg('pk-org-repo-b');
+      await getDb().insert(schema.githubSources).values({
+        organizationId: orgB,
+        owner: 'org-b-owner',
+        repo: 'org-b-repo',
+        url: 'https://github.com/org-b-owner/org-b-repo',
+        description: "org B's private repo",
+        active: true,
+        fetchedAt: new Date(),
+      });
+      const projBound = await makeProject(
+        orgA,
+        'pk-bound-repo',
+        'A product with no repos of its own',
+      );
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBound });
+      const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
+        projectId: projBound,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.repos).toHaveLength(0);
+    });
+  });
+
+  describe('my_prior_takes', () => {
+    it("never returns another organization's prior writing - org scoping", async () => {
+      const orgA = await ensureOrg('pt-org-a');
+      const orgB = await ensureOrg('pt-org-b');
+      const linkedin = await platformId('linkedin');
+      await recordVoiceSamples(getDb(), orgA, linkedin, [
+        { externalId: 'pt-a-1', text: 'We just finished a big database migration this week.' },
+      ]);
+      await recordVoiceSamples(getDb(), orgB, linkedin, [
+        {
+          externalId: 'pt-b-1',
+          text: "Org B's own database migration story, never seen by org A.",
+        },
+      ]);
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: 1 });
+      const result = await ASSIST_TOOLS_BY_NAME.my_prior_takes.handler(ctx, {
+        query: 'database migration',
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.matches).toHaveLength(1);
+      expect(result.data.matches[0].excerpt).toContain('We just finished');
+    });
+
+    it('refuses with an explicit nothing when nothing matches', async () => {
+      const orgA = await ensureOrg('pt-org-empty');
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: 1 });
+      const result = await ASSIST_TOOLS_BY_NAME.my_prior_takes.handler(ctx, {
+        query: 'quantum photosynthesis',
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it('refuses with an explicit nothing when the query has no searchable words', async () => {
+      const orgA = await ensureOrg('pt-org-nowords');
+      const ctx = baseCtx({ orgId: orgA, boundProjectId: 1 });
+      const result = await ASSIST_TOOLS_BY_NAME.my_prior_takes.handler(ctx, { query: 'a an it' });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('check_style', () => {
+    it('never refuses - a clean draft gets an empty findings list', async () => {
+      const ctx = baseCtx({ orgId: 1, boundProjectId: 1 });
+      const result = await ASSIST_TOOLS_BY_NAME.check_style.handler(ctx, {
+        text: 'A clean, direct sentence.',
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.findings).toEqual([]);
+    });
+
+    it('surfaces a real house-style finding', async () => {
+      const ctx = baseCtx({ orgId: 1, boundProjectId: 1 });
+      const result = await ASSIST_TOOLS_BY_NAME.check_style.handler(ctx, {
+        text: 'This is great \u2014 really great.',
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.findings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('the tool set', () => {
+    it('declares exactly the seven tools the design doc names', () => {
+      expect(ASSIST_TOOLS.map((t) => t.name).sort()).toEqual([
+        'author_history',
+        'check_style',
+        'look_at_image',
+        'my_prior_takes',
+        'operator_voice',
+        'project_knowledge',
+        'read_thread',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## What changed

Declares the seven read-only tools the in-page assistant's agent loop may call, per `docs/design/in-page-agent.md` section 3 and #567's own acceptance criteria.

- `shared/src/assist/tools.ts` (new): `read_thread`, `look_at_image`, `author_history`, `operator_voice`, `project_knowledge`, `my_prior_takes`, `check_style`. One implementation, shared by both transports the epic needs (native SDK tools and the assist MCP path) - each tool is `{ name, description, schema (zod raw shape), handler(ctx, args, signal?) }`.
- `shared/src/assist/budget.ts` (new): the six budget constants the design doc names (`ASSIST_MAX_STEPS`, `ASSIST_SOFT_BUDGET_MS`, `ASSIST_HARD_TIMEOUT_MS`, `ASSIST_TOOL_TIMEOUT_MS`, `ASSIST_VISION_TIMEOUT_MS`, `ASSIST_TOKEN_BUDGET`), each with the doc's own rationale as a comment.
- `shared/src/ai/model-functions.ts`: added `assist_vision`, the per-function model knob `look_at_image`'s real vision call resolves and gates against, alongside the existing five.
- `cli/src/mcp/assist-server.ts` + `assist-index.ts` + `bin/pitchbox-assist-mcp` (new): the assist MCP entry point, a sibling of `bin/pitchbox-mcp`. Registers exactly the seven `ASSIST_TOOLS`, imports nothing from `cli/src/mcp/server.ts` (the campaign server, untouched, still 26 tools). Binds to an organization and a project rather than a run; the observed target and operator persona - too large and too structured for scalar env vars - travel as a JSON context file the caller writes into the run's temp cwd (`PITCHBOX_ASSIST_CONTEXT_FILE`), mirroring `suggest.ts`'s existing `mkdtemp`/`rm` lifecycle.

## Design decisions worth flagging

- **Authority is server-resolved, never model-supplied.** `AssistToolContext` carries `db`, `orgId`, `boundProjectId`, `observedTarget`, `operator`. `project_knowledge` is the one tool with an id argument, and it is validated against the bound project or the org's personal project (read-only lookup, never `ensurePersonalProject`, since no tool writes anything) rather than trusted.
- **Explicit nothing, never an empty success.** Every tool but `check_style` returns `{ ok: false, reason }` when it has nothing to say - "no prior contact with this person" is information, not a retry signal.
- **`look_at_image` is the one tool with real spend.** It calls `generateText` against the Gateway with the new `assist_vision` model function, gated by `gateModelForPlan` the same way `assist_suggest` already is. No `AI_GATEWAY_API_KEY` (self-host on the ACP backend, per the design doc's authentication-model argument) degrades to an explicit nothing rather than failing the suggestion. It accepts an optional `signal?: AbortSignal` (the only tool that does) threaded into `abortSignal`, so a cancelled suggestion actually stops paying for the in-flight call rather than merely walking away from the promise - coordinated with `AssistLoop`/#566 over `hub` so the loop's cancellation wrapper has something real to abort.
- **`ObservedImage` is declared locally in `tools.ts`** (`ObservedPost & { image?: ObservedImage }`) rather than added to `suggest-prompt.ts` directly, since #569 (`PostImage`) is landing that exact field on `ObservedPost` in parallel on its own branch - the shape was agreed over `hub` first, and once #569 lands the two are structurally redundant, never in conflict.
- **`operator_voice` builds against today's `loadVoiceProfile` + the existing `MIN_ITEMS_TO_DERIVE`**, deciding measured-vs-default itself, rather than the `resolveOperatorVoiceProfile` wrapper #570/#571 (`WritingProfile`) is landing - decouples this PR's merge order from theirs; swapping over once that lands is a clean small follow-up, not blocking here.

## Non-goals (owned elsewhere in this wave)

- The loop itself and wiring these tools into `SdkRunner`/`AcpRunner` (#566).
- The extension's image capture and the `ObservedImage` field landing on `ObservedPost` for real (#569).
- The writing profile's own derivation depth (#570).

## Verified

```
pnpm -F @pitchbox/shared typecheck
pnpm -F @pitchbox/cli typecheck
npx eslint shared/src/assist/tools.ts shared/src/assist/budget.ts shared/src/ai/model-functions.ts shared/tests/assist-tools.test.ts cli/src/mcp/assist-server.ts cli/src/mcp/assist-index.ts cli/tests/mcp/assist-server.test.ts
npx prettier --check <same files, plus shared/package.json>
DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5434/pitchbox_test_tools pnpm exec vitest run shared/tests/assist-tools.test.ts cli/tests/mcp/assist-server.test.ts
DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5434/pitchbox_test_tools pnpm exec vitest run shared/tests/model-functions.test.ts shared/tests/model-premium-gate.test.ts
```

35 tests pass (25 in `assist-tools.test.ts`, 5 in `assist-server.test.ts`, 17 pre-existing model-function tests unaffected by the `assist_vision` addition, minus overlap).

**Proved the org-scoping test actually bites**, per the acceptance criteria: temporarily removed the `organizationId` predicate from `author_history`'s `contact_history` query, re-ran `-t "org scoping"`, watched it fail (org B's later `repliedAt`/`uncontactable` leaked into org A's answer), then restored the predicate and confirmed green again.

Also directly smoke-tested the assist MCP server over an in-memory MCP transport (`createAssistMcpServer` + `@ai-sdk/mcp`'s client): exactly 7 tools listed, matching `ASSIST_TOOLS_BY_NAME`'s keys.

Did **not** run `pnpm test` (full suite) or `pnpm run lint` (whole repo) per the batch's minimal-covering-subset instruction - parallel siblings are mid-flight on shared files.

## Left deliberately open

- `operator_voice`'s default-voice text is a plain honest line I wrote (`DEFAULT_VOICE_NOTE`), not #571's real defaults - #571 hasn't landed yet, and swapping it in later is additive.
- `my_prior_takes` matches lexically via `ILIKE` per significant word rather than full-text search - no migration in this wave adds a `tsvector` index, and a straightforward query is proportionate to an early-stage corpus size.
- No test exercises `look_at_image`'s real Gateway call end to end (would need a live `AI_GATEWAY_API_KEY` and a real model) - covered instead by the no-image / no-capture / alt-text-only / no-Gateway-key paths, which are the tool's actual refusal surface.
