### PR TITLE
feat(shared): measure the operator's own voice past openings and closings, with human defaults and real versioning

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -38,6 +38,7 @@
     "./assist/voice-profile": "./src/assist/voice-profile.ts",
     "./assist/tools": "./src/assist/tools.ts",
     "./assist/budget": "./src/assist/budget.ts",
+    "./assist/voice-defaults": "./src/assist/voice-defaults.ts",
     "./operator-profile": "./src/operator-profile.ts",
     "./operator-voice-profile": "./src/operator-voice-profile.ts",
     "./github-sources": "./src/github-sources.ts",

--- a/shared/src/assist/voice-defaults.ts
+++ b/shared/src/assist/voice-defaults.ts
@@ -1,0 +1,63 @@
+// shared/src/assist/voice-defaults.ts
+//
+// #571: what the model is told about "how the operator writes" before there
+// is enough of the operator's own writing to measure it honestly
+// (`measureVoiceCorpus`'s own MIN_ITEMS_TO_DERIVE floor, `voice-profile.ts`).
+// A new user has nothing on file, and the fallback used to be a single
+// "professional register" line plus the house style section - not enough to
+// keep a draft from sounding like every other LinkedIn comment.
+//
+// This is not a second derivation path, and it is not shaped like one on
+// purpose: `DefaultVoiceProfile` shares no fields with `VoiceMeasurement`,
+// so nothing here can be mistaken for something that was measured.
+// `resolveVoiceProfile` (`../operator-voice-profile.ts`) is the only thing
+// that reaches for this object, and only once the corpus is too thin to
+// measure - it marks every axis it hands out as 'default', never
+// 'measured'. One named object, so a caller has one thing to render or
+// override, not sentences scattered through a prompt builder.
+
+export type DefaultVoiceProfile = {
+  /** One human-readable paragraph a prompt or a Settings page can show
+   * verbatim, the same shape `describeVoiceProfile` returns for a real
+   * measurement - but stated as a default, never phrased as if it were
+   * read off the operator's own writing. */
+  summary: string;
+  /** The rules themselves, one sentence each, so a consumer can render
+   * them as a list or fold them into a prompt without re-splitting prose. */
+  rules: string[];
+  /** Candidate words a default-sounding draft leaks. Overlaps house style's
+   * puffery bans (`shared/src/style-check.ts`'s PUFFERY_WORDS and
+   * WRAPUP_CLOSERS already cover "unlock" and "game-changer") and adds the
+   * rest of the LinkedIn-specific ones #571 names ("humbled", "thrilled to
+   * share", "this resonates") that the checker does not ban yet. Read-only
+   * evidence for what "plain words" means here, never a second enforcement
+   * path - `checkStyle` is still the only thing that blocks a draft. */
+  avoidWords: string[];
+};
+
+export const DEFAULT_VOICE_PROFILE: DefaultVoiceProfile = {
+  summary:
+    "No writing on file yet, so this is a default style, not a measurement: a short first sentence with no preamble, one idea anchored to a concrete detail from the post, plain words, and a length that fits the room rather than a paragraph - matched to the post's own language and register rather than a house tone.",
+  rules: [
+    'Open with a short first sentence: no preamble, no restating the post, no "Great post!".',
+    'No tricolons, no "not just X but Y", no rhetorical question as an opener.',
+    'No wrap-up closer that summarises what was just said.',
+    'Plain words: avoid the candidates in avoidWords.',
+    'One idea per comment, anchored to a concrete detail from the post or thread.',
+    "Match the post's own language and register rather than a house tone.",
+    'Length that fits the room: about as long as the median visible comment under the post, not a paragraph.',
+  ],
+  avoidWords: [
+    'leverage',
+    'seamless',
+    'robust',
+    'comprehensive',
+    'delve',
+    'unlock',
+    'elevate',
+    'game-changer',
+    'humbled',
+    'thrilled to share',
+    'this resonates',
+  ],
+};

--- a/shared/src/assist/voice-profile.ts
+++ b/shared/src/assist/voice-profile.ts
@@ -16,10 +16,27 @@
 // nothing, the same rule register.ts's MIN_WORDS_TO_DESCRIBE follows:
 // describing three posts as having a "recurring" anything is inventing a
 // pattern out of noise.
+//
+// 2026-09-09 (#570): extended past openings/closings/reused words into six
+// more axes - rhythm, punctuation, shape, voice markers, lexicon and
+// language split - because that quartet was a fraction of what makes
+// writing recognisably somebody's. Every new axis follows the same
+// discipline: a countable property, a named floor, and an empty result
+// rather than a guess when the corpus has not earned an opinion. #571's
+// human defaults (`assist/voice-defaults.ts`) are a separate, deliberately
+// different-shaped object for exactly this reason - a default is a rule to
+// follow, not a number this module claims to have measured.
 
 import { readPostRegister, type RegisterTrait } from './register.js';
 
 export type VoiceCorpusItemKind = 'voice_sample' | 'message' | 'draft' | 'template';
+
+const VOICE_CORPUS_ITEM_KINDS: readonly VoiceCorpusItemKind[] = [
+  'voice_sample',
+  'message',
+  'draft',
+  'template',
+];
 
 /** One piece of the operator's own writing, tagged with where it came from
  * and its id, so the caller can turn a measurement back into evidence
@@ -34,8 +51,9 @@ export type VoiceCorpusItem = {
  * two posts sharing an opening word is coincidence, not a habit. */
 export const MIN_ITEMS_TO_DERIVE = 3;
 
-/** A register trait counts as habitual, not incidental, only once it shows
- * up in a clear majority of the measurable corpus. */
+/** A register trait, or any other boolean habit below, counts as habitual
+ * rather than incidental only once it shows up in a clear majority of the
+ * measurable corpus. */
 const TRAIT_DOMINANCE_RATIO = 0.6;
 
 /** How many words of an opening are compared when looking for a repeated
@@ -47,8 +65,8 @@ const OPENING_WORDS = 2;
  * what you think") reads as a phrase over a longer span than an opening
  * hook does. */
 const CLOSING_WORDS = 3;
-/** Floor on how many separate items must share a phrase before it counts as
- * recurring, regardless of corpus size. */
+/** Floor on how many separate items must share a phrase, emoji or hashtag
+ * before it counts as recurring, regardless of corpus size. */
 const MIN_PHRASE_REPEATS = 2;
 /** Above the floor, a phrase has to cover this fraction of the corpus - a
  * bigger corpus should need more than two coincidental matches to call
@@ -198,6 +216,524 @@ function topCommonWords(wordLists: string[][]): string[] {
     .map(([w]) => w);
 }
 
+// ---------------------------------------------------------------------------
+// Small numeric helpers shared by the axes below. Kept local: none of this
+// is specific to voice, but a shared math-utils module would be one more
+// place to look for what is otherwise a handful of small functions.
+// ---------------------------------------------------------------------------
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function median(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+/** Interquartile range - the spread measure #570 asks for ("median and
+ * spread, not just mean"). Robust to one unusually long or short item in a
+ * small corpus the way a standard deviation is not. */
+function interquartileRange(nums: number[]): number {
+  if (nums.length < 4) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const half = Math.floor(sorted.length / 2);
+  const q1 = median(sorted.slice(0, half));
+  const q3 = median(sorted.slice(sorted.length - half));
+  return round2(q3 - q1);
+}
+
+function perHundredWords(count: number, wordCount: number): number {
+  return wordCount > 0 ? round2((count / wordCount) * 100) : 0;
+}
+
+// Sentence ends, with the common abbreviations that would otherwise split a
+// sentence in half left alone by requiring whitespace or a line break after
+// the mark - the same split register.ts uses, kept in step on purpose.
+function splitSentences(text: string): string[] {
+  return text
+    .split(/(?<=[.!?…])(?:\s+|\n)/u)
+    .map((s) => s.trim())
+    .filter((s) => s.split(/\s+/u).filter(Boolean).length > 0);
+}
+
+function splitParagraphs(text: string): string[] {
+  return text
+    .split(/\n\s*\n/u)
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Rhythm: sentence and paragraph length, and whether a piece opens short.
+// ---------------------------------------------------------------------------
+
+export type RhythmProfile = {
+  /** Median words per sentence, pooled across every sentence in the corpus
+   * - not the mean of each item's own mean, which one long or short outlier
+   * post can skew more than it should. */
+  medianSentenceWords: number;
+  /** Interquartile range of sentence length: how much it varies, not just
+   * where the middle sits. */
+  sentenceWordsSpread: number;
+  medianParagraphWords: number;
+  /** Fraction of sentences at or under FRAGMENT_MAX_WORDS - "shipped
+   * yesterday" reads as a fragment, not a sentence missing its subject. */
+  fragmentRatio: number;
+  /** Fraction of items whose first sentence is at or under
+   * SHORT_OPENING_MAX_WORDS words. */
+  shortOpeningRatio: number;
+};
+
+const FRAGMENT_MAX_WORDS = 4;
+const SHORT_OPENING_MAX_WORDS = 6;
+
+export const EMPTY_RHYTHM: RhythmProfile = {
+  medianSentenceWords: 0,
+  sentenceWordsSpread: 0,
+  medianParagraphWords: 0,
+  fragmentRatio: 0,
+  shortOpeningRatio: 0,
+};
+
+function measureRhythm(texts: string[]): RhythmProfile {
+  const sentenceWordCounts: number[] = [];
+  const paragraphWordCounts: number[] = [];
+  let shortOpenings = 0;
+  let fragments = 0;
+
+  for (const text of texts) {
+    const sentences = splitSentences(text);
+    for (const s of sentences) {
+      const words = s.split(/\s+/u).filter(Boolean).length;
+      sentenceWordCounts.push(words);
+      if (words <= FRAGMENT_MAX_WORDS) fragments += 1;
+    }
+    if (sentences.length > 0) {
+      const firstWords = sentences[0]!.split(/\s+/u).filter(Boolean).length;
+      if (firstWords <= SHORT_OPENING_MAX_WORDS) shortOpenings += 1;
+    }
+    for (const p of splitParagraphs(text)) {
+      paragraphWordCounts.push(p.split(/\s+/u).filter(Boolean).length);
+    }
+  }
+
+  return {
+    medianSentenceWords: Math.round(median(sentenceWordCounts)),
+    sentenceWordsSpread: interquartileRange(sentenceWordCounts),
+    medianParagraphWords: Math.round(median(paragraphWordCounts)),
+    fragmentRatio:
+      sentenceWordCounts.length > 0 ? round2(fragments / sentenceWordCounts.length) : 0,
+    shortOpeningRatio: texts.length > 0 ? round2(shortOpenings / texts.length) : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Punctuation and typography.
+// ---------------------------------------------------------------------------
+
+export type PunctuationProfile = {
+  commasPer100Words: number;
+  colonsPer100Words: number;
+  parenthesesPer100Words: number;
+  /** An em dash, en dash, or a hyphen surrounded by spaces used as a pause
+   * - not a hyphen inside a compound word ("self-host", "game-changer"),
+   * which is spelling rather than punctuation. */
+  dashesPer100Words: number;
+  questionMarksPer100Words: number;
+  exclamationMarksPer100Words: number;
+  ellipsesPer100Words: number;
+  /** Whether a clear majority of items start with an uppercase letter. */
+  capitalizesOpenings: boolean;
+  /** Whether a clear majority of the colons on file are followed by a
+   * lowercase letter rather than a capital ("the point: it worked" vs "The
+   * point: It worked"). Only counted on colons that are actually followed
+   * by a letter. */
+  lowercasesAfterColon: boolean;
+};
+
+const DASH_PATTERN = /\u2014|\u2013|\s-\s/gu;
+const ELLIPSIS_PATTERN = /\.\.\.|\u2026/gu;
+const COLON_FOLLOWED_BY_LETTER = /:\s*(\p{L})/gu;
+
+export const EMPTY_PUNCTUATION: PunctuationProfile = {
+  commasPer100Words: 0,
+  colonsPer100Words: 0,
+  parenthesesPer100Words: 0,
+  dashesPer100Words: 0,
+  questionMarksPer100Words: 0,
+  exclamationMarksPer100Words: 0,
+  ellipsesPer100Words: 0,
+  capitalizesOpenings: false,
+  lowercasesAfterColon: false,
+};
+
+function measurePunctuation(texts: string[], wordCount: number): PunctuationProfile {
+  let commas = 0;
+  let colons = 0;
+  let parens = 0;
+  let dashes = 0;
+  let questions = 0;
+  let exclamations = 0;
+  let ellipses = 0;
+  let capitalized = 0;
+  let capitalizable = 0;
+  let lowercaseAfterColon = 0;
+  let colonSamples = 0;
+
+  for (const text of texts) {
+    commas += (text.match(/,/gu) ?? []).length;
+    colons += (text.match(/:/gu) ?? []).length;
+    parens += (text.match(/[()]/gu) ?? []).length;
+    dashes += (text.match(DASH_PATTERN) ?? []).length;
+    questions += (text.match(/\?/gu) ?? []).length;
+    exclamations += (text.match(/!/gu) ?? []).length;
+    ellipses += (text.match(ELLIPSIS_PATTERN) ?? []).length;
+
+    const firstLetter = text.match(/\p{L}/u)?.[0];
+    if (firstLetter) {
+      capitalizable += 1;
+      if (firstLetter === firstLetter.toUpperCase() && firstLetter !== firstLetter.toLowerCase()) {
+        capitalized += 1;
+      }
+    }
+
+    for (const match of text.matchAll(COLON_FOLLOWED_BY_LETTER)) {
+      colonSamples += 1;
+      const letter = match[1]!;
+      if (letter === letter.toLowerCase() && letter !== letter.toUpperCase()) {
+        lowercaseAfterColon += 1;
+      }
+    }
+  }
+
+  return {
+    commasPer100Words: perHundredWords(commas, wordCount),
+    colonsPer100Words: perHundredWords(colons, wordCount),
+    parenthesesPer100Words: perHundredWords(parens, wordCount),
+    dashesPer100Words: perHundredWords(dashes, wordCount),
+    questionMarksPer100Words: perHundredWords(questions, wordCount),
+    exclamationMarksPer100Words: perHundredWords(exclamations, wordCount),
+    ellipsesPer100Words: perHundredWords(ellipses, wordCount),
+    capitalizesOpenings: capitalizable > 0 && capitalized / capitalizable >= TRAIT_DOMINANCE_RATIO,
+    lowercasesAfterColon:
+      colonSamples > 0 && lowercaseAfterColon / colonSamples >= TRAIT_DOMINANCE_RATIO,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shape: paragraph layout, emoji, hashtags, how a piece ends.
+// ---------------------------------------------------------------------------
+
+export type PostEnding = 'question' | 'claim' | 'none';
+
+export type ShapeProfile = {
+  lineBreaksPerParagraph: number;
+  /** Mirrors the corpus-level 'list-layout' register trait rather than
+   * re-deriving it - one detector for "is this laid out as a list". */
+  usesLists: boolean;
+  /** Distinct emoji reused across at least two separate items, most-used
+   * first. */
+  emoji: string[];
+  /** Distinct hashtags reused the same way. */
+  hashtags: string[];
+  /** How the corpus tends to end - question, claim (a full stop or
+   * exclamation) or trailing off with neither - only when a clear majority
+   * agree; null otherwise. */
+  ending: PostEnding | null;
+};
+
+const MAX_EMOJI = 5;
+const MAX_HASHTAGS = 5;
+// Same pictographic ranges register.ts's EMOJI pattern uses, global so every
+// occurrence in a piece is found rather than just the first.
+const EMOJI_GLOBAL =
+  /[\u{1F300}-\u{1FAFF}\u{1F000}-\u{1F2FF}\u{2600}-\u{27BF}\u{1F1E6}-\u{1F1FF}]\u{FE0F}?/gu;
+const HASHTAG_GLOBAL = /#[\p{L}\p{N}_]+/gu;
+
+export const EMPTY_SHAPE: ShapeProfile = {
+  lineBreaksPerParagraph: 0,
+  usesLists: false,
+  emoji: [],
+  hashtags: [],
+  ending: null,
+};
+
+/** Distinct tokens (emoji, hashtags) that show up in at least
+ * MIN_PHRASE_REPEATS separate items, ranked by how many items carry them -
+ * the same per-item-coverage discipline `topCommonWords` uses for
+ * vocabulary. */
+function topRepeatedTokens(texts: string[], pattern: RegExp, max: number): string[] {
+  const coverage = new Map<string, { count: number; display: string }>();
+  for (const text of texts) {
+    const seen = new Set<string>();
+    for (const match of text.matchAll(pattern)) {
+      const tok = match[0];
+      const key = tok.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const existing = coverage.get(key);
+      if (existing) existing.count += 1;
+      else coverage.set(key, { count: 1, display: tok });
+    }
+  }
+  return [...coverage.values()]
+    .filter((v) => v.count >= MIN_PHRASE_REPEATS)
+    .sort((a, b) => b.count - a.count || a.display.localeCompare(b.display))
+    .slice(0, max)
+    .map((v) => v.display);
+}
+
+function measureShape(texts: string[], usesLists: boolean): ShapeProfile {
+  const paragraphLineBreaks: number[] = [];
+  const endings: PostEnding[] = [];
+
+  for (const text of texts) {
+    for (const p of splitParagraphs(text)) {
+      paragraphLineBreaks.push((p.match(/\n/gu) ?? []).length);
+    }
+    const lastChar = text.trim().slice(-1);
+    if (lastChar === '?') endings.push('question');
+    else if (lastChar === '.' || lastChar === '!') endings.push('claim');
+    else endings.push('none');
+  }
+
+  const endingCounts = new Map<PostEnding, number>();
+  for (const e of endings) endingCounts.set(e, (endingCounts.get(e) ?? 0) + 1);
+  let dominantEnding: PostEnding | null = null;
+  for (const [e, count] of endingCounts) {
+    if (count >= endings.length * TRAIT_DOMINANCE_RATIO) dominantEnding = e;
+  }
+
+  return {
+    lineBreaksPerParagraph:
+      paragraphLineBreaks.length > 0
+        ? round2(paragraphLineBreaks.reduce((a, b) => a + b, 0) / paragraphLineBreaks.length)
+        : 0,
+    usesLists,
+    emoji: topRepeatedTokens(texts, EMOJI_GLOBAL, MAX_EMOJI),
+    hashtags: topRepeatedTokens(texts, HASHTAG_GLOBAL, MAX_HASHTAGS),
+    ending: dominantEnding,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Voice markers: first/second person, hedges, certainty, imperatives.
+// ---------------------------------------------------------------------------
+
+export type VoiceMarkerProfile = {
+  firstPersonPer100Words: number;
+  secondPersonPer100Words: number;
+  hedgesPer100Words: number;
+  certaintyPer100Words: number;
+  /** Fraction of sentences that open on a known imperative verb ("Try",
+   * "Ship", "Prova", "Non"...). Approximate by design - the same spirit as
+   * register.ts's CODE_OR_JARGON heuristic, a short named list rather than
+   * real parsing, good enough to say "sometimes" versus "never". */
+  imperativeRatio: number;
+};
+
+const FIRST_PERSON_GLOBAL =
+  /\b(?:i|i'm|i've|my|me|we|we're|our|io|mi|miei|mia|noi|nostro|nostra|abbiamo|ho)\b/giu;
+const SECOND_PERSON_GLOBAL =
+  /\b(?:you|you're|your|yours|tu|tuo|tua|tuoi|tue|voi|vostro|vostra)\b/giu;
+const HEDGE_GLOBAL =
+  /\b(?:i think|i guess|probably|maybe|kind of|sort of|credo|forse|penso|magari)\b/giu;
+const CERTAINTY_GLOBAL =
+  /\b(?:clearly|obviously|definitely|certainly|without a doubt|certamente|chiaramente|sicuramente|ovviamente)\b/giu;
+
+const IMPERATIVE_OPENERS: Record<string, true> = {
+  try: true,
+  build: true,
+  ship: true,
+  stop: true,
+  start: true,
+  look: true,
+  think: true,
+  consider: true,
+  "don't": true,
+  dont: true,
+  do: true,
+  prova: true,
+  costruisci: true,
+  inizia: true,
+  guarda: true,
+  pensa: true,
+  smetti: true,
+  fai: true,
+};
+
+export const EMPTY_VOICE_MARKERS: VoiceMarkerProfile = {
+  firstPersonPer100Words: 0,
+  secondPersonPer100Words: 0,
+  hedgesPer100Words: 0,
+  certaintyPer100Words: 0,
+  imperativeRatio: 0,
+};
+
+function measureVoiceMarkers(texts: string[], wordCount: number): VoiceMarkerProfile {
+  let firstPerson = 0;
+  let secondPerson = 0;
+  let hedges = 0;
+  let certainty = 0;
+  let imperativeSentences = 0;
+  let totalSentences = 0;
+
+  for (const text of texts) {
+    firstPerson += (text.match(FIRST_PERSON_GLOBAL) ?? []).length;
+    secondPerson += (text.match(SECOND_PERSON_GLOBAL) ?? []).length;
+    hedges += (text.match(HEDGE_GLOBAL) ?? []).length;
+    certainty += (text.match(CERTAINTY_GLOBAL) ?? []).length;
+
+    for (const s of splitSentences(text)) {
+      totalSentences += 1;
+      const firstWord = normalizeWord(s.split(/\s+/u)[0] ?? '');
+      if (IMPERATIVE_OPENERS[firstWord]) imperativeSentences += 1;
+    }
+  }
+
+  return {
+    firstPersonPer100Words: perHundredWords(firstPerson, wordCount),
+    secondPersonPer100Words: perHundredWords(secondPerson, wordCount),
+    hedgesPer100Words: perHundredWords(hedges, wordCount),
+    certaintyPer100Words: perHundredWords(certainty, wordCount),
+    imperativeRatio: totalSentences > 0 ? round2(imperativeSentences / totalSentences) : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Lexicon: which candidate "default-sounding" words never show up.
+// ---------------------------------------------------------------------------
+
+export type LexiconProfile = {
+  /** Candidate puffery/filler words that never appear anywhere in the
+   * corpus. Only populated once the corpus is large enough that an absence
+   * means something (AVOIDED_WORDS_MIN_WORDS) - a two-post corpus that
+   * never says "leverage" has not avoided it, it has not had the chance to
+   * use it. */
+  avoidedWords: string[];
+};
+
+/** Below this many words, an absence proves nothing. */
+const AVOIDED_WORDS_MIN_WORDS = 200;
+
+/** Candidate words a default-sounding draft leaks - mirrors house style's
+ * puffery bans (`shared/src/style-check.ts`'s PUFFERY_WORDS and
+ * WRAPUP_CLOSERS) plus the LinkedIn-specific ones #571 names. Kept local
+ * rather than imported: this is read-only evidence about what the
+ * operator's own writing never touches, not a second enforcement surface -
+ * `checkStyle` stays the one thing that blocks a draft, so a local list
+ * here cannot drift into changing what it blocks. */
+const AVOIDABLE_WORD_CANDIDATES = [
+  'leverage',
+  'seamless',
+  'robust',
+  'comprehensive',
+  'delve',
+  'unlock',
+  'elevate',
+  'game-changer',
+  'humbled',
+  'thrilled to share',
+  'this resonates',
+  'hope this helps',
+  'at the end of the day',
+  'the bottom line is',
+];
+
+export const EMPTY_LEXICON: LexiconProfile = { avoidedWords: [] };
+
+function measureLexicon(joinedText: string, wordCount: number): LexiconProfile {
+  if (wordCount < AVOIDED_WORDS_MIN_WORDS) return { avoidedWords: [] };
+  const lower = joinedText.toLowerCase();
+  return { avoidedWords: AVOIDABLE_WORD_CANDIDATES.filter((w) => !lower.includes(w)) };
+}
+
+// ---------------------------------------------------------------------------
+// Language: the English/Italian split, overall and per corpus surface.
+// ---------------------------------------------------------------------------
+
+export type LanguageMix = {
+  primary: 'en' | 'it' | 'mixed' | null;
+  englishRatio: number;
+  italianRatio: number;
+};
+
+export type LanguageProfile = LanguageMix & {
+  /** The same split computed separately for each corpus surface that has
+   * enough items of its own to classify - a suggestion has to match the
+   * post's language, and an operator whose voice samples are all English
+   * but whose sent messages are half Italian is not describable by one
+   * average. Kinds with too few items of their own are simply absent. */
+  byKind: Partial<Record<VoiceCorpusItemKind, LanguageMix>>;
+};
+
+// A short, real stopword list per language rather than a library
+// dependency - the same tradeoff register.ts's FORMAL_WORDS makes. Enough
+// to tell "the update shipped today" from "l'aggiornamento è uscito oggi"
+// without claiming to be a general-purpose language detector.
+const EN_STOPWORDS_GLOBAL =
+  /\b(?:the|and|of|to|is|that|with|for|this|was|are|it's|i'm|we|you)\b/giu;
+const IT_STOPWORDS_GLOBAL =
+  /\b(?:il|la|di|che|per|con|un|una|è|non|questo|questa|sono|abbiamo|nel|della)\b/giu;
+
+/** Below this many stopword hits, a text has not said enough to classify -
+ * one stray "the" in an otherwise Italian post is not evidence. */
+const LANGUAGE_MARKER_MIN = 2;
+/** Above this share, one language is called primary outright rather than
+ * "mixed" - the split has to be lopsided, not just plurality. */
+const PRIMARY_LANGUAGE_RATIO = 0.7;
+
+export const EMPTY_LANGUAGE: LanguageProfile = {
+  primary: null,
+  englishRatio: 0,
+  italianRatio: 0,
+  byKind: {},
+};
+
+function classifyLanguage(text: string): 'en' | 'it' | 'unknown' {
+  const en = (text.match(EN_STOPWORDS_GLOBAL) ?? []).length;
+  const it = (text.match(IT_STOPWORDS_GLOBAL) ?? []).length;
+  if (en >= LANGUAGE_MARKER_MIN && en > it) return 'en';
+  if (it >= LANGUAGE_MARKER_MIN && it > en) return 'it';
+  return 'unknown';
+}
+
+function summarizeLanguage(texts: string[]): LanguageMix {
+  if (texts.length === 0) return { primary: null, englishRatio: 0, italianRatio: 0 };
+  const classified = texts.map(classifyLanguage);
+  const en = classified.filter((c) => c === 'en').length;
+  const it = classified.filter((c) => c === 'it').length;
+  const englishRatio = round2(en / texts.length);
+  const italianRatio = round2(it / texts.length);
+
+  let primary: 'en' | 'it' | 'mixed' | null;
+  if (en === 0 && it === 0) primary = null;
+  else if (englishRatio >= PRIMARY_LANGUAGE_RATIO) primary = 'en';
+  else if (italianRatio >= PRIMARY_LANGUAGE_RATIO) primary = 'it';
+  else if (en > 0 && it > 0) primary = 'mixed';
+  else primary = en > it ? 'en' : 'it';
+
+  return { primary, englishRatio, italianRatio };
+}
+
+function measureLanguage(items: VoiceCorpusItem[]): LanguageProfile {
+  const overall = summarizeLanguage(items.map((i) => i.text));
+  const byKind: LanguageProfile['byKind'] = {};
+  for (const kind of VOICE_CORPUS_ITEM_KINDS) {
+    const kindTexts = items.filter((i) => i.kind === kind).map((i) => i.text);
+    if (kindTexts.length < MIN_ITEMS_TO_DERIVE) continue;
+    byKind[kind] = summarizeLanguage(kindTexts);
+  }
+  return { ...overall, byKind };
+}
+
+// ---------------------------------------------------------------------------
+// The measurement itself.
+// ---------------------------------------------------------------------------
+
 export type VoiceMeasurement = {
   /** Non-empty corpus items considered, regardless of whether any were
    * individually long enough to read a register off. */
@@ -214,6 +750,12 @@ export type VoiceMeasurement = {
   openings: string[];
   closings: string[];
   commonWords: string[];
+  rhythm: RhythmProfile;
+  punctuation: PunctuationProfile;
+  shape: ShapeProfile;
+  voiceMarkers: VoiceMarkerProfile;
+  lexicon: LexiconProfile;
+  language: LanguageProfile;
 };
 
 /**
@@ -223,7 +765,8 @@ export type VoiceMeasurement = {
  * `suggest-prompt.ts` keeps from `context.ts`.
  */
 export function measureVoiceCorpus(corpus: VoiceCorpusItem[]): VoiceMeasurement {
-  const texts = corpus.map((c) => c.text.trim()).filter(Boolean);
+  const items = corpus.map((c) => ({ ...c, text: c.text.trim() })).filter((c) => c.text);
+  const texts = items.map((i) => i.text);
   const wordLists = texts.map((t) => t.split(/\s+/u).filter(Boolean));
   const wordCount = wordLists.reduce((sum, w) => sum + w.length, 0);
   const itemCount = texts.length;
@@ -238,6 +781,12 @@ export function measureVoiceCorpus(corpus: VoiceCorpusItem[]): VoiceMeasurement 
       openings: [],
       closings: [],
       commonWords: [],
+      rhythm: EMPTY_RHYTHM,
+      punctuation: EMPTY_PUNCTUATION,
+      shape: EMPTY_SHAPE,
+      voiceMarkers: EMPTY_VOICE_MARKERS,
+      lexicon: EMPTY_LEXICON,
+      language: EMPTY_LANGUAGE,
     };
   }
 
@@ -272,6 +821,12 @@ export function measureVoiceCorpus(corpus: VoiceCorpusItem[]): VoiceMeasurement 
     openings: topRepeatedPhrases(wordLists, OPENING_WORDS, false),
     closings: topRepeatedPhrases(wordLists, CLOSING_WORDS, true),
     commonWords: topCommonWords(wordLists),
+    rhythm: measureRhythm(texts),
+    punctuation: measurePunctuation(texts, wordCount),
+    shape: measureShape(texts, traits.includes('list-layout')),
+    voiceMarkers: measureVoiceMarkers(texts, wordCount),
+    lexicon: measureLexicon(texts.join(' '), wordCount),
+    language: measureLanguage(items),
   };
 }
 
@@ -289,6 +844,18 @@ const TRAIT_PROSE: Record<RegisterTrait, string> = {
   'list-layout': 'laid out as a list',
   numbers: 'argues with numbers',
   'code-or-jargon': 'technical terms and identifiers',
+};
+
+const ENDING_PROSE: Record<PostEnding, string> = {
+  question: 'a question',
+  claim: 'a claim',
+  none: 'no clear ending, trailing off',
+};
+
+const LANGUAGE_PROSE: Record<Exclude<LanguageMix['primary'], null>, string> = {
+  en: 'English',
+  it: 'Italian',
+  mixed: 'both English and Italian',
 };
 
 /**
@@ -320,6 +887,21 @@ export function describeVoiceProfile(m: VoiceMeasurement): string | null {
   }
   if (m.commonWords.length > 0) {
     sentences.push(`Reuses these words often: ${m.commonWords.join(', ')}.`);
+  }
+  if (m.shape.ending) {
+    sentences.push(`Tends to end on ${ENDING_PROSE[m.shape.ending]}.`);
+  }
+  if (m.shape.emoji.length > 0) {
+    sentences.push(`Uses these emoji: ${m.shape.emoji.join(' ')}.`);
+  }
+  if (m.shape.hashtags.length > 0) {
+    sentences.push(`Uses these hashtags: ${m.shape.hashtags.join(', ')}.`);
+  }
+  if (m.lexicon.avoidedWords.length > 0) {
+    sentences.push(`Never uses: ${m.lexicon.avoidedWords.join(', ')}.`);
+  }
+  if (m.language.primary) {
+    sentences.push(`Writes primarily in ${LANGUAGE_PROSE[m.language.primary]}.`);
   }
 
   if (sentences.length === 0) return null;

--- a/shared/src/operator-voice-profile.ts
+++ b/shared/src/operator-voice-profile.ts
@@ -1,29 +1,84 @@
-// The DB layer for the operator's derived voice profile (#407):
-// operator_voice_profiles (see shared/src/db/schema.ts's own doc comment on
-// the table). Gathers the corpus (voice samples, sent messages, sent
-// drafts, project templates - every one org-scoped), hands it to the pure
-// measurement in `assist/voice-profile.ts`, and stores the result the same
-// way `operator-profile.ts` stores the persona: a `source` of 'derived' or
-// 'manual' so a hand-edited summary survives a later refresh until the
+// The DB layer for the operator's derived voice profile (#407, extended by
+// #570/#571): operator_voice_profiles (see shared/src/db/schema.ts's own doc
+// comment on the table). Gathers the corpus (voice samples, sent messages,
+// sent drafts, project templates - every one org-scoped), hands it to the
+// pure measurement in `assist/voice-profile.ts`, and stores the result the
+// same way `operator-profile.ts` stores the persona: a `source` of 'derived'
+// or 'manual' so a hand-edited summary survives a later refresh until the
 // human explicitly resets it.
+//
+// 2026-09-09 (#570/#571): two additions, both without a schema change -
+// nobody in this wave holds the migration slot, and `evidence` was already
+// schemaless jsonb, which is what makes both possible:
+//
+// - Versioned, and readable across versions. `evidence.version` is a
+//   per-org counter that increments on every real derivation (never on a
+//   manual edit, which does not re-derive anything) - a recompute is
+//   provably a new version rather than a silent overwrite, which is what
+//   makes a change in output explainable and a stale profile detectable.
+//   A row written before this shipped carries no `version` and none of the
+//   six new measurement axes; `normalizeEvidence` reads it as version 0
+//   with every new axis present as a valid empty measurement rather than
+//   throwing - an older profile stays readable, it does not have to be
+//   re-derived to be loaded.
+// - `resolveVoiceProfile`/`resolveOperatorVoiceProfile` answer "what should
+//   the model be told about how the operator writes" honestly: the real
+//   measurement once the corpus clears `MIN_ITEMS_TO_DERIVE`,
+//   `DEFAULT_VOICE_PROFILE` (#571) otherwise - never a blend, and always
+//   labelled which one it is, axis by axis, so a caller can never present a
+//   default as if it were measured.
 
 import { and, desc, eq, isNotNull } from 'drizzle-orm';
 import { schema, type Db } from './db/client.js';
 import {
   measureVoiceCorpus,
   describeVoiceProfile,
+  MIN_ITEMS_TO_DERIVE,
   type VoiceCorpusItem,
+  type RhythmProfile,
+  type PunctuationProfile,
+  type ShapeProfile,
+  type VoiceMarkerProfile,
+  type LexiconProfile,
+  type LanguageProfile,
 } from './assist/voice-profile.js';
+import {
+  EMPTY_RHYTHM,
+  EMPTY_PUNCTUATION,
+  EMPTY_SHAPE,
+  EMPTY_VOICE_MARKERS,
+  EMPTY_LEXICON,
+  EMPTY_LANGUAGE,
+} from './assist/voice-profile.js';
+import { DEFAULT_VOICE_PROFILE, type DefaultVoiceProfile } from './assist/voice-defaults.js';
 import type { RegisterTrait } from './assist/register.js';
 
 export type OperatorVoiceProfileSource = 'derived' | 'manual';
 
-export type VoiceProfileEvidence = {
+/** What the corpus gather actually read: which rows, and how many per
+ * source. Separate from `VoiceProfileEvidence` below so the DB query layer
+ * and the stored-row shape are not the same type by accident. */
+export type VoiceCorpusProvenance = {
   voiceSampleIds: number[];
   messageIds: number[];
   draftIds: number[];
   templateIds: number[];
   counts: { voiceSamples: number; messages: number; drafts: number; templates: number };
+};
+
+/** What a stored row carries about its own derivation: the provenance
+ * above, the format version it was derived with (#570), and the six
+ * extended measurement axes - stored here rather than in a new column
+ * because `evidence` is already schemaless jsonb and nobody in this wave
+ * holds the migration slot. */
+export type VoiceProfileEvidence = VoiceCorpusProvenance & {
+  version: number;
+  rhythm: RhythmProfile;
+  punctuation: PunctuationProfile;
+  shape: ShapeProfile;
+  voiceMarkers: VoiceMarkerProfile;
+  lexicon: LexiconProfile;
+  language: LanguageProfile;
 };
 
 export type OperatorVoiceProfileRow = {
@@ -44,13 +99,53 @@ export type OperatorVoiceProfileRow = {
   updatedAt: Date;
 };
 
-const EMPTY_EVIDENCE: VoiceProfileEvidence = {
+const EMPTY_PROVENANCE: VoiceCorpusProvenance = {
   voiceSampleIds: [],
   messageIds: [],
   draftIds: [],
   templateIds: [],
   counts: { voiceSamples: 0, messages: 0, drafts: 0, templates: 0 },
 };
+
+const EMPTY_EVIDENCE: VoiceProfileEvidence = {
+  ...EMPTY_PROVENANCE,
+  version: 0,
+  rhythm: EMPTY_RHYTHM,
+  punctuation: EMPTY_PUNCTUATION,
+  shape: EMPTY_SHAPE,
+  voiceMarkers: EMPTY_VOICE_MARKERS,
+  lexicon: EMPTY_LEXICON,
+  language: EMPTY_LANGUAGE,
+};
+
+/** Reads a stored `evidence` blob back into the current full shape,
+ * whichever version wrote it. A field absent from the stored JSON (a row
+ * from before #570, or before #407 for `counts`/the id arrays) reads as
+ * this axis's empty value rather than `undefined` - the loader never
+ * throws on an older profile, and never invents a measurement for an axis
+ * that was never derived. */
+function normalizeEvidence(raw: unknown): VoiceProfileEvidence {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Partial<VoiceProfileEvidence>;
+  return {
+    version: typeof r.version === 'number' ? r.version : 0,
+    voiceSampleIds: r.voiceSampleIds ?? [],
+    messageIds: r.messageIds ?? [],
+    draftIds: r.draftIds ?? [],
+    templateIds: r.templateIds ?? [],
+    counts: r.counts ?? EMPTY_PROVENANCE.counts,
+    rhythm: r.rhythm ?? EMPTY_RHYTHM,
+    punctuation: r.punctuation ?? EMPTY_PUNCTUATION,
+    shape: r.shape ?? EMPTY_SHAPE,
+    voiceMarkers: r.voiceMarkers ?? EMPTY_VOICE_MARKERS,
+    lexicon: r.lexicon ?? EMPTY_LEXICON,
+    language: r.language ?? EMPTY_LANGUAGE,
+  };
+}
+
+function toRow(raw: unknown): OperatorVoiceProfileRow {
+  const r = raw as OperatorVoiceProfileRow;
+  return { ...r, evidence: normalizeEvidence(r.evidence) };
+}
 
 /** Past this many recent items per source, the derivation does not get any
  * more accurate, only slower - 200 is already an implausibly large corpus
@@ -67,7 +162,7 @@ export async function loadVoiceProfile(
     .from(schema.operatorVoiceProfiles)
     .where(eq(schema.operatorVoiceProfiles.organizationId, organizationId))
     .limit(1);
-  return (row as OperatorVoiceProfileRow | undefined) ?? null;
+  return row ? toRow(row) : null;
 }
 
 /**
@@ -81,7 +176,7 @@ export async function loadVoiceProfile(
 async function gatherVoiceCorpus(
   db: Db,
   organizationId: number,
-): Promise<{ corpus: VoiceCorpusItem[]; evidence: VoiceProfileEvidence }> {
+): Promise<{ corpus: VoiceCorpusItem[]; evidence: VoiceCorpusProvenance }> {
   const [sampleRows, messageRows, draftRows, templateRows] = await Promise.all([
     db
       .select({ id: schema.operatorVoiceSamples.id, text: schema.operatorVoiceSamples.text })
@@ -135,7 +230,7 @@ async function gatherVoiceCorpus(
     ...templateRows.map((r) => ({ id: r.id, kind: 'template' as const, text: r.text })),
   ];
 
-  const evidence: VoiceProfileEvidence = {
+  const evidence: VoiceCorpusProvenance = {
     voiceSampleIds: sampleRows.map((r) => r.id),
     messageIds: messageRows.map((r) => r.id),
     draftIds: draftRows.map((r) => r.id),
@@ -160,6 +255,13 @@ async function gatherVoiceCorpus(
  * derivation, and a passive refresh must not silently discard that. Pass
  * `overwrite: true` (Settings' "Reset to derived" action) to force a fresh
  * derivation over a manual edit.
+ *
+ * `evidence.version` increments on every call that reaches this far,
+ * regardless of whether the resulting measurement is byte-identical to the
+ * last one - the counter tracks derivation events, not content changes, so
+ * "the same evidence produces the same profile" (determinism) and "a
+ * recompute is a new version" are both true at once rather than in
+ * tension.
  */
 export async function refreshVoiceProfile(
   db: Db,
@@ -171,9 +273,20 @@ export async function refreshVoiceProfile(
     return existing;
   }
 
-  const { corpus, evidence } = await gatherVoiceCorpus(db, organizationId);
+  const { corpus, evidence: provenance } = await gatherVoiceCorpus(db, organizationId);
   const measurement = measureVoiceCorpus(corpus);
   const summary = describeVoiceProfile(measurement) ?? '';
+
+  const evidence: VoiceProfileEvidence = {
+    ...provenance,
+    version: (existing?.evidence.version ?? 0) + 1,
+    rhythm: measurement.rhythm,
+    punctuation: measurement.punctuation,
+    shape: measurement.shape,
+    voiceMarkers: measurement.voiceMarkers,
+    lexicon: measurement.lexicon,
+    language: measurement.language,
+  };
 
   const values = {
     organizationId,
@@ -192,7 +305,7 @@ export async function refreshVoiceProfile(
 
   if (!existing) {
     const [row] = await db.insert(schema.operatorVoiceProfiles).values(values).returning();
-    return row as OperatorVoiceProfileRow;
+    return toRow(row);
   }
 
   const [row] = await db
@@ -200,7 +313,7 @@ export async function refreshVoiceProfile(
     .set({ ...values, updatedAt: new Date() })
     .where(eq(schema.operatorVoiceProfiles.organizationId, organizationId))
     .returning();
-  return row as OperatorVoiceProfileRow;
+  return toRow(row);
 }
 
 /**
@@ -223,7 +336,7 @@ export async function saveVoiceProfileSummary(
       .insert(schema.operatorVoiceProfiles)
       .values({ organizationId, summary: trimmed, evidence: EMPTY_EVIDENCE, source: 'manual' })
       .returning();
-    return row as OperatorVoiceProfileRow;
+    return toRow(row);
   }
 
   const [row] = await db
@@ -231,7 +344,7 @@ export async function saveVoiceProfileSummary(
     .set({ summary: trimmed, source: 'manual', updatedAt: new Date() })
     .where(eq(schema.operatorVoiceProfiles.organizationId, organizationId))
     .returning();
-  return row as OperatorVoiceProfileRow;
+  return toRow(row);
 }
 
 /** Discards a manual edit and forces a fresh derivation, even over a
@@ -241,4 +354,123 @@ export async function resetVoiceProfileToDerived(
   organizationId: number,
 ): Promise<OperatorVoiceProfileRow> {
   return refreshVoiceProfile(db, organizationId, { overwrite: true });
+}
+
+// ---------------------------------------------------------------------------
+// #571: resolving "how the operator writes" honestly - the real measurement
+// once there is enough of it, DEFAULT_VOICE_PROFILE otherwise, always
+// labelled which one a caller is looking at.
+// ---------------------------------------------------------------------------
+
+export type VoiceProfileAxisStatus = 'measured' | 'default';
+
+export type VoiceAxis =
+  'rhythm' | 'punctuation' | 'shape' | 'voiceMarkers' | 'lexicon' | 'language';
+
+export const VOICE_AXES: readonly VoiceAxis[] = [
+  'rhythm',
+  'punctuation',
+  'shape',
+  'voiceMarkers',
+  'lexicon',
+  'language',
+];
+
+export type ResolvedOperatorVoiceProfile = {
+  organizationId: number;
+  /** 'measured' once a row on file cleared MIN_ITEMS_TO_DERIVE; 'default'
+   * for a thin or absent corpus. Never invented - the design doc's rule for
+   * the operator_voice tool (#567): thin evidence gets the defaults from
+   * #571, never a profile derived from nothing. */
+  status: 'measured' | 'default';
+  summary: string;
+  /** Every axis labelled the same way as `status`. Its own field, not just
+   * a restatement of `status`, so a caller has one place to check before
+   * rendering any single axis as a measurement. */
+  axes: Record<VoiceAxis, VoiceProfileAxisStatus>;
+  /** The stored row, present only when `status` is 'measured'. */
+  measured: OperatorVoiceProfileRow | null;
+  defaults: DefaultVoiceProfile;
+  version: number;
+  derivedAt: string | null;
+  itemCount: number;
+  /** What a thin corpus still needs, e.g. "2 more pieces of their own
+   * writing...". Null once `status` is 'measured'. */
+  gap: string | null;
+};
+
+const MEASURED_AXES: Record<VoiceAxis, VoiceProfileAxisStatus> = {
+  rhythm: 'measured',
+  punctuation: 'measured',
+  shape: 'measured',
+  voiceMarkers: 'measured',
+  lexicon: 'measured',
+  language: 'measured',
+};
+
+const DEFAULT_AXES: Record<VoiceAxis, VoiceProfileAxisStatus> = {
+  rhythm: 'default',
+  punctuation: 'default',
+  shape: 'default',
+  voiceMarkers: 'default',
+  lexicon: 'default',
+  language: 'default',
+};
+
+function describeVoiceProfileGap(itemCount: number): string {
+  const needed = MIN_ITEMS_TO_DERIVE - itemCount;
+  const piece = needed === 1 ? 'piece' : 'pieces';
+  return `${needed} more ${piece} of their own writing (a post, a sent message or a sent draft) and this can start measuring their habits instead of defaulting.`;
+}
+
+/**
+ * Resolves what the model and the operator should be told about how the
+ * operator writes: the stored measurement once the corpus has cleared
+ * `MIN_ITEMS_TO_DERIVE`, `DEFAULT_VOICE_PROFILE` otherwise - never a blend
+ * of the two. Pure: takes an already-loaded row, so it is unit-testable
+ * without a database and without a model call anywhere in reach.
+ */
+export function resolveVoiceProfile(
+  organizationId: number,
+  row: OperatorVoiceProfileRow | null,
+): ResolvedOperatorVoiceProfile {
+  const itemCount = row?.itemCount ?? 0;
+
+  if (row && itemCount >= MIN_ITEMS_TO_DERIVE) {
+    return {
+      organizationId,
+      status: 'measured',
+      summary: row.summary,
+      axes: MEASURED_AXES,
+      measured: row,
+      defaults: DEFAULT_VOICE_PROFILE,
+      version: row.evidence.version,
+      derivedAt: row.derivedAt ? row.derivedAt.toISOString() : null,
+      itemCount,
+      gap: null,
+    };
+  }
+
+  return {
+    organizationId,
+    status: 'default',
+    summary: DEFAULT_VOICE_PROFILE.summary,
+    axes: DEFAULT_AXES,
+    measured: null,
+    defaults: DEFAULT_VOICE_PROFILE,
+    version: row?.evidence.version ?? 0,
+    derivedAt: row?.derivedAt ? row.derivedAt.toISOString() : null,
+    itemCount,
+    gap: describeVoiceProfileGap(itemCount),
+  };
+}
+
+/** `resolveVoiceProfile`, loading the row itself - what a caller reaches
+ * for in practice (the operator_voice tool, #567; Settings). */
+export async function resolveOperatorVoiceProfile(
+  db: Db,
+  organizationId: number,
+): Promise<ResolvedOperatorVoiceProfile> {
+  const row = await loadVoiceProfile(db, organizationId);
+  return resolveVoiceProfile(organizationId, row);
 }

--- a/shared/tests/assist-voice-profile.test.ts
+++ b/shared/tests/assist-voice-profile.test.ts
@@ -1,8 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   measureVoiceCorpus,
   describeVoiceProfile,
   MIN_ITEMS_TO_DERIVE,
+  EMPTY_RHYTHM,
+  EMPTY_PUNCTUATION,
+  EMPTY_SHAPE,
+  EMPTY_VOICE_MARKERS,
+  EMPTY_LEXICON,
+  EMPTY_LANGUAGE,
   type VoiceCorpusItem,
   type VoiceMeasurement,
 } from '../src/assist/voice-profile.js';
@@ -15,6 +23,11 @@ import {
 // too small says nothing, a trait or phrase has to repeat across separate
 // pieces of writing to count as a habit, and excluding a piece of writing
 // changes what comes out.
+//
+// #570 extends this file past openings/closings/reused words into six more
+// axes - rhythm, punctuation, shape, voice markers, lexicon, language - each
+// with its own fixture built to make a specific, hand-checkable claim: not
+// "the code runs" but "this exact corpus produces this exact number".
 
 const SHORT_FIRST_PERSON = [
   'I shipped the new dashboard today. It took longer than I hoped. The team is happy with it now.',
@@ -44,6 +57,12 @@ describe('measureVoiceCorpus', () => {
     expect(m.wordCount).toBeGreaterThan(0);
     expect(m.traits).toEqual([]);
     expect(m.openings).toEqual([]);
+    expect(m.rhythm).toEqual(EMPTY_RHYTHM);
+    expect(m.punctuation).toEqual(EMPTY_PUNCTUATION);
+    expect(m.shape).toEqual(EMPTY_SHAPE);
+    expect(m.voiceMarkers).toEqual(EMPTY_VOICE_MARKERS);
+    expect(m.lexicon).toEqual(EMPTY_LEXICON);
+    expect(m.language).toEqual(EMPTY_LANGUAGE);
     expect(describeVoiceProfile(m)).toBeNull();
   });
 
@@ -56,6 +75,13 @@ describe('measureVoiceCorpus', () => {
     // alongside the one that actually dominates.
     expect(m.traits).not.toContain('impersonal');
     expect(m.traits).not.toContain('long-sentences');
+  });
+
+  it('is deterministic: the same corpus measured twice produces byte-identical output', () => {
+    const corpus = corpusOf([...SHORT_FIRST_PERSON, ...LONG_IMPERSONAL]);
+    const first = measureVoiceCorpus(corpus);
+    const second = measureVoiceCorpus(corpus);
+    expect(second).toEqual(first);
   });
 
   describe('recurring openings', () => {
@@ -134,21 +160,215 @@ describe('measureVoiceCorpus', () => {
       expect(m.commonWords).not.toContain('shipped');
     });
   });
+
+  describe('rhythm', () => {
+    it('measures median sentence length, spread and how often a piece opens on a short line', () => {
+      const corpus = corpusOf([
+        'Shipped it. Small change, big relief for everyone on the team this week.',
+        'Fixed it. The bug had been hiding in the retry logic for three whole months.',
+        'Closed it. The ticket sat open longer than it should have, but it is done.',
+      ]);
+      const m = measureVoiceCorpus(corpus);
+      // Every item opens on a two-word sentence ("Shipped it.", "Fixed it.",
+      // "Closed it.") - a clear majority, so the ratio is 1.
+      expect(m.rhythm.shortOpeningRatio).toBe(1);
+      expect(m.rhythm.fragmentRatio).toBeGreaterThan(0);
+      expect(m.rhythm.medianSentenceWords).toBeGreaterThan(0);
+    });
+  });
+
+  describe('punctuation', () => {
+    it('counts a dash used as a pause, not a hyphen inside a word', () => {
+      const corpus = corpusOf([
+        'the point is - it worked out fine in the end this time.',
+        'here is the thing - it shipped a lot faster than planned.',
+        'one more note - it held up great under real load today.',
+      ]);
+      const m = measureVoiceCorpus(corpus);
+      expect(m.punctuation.dashesPer100Words).toBeGreaterThan(0);
+      // Every item opens lowercase on purpose - the majority habit, not the
+      // occasional one.
+      expect(m.punctuation.capitalizesOpenings).toBe(false);
+    });
+
+    it('reads whether a colon is usually followed by a lowercase letter', () => {
+      const corpus = corpusOf([
+        'The lesson: shortcuts always cost more than they save eventually.',
+        'The takeaway: nobody reads the docs until something breaks badly.',
+        'The result: fewer support tickets and a much calmer on-call week.',
+      ]);
+      const m = measureVoiceCorpus(corpus);
+      expect(m.punctuation.colonsPer100Words).toBeGreaterThan(0);
+      expect(m.punctuation.lowercasesAfterColon).toBe(true);
+      expect(m.punctuation.capitalizesOpenings).toBe(true);
+    });
+
+    it('reports zero, not a guess, for a mark that never appears', () => {
+      const corpus = corpusOf([
+        'the point is - it worked out fine in the end this time.',
+        'here is the thing - it shipped a lot faster than planned.',
+        'one more note - it held up great under real load today.',
+      ]);
+      const m = measureVoiceCorpus(corpus);
+      expect(m.punctuation.colonsPer100Words).toBe(0);
+      expect(m.punctuation.lowercasesAfterColon).toBe(false);
+    });
+  });
+
+  describe('shape', () => {
+    it('finds an emoji or hashtag reused across separate items, not one used once', () => {
+      const reused = corpusOf([
+        'Shipped the new dashboard today \u{1F389} and it went smoothly overall.',
+        'Closed out the migration this week \u{1F389} the team is relieved it is done.',
+        'Nothing to report this week, steady progress on the roadmap as usual.',
+      ]);
+      const m = measureVoiceCorpus(reused);
+      expect(m.shape.emoji).toContain('\u{1F389}');
+
+      const once = corpusOf([
+        'Shipped the new dashboard today \u{1F389} and it went smoothly overall.',
+        'Talked to five customers this week about their onboarding pain points.',
+        'Closed out three tickets this afternoon, steady progress on the roadmap.',
+      ]);
+      expect(measureVoiceCorpus(once).shape.emoji).toEqual([]);
+    });
+
+    it('finds the dominant ending style across the corpus', () => {
+      const questions = corpusOf([
+        'Why does every dashboard ship with five charts nobody asked for?',
+        'Why do onboarding flows always assume the user already knows the product?',
+        'Why is the default timeout always thirty seconds no matter the API?',
+      ]);
+      expect(measureVoiceCorpus(questions).shape.ending).toBe('question');
+
+      const claims = corpusOf([
+        'Shipped the dashboard today. It went smoothly overall.',
+        'Closed out the migration this week. The team is relieved it is done.',
+        'Fixed the flaky test suite. It was harder than it looked.',
+      ]);
+      expect(measureVoiceCorpus(claims).shape.ending).toBe('claim');
+    });
+
+    it('mirrors the list-layout register trait rather than re-deriving it', () => {
+      const corpus = corpusOf([
+        '- shipped the dashboard\n- fixed the flaky test\n- closed the migration ticket today',
+        '- talked to five customers\n- learned about pricing\n- wrote up the notes afterward',
+        '- reviewed three pull requests\n- merged the small fixes\n- deployed before lunch today',
+      ]);
+      const m = measureVoiceCorpus(corpus);
+      expect(m.traits).toContain('list-layout');
+      expect(m.shape.usesLists).toBe(true);
+    });
+  });
+
+  describe('voice markers', () => {
+    it('measures second person, hedges and an imperative opener', () => {
+      const corpus = corpusOf([
+        'You should probably try this approach on your own project first.',
+        'Try shipping smaller changes, you will probably thank yourself later.',
+        'Ship the small fix first, then you can decide what comes next.',
+      ]);
+      const m = measureVoiceCorpus(corpus);
+      expect(m.voiceMarkers.secondPersonPer100Words).toBeGreaterThan(0);
+      expect(m.voiceMarkers.hedgesPer100Words).toBeGreaterThan(0);
+      // Two of three sentences open on a known imperative verb ("Try",
+      // "Ship") - a real majority, not a guess.
+      expect(m.voiceMarkers.imperativeRatio).toBeCloseTo(2 / 3, 2);
+    });
+  });
+
+  describe('lexicon', () => {
+    it('says nothing about an avoided word below the word-count floor', () => {
+      const corpus = corpusOf([
+        'Shipped a small fix today, nothing dramatic, just steady progress on the roadmap this week.',
+        'Talked to a customer about pricing, learned a lot about what they actually need from us.',
+        'Closed out three tickets this afternoon, small wins add up over a long enough week.',
+      ]);
+      const m = measureVoiceCorpus(corpus);
+      expect(m.wordCount).toBeLessThan(200);
+      expect(m.lexicon.avoidedWords).toEqual([]);
+    });
+
+    it('reports a candidate word only once the corpus clears the floor, and never one actually used', () => {
+      const padding = Array.from(
+        { length: 20 },
+        (_, i) => `padding word number ${i} about nothing important at all today`,
+      ).join('. ');
+      const corpus = corpusOf([
+        `We should leverage the new pipeline to ship faster. ${padding}.`,
+        `The onboarding felt seamless this time around honestly. ${padding}.`,
+        `Closed out three tickets this afternoon with the team. ${padding}.`,
+      ]);
+      const m = measureVoiceCorpus(corpus);
+      expect(m.wordCount).toBeGreaterThanOrEqual(200);
+      expect(m.lexicon.avoidedWords).not.toContain('leverage');
+      expect(m.lexicon.avoidedWords).not.toContain('seamless');
+      expect(m.lexicon.avoidedWords).toContain('humbled');
+    });
+  });
+
+  describe('language', () => {
+    it('classifies English and Italian items and reports both a mix and a per-kind split', () => {
+      const corpus: VoiceCorpusItem[] = [
+        {
+          id: 1,
+          kind: 'voice_sample',
+          text: 'Shipped the new onboarding flow today, it took three tries to get right.',
+        },
+        {
+          id: 2,
+          kind: 'voice_sample',
+          text: 'Talked to five different customers this week about the export feature.',
+        },
+        {
+          id: 3,
+          kind: 'voice_sample',
+          text: 'Fixed a nasty race condition in the background queue this afternoon.',
+        },
+        {
+          id: 4,
+          kind: 'message',
+          text: 'Abbiamo chiuso la migrazione questa mattina, il team dovrebbe notarlo.',
+        },
+        {
+          id: 5,
+          kind: 'message',
+          text: 'Il nostro piccolo team ha avuto un trimestre difficile ma produttivo.',
+        },
+        {
+          id: 6,
+          kind: 'message',
+          text: 'Ho scritto tutta la specifica in aereo senza wifi ne distrazioni.',
+        },
+      ];
+      const m = measureVoiceCorpus(corpus);
+      expect(m.language.primary).toBe('mixed');
+      expect(m.language.byKind.voice_sample?.primary).toBe('en');
+      expect(m.language.byKind.message?.primary).toBe('it');
+    });
+  });
 });
 
 describe('describeVoiceProfile', () => {
+  const BASE: VoiceMeasurement = {
+    itemCount: 12,
+    wordCount: 640,
+    measurable: true,
+    traits: ['first-person', 'short-sentences'],
+    wordsPerSentence: 9,
+    openings: ['Just shipped'],
+    closings: ['what you think.'],
+    commonWords: ['team', 'shipped'],
+    rhythm: EMPTY_RHYTHM,
+    punctuation: EMPTY_PUNCTUATION,
+    shape: EMPTY_SHAPE,
+    voiceMarkers: EMPTY_VOICE_MARKERS,
+    lexicon: EMPTY_LEXICON,
+    language: EMPTY_LANGUAGE,
+  };
+
   it('assembles the measured pieces into prose, omitting whichever came back empty', () => {
-    const full: VoiceMeasurement = {
-      itemCount: 12,
-      wordCount: 640,
-      measurable: true,
-      traits: ['first-person', 'short-sentences'],
-      wordsPerSentence: 9,
-      openings: ['Just shipped'],
-      closings: ['what you think.'],
-      commonWords: ['team', 'shipped'],
-    };
-    const described = describeVoiceProfile(full)!;
+    const described = describeVoiceProfile(BASE)!;
     expect(described).toMatch(/12 pieces of their own writing/);
     expect(described).toMatch(/640 words/);
     expect(described).toMatch(/first person, speaking as themselves/);
@@ -156,9 +376,13 @@ describe('describeVoiceProfile', () => {
     expect(described).toContain('Often opens with "Just shipped"');
     expect(described).toContain('Often closes with "what you think."');
     expect(described).toContain('team, shipped');
+    expect(described).not.toMatch(/Tends to end/);
+    expect(described).not.toMatch(/Uses these emoji/);
+    expect(described).not.toMatch(/Never uses/);
+    expect(described).not.toMatch(/Writes primarily/);
 
     const noPhrasesOrWords: VoiceMeasurement = {
-      ...full,
+      ...BASE,
       openings: [],
       closings: [],
       commonWords: [],
@@ -169,11 +393,29 @@ describe('describeVoiceProfile', () => {
     expect(withoutExtras).not.toMatch(/Reuses/);
   });
 
+  it('adds the ending, emoji, hashtag, avoided-word and language sentences only when they say something', () => {
+    const rich: VoiceMeasurement = {
+      ...BASE,
+      shape: {
+        ...EMPTY_SHAPE,
+        emoji: ['\u{1F680}'],
+        hashtags: ['#buildinpublic'],
+        ending: 'claim',
+      },
+      lexicon: { avoidedWords: ['leverage', 'seamless'] },
+      language: { primary: 'mixed', englishRatio: 0.5, italianRatio: 0.4, byKind: {} },
+    };
+    const described = describeVoiceProfile(rich)!;
+    expect(described).toContain('Tends to end on a claim.');
+    expect(described).toContain('Uses these emoji: \u{1F680}.');
+    expect(described).toContain('Uses these hashtags: #buildinpublic.');
+    expect(described).toContain('Never uses: leverage, seamless.');
+    expect(described).toContain('Writes primarily in both English and Italian.');
+  });
+
   it('says nothing when the corpus was measurable but had no dominant trait, phrase or word', () => {
     const flat: VoiceMeasurement = {
-      itemCount: 5,
-      wordCount: 300,
-      measurable: true,
+      ...BASE,
       traits: [],
       wordsPerSentence: 0,
       openings: [],
@@ -185,6 +427,7 @@ describe('describeVoiceProfile', () => {
 
   it('returns null outright for an unmeasurable corpus regardless of its counts', () => {
     const tooSmall: VoiceMeasurement = {
+      ...BASE,
       itemCount: 2,
       wordCount: 40,
       measurable: false,
@@ -196,4 +439,38 @@ describe('describeVoiceProfile', () => {
     };
     expect(describeVoiceProfile(tooSmall)).toBeNull();
   });
+});
+
+// #570/#571's acceptance: no model call anywhere in the derivation path.
+// Asserted by scanning the real source text of the pure measurement module
+// and its DB layer, so a future import of a model client or a Gateway call
+// fails this test immediately rather than being caught by review.
+describe('no model call in the derivation path', () => {
+  const FORBIDDEN_PATTERNS = [
+    /\bfrom\s+['"]ai['"]/i,
+    /@ai-sdk/i,
+    /streamText/,
+    /generateText/,
+    /AI_GATEWAY/,
+    /gateway-catalogue/i,
+    /agents\/sdk/i,
+    /completion\(/,
+    /\bfetch\(/,
+  ];
+
+  const FILES = [
+    '../src/assist/voice-profile.ts',
+    '../src/assist/voice-defaults.ts',
+    '../src/operator-voice-profile.ts',
+  ];
+
+  for (const relativePath of FILES) {
+    it(`${relativePath} never imports or calls a model`, () => {
+      const path = fileURLToPath(new URL(relativePath, import.meta.url));
+      const source = readFileSync(path, 'utf8');
+      for (const pattern of FORBIDDEN_PATTERNS) {
+        expect(source).not.toMatch(pattern);
+      }
+    });
+  }
 });

--- a/shared/tests/operator-voice-profile.test.ts
+++ b/shared/tests/operator-voice-profile.test.ts
@@ -2,11 +2,16 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { getDb, schema } from '../src/db/client.js';
 import { recordVoiceSamples, setVoiceSampleExcluded } from '../src/operator-profile.js';
+import { EMPTY_RHYTHM, MIN_ITEMS_TO_DERIVE } from '../src/assist/voice-profile.js';
+import { DEFAULT_VOICE_PROFILE } from '../src/assist/voice-defaults.js';
 import {
   loadVoiceProfile,
   refreshVoiceProfile,
   saveVoiceProfileSummary,
   resetVoiceProfileToDerived,
+  resolveOperatorVoiceProfile,
+  VOICE_AXES,
+  type VoiceProfileEvidence,
 } from '../src/operator-voice-profile.js';
 
 // #407: the operator's derived voice profile, end to end against a real
@@ -15,6 +20,14 @@ import {
 // cannot check on their own: the corpus is gathered org-scoped across four
 // different tables, excluding a real voice sample row changes what gets
 // derived, and a manual edit really does survive a real refresh.
+//
+// 2026-09-09 (#570/#571): the versioning and default-resolution tests below
+// are the DB-round-trip half of that work - the pure logic (what "measured"
+// vs "default" means, what a legacy row normalizes to) is already pinned in
+// assist-voice-profile.test.ts and the pure resolveVoiceProfile tests here;
+// what only a real database can prove is that a row actually written by an
+// older shape reads back correctly, and that a real recompute against
+// Postgres bumps the version rather than silently overwriting.
 
 async function reset() {
   await getDb().execute(
@@ -119,6 +132,72 @@ async function seedCorpus(orgId: number, tag: string) {
   });
 
   return { proj, account, campaign, run, linkedin };
+}
+
+// A real-looking corpus sized and worded to make a specific claim per axis
+// (#570's acceptance: "the rich case produces measurements that actually
+// differ from the defaults"). Verified by hand against `measureVoiceCorpus`
+// directly before being written here: 12 items, 201 words, so it clears
+// both `MIN_ITEMS_TO_DERIVE` and the lexicon's 200-word avoided-word floor.
+// Eight English voice samples share a repeated emoji and hashtag and end on
+// a claim; four Italian sent messages give the language split something
+// real to report both overall and per corpus surface.
+const RICH_ENGLISH_SAMPLES = [
+  'Shipped the new onboarding flow today. It took three tries to get the copy exactly right. \u{1F680} #buildinpublic.',
+  'Talked to five different customers this week. Every single one asked for the same export feature. \u{1F680} #buildinpublic.',
+  'Fixed a nasty race condition in the background queue. Took two full days to track it down.',
+  'Wrote the whole feature spec on a plane. No wifi, no distractions, just me and the document.',
+  'I think the pricing page still confuses people. Probably needs another pass next sprint.',
+  'Our whole team debated this for a week before deciding. We chose the simpler approach in the end.',
+  'Reviewed every pull request myself this sprint. Small changes, merged fast, nothing sat waiting overnight.',
+  'Wrote a short retro after the outage last night. Named exactly what broke and what changes next.',
+];
+const RICH_ITALIAN_MESSAGES = [
+  'Abbiamo chiuso la migrazione questa mattina. Il team dovrebbe notare una vera differenza di velocita adesso.',
+  'Il nostro piccolo team ha avuto un trimestre difficile. Ne abbiamo parlato apertamente e siamo andati avanti.',
+  'Ho scritto tutta la specifica in aereo. Niente wifi, nessuna distrazione, solo io e il documento.',
+  'Penso che la pagina dei prezzi confonda ancora le persone. Probabilmente serve un altro passaggio nel prossimo sprint.',
+];
+
+async function seedRichCorpus(orgId: number, tag: string) {
+  const db = getDb();
+  const linkedin = await platformId('linkedin');
+  await recordVoiceSamples(
+    db,
+    orgId,
+    linkedin,
+    RICH_ENGLISH_SAMPLES.map((text, i) => ({ externalId: `${tag}-rich-sample-${i}`, text })),
+  );
+
+  const [proj] = await db
+    .insert(schema.projects)
+    .values({ organizationId: orgId, slug: `${tag}-rich-proj`, name: `${tag} rich proj` })
+    .returning();
+  const [account] = await db
+    .insert(schema.accounts)
+    .values({ projectId: proj.id, platformId: linkedin, handle: `${tag}-rich-acct` })
+    .returning();
+  const [contact] = await db
+    .insert(schema.contactHistory)
+    .values({
+      platformId: linkedin,
+      accountHandle: account.handle,
+      targetUser: `${tag}-rich-target`,
+      organizationId: orgId,
+    })
+    .returning();
+  for (const [i, body] of RICH_ITALIAN_MESSAGES.entries()) {
+    await db.insert(schema.messages).values({
+      contactId: contact.id,
+      platformId: linkedin,
+      author: account.handle,
+      isFromUs: true,
+      body,
+      platformMessageId: `${tag}-rich-msg-${i}`,
+      createdAtPlatform: new Date(),
+      source: 'linkedin',
+    });
+  }
 }
 
 describe('shared/src/operator-voice-profile', () => {
@@ -239,5 +318,126 @@ describe('shared/src/operator-voice-profile', () => {
     const reset = await resetVoiceProfileToDerived(getDb(), orgId);
     expect(reset.source).toBe('derived');
     expect(reset.summary).toBe(derived.summary);
+  });
+
+  it('a recompute on an unchanged corpus reproduces identical measurements but bumps the version', async () => {
+    const orgId = await ensureOrg('vp-org-version');
+    await seedCorpus(orgId, 'vr');
+
+    const first = await refreshVoiceProfile(getDb(), orgId);
+    expect(first.evidence.version).toBe(1);
+
+    const second = await refreshVoiceProfile(getDb(), orgId);
+    expect(second.evidence.version).toBe(2);
+    // The counter moved; the content it describes did not - determinism and
+    // "a recompute is a new version" hold at the same time, not in tension.
+    expect(second.summary).toBe(first.summary);
+    expect(second.traits).toEqual(first.traits);
+    expect(second.openings).toEqual(first.openings);
+    expect(second.evidence.rhythm).toEqual(first.evidence.rhythm);
+    expect(second.evidence.language).toEqual(first.evidence.language);
+
+    const third = await refreshVoiceProfile(getDb(), orgId);
+    expect(third.evidence.version).toBe(3);
+  });
+
+  it('reads a row written before #570 shipped without throwing, as version 0 with valid empty axes', async () => {
+    const orgId = await ensureOrg('vp-org-legacy');
+    // The exact shape `refreshVoiceProfile` wrote before this change: no
+    // `version`, none of the six extended axes - just the corpus ids and
+    // counts #407 already stored.
+    const legacyEvidence = {
+      voiceSampleIds: [1, 2],
+      messageIds: [],
+      draftIds: [],
+      templateIds: [],
+      counts: { voiceSamples: 2, messages: 0, drafts: 0, templates: 0 },
+    };
+    await getDb()
+      .insert(schema.operatorVoiceProfiles)
+      .values({
+        organizationId: orgId,
+        summary: 'Usually writes with first person, speaking as themselves.',
+        traits: ['first-person'],
+        openings: [],
+        closings: [],
+        commonWords: [],
+        wordsPerSentence: 12,
+        itemCount: 4,
+        wordCount: 80,
+        evidence: legacyEvidence,
+        source: 'derived',
+        derivedAt: new Date(),
+      });
+
+    const row = await loadVoiceProfile(getDb(), orgId);
+    expect(row).not.toBeNull();
+    expect(row!.evidence.version).toBe(0);
+    expect(row!.evidence.voiceSampleIds).toEqual([1, 2]);
+    expect(row!.evidence.rhythm).toEqual(EMPTY_RHYTHM);
+    expect(row!.summary).toBe('Usually writes with first person, speaking as themselves.');
+
+    // A recompute over a legacy row starts counting from its version, not
+    // from zero every time - 0 is "never versioned", not "version zero of a
+    // fresh count".
+    const refreshed = await refreshVoiceProfile(getDb(), orgId);
+    expect(refreshed.evidence.version).toBe(1);
+  });
+});
+
+describe('resolveOperatorVoiceProfile', () => {
+  beforeEach(reset);
+
+  it('a thin or absent corpus resolves to the labelled defaults, never an invented profile', async () => {
+    const orgId = await ensureOrg('vp-org-resolve-thin');
+
+    const beforeAnyDerivation = await resolveOperatorVoiceProfile(getDb(), orgId);
+    expect(beforeAnyDerivation.status).toBe('default');
+    expect(beforeAnyDerivation.summary).toBe(DEFAULT_VOICE_PROFILE.summary);
+    for (const axis of VOICE_AXES) expect(beforeAnyDerivation.axes[axis]).toBe('default');
+    expect(beforeAnyDerivation.measured).toBeNull();
+    expect(beforeAnyDerivation.gap).toMatch(/more pieces? of their own writing/);
+
+    // Below MIN_ITEMS_TO_DERIVE even after a real derivation ran.
+    const linkedin = await platformId('linkedin');
+    await recordVoiceSamples(getDb(), orgId, linkedin, [
+      { externalId: 'thin-1', text: 'Just one lone post here, nothing to compare it to yet.' },
+    ]);
+    await refreshVoiceProfile(getDb(), orgId);
+    const stillThin = await resolveOperatorVoiceProfile(getDb(), orgId);
+    expect(stillThin.itemCount).toBeLessThan(MIN_ITEMS_TO_DERIVE);
+    expect(stillThin.status).toBe('default');
+    expect(stillThin.axes.rhythm).toBe('default');
+  });
+
+  it('a rich, real-looking corpus resolves to measurements that actually differ from the defaults', async () => {
+    const orgId = await ensureOrg('vp-org-resolve-rich');
+    await seedRichCorpus(orgId, 'rr');
+    await refreshVoiceProfile(getDb(), orgId);
+
+    const resolved = await resolveOperatorVoiceProfile(getDb(), orgId);
+    expect(resolved.status).toBe('measured');
+    for (const axis of VOICE_AXES) expect(resolved.axes[axis]).toBe('measured');
+    expect(resolved.gap).toBeNull();
+    expect(resolved.summary).not.toBe(DEFAULT_VOICE_PROFILE.summary);
+
+    const evidence = resolved.measured!.evidence as VoiceProfileEvidence;
+    // Real content, not the defaults' placeholder rules: an emoji and a
+    // hashtag genuinely reused across the fixture, a claim-dominant ending,
+    // a mixed language split overall and a clean split per corpus surface,
+    // and every default-sounding candidate word the fixture never used.
+    expect(evidence.shape.emoji).toContain('\u{1F680}');
+    expect(evidence.shape.hashtags).toContain('#buildinpublic');
+    expect(evidence.shape.ending).toBe('claim');
+    expect(evidence.language.primary).toBe('mixed');
+    expect(evidence.language.byKind.voice_sample?.primary).toBe('en');
+    expect(evidence.language.byKind.message?.primary).toBe('it');
+    // None of the candidate words appear anywhere in the fixture, so the
+    // corpus genuinely avoided all of them - a real absence, not a partial
+    // or invented list.
+    expect(evidence.lexicon.avoidedWords).toContain('leverage');
+    expect(evidence.lexicon.avoidedWords).toContain('humbled');
+    expect(evidence.lexicon.avoidedWords.length).toBeGreaterThanOrEqual(10);
+    expect(evidence.rhythm.medianSentenceWords).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What changed

`shared/src/assist/voice-profile.ts` (#407) measured a corpus of the operator's own writing (voice samples, sent messages, sent drafts, templates) but only reported openings, closings and reused words. This extends the derivation into six more axes, every one countable and none of them a model call:

- **Rhythm**: median sentence length and spread (interquartile range, not just mean), paragraph length, how often a sentence is a fragment, whether a piece opens on a short line.
- **Punctuation and typography**: comma/colon/parenthesis/dash/question-mark/exclamation-mark/ellipsis density per 100 words, whether openings are usually capitalised, whether a colon is usually followed by a lowercase letter.
- **Shape**: line breaks per paragraph, list use (reuses the existing `list-layout` register trait rather than re-deriving it), which emoji and hashtags actually repeat across separate items, whether a piece tends to end on a question, a claim, or nothing.
- **Voice markers**: first- and second-person density, hedges ("I think", "probably"), certainty markers, and an imperative-opener ratio (a short named list, the same heuristic register.ts already uses for jargon detection).
- **Lexicon**: which candidate default-sounding words (house style's puffery list plus the LinkedIn-specific ones #571 names) the operator's own writing never touches - only once the corpus is large enough (200+ words) that an absence means something.
- **Language**: the English/Italian split, both overall and per corpus surface (voice sample vs message vs draft vs template), since a suggestion has to match the post's language rather than the operator's average.

`describeVoiceProfile` gained a few more sentences (ending, emoji, hashtags, avoided words, language) on the same "present only if it says something" discipline the existing prose already followed.

### #571: human defaults for a thin corpus

`shared/src/assist/voice-defaults.ts` is a new, small module: `DEFAULT_VOICE_PROFILE`, one named object (a summary, a list of rules, a list of candidate words to avoid), not sentences scattered through a prompt builder. It is deliberately shaped nothing like `VoiceMeasurement` - no overlapping fields - so it can never be mistaken for something measured.

`resolveVoiceProfile` (pure) and `resolveOperatorVoiceProfile` (loads the row) decide which one a caller gets: the real measurement once the corpus clears `MIN_ITEMS_TO_DERIVE` (3 items, unchanged), the defaults otherwise - never a blend. The result carries `status: 'measured' | 'default'` and an `axes` map (one entry per new axis, same two values) so a consumer can render "measured" versus "default" honestly instead of presenting a default as if it were read off the operator's own writing.

### Versioning, without a migration

Nobody in this wave holds the migration slot, and `operator_voice_profiles`' `evidence` column was already schemaless jsonb, so I didn't need one. `evidence.version` is a per-org counter that increments on every real derivation (never on a manual edit, which doesn't re-derive anything) - a recompute is provably a new version, not a silent overwrite. A row written before this shipped carries no `version` and none of the six new axes; `normalizeEvidence` reads it back as version 0 with every new axis present as a valid empty measurement, never a crash. An older profile stays readable without being re-derived.

## Non-goals (left to siblings in the same wave)

- Which examples go into a given prompt (#578).
- The tool that serves this to the agent (`operator_voice`, #567/AssistTools) - I coordinated the shape with them over `hub` early; they're building against today's `loadVoiceProfile` + `MIN_ITEMS_TO_DERIVE` directly for now and will swap to `resolveOperatorVoiceProfile` as a follow-up, so nothing in this PR blocks or is blocked by theirs.
- Settings/panel rendering of "which profile is in use and what would improve it" - the data (`status`, `axes`, `gap`) is here; rendering it is a UI change outside `shared/`.

## Verified

- `pnpm -F @pitchbox/shared typecheck` - clean.
- `pnpm -F web check` - 0 errors (confirms the two existing `web/` consumers of `OperatorVoiceProfileRow`/`refreshVoiceProfile` still compile against the extended, backward-compatible type).
- `npx eslint shared/src/assist/voice-profile.ts shared/src/assist/voice-defaults.ts shared/src/operator-voice-profile.ts shared/tests/assist-voice-profile.test.ts shared/tests/operator-voice-profile.test.ts` - clean.
- `npx prettier --check` on the same files - clean.
- `DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5434/pitchbox_test_voice pnpm exec vitest run shared/tests/assist-voice-profile.test.ts shared/tests/operator-voice-profile.test.ts` - 36/36 passing, including:
  - Determinism: the same corpus measured twice is byte-identical (`toEqual`).
  - A hand-verified fixture (checked against the real measurement with `tsx` before being written into the test, not guessed): 12 items, 201 words, an emoji and a hashtag that genuinely repeat, a claim-dominant ending, a mixed English/Italian split overall with a clean split per corpus surface, and every one of the candidate avoid-words present because the fixture never uses them - the rich case produces measurements that differ from the defaults on real content, not just a passing status flag.
  - The thin-evidence case (below `MIN_ITEMS_TO_DERIVE`, or no row at all) resolves to `DEFAULT_VOICE_PROFILE` verbatim, labelled `status: 'default'` on every axis.
  - A row inserted with the exact pre-#570 shape (no `version`, no extended axes) loads without throwing, reads as version 0, and a subsequent recompute bumps it to 1.
  - Two consecutive recomputes on an unchanged corpus: identical summary/traits/rhythm/language, but `version` 1 then 2 then 3 - determinism and "a recompute is a new version" hold at once.
  - A source-scan test over all three files asserting none of them import `ai`, `@ai-sdk`, `streamText`, `generateText`, the AI Gateway, `agents/sdk`, or call `fetch` - fails immediately if a future change introduces a model call into the derivation path.

## Deliberately left alone

`shared/src/assist/register.ts` (per-post register, #406) is unchanged - I read it but only reused its sentence-splitting convention and its bilingual stopword-list pattern, never modified it. The campaign MCP server and the assist tool surface are untouched, per the epic's design doc.
