### PR TITLE
feat(web,shared): Stripe billing - a customer per org, Checkout, the webhook, and the portal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,18 @@ WEB_PORT=5180
 # SMTP_SECURE=false
 # SMTP_USER=
 # SMTP_PASS=
+
+# Hosted billing (#550/#551/#552, docs/billing.md). Off/unset means exactly
+# today's self-host behaviour: no Stripe client is built, every plan limit
+# stays off. PITCHBOX_BILLING=on with no STRIPE_SECRET_KEY still falls back
+# to disabled rather than a client that only fails once it tries to call
+# Stripe - same convention as MAIL_PROVIDER above.
+# PITCHBOX_BILLING=on
+# STRIPE_SECRET_KEY=
+# STRIPE_PUBLISHABLE_KEY=
+# Signing secret of *this deployment's own* webhook endpoint - production
+# and preview each have their own, never share one (docs/billing.md).
+# STRIPE_WEBHOOK_SECRET=
+# Optional: pins the customer portal to a specific configuration instead of
+# the account default (`scripts/stripe-setup.ts` creates it).
+# STRIPE_PORTAL_CONFIGURATION=

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -19,14 +19,25 @@ That choice is not just a fee, it constrains the integration:
 
 - Checkout Sessions **must** set `managed_payments[enabled]=true` and use API
   version `2025-03-31.basil` or later.
-- These parameters are **rejected** on such a session: `automatic_tax`,
-  `tax_id_collection`, `subscription_data.default_tax_rates`,
-  `payment_method_collection`, `payment_method_configuration`,
-  `payment_method_options`, `payment_method_types`,
-  `saved_payment_method_options`, `customer_update[name]`,
-  `customer_update[address]`, `shipping_address_collection`, `shipping_options`,
-  `subscription_data.application_fee_percent`, `subscription_data.on_behalf_of`,
-  `subscription_data.transfer_data`, `subscription_data.invoice_settings`.
+- These parameters are **rejected**, per Stripe's own documentation:
+  `subscription_data.default_tax_rates`, `payment_method_collection`,
+  `payment_method_configuration`, `payment_method_options`,
+  `payment_method_types`, `saved_payment_method_options`,
+  `shipping_address_collection`, `shipping_options`,
+  `subscription_data.application_fee_percent`,
+  `subscription_data.on_behalf_of`, `subscription_data.transfer_data`,
+  `subscription_data.invoice_settings`. Verified against the real test
+  account under `2025-03-31.basil` (#550/#551 PR): `payment_method_types`,
+  `shipping_address_collection` and `subscription_data.invoice_settings` do
+  reject outright with exactly that message. `automatic_tax[enabled]` and
+  `tax_id_collection[enabled]` are a narrower case Stripe's own error message
+  states directly - Managed Payments pins both to `true` and only the
+  opposite value errors ("must be true when Managed Payments is enabled");
+  omitting either is silently equivalent to `true`. Two more from Stripe's
+  own list, `customer_update[name]` and `customer_update[address]`, did
+  **not** error in that same test-mode run - a discrepancy worth knowing
+  about but not worth relying on, since the app never sets any of the above
+  either way.
 - A subscription **cannot be created outside Checkout or a Payment Link**, and
   one-off invoices and customer invoice items are not available on it. Updating
   or cancelling an existing subscription through the API still works.
@@ -83,11 +94,18 @@ writes: not a second source of truth, but what an org resolves to _before_
 Stripe is asked - Free (which has no Stripe object, ever), an instance-admin
 grant (never Stripe-backed), and the gap before a subscription's first
 webhook lands. `organizations.plan`/`plan_source`/`plan_updated_at` record
-which plan and why; `org_subscriptions` mirrors a live subscription's
-metadata limits per org, one row per org, separate from `organizations`
-because a subscription has its own lifecycle - Stripe can delete it out from
-under us (see "A customer can ask Stripe to delete their data" below), and
-that has to look like a row disappearing, not a pile of nulled columns.
+which plan and why, and `organizations.stripe_customer_id` records the
+org's Stripe customer (#550) - created lazily on first checkout and kept
+there rather than on `org_subscriptions`, since a customer can exist with
+no subscription yet (or after one is cancelled) and `org_subscriptions`
+is itself deleted wholesale when Stripe's subscription is. `org_subscriptions`
+mirrors a live subscription's metadata limits per org, one row per org,
+separate from `organizations` because a subscription has its own lifecycle -
+Stripe can delete it out from under us (see "A customer can ask Stripe to
+delete their data" below), and that has to look like a row disappearing,
+not a pile of nulled columns. `stripe_events` is the webhook's own
+idempotency ledger (#551): Stripe's event id as the primary key, so a
+retried or replayed delivery is a no-op rather than a double-apply.
 
 Precedence, highest first: self-host (unlimited, no plan, no Stripe key
 required); an instance-admin grant (`plan_source='grant'`), which survives
@@ -128,14 +146,15 @@ A webhook signing secret is returned only when the endpoint is created. Pass
 
 ## Environment
 
-| Variable                      | Where             | What                                                           |
-| ----------------------------- | ----------------- | -------------------------------------------------------------- |
-| `STRIPE_SECRET_KEY`           | web (server only) | `sk_live_…` in production, `sk_test_…` in preview and locally  |
-| `STRIPE_PUBLISHABLE_KEY`      | web               | `pk_live_…` / `pk_test_…`, safe to expose                      |
-| `STRIPE_WEBHOOK_SECRET`       | web (server only) | signing secret of **that deployment's own** endpoint           |
-| `STRIPE_PORTAL_CONFIGURATION` | web (server only) | optional; pins the portal configuration instead of the default |
-| `PITCHBOX_APP_ORIGIN`         | setup script      | defaults to `https://app.pitchbox.app`                         |
-| `PITCHBOX_PREVIEW_ORIGIN`     | setup script      | defaults to `https://preview.pitchbox.app`                     |
+| Variable                      | Where             | What                                                                                                                       |
+| ----------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `PITCHBOX_BILLING`            | web (server only) | `on` to enable the billing routes; unset means self-host posture, same 404 `/api/auth/*` takes when `PITCHBOX_AUTH` is off |
+| `STRIPE_SECRET_KEY`           | web (server only) | `sk_live_…` in production, `sk_test_…` in preview and locally                                                              |
+| `STRIPE_PUBLISHABLE_KEY`      | web               | `pk_live_…` / `pk_test_…`, safe to expose                                                                                  |
+| `STRIPE_WEBHOOK_SECRET`       | web (server only) | signing secret of **that deployment's own** endpoint                                                                       |
+| `STRIPE_PORTAL_CONFIGURATION` | web (server only) | optional; pins the portal configuration instead of the default                                                             |
+| `PITCHBOX_APP_ORIGIN`         | setup script      | defaults to `https://app.pitchbox.app`                                                                                     |
+| `PITCHBOX_PREVIEW_ORIGIN`     | setup script      | defaults to `https://preview.pitchbox.app`                                                                                 |
 
 Production and preview have **separate webhook endpoints with separate signing
 secrets** on purpose: a preview deployment holding the production secret could

--- a/shared/package.json
+++ b/shared/package.json
@@ -88,7 +88,14 @@
     "./mail/template": "./src/mail/template.ts",
     "./mail/env": "./src/mail/env.ts",
     "./registration-policy": "./src/registration-policy.ts",
-    "./plans": "./src/plans.ts"
+    "./plans": "./src/plans.ts",
+    "./stripe/env": "./src/stripe/env.ts",
+    "./stripe/client": "./src/stripe/client.ts",
+    "./stripe/signature": "./src/stripe/signature.ts",
+    "./billing/customer": "./src/billing/customer.ts",
+    "./billing/checkout": "./src/billing/checkout.ts",
+    "./billing/portal": "./src/billing/portal.ts",
+    "./billing/webhook": "./src/billing/webhook.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",

--- a/shared/src/billing/checkout.ts
+++ b/shared/src/billing/checkout.ts
@@ -1,0 +1,54 @@
+// A Checkout session per plan and interval (#550). This route never writes
+// a plan: `org_subscriptions`/`organizations.plan` are the webhook's alone
+// (#551) - a success redirect that optimistically upgrades here is exactly
+// the bug that lets somebody abandon payment and keep the plan.
+import { type PlanId, stripeLookupKey } from '../plans.js';
+import type { Db } from '../db/client.js';
+import type { StripeClient } from '../stripe/client.js';
+import { ensureStripeCustomer } from './customer.js';
+
+export class UnknownPriceError extends Error {}
+
+export type CreateCheckoutSessionArgs = {
+  orgId: number;
+  planId: PlanId;
+  interval: 'month' | 'year';
+  successUrl: string;
+  cancelUrl: string;
+};
+
+/**
+ * Starts a subscription Checkout session for `args.planId`/`args.interval`,
+ * resolved to a Stripe price by `lookup_key` (docs/billing.md - the app
+ * never accepts a price id from the caller). Every parameter Managed
+ * Payments rejects (`automatic_tax`, `tax_id_collection`, `payment_method_*`,
+ * `customer_update[name/address]`, `shipping_*`,
+ * `subscription_data.invoice_settings`, ...) is simply never set here -
+ * confirmed against a real test-mode session for `pitchbox_growth_monthly`,
+ * see the PR for the verbatim Stripe errors this omission avoids.
+ */
+export async function createCheckoutSession(
+  db: Db,
+  stripe: StripeClient,
+  args: CreateCheckoutSessionArgs,
+): Promise<{ url: string }> {
+  const lookupKey = stripeLookupKey(args.planId, args.interval === 'month' ? 'monthly' : 'yearly');
+  if (!lookupKey) throw new UnknownPriceError(`plan ${args.planId} has no Stripe price`);
+  const price = await stripe.getPriceByLookupKey(lookupKey);
+  if (!price) throw new UnknownPriceError(`no active Stripe price for lookup key ${lookupKey}`);
+
+  const customerId = await ensureStripeCustomer(db, stripe, args.orgId);
+  const session = await stripe.createCheckoutSession({
+    mode: 'subscription',
+    customer: customerId,
+    line_items: [{ price: price.id, quantity: 1 }],
+    client_reference_id: String(args.orgId),
+    subscription_data: { metadata: { organization_id: String(args.orgId) } },
+    allow_promotion_codes: true,
+    managed_payments: { enabled: true },
+    success_url: args.successUrl,
+    cancel_url: args.cancelUrl,
+  });
+  if (!session.url) throw new Error(`Stripe returned no url for checkout session ${session.id}`);
+  return { url: session.url };
+}

--- a/shared/src/billing/customer.ts
+++ b/shared/src/billing/customer.ts
@@ -1,0 +1,70 @@
+// One Stripe customer per organization (#550), created lazily and reused -
+// never per user, because the subscription belongs to the tenant and seats
+// are an org attribute (docs/billing.md, `organizations.stripe_customer_id`
+// in `db/schema.ts`). This is the only writer of that column.
+import { and, eq, isNull } from 'drizzle-orm';
+import { memberships, organizations, users } from '../db/schema.js';
+import type { Db } from '../db/client.js';
+import type { StripeClient } from '../stripe/client.js';
+
+/** The org's oldest owner's email, or `null` if the org has no owner with a
+ * verified account email yet (self-host with auth off, or a pre-#530
+ * account that never set one). Stripe's `email` on a customer is optional,
+ * so a `null` here just means the Checkout page collects it instead. */
+async function ownerEmail(db: Db, orgId: number): Promise<string | null> {
+  const [row] = await db
+    .select({ email: users.email })
+    .from(memberships)
+    .innerJoin(users, eq(users.id, memberships.userId))
+    .where(and(eq(memberships.organizationId, orgId), eq(memberships.role, 'owner')))
+    .orderBy(memberships.userId)
+    .limit(1);
+  return row?.email ?? null;
+}
+
+/**
+ * Returns the org's Stripe customer id, creating one on Stripe and
+ * persisting it to `organizations.stripe_customer_id` if this is the org's
+ * first checkout. Two concurrent first checkouts for one org race on the
+ * same `UPDATE ... WHERE stripe_customer_id IS NULL`: only one of them
+ * actually claims the column (the loser's own freshly-created Stripe
+ * customer is simply never referenced again - an orphaned test-mode
+ * customer object costs nothing and is not worth a compensating delete),
+ * and both callers end up returning the id that won, so the org never ends
+ * up with two live customer ids across two `org_subscriptions` rows.
+ */
+export async function ensureStripeCustomer(
+  db: Db,
+  stripe: StripeClient,
+  orgId: number,
+): Promise<string> {
+  const [org] = await db
+    .select({ slug: organizations.slug, stripeCustomerId: organizations.stripeCustomerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  if (!org) throw new Error(`org ${orgId} does not exist`);
+  if (org.stripeCustomerId) return org.stripeCustomerId;
+
+  const email = await ownerEmail(db, orgId);
+  const customer = await stripe.createCustomer({
+    email: email ?? undefined,
+    metadata: { organization_id: String(orgId), organization_slug: org.slug },
+  });
+
+  const [claimed] = await db
+    .update(organizations)
+    .set({ stripeCustomerId: customer.id })
+    .where(and(eq(organizations.id, orgId), isNull(organizations.stripeCustomerId)))
+    .returning({ stripeCustomerId: organizations.stripeCustomerId });
+  if (!claimed) {
+    const [row] = await db
+      .select({ stripeCustomerId: organizations.stripeCustomerId })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+    if (row?.stripeCustomerId) return row.stripeCustomerId;
+    throw new Error(`org ${orgId} lost its stripe_customer_id race with no winner`);
+  }
+  return claimed.stripeCustomerId ?? customer.id;
+}

--- a/shared/src/billing/portal.ts
+++ b/shared/src/billing/portal.ts
@@ -1,0 +1,39 @@
+// The customer portal is where a plan changes and a card is updated (#552).
+// Every change made there comes back as a `customer.subscription.updated`
+// or `.deleted` webhook (#551), so this module writes nothing either.
+import { eq } from 'drizzle-orm';
+import { organizations } from '../db/schema.js';
+import type { Db } from '../db/client.js';
+import type { StripeClient } from '../stripe/client.js';
+
+export class NoStripeCustomerError extends Error {}
+
+/**
+ * Starts a billing portal session for the org's Stripe customer, pinned to
+ * `portalConfiguration` when the deployment has one
+ * (`STRIPE_PORTAL_CONFIGURATION`, `docs/billing.md`'s environment table).
+ * Throws `NoStripeCustomerError` for an org with no customer yet (the
+ * free-plan case, docs/billing.md #552: "the button offers checkout
+ * instead") - the caller decides what that looks like in the response,
+ * this module never creates a customer just to open a portal on it.
+ */
+export async function createPortalSession(
+  db: Db,
+  stripe: StripeClient,
+  args: { orgId: number; returnUrl: string; portalConfiguration: string | null },
+): Promise<{ url: string }> {
+  const [org] = await db
+    .select({ stripeCustomerId: organizations.stripeCustomerId })
+    .from(organizations)
+    .where(eq(organizations.id, args.orgId))
+    .limit(1);
+  if (!org?.stripeCustomerId) {
+    throw new NoStripeCustomerError(`org ${args.orgId} has no Stripe customer`);
+  }
+  const session = await stripe.createPortalSession({
+    customer: org.stripeCustomerId,
+    return_url: args.returnUrl,
+    configuration: args.portalConfiguration ?? undefined,
+  });
+  return { url: session.url };
+}

--- a/shared/src/billing/webhook.ts
+++ b/shared/src/billing/webhook.ts
@@ -1,0 +1,341 @@
+// The Stripe webhook is the only writer of subscription state (#551).
+// Every exported entry point here assumes the caller (the web route) has
+// already verified `Stripe-Signature` against `STRIPE_WEBHOOK_SECRET` - this
+// module never sees a request that failed that check, and never touches the
+// database before it passes.
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+import { organizations, orgSubscriptions, stripeEvents } from '../db/schema.js';
+import type { Db } from '../db/client.js';
+import { recordInstanceAudit } from '../instance-audit.js';
+import { normalizePlanId, type PlanId } from '../plans.js';
+import { setOrgPlan } from '../orgs.js';
+import type {
+  StripeClient,
+  StripeEvent,
+  StripeMetadata,
+  StripeSubscription,
+} from '../stripe/client.js';
+
+/** The system actor recorded on every audit row this module writes -
+ * `recordInstanceAudit` only ever reads `.username` off this, `id` is
+ * unused but required by its `InstanceAuditActor` type. */
+const WEBHOOK_ACTOR = { id: -1, username: 'stripe:webhook' };
+
+export type ApplyOutcome =
+  'duplicate' | 'unknown-customer' | 'stale' | 'no-op' | 'ignored' | 'applied';
+
+export type ApplyResult = { outcome: ApplyOutcome; detail?: string };
+
+/**
+ * The Stripe product metadata this app defines (`scripts/stripe-setup.ts`,
+ * docs/billing.md "The plan catalogue lives in Stripe, not in the code")
+ * turned into `org_subscriptions` columns. The string `'0'` on any `limit_*`
+ * key means unlimited on that axis and becomes a real SQL `NULL`, never a
+ * stored `0` - the same convention the setup script's own comments use.
+ */
+export function limitsFromProductMetadata(metadata: StripeMetadata): {
+  planId: PlanId;
+  limitRuns: number | null;
+  limitSuggestions: number | null;
+  limitProjects: number | null;
+  limitSeats: number | null;
+  limitDevices: number | null;
+  limitConcurrency: number | null;
+  limitBudgetUsd: string | null;
+  limitRetentionDays: number | null;
+  limitPremiumModels: boolean;
+} {
+  const int = (raw: string | undefined): number | null => {
+    if (raw === undefined) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) && n !== 0 ? n : null;
+  };
+  const budget = (raw: string | undefined): string | null => {
+    if (raw === undefined) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) && n !== 0 ? n.toFixed(2) : null;
+  };
+  return {
+    planId: normalizePlanId(metadata.plan),
+    limitRuns: int(metadata.limit_runs),
+    limitSuggestions: int(metadata.limit_suggestions),
+    limitProjects: int(metadata.limit_projects),
+    limitSeats: int(metadata.limit_seats),
+    limitDevices: int(metadata.limit_devices),
+    limitConcurrency: int(metadata.limit_concurrency),
+    limitBudgetUsd: budget(metadata.limit_budget_usd),
+    limitRetentionDays: int(metadata.limit_retention_days),
+    limitPremiumModels: metadata.limit_premium_models === 'true',
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function markProcessed(db: PgDatabase<any, any, any>, eventId: string): Promise<void> {
+  await db
+    .update(stripeEvents)
+    .set({ processedAt: new Date() })
+    .where(eq(stripeEvents.id, eventId));
+}
+
+/**
+ * Refetches `subscriptionId` live from Stripe - never trusts the possibly
+ * stale object embedded in the webhook event, Stripe's own recommendation
+ * for handling delivery order it does not guarantee - and mirrors it onto
+ * `org_subscriptions`/`organizations` wholesale, in one transaction with
+ * marking the ledger row processed.
+ *
+ * Version guard: `2025-03-31.basil` moved `current_period_start`/`_end` off
+ * the Subscription object onto each subscription item (confirmed against
+ * the real test account - see the PR), so the item's own
+ * `current_period_end` is what this reads. It is also this function's
+ * out-of-order marker: an incoming value strictly less than what is already
+ * stored would mean this event describes an earlier billing period than one
+ * already recorded, so it is ignored rather than applied. Equal or greater
+ * is applied even when nothing period-related changed (a plan swap mid
+ * cycle typically leaves `current_period_end` unchanged) - only a real step
+ * backwards is "stale". `event.created` is not used for this at all: two
+ * events can share the same second (Stripe's own documented limitation),
+ * while this field only moves forward in the object it actually describes.
+ */
+export async function syncSubscriptionFromStripe(
+  db: Db,
+  stripe: StripeClient,
+  subscriptionId: string,
+  eventId: string,
+): Promise<ApplyResult> {
+  const sub = await stripe.getSubscription(subscriptionId);
+  const item = sub.items.data[0];
+  if (!item) {
+    throw new Error(`subscription ${subscriptionId} has no items`);
+  }
+  const product = item.price.product;
+  if (typeof product === 'string') {
+    throw new Error(`subscription ${subscriptionId}'s product was not expanded`);
+  }
+
+  return db.transaction(async (tx) => {
+    const [org] = await tx
+      .select({
+        id: organizations.id,
+        plan: organizations.plan,
+        planSource: organizations.planSource,
+      })
+      .from(organizations)
+      .where(eq(organizations.stripeCustomerId, sub.customer))
+      .limit(1);
+    if (!org) {
+      await markProcessed(tx, eventId);
+      return { outcome: 'unknown-customer' as const, detail: sub.customer };
+    }
+
+    const [existing] = await tx
+      .select({ currentPeriodEnd: orgSubscriptions.currentPeriodEnd })
+      .from(orgSubscriptions)
+      .where(eq(orgSubscriptions.organizationId, org.id))
+      .limit(1);
+    const currentPeriodEnd = new Date(item.current_period_end * 1000);
+    if (existing && currentPeriodEnd.getTime() < existing.currentPeriodEnd.getTime()) {
+      await markProcessed(tx, eventId);
+      return { outcome: 'stale' as const };
+    }
+
+    const limits = limitsFromProductMetadata(product.metadata);
+    const row = {
+      organizationId: org.id,
+      stripeCustomerId: sub.customer,
+      stripeSubscriptionId: sub.id,
+      planId: limits.planId,
+      status: sub.status,
+      currentPeriodStart: new Date(item.current_period_start * 1000),
+      currentPeriodEnd,
+      cancelAtPeriodEnd: sub.cancel_at_period_end,
+      limitRuns: limits.limitRuns,
+      limitSuggestions: limits.limitSuggestions,
+      limitProjects: limits.limitProjects,
+      limitSeats: limits.limitSeats,
+      limitDevices: limits.limitDevices,
+      limitConcurrency: limits.limitConcurrency,
+      limitBudgetUsd: limits.limitBudgetUsd,
+      limitRetentionDays: limits.limitRetentionDays,
+      limitPremiumModels: limits.limitPremiumModels,
+      updatedAt: new Date(),
+    };
+    await tx
+      .insert(orgSubscriptions)
+      .values(row)
+      .onConflictDoUpdate({ target: orgSubscriptions.organizationId, set: row });
+
+    // A grant survives whatever Stripe says about the same org (docs/billing.md,
+    // shared/src/plans.ts's resolveEntitlements) - the row above still mirrors
+    // Stripe's state for visibility, but `organizations.plan`/`plan_source`
+    // themselves are left alone.
+    if (org.planSource !== 'grant') {
+      await setOrgPlan(tx, org.id, limits.planId, 'stripe');
+    }
+
+    await recordInstanceAudit(tx, {
+      key: `billing.subscription:${org.id}`,
+      actor: WEBHOOK_ACTOR,
+      before: { plan: org.plan, planSource: org.planSource },
+      after: {
+        plan: org.planSource === 'grant' ? org.plan : limits.planId,
+        planSource: org.planSource,
+        stripeStatus: sub.status,
+        stripeSubscriptionId: sub.id,
+      },
+    });
+
+    await markProcessed(tx, eventId);
+    return {
+      outcome: 'applied' as const,
+      detail: org.planSource === 'grant' ? 'grant preserved' : undefined,
+    };
+  });
+}
+
+/**
+ * `customer.subscription.deleted`: the subscription is gone (cancelled at
+ * Stripe, or removed along with the rest of the customer's data -
+ * docs/billing.md "Emails and support"). Drops the org's mirrored row and
+ * its plan to free, `organizations`' data untouched - a grant is preserved
+ * the same way `syncSubscriptionFromStripe` preserves it.
+ */
+export async function clearSubscription(
+  db: Db,
+  customerId: string,
+  eventId: string,
+): Promise<ApplyResult> {
+  return db.transaction(async (tx) => {
+    const [org] = await tx
+      .select({
+        id: organizations.id,
+        plan: organizations.plan,
+        planSource: organizations.planSource,
+      })
+      .from(organizations)
+      .where(eq(organizations.stripeCustomerId, customerId))
+      .limit(1);
+    if (!org) {
+      await markProcessed(tx, eventId);
+      return { outcome: 'unknown-customer' as const, detail: customerId };
+    }
+
+    await tx.delete(orgSubscriptions).where(eq(orgSubscriptions.organizationId, org.id));
+    if (org.planSource !== 'grant') {
+      await setOrgPlan(tx, org.id, 'free', 'stripe');
+    }
+
+    await recordInstanceAudit(tx, {
+      key: `billing.subscription:${org.id}`,
+      actor: WEBHOOK_ACTOR,
+      before: { plan: org.plan, planSource: org.planSource },
+      after: {
+        plan: org.planSource === 'grant' ? org.plan : 'free',
+        planSource: org.planSource,
+        stripeStatus: 'deleted',
+      },
+    });
+
+    await markProcessed(tx, eventId);
+    return {
+      outcome: 'applied' as const,
+      detail: org.planSource === 'grant' ? 'grant preserved' : undefined,
+    };
+  });
+}
+
+// The event envelope's `data.object` shape is Stripe's, not ours - each
+// schema below validates only the field(s) this module actually reads off
+// it, `.strip()`ping the rest (zod's object default), rather than growing a
+// full Subscription/Invoice/CheckoutSession type here.
+const CheckoutSessionObjectSchema = z.object({ subscription: z.string().nullable() });
+const SubscriptionRefObjectSchema = z.object({ id: z.string() });
+const SubscriptionCustomerObjectSchema = z.object({ customer: z.string() });
+const InvoiceObjectSchema = z.object({ subscription: z.string().nullable() });
+
+/**
+ * Applies one verified Stripe event. `event.id` is inserted into
+ * `stripe_events` first, before any of the seven event types below are even
+ * considered: zero rows affected means this id already exists, and only a
+ * row whose `processed_at` is still null - a previous delivery that was
+ * recorded but crashed before finishing - gets reprocessed; a fully
+ * processed row is a true replay and is left untouched (docs/billing.md's
+ * webhook list is the seven event types handled here; anything else is
+ * recorded and ignored).
+ */
+export async function applyStripeEvent(
+  db: Db,
+  stripe: StripeClient,
+  event: StripeEvent,
+): Promise<ApplyResult> {
+  const inserted = await db
+    .insert(stripeEvents)
+    .values({ id: event.id, type: event.type, payload: event })
+    .onConflictDoNothing()
+    .returning({ id: stripeEvents.id });
+  if (inserted.length === 0) {
+    const [existing] = await db
+      .select({ processedAt: stripeEvents.processedAt })
+      .from(stripeEvents)
+      .where(eq(stripeEvents.id, event.id))
+      .limit(1);
+    if (existing?.processedAt) return { outcome: 'duplicate' };
+  }
+
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const parsed = CheckoutSessionObjectSchema.safeParse(event.data.object);
+      if (!parsed.success || !parsed.data.subscription) {
+        await markProcessed(db, event.id);
+        return { outcome: 'ignored', detail: 'checkout session has no subscription' };
+      }
+      return syncSubscriptionFromStripe(db, stripe, parsed.data.subscription, event.id);
+    }
+    case 'customer.subscription.created':
+    case 'customer.subscription.updated': {
+      const parsed = SubscriptionRefObjectSchema.safeParse(event.data.object);
+      if (!parsed.success) {
+        await markProcessed(db, event.id);
+        return { outcome: 'ignored', detail: 'subscription event has no id' };
+      }
+      return syncSubscriptionFromStripe(db, stripe, parsed.data.id, event.id);
+    }
+    case 'customer.subscription.deleted': {
+      const parsed = SubscriptionCustomerObjectSchema.safeParse(event.data.object);
+      if (!parsed.success) {
+        await markProcessed(db, event.id);
+        return { outcome: 'ignored', detail: 'subscription event has no customer' };
+      }
+      return clearSubscription(db, parsed.data.customer, event.id);
+    }
+    case 'customer.subscription.trial_will_end':
+      // There is no trial (docs/billing.md, shared/src/plans.ts): Free is
+      // the trial and never expires, so this fires without ever meaning
+      // anything for us. Subscribed to only because the account carries it
+      // regardless; recorded for idempotency, nothing to change.
+      await markProcessed(db, event.id);
+      return { outcome: 'no-op' };
+    case 'invoice.paid':
+    case 'invoice.payment_failed': {
+      // Both are "go read the subscription's live status again": Stripe
+      // itself flips the subscription to `past_due` before/alongside
+      // `invoice.payment_failed`, and back before/alongside `invoice.paid`
+      // once dunning succeeds - refetching and mirroring wholesale already
+      // captures the grace-period transition without this module guessing
+      // a status of its own.
+      const parsed = InvoiceObjectSchema.safeParse(event.data.object);
+      if (!parsed.success || !parsed.data.subscription) {
+        await markProcessed(db, event.id);
+        return { outcome: 'ignored', detail: 'invoice has no subscription' };
+      }
+      return syncSubscriptionFromStripe(db, stripe, parsed.data.subscription, event.id);
+    }
+    default:
+      await markProcessed(db, event.id);
+      return { outcome: 'ignored', detail: `unhandled event type ${event.type}` };
+  }
+}
+
+export type { StripeSubscription };

--- a/shared/src/db/migrations/0029_stripe_customer_and_events.sql
+++ b/shared/src/db/migrations/0029_stripe_customer_and_events.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "stripe_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"type" text NOT NULL,
+	"received_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"processed_at" timestamp with time zone,
+	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "org_subscriptions" ADD COLUMN "current_period_start" timestamp with time zone NOT NULL;--> statement-breakpoint
+ALTER TABLE "organizations" ADD COLUMN "stripe_customer_id" text;--> statement-breakpoint
+ALTER TABLE "organizations" ADD CONSTRAINT "organizations_stripe_customer_id_unique" UNIQUE("stripe_customer_id");

--- a/shared/src/db/migrations/meta/0029_snapshot.json
+++ b/shared/src/db/migrations/meta/0029_snapshot.json
@@ -1,0 +1,5010 @@
+{
+  "id": "10643b98-43d8-4cb6-aa29-ee4af1669e82",
+  "prevId": "c6abc8da-f99d-485a-a369-ca7c46ae48d8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cookie_session": {
+          "name": "cookie_session",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_limit": {
+          "name": "weekly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_project_id_projects_id_fk": {
+          "name": "accounts_project_id_projects_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_platform_id_platforms_id_fk": {
+          "name": "accounts_platform_id_platforms_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assist_usage": {
+      "name": "assist_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assist_usage_org_created_idx": {
+          "name": "assist_usage_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assist_usage_project_created_idx": {
+          "name": "assist_usage_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assist_usage_organization_id_organizations_id_fk": {
+          "name": "assist_usage_organization_id_organizations_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_project_id_projects_id_fk": {
+          "name": "assist_usage_project_id_projects_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_device_id_extension_devices_id_fk": {
+          "name": "assist_usage_device_id_extension_devices_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "extension_devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assist_usage_platform_id_platforms_id_fk": {
+          "name": "assist_usage_platform_id_platforms_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_failures": {
+      "name": "auth_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login_attempt'"
+        }
+      },
+      "indexes": {
+        "auth_failures_identifier_idx": {
+          "name": "auth_failures_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist": {
+      "name": "blocklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocklist_platform_id_platforms_id_fk": {
+          "name": "blocklist_platform_id_platforms_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocklist_project_id_projects_id_fk": {
+          "name": "blocklist_project_id_projects_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_recommendations": {
+      "name": "campaign_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_slug": {
+          "name": "scenario_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_recommendations_project_idx": {
+          "name": "campaign_recommendations_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_recommendations_project_id_projects_id_fk": {
+          "name": "campaign_recommendations_project_id_projects_id_fk",
+          "tableFrom": "campaign_recommendations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_slug": {
+          "name": "skill_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_attempts": {
+          "name": "failure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_due_to_failures": {
+          "name": "paused_due_to_failures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_post": {
+          "name": "auto_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_platform_id_platforms_id_fk": {
+          "name": "campaigns_platform_id_platforms_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_history": {
+      "name": "contact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_handle": {
+          "name": "account_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_checked_at": {
+          "name": "reply_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_room_id": {
+          "name": "chat_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_context_url": {
+          "name": "platform_context_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uncontactable": {
+          "name": "uncontactable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uncontactable_reason": {
+          "name": "uncontactable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_history_target_idx": {
+          "name": "contact_history_target_idx",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_target_idx": {
+          "name": "messages_account_target_idx",
+          "columns": [
+            {
+              "expression": "account_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_org_idx": {
+          "name": "contact_history_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_contacted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_history_platform_id_platforms_id_fk": {
+          "name": "contact_history_platform_id_platforms_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contact_history_draft_id_drafts_id_fk": {
+          "name": "contact_history_draft_id_drafts_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_history_organization_id_organizations_id_fk": {
+          "name": "contact_history_organization_id_organizations_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_heartbeats": {
+      "name": "daemon_heartbeats",
+      "schema": "",
+      "columns": {
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tick_at": {
+          "name": "tick_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_events": {
+      "name": "draft_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_events_kind_created_idx": {
+          "name": "draft_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_events_draft_id_drafts_id_fk": {
+          "name": "draft_events_draft_id_drafts_id_fk",
+          "tableFrom": "draft_events",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_regeneration_hints": {
+      "name": "draft_regeneration_hints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint_text": {
+          "name": "hint_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_regeneration_hints_draft_id_drafts_id_fk": {
+          "name": "draft_regeneration_hints_draft_id_drafts_id_fk",
+          "tableFrom": "draft_regeneration_hints",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "fit_score": {
+          "name": "fit_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_url": {
+          "name": "compose_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_content": {
+          "name": "sent_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_comment_id": {
+          "name": "platform_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dedup_warning": {
+          "name": "dedup_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_edited": {
+          "name": "body_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_send_after": {
+          "name": "scheduled_send_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerating_run_id": {
+          "name": "regenerating_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drafting_run_id": {
+          "name": "drafting_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_reason": {
+          "name": "quality_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_model": {
+          "name": "quality_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_id": {
+          "name": "variant_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undeliverable_reason": {
+          "name": "undeliverable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drafts_state_idx": {
+          "name": "drafts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_project_idx": {
+          "name": "drafts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_run_idx": {
+          "name": "drafts_state_run_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_campaign_created_idx": {
+          "name": "drafts_state_campaign_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_variant_group_idx": {
+          "name": "drafts_variant_group_idx",
+          "columns": [
+            {
+              "expression": "variant_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_run_id_runs_id_fk": {
+          "name": "drafts_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_project_id_projects_id_fk": {
+          "name": "drafts_project_id_projects_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_platform_id_platforms_id_fk": {
+          "name": "drafts_platform_id_platforms_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_accounts_id_fk": {
+          "name": "drafts_account_id_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_regenerating_run_id_runs_id_fk": {
+          "name": "drafts_regenerating_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "regenerating_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drafts_drafting_run_id_runs_id_fk": {
+          "name": "drafts_drafting_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "drafting_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_verification_tokens_user_idx": {
+          "name": "email_verification_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_devices": {
+      "name": "extension_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unnamed device'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "extension_devices_token_hash_unique": {
+          "name": "extension_devices_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extension_devices_organization_id_organizations_id_fk": {
+          "name": "extension_devices_organization_id_organizations_id_fk",
+          "tableFrom": "extension_devices",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_pairings": {
+      "name": "extension_pairings",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extension_pairings_organization_id_organizations_id_fk": {
+          "name": "extension_pairings_organization_id_organizations_id_fk",
+          "tableFrom": "extension_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'User'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selected'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_unique": {
+          "name": "github_installations_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_organization_id_organizations_id_fk": {
+          "name": "github_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sources": {
+      "name": "github_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_language": {
+          "name": "primary_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readme_excerpt": {
+          "name": "readme_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_commits": {
+          "name": "recent_commits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_sources_org_repo_unique": {
+          "name": "github_sources_org_repo_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_sources_organization_id_organizations_id_fk": {
+          "name": "github_sources_organization_id_organizations_id_fk",
+          "tableFrom": "github_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_audit_log": {
+      "name": "instance_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_audit_log_created_idx": {
+          "name": "instance_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_watches": {
+      "name": "keyword_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_field": {
+          "name": "match_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keyword_watches_campaign_idx": {
+          "name": "keyword_watches_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_watches_project_idx": {
+          "name": "keyword_watches_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_watches_project_id_projects_id_fk": {
+          "name": "keyword_watches_project_id_projects_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keyword_watches_campaign_id_campaigns_id_fk": {
+          "name": "keyword_watches_campaign_id_campaigns_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_org_user_unique": {
+          "name": "memberships_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_from_us": {
+          "name": "is_from_us",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_platform": {
+          "name": "created_at_platform",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_contact_idx": {
+          "name": "messages_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_platform_message_unique": {
+          "name": "messages_platform_message_unique",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_contact_id_contact_history_id_fk": {
+          "name": "messages_contact_id_contact_history_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "contact_history",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_draft_id_drafts_id_fk": {
+          "name": "messages_draft_id_drafts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_platform_id_platforms_id_fk": {
+          "name": "messages_platform_id_platforms_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_unread_idx": {
+          "name": "notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_idx": {
+          "name": "notifications_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organization_id_organizations_id_fk": {
+          "name": "notifications_organization_id_organizations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observed_targets": {
+      "name": "observed_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_by_run_id": {
+          "name": "consumed_by_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "observed_targets_dedup_idx": {
+          "name": "observed_targets_dedup_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "observed_targets_project_unconsumed_idx": {
+          "name": "observed_targets_project_unconsumed_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_by_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "observed_targets_organization_id_organizations_id_fk": {
+          "name": "observed_targets_organization_id_organizations_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_project_id_projects_id_fk": {
+          "name": "observed_targets_project_id_projects_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_platform_id_platforms_id_fk": {
+          "name": "observed_targets_platform_id_platforms_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observed_targets_consumed_by_run_id_runs_id_fk": {
+          "name": "observed_targets_consumed_by_run_id_runs_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "consumed_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_profiles": {
+      "name": "operator_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiences": {
+          "name": "experiences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'linkedin_capture'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_profiles_org_unique": {
+          "name": "operator_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_profiles": {
+      "name": "operator_voice_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "openings": {
+          "name": "openings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "closings": {
+          "name": "closings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "common_words": {
+          "name": "common_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "words_per_sentence": {
+          "name": "words_per_sentence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'derived'"
+        },
+        "derived_at": {
+          "name": "derived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_profiles_org_unique": {
+          "name": "operator_voice_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_voice_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_samples": {
+      "name": "operator_voice_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_samples_org_external_unique": {
+          "name": "operator_voice_samples_org_external_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operator_voice_samples_org_idx": {
+          "name": "operator_voice_samples_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "excluded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_samples_organization_id_organizations_id_fk": {
+          "name": "operator_voice_samples_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_voice_samples_platform_id_platforms_id_fk": {
+          "name": "operator_voice_samples_platform_id_platforms_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invites": {
+      "name": "org_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_invites_org_idx": {
+          "name": "org_invites_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invites_organization_id_organizations_id_fk": {
+          "name": "org_invites_organization_id_organizations_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invites_created_by_user_id_users_id_fk": {
+          "name": "org_invites_created_by_user_id_users_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invites_token_unique": {
+          "name": "org_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_subscriptions": {
+      "name": "org_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "limit_runs": {
+          "name": "limit_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_suggestions": {
+          "name": "limit_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_projects": {
+          "name": "limit_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_seats": {
+          "name": "limit_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_devices": {
+          "name": "limit_devices",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrency": {
+          "name": "limit_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_budget_usd": {
+          "name": "limit_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_retention_days": {
+          "name": "limit_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_premium_models": {
+          "name": "limit_premium_models",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_org_unique": {
+          "name": "org_subscriptions_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_stripe_subscription_unique": {
+          "name": "org_subscriptions_stripe_subscription_unique",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_subscriptions_organization_id_organizations_id_fk": {
+          "name": "org_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "org_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_run_budget_usd": {
+          "name": "monthly_run_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_source": {
+          "name": "plan_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "plan_updated_at": {
+          "name": "plan_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organizations_stripe_customer_id_unique": {
+          "name": "organizations_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_user_idx": {
+          "name": "password_reset_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platforms": {
+      "name": "platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platforms_slug_unique": {
+          "name": "platforms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playbooks": {
+      "name": "playbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playbooks_slug_unique": {
+          "name": "playbooks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_insights": {
+      "name": "project_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary_md": {
+          "name": "summary_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_insights_project_idx": {
+          "name": "project_insights_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_insights_project_id_projects_id_fk": {
+          "name": "project_insights_project_id_projects_id_fk",
+          "tableFrom": "project_insights",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_sources": {
+      "name": "project_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_runner": {
+          "name": "default_agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "voice_tone": {
+          "name": "voice_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_tone_notes": {
+          "name": "voice_tone_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_unique": {
+          "name": "projects_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_events_run_idx": {
+          "name": "run_events_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_events_kind_created_idx": {
+          "name": "run_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'campaign'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout_log_path": {
+          "name": "stdout_log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playbook_body": {
+          "name": "playbook_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_project_kind_idx": {
+          "name": "runs_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_campaign_id_campaigns_id_fk": {
+          "name": "runs_campaign_id_campaigns_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_scout_candidates": {
+      "name": "staging_scout_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staging_scout_candidates_run_id_runs_id_fk": {
+          "name": "staging_scout_candidates_run_id_runs_id_fk",
+          "tableFrom": "staging_scout_candidates",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_project_kind_idx": {
+          "name": "templates_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_project_id_projects_id_fk": {
+          "name": "templates_project_id_projects_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_instance_admin": {
+          "name": "is_instance_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recent_idx": {
+          "name": "webhook_deliveries_recent_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_org_idx": {
+          "name": "webhook_deliveries_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_organization_id_organizations_id_fk": {
+          "name": "webhook_deliveries_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1788960000015,
       "tag": "0028_github_installations",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1788960000016,
+      "tag": "0029_stripe_customer_and_events",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -98,6 +98,19 @@ export const organizations = pgTable('organizations', {
   plan: text('plan').notNull().default('free'),
   planSource: text('plan_source').notNull().default('default'),
   planUpdatedAt: timestamp('plan_updated_at', { withTimezone: true }).notNull().defaultNow(),
+  // The Stripe customer for this org, created lazily on first checkout
+  // (#550) and independent of whether a subscription currently exists:
+  // `org_subscriptions.stripe_customer_id` is NOT NULL and that row *is*
+  // the subscription (deleted wholesale when Stripe's isn't there any
+  // more, see below), so a customer created before any subscription - or
+  // surviving after one is cancelled and its row is torn down - has
+  // nowhere else to live. One customer per org (never per user): the
+  // subscription belongs to the tenant, seats are an org attribute, and
+  // the checkout route reuses this column instead of minting a second
+  // Stripe customer on a repeat visit. Unique, not `.references` a Stripe
+  // object - Stripe is external, nothing here can enforce a foreign key
+  // into it.
+  stripeCustomerId: text('stripe_customer_id').unique(),
 });
 
 // The Stripe side of a plan (#544, #551 writes it): a subscription has its
@@ -138,6 +151,7 @@ export const orgSubscriptions = pgTable(
     // 'canceled', ...) - the grace-window and read-only handling that reads
     // this is #548/#556, not built here.
     status: text('status').notNull(),
+    currentPeriodStart: timestamp('current_period_start', { withTimezone: true }).notNull(),
     currentPeriodEnd: timestamp('current_period_end', { withTimezone: true }).notNull(),
     cancelAtPeriodEnd: boolean('cancel_at_period_end').notNull().default(false),
     limitRuns: integer('limit_runs'),
@@ -159,6 +173,29 @@ export const orgSubscriptions = pgTable(
     ),
   }),
 );
+
+// Idempotency ledger for the Stripe webhook (#551): `id` is Stripe's own
+// event id, inserted with `onConflictDoNothing` before anything else the
+// handler does, in its own statement rather than the same transaction as
+// the state write below - the handler still has a Stripe API call to make
+// (`shared/src/billing/webhook.ts` refetches the live subscription rather
+// than trusting the event's embedded snapshot) and a DB transaction has no
+// business sitting open across that. Zero rows affected on the insert
+// means this event id already exists; `processedAt` on *that* row is what
+// decides what happens next - already set means a true replay (answer 200,
+// touch nothing else), still null means a previous delivery was recorded
+// but crashed before finishing, so the handler reprocesses it rather than
+// swallowing it as a duplicate of work that never actually happened.
+// `processedAt` itself is written in the same transaction as the
+// `org_subscriptions`/`organizations` write it accompanies, so it is never
+// observed set without that write having committed too.
+export const stripeEvents = pgTable('stripe_events', {
+  id: text('id').primaryKey(),
+  type: text('type').notNull(),
+  receivedAt: timestamp('received_at', { withTimezone: true }).notNull().defaultNow(),
+  processedAt: timestamp('processed_at', { withTimezone: true }),
+  payload: jsonb('payload').notNull().default({}),
+});
 
 export const memberships = pgTable(
   'memberships',

--- a/shared/src/instance-audit.ts
+++ b/shared/src/instance-audit.ts
@@ -11,8 +11,16 @@
 
 import { desc } from 'drizzle-orm';
 import { createHash } from 'node:crypto';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
 import { instanceAuditLog } from './db/schema.js';
-import type { Db } from './db/client.js';
+
+// Loose on purpose (matches shared/src/orgs.ts's own alias): a real `Db`
+// (shared/src/db/client.ts) and a `db.transaction` callback's `tx` are both
+// assignable to this, and the Stripe webhook (#551) is the first caller
+// that needs to write an audit row inside the same transaction as the
+// state change it describes.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Db = PgDatabase<any, any, any>;
 
 export type InstanceAuditActor = { id: number; username: string } | null;
 

--- a/shared/src/stripe/client.ts
+++ b/shared/src/stripe/client.ts
@@ -1,0 +1,217 @@
+// A thin REST client over the Stripe API, mirroring `scripts/stripe-setup.ts`'s
+// own `stripe()`/`form()` helpers rather than adding the `stripe` npm package as
+// a dependency: the whole surface the app needs (create a customer, start a
+// Checkout session, start a portal session, read a subscription/product back)
+// is a handful of endpoints, and the setup script already proved this shape
+// works against the real API, including the Managed Payments quirks. Every
+// call is pinned to `STRIPE_API_VERSION` via the `Stripe-Version` header, so
+// the response shape this file's types describe cannot drift under it.
+import { z } from 'zod';
+import { STRIPE_API_VERSION } from './env.js';
+
+export type StripeMetadata = Record<string, string>;
+
+export type StripeCustomer = {
+  id: string;
+  email: string | null;
+  metadata: StripeMetadata;
+  deleted?: boolean;
+};
+
+export type StripeCheckoutSession = {
+  id: string;
+  url: string | null;
+  mode: string;
+  customer: string | null;
+  client_reference_id: string | null;
+  subscription: string | null;
+};
+
+export type StripePortalSession = {
+  id: string;
+  url: string;
+};
+
+export type StripeSubscriptionItem = {
+  id: string;
+  price: StripePrice;
+  current_period_start: number;
+  current_period_end: number;
+};
+
+export type StripeSubscription = {
+  id: string;
+  customer: string;
+  status:
+    | 'trialing'
+    | 'active'
+    | 'past_due'
+    | 'canceled'
+    | 'incomplete'
+    | 'incomplete_expired'
+    | 'unpaid'
+    | 'paused';
+  cancel_at_period_end: boolean;
+  metadata: StripeMetadata;
+  items: { data: StripeSubscriptionItem[] };
+};
+
+export type StripePrice = {
+  id: string;
+  lookup_key: string | null;
+  product: string | StripeProduct;
+};
+
+export type StripeProduct = {
+  id: string;
+  metadata: StripeMetadata;
+};
+
+export type StripeInvoice = {
+  id: string;
+  customer: string;
+  subscription: string | null;
+};
+
+// The envelope Stripe posts to a webhook endpoint. `data.object` stays
+// `z.unknown()` here on purpose: each handler in
+// `shared/src/billing/webhook.ts` validates it against the event-specific
+// schema its own event type actually carries, rather than this module
+// trying to describe every object shape Stripe can ever deliver.
+const StripeEventSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  created: z.number(),
+  data: z.object({ object: z.unknown() }),
+});
+export type StripeEvent = z.infer<typeof StripeEventSchema>;
+
+export class InvalidStripeEventError extends Error {}
+
+/** Parses the raw JSON body of a webhook delivery into a `StripeEvent`,
+ * throwing `InvalidStripeEventError` if it does not even carry the fields
+ * every Stripe event has. The caller (the webhook route) has already
+ * verified the signature over these exact bytes before calling this - a
+ * signed-but-malformed body is not something Stripe itself would ever
+ * send, so this is a defensive last check, not the primary validation. */
+export function parseStripeEvent(rawBody: string): StripeEvent {
+  let json: unknown;
+  try {
+    json = JSON.parse(rawBody);
+  } catch {
+    throw new InvalidStripeEventError('webhook body is not valid JSON');
+  }
+  const parsed = StripeEventSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new InvalidStripeEventError(
+      `webhook body is not a Stripe event: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+}
+
+export class StripeApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly stripeType: string | undefined,
+    public readonly stripeCode: string | undefined,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'StripeApiError';
+  }
+}
+
+function form(value: unknown, prefix = '', out = new URLSearchParams()): URLSearchParams {
+  if (value === null || value === undefined) return out;
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => form(item, `${prefix}[${i}]`, out));
+    return out;
+  }
+  if (typeof value === 'object') {
+    for (const [k, v] of Object.entries(value)) {
+      form(v, prefix ? `${prefix}[${k}]` : k, out);
+    }
+    return out;
+  }
+  out.append(prefix, String(value));
+  return out;
+}
+
+export type StripeClient = {
+  createCustomer(params: { email?: string; metadata?: StripeMetadata }): Promise<StripeCustomer>;
+  getCustomer(id: string): Promise<StripeCustomer>;
+  createCheckoutSession(params: Record<string, unknown>): Promise<StripeCheckoutSession>;
+  createPortalSession(params: Record<string, unknown>): Promise<StripePortalSession>;
+  getSubscription(id: string): Promise<StripeSubscription>;
+  getProduct(id: string): Promise<StripeProduct>;
+  getPriceByLookupKey(lookupKey: string): Promise<StripePrice | null>;
+};
+
+/** Builds a client bound to one secret key (test or live - the caller decides
+ * which by which key `loadStripeEnv` handed it). No shared mutable state
+ * between calls; safe to construct per-request. */
+export function createStripeClient(secretKey: string): StripeClient {
+  async function request<T>(path: string, body?: unknown, method?: string): Promise<T> {
+    const verb = method ?? (body ? 'POST' : 'GET');
+    const res = await fetch(`https://api.stripe.com/v1/${path}`, {
+      method: verb,
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Stripe-Version': STRIPE_API_VERSION,
+      },
+      body: body ? form(body) : undefined,
+    });
+    const payload: unknown = await res.json();
+    if (!res.ok) {
+      let message = `${verb} /v1/${path} -> ${res.status}`;
+      let type: string | undefined;
+      let code: string | undefined;
+      if (payload && typeof payload === 'object' && 'error' in payload) {
+        const err = payload.error;
+        if (err && typeof err === 'object') {
+          if ('message' in err && typeof err.message === 'string') {
+            message = `${message} ${err.message}`;
+          }
+          if ('type' in err && typeof err.type === 'string') type = err.type;
+          if ('code' in err && typeof err.code === 'string') code = err.code;
+        }
+      }
+      throw new StripeApiError(res.status, type, code, message);
+    }
+    // Stripe's response shape is documented per endpoint, and each typed
+    // method below names the fields it reads - a wrong shape surfaces
+    // immediately as `undefined` rather than a runtime schema failure.
+    return payload as T;
+  }
+
+  return {
+    createCustomer(params) {
+      return request('customers', params);
+    },
+    getCustomer(id) {
+      return request(`customers/${id}`, undefined, 'GET');
+    },
+    createCheckoutSession(params) {
+      return request('checkout/sessions', params);
+    },
+    createPortalSession(params) {
+      return request('billing_portal/sessions', params);
+    },
+    getSubscription(id) {
+      return request(`subscriptions/${id}?expand[]=items.data.price.product`, undefined, 'GET');
+    },
+    getProduct(id) {
+      return request(`products/${id}`, undefined, 'GET');
+    },
+    async getPriceByLookupKey(lookupKey) {
+      const list = await request<{ data: StripePrice[] }>(
+        `prices?lookup_keys[]=${encodeURIComponent(lookupKey)}`,
+        undefined,
+        'GET',
+      );
+      return list.data[0] ?? null;
+    },
+  };
+}

--- a/shared/src/stripe/env.ts
+++ b/shared/src/stripe/env.ts
@@ -1,0 +1,56 @@
+/**
+ * Reads the deployment's Stripe configuration straight from the environment,
+ * the same convention `shared/src/mail/env.ts` uses for a deployment-level
+ * secret: read once from `process.env`, never persisted to the database or
+ * exposed on a Settings page. `PITCHBOX_BILLING` is the feature flag (a
+ * self-host build never sets it, and the docker-compose/`.env.example`
+ * default is unset); `STRIPE_SECRET_KEY` is the credential. Either one
+ * missing collapses to `{ enabled: false }` rather than a client that only
+ * fails once it tries to call Stripe - the same "half-configured provider
+ * must not become a transport" rule `shared/src/mail/registry.ts` documents,
+ * applied to a single provider instead of a choice between several.
+ *
+ * `STRIPE_WEBHOOK_SECRET` and `STRIPE_PORTAL_CONFIGURATION` are optional on
+ * top of that: the webhook route 404s without a secret (nothing to verify
+ * a signature against), and the portal route falls back to the account's
+ * default configuration without a pinned one - see `docs/billing.md`'s
+ * environment table.
+ */
+export type StripeEnv =
+  | { enabled: false }
+  | {
+      enabled: true;
+      secretKey: string;
+      webhookSecret: string | null;
+      portalConfiguration: string | null;
+    };
+
+/**
+ * Managed Payments requires this version or later (`docs/billing.md`,
+ * "Checkout Sessions must set managed_payments[enabled]=true and use API
+ * version 2025-03-31.basil or later"). Pinned as a constant, not read from
+ * the environment, because the app's Checkout/portal payloads are written
+ * against this exact shape - `2025-03-31.basil` moved `current_period_start`
+ * / `current_period_end` off the Subscription object onto each subscription
+ * item (confirmed against the real test account, `shared/src/stripe/client.ts`),
+ * so silently floating to a newer version could change the response shape
+ * again without anything here noticing.
+ */
+export const STRIPE_API_VERSION = '2025-03-31.basil';
+
+export function loadStripeEnv(env: Record<string, string | undefined> = process.env): StripeEnv {
+  if (env.PITCHBOX_BILLING !== 'on') return { enabled: false };
+  const secretKey = env.STRIPE_SECRET_KEY?.trim();
+  if (!secretKey) {
+    console.warn(
+      '[stripe] PITCHBOX_BILLING=on but STRIPE_SECRET_KEY is not set - billing routes will 404',
+    );
+    return { enabled: false };
+  }
+  return {
+    enabled: true,
+    secretKey,
+    webhookSecret: env.STRIPE_WEBHOOK_SECRET?.trim() || null,
+    portalConfiguration: env.STRIPE_PORTAL_CONFIGURATION?.trim() || null,
+  };
+}

--- a/shared/src/stripe/signature.ts
+++ b/shared/src/stripe/signature.ts
@@ -1,0 +1,53 @@
+// Verifies the `Stripe-Signature` header Stripe attaches to every webhook
+// delivery, without the `stripe` npm package (see `client.ts` for why this
+// integration stays on raw `fetch`/`node:crypto` throughout). The algorithm
+// is Stripe's own (https://docs.stripe.com/webhooks#verify-manually):
+// `v1=` is `HMAC-SHA256(webhookSecret, "<timestamp>.<rawBody>")` hex-encoded,
+// and the header carries one or more `v1=` values (a secret rotation sends
+// two) plus the `t=` timestamp used to build the signed payload and to
+// reject a stale request. The raw, unparsed request body is required - a
+// route that reads it as JSON first has already lost the exact bytes this
+// computation needs.
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const DEFAULT_TOLERANCE_SECONDS = 300;
+
+/**
+ * `true` only if `header` carries a `v1` signature matching `secret` over
+ * `rawBody`, computed at the header's own `t=` timestamp, and that
+ * timestamp is within `toleranceSeconds` of now. Every failure mode -
+ * missing `t=`, no `v1=` entry, a mismatched HMAC, or a stale timestamp -
+ * returns `false` rather than throwing, since the caller's only decision on
+ * a `false` is "answer 400 and write nothing".
+ */
+export function verifyStripeSignature(
+  rawBody: string,
+  header: string | null,
+  secret: string,
+  toleranceSeconds = DEFAULT_TOLERANCE_SECONDS,
+): boolean {
+  if (!header) return false;
+  let timestamp: string | undefined;
+  const signatures: string[] = [];
+  for (const part of header.split(',')) {
+    const [key, value] = part.split('=', 2);
+    if (key === 't') timestamp = value;
+    else if (key === 'v1' && value) signatures.push(value);
+  }
+  if (!timestamp || signatures.length === 0) return false;
+
+  const expected = createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`, 'utf8')
+    .digest('hex');
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  const signatureMatches = signatures.some((sig) => {
+    const sigBuf = Buffer.from(sig, 'utf8');
+    return sigBuf.length === expectedBuf.length && timingSafeEqual(sigBuf, expectedBuf);
+  });
+  if (!signatureMatches) return false;
+
+  const timestampSeconds = Number(timestamp);
+  if (!Number.isFinite(timestampSeconds)) return false;
+  const ageSeconds = Math.abs(Date.now() / 1000 - timestampSeconds);
+  return ageSeconds <= toleranceSeconds;
+}

--- a/shared/tests/billing-checkout-portal.test.ts
+++ b/shared/tests/billing-checkout-portal.test.ts
@@ -1,0 +1,166 @@
+// #550 (a Stripe customer per org, a Checkout session per plan) and #552
+// (the customer portal). The customer race and the "no price"/"no
+// customer" refusals are exercised against a fake StripeClient; starting a
+// real Checkout/portal session is exercised against the real test-mode
+// account, since that is the only way to know the payload this module
+// actually sends is one Stripe accepts (see docs/billing.md's Managed
+// Payments constraints, and the PR for the parameters this deliberately
+// never sets).
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import { ensureStripeCustomer } from '../src/billing/customer.js';
+import { createCheckoutSession, UnknownPriceError } from '../src/billing/checkout.js';
+import { createPortalSession, NoStripeCustomerError } from '../src/billing/portal.js';
+import { createStripeClient } from '../src/stripe/client.js';
+import type { StripeClient, StripeCustomer } from '../src/stripe/client.js';
+
+const createdOrgIds: number[] = [];
+
+afterEach(async () => {
+  const db = getDb();
+  while (createdOrgIds.length > 0) {
+    const id = createdOrgIds.pop()!;
+    await db.delete(schema.organizations).where(eq(schema.organizations.id, id));
+  }
+});
+
+async function makeOrg(): Promise<number> {
+  const db = getDb();
+  const slug = `billing-checkout-test-${randomUUID()}`;
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  createdOrgIds.push(org.id);
+  return org.id;
+}
+
+function notImplementedStripeClient(): StripeClient {
+  const fail = (method: string) => () => {
+    throw new Error(`stub StripeClient.${method} should not have been called`);
+  };
+  return {
+    createCustomer: fail('createCustomer'),
+    getCustomer: fail('getCustomer'),
+    createCheckoutSession: fail('createCheckoutSession'),
+    createPortalSession: fail('createPortalSession'),
+    getProduct: fail('getProduct'),
+    getPriceByLookupKey: fail('getPriceByLookupKey'),
+    getSubscription: fail('getSubscription'),
+  };
+}
+
+function fakeCustomerCreator(idsToReturn: string[]): StripeClient {
+  let call = 0;
+  return {
+    ...notImplementedStripeClient(),
+    async createCustomer(): Promise<StripeCustomer> {
+      const id = idsToReturn[call] ?? idsToReturn[idsToReturn.length - 1];
+      call += 1;
+      return { id, email: null, metadata: {} };
+    },
+  };
+}
+
+describe('ensureStripeCustomer', () => {
+  it('creates one customer on first call and reuses it without calling Stripe again', async () => {
+    const db = getDb();
+    const orgId = await makeOrg();
+    const first = await ensureStripeCustomer(db, fakeCustomerCreator(['cus_first']), orgId);
+    expect(first).toBe('cus_first');
+
+    // A stub whose createCustomer throws: reuse must never reach it.
+    const second = await ensureStripeCustomer(db, notImplementedStripeClient(), orgId);
+    expect(second).toBe('cus_first');
+
+    const [org] = await db
+      .select()
+      .from(schema.organizations)
+      .where(eq(schema.organizations.id, orgId));
+    expect(org.stripeCustomerId).toBe('cus_first');
+  });
+
+  it('two concurrent first calls converge on one winning customer id', async () => {
+    const db = getDb();
+    const orgId = await makeOrg();
+    const [a, b] = await Promise.all([
+      ensureStripeCustomer(db, fakeCustomerCreator(['cus_a']), orgId),
+      ensureStripeCustomer(db, fakeCustomerCreator(['cus_b']), orgId),
+    ]);
+    expect(a).toBe(b);
+    expect(['cus_a', 'cus_b']).toContain(a);
+
+    const [org] = await db
+      .select()
+      .from(schema.organizations)
+      .where(eq(schema.organizations.id, orgId));
+    expect(org.stripeCustomerId).toBe(a);
+  });
+});
+
+describe('createCheckoutSession', () => {
+  it('refuses a plan with no Stripe price rather than calling Stripe', async () => {
+    const db = getDb();
+    const orgId = await makeOrg();
+    await expect(
+      createCheckoutSession(db, notImplementedStripeClient(), {
+        orgId,
+        planId: 'free',
+        interval: 'month',
+        successUrl: 'https://example.test/settings/billing?checkout=success',
+        cancelUrl: 'https://example.test/settings/billing?checkout=cancelled',
+      }),
+    ).rejects.toBeInstanceOf(UnknownPriceError);
+  });
+
+  it('starts a real test-mode Checkout session for growth/month with Managed Payments enabled', async () => {
+    const secretKey = readFileSync(
+      join(homedir(), '.config/pitchbox-stripe-test.key'),
+      'utf8',
+    ).trim();
+    const stripe = createStripeClient(secretKey);
+    const db = getDb();
+    const orgId = await makeOrg();
+    const session = await createCheckoutSession(db, stripe, {
+      orgId,
+      planId: 'growth',
+      interval: 'month',
+      successUrl: 'https://example.test/settings/billing?checkout=success',
+      cancelUrl: 'https://example.test/settings/billing?checkout=cancelled',
+    });
+    expect(session.url).toMatch(/^https:\/\/checkout\.stripe\.com\//);
+  });
+});
+
+describe('createPortalSession', () => {
+  it('refuses an org with no Stripe customer rather than calling Stripe', async () => {
+    const db = getDb();
+    const orgId = await makeOrg();
+    await expect(
+      createPortalSession(db, notImplementedStripeClient(), {
+        orgId,
+        returnUrl: 'https://example.test/settings/billing',
+        portalConfiguration: null,
+      }),
+    ).rejects.toBeInstanceOf(NoStripeCustomerError);
+  });
+
+  it('starts a real test-mode portal session for an org with a Stripe customer', async () => {
+    const secretKey = readFileSync(
+      join(homedir(), '.config/pitchbox-stripe-test.key'),
+      'utf8',
+    ).trim();
+    const stripe = createStripeClient(secretKey);
+    const db = getDb();
+    const orgId = await makeOrg();
+    await ensureStripeCustomer(db, stripe, orgId);
+    const session = await createPortalSession(db, stripe, {
+      orgId,
+      returnUrl: 'https://example.test/settings/billing',
+      portalConfiguration: null,
+    });
+    expect(session.url).toMatch(/^https:\/\/billing\.stripe\.com\//);
+  });
+});

--- a/shared/tests/billing-webhook.test.ts
+++ b/shared/tests/billing-webhook.test.ts
@@ -1,0 +1,336 @@
+// The Stripe webhook is the only writer of subscription state (#551).
+// These exercise the state machine directly - applyStripeEvent - against a
+// fake StripeClient standing in for the network, since the signature check
+// itself lives at the route layer (web/tests covers that). The one test
+// that needs a real Stripe object (`maps a real Stripe product's metadata`)
+// hits the actual test-mode account: no fixture stands in for the shape
+// `scripts/stripe-setup.ts` actually produced there.
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import { applyStripeEvent, limitsFromProductMetadata } from '../src/billing/webhook.js';
+import { createStripeClient } from '../src/stripe/client.js';
+import type { StripeClient, StripeProduct, StripeSubscription } from '../src/stripe/client.js';
+
+const createdOrgIds: number[] = [];
+
+afterEach(async () => {
+  const db = getDb();
+  while (createdOrgIds.length > 0) {
+    const id = createdOrgIds.pop()!;
+    await db.delete(schema.organizations).where(eq(schema.organizations.id, id));
+  }
+});
+
+async function makeOrg(
+  overrides: {
+    plan?: string;
+    planSource?: string;
+    stripeCustomerId?: string;
+  } = {},
+): Promise<{ id: number; stripeCustomerId: string }> {
+  const db = getDb();
+  const slug = `billing-webhook-test-${randomUUID()}`;
+  const stripeCustomerId = overrides.stripeCustomerId ?? `cus_test_${randomUUID()}`;
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({
+      slug,
+      name: slug,
+      stripeCustomerId,
+      ...(overrides.plan ? { plan: overrides.plan } : {}),
+      ...(overrides.planSource ? { planSource: overrides.planSource } : {}),
+    })
+    .returning();
+  createdOrgIds.push(org.id);
+  return { id: org.id, stripeCustomerId };
+}
+
+const GROWTH_PRODUCT: StripeProduct = {
+  id: 'prod_test_growth',
+  metadata: {
+    plan: 'growth',
+    limit_runs: '2000',
+    limit_suggestions: '2000',
+    limit_projects: '10',
+    limit_seats: '3',
+    limit_devices: '10',
+    limit_concurrency: '4',
+    limit_budget_usd: '30',
+    limit_retention_days: '90',
+    limit_premium_models: 'true',
+  },
+};
+
+/** Builds a subscription object shaped like a real `2025-03-31.basil`
+ * response (`current_period_start`/`_end` on the item, not the top-level
+ * object - see shared/src/billing/webhook.ts's comment on why). */
+function fakeSubscription(overrides: {
+  id: string;
+  customer: string;
+  status?: StripeSubscription['status'];
+  cancelAtPeriodEnd?: boolean;
+  currentPeriodStart?: number;
+  currentPeriodEnd?: number;
+  product?: StripeProduct;
+}): StripeSubscription {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id: overrides.id,
+    customer: overrides.customer,
+    status: overrides.status ?? 'active',
+    cancel_at_period_end: overrides.cancelAtPeriodEnd ?? false,
+    metadata: {},
+    items: {
+      data: [
+        {
+          id: `si_${overrides.id}`,
+          price: {
+            id: `price_test_${overrides.id}`,
+            lookup_key: 'pitchbox_growth_monthly',
+            product: overrides.product ?? GROWTH_PRODUCT,
+          },
+          current_period_start: overrides.currentPeriodStart ?? now,
+          current_period_end: overrides.currentPeriodEnd ?? now + 30 * 24 * 60 * 60,
+        },
+      ],
+    },
+  };
+}
+
+/** A `StripeClient` whose `getSubscription` is fully controlled by the
+ * test; every other method throws if a test reaches it, since none of the
+ * webhook scenarios below call anything else. */
+function fakeStripeClient(subscriptions: Record<string, StripeSubscription>): StripeClient {
+  const notImplemented = (method: string) => () => {
+    throw new Error(`fakeStripeClient.${method} was not stubbed for this test`);
+  };
+  return {
+    createCustomer: notImplemented('createCustomer'),
+    getCustomer: notImplemented('getCustomer'),
+    createCheckoutSession: notImplemented('createCheckoutSession'),
+    createPortalSession: notImplemented('createPortalSession'),
+    getProduct: notImplemented('getProduct'),
+    getPriceByLookupKey: notImplemented('getPriceByLookupKey'),
+    async getSubscription(id: string) {
+      const sub = subscriptions[id];
+      if (!sub) throw new Error(`fakeStripeClient has no subscription stubbed for ${id}`);
+      return sub;
+    },
+  };
+}
+
+describe('applyStripeEvent', () => {
+  it('checkout.session.completed derives the plan from the subscription product metadata', async () => {
+    const org = await makeOrg();
+    const sub = fakeSubscription({ id: `sub_${randomUUID()}`, customer: org.stripeCustomerId });
+    const stripe = fakeStripeClient({ [sub.id]: sub });
+
+    const result = await applyStripeEvent(getDb(), stripe, {
+      id: `evt_${randomUUID()}`,
+      type: 'checkout.session.completed',
+      created: Math.floor(Date.now() / 1000),
+      data: { object: { subscription: sub.id, customer: org.stripeCustomerId } },
+    });
+    expect(result.outcome).toBe('applied');
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.organizationId, org.id));
+    expect(row.planId).toBe('growth');
+    expect(row.limitRuns).toBe(2000);
+    expect(row.limitDevices).toBe(10);
+    expect(row.status).toBe('active');
+
+    const [freshOrg] = await getDb()
+      .select({ plan: schema.organizations.plan, planSource: schema.organizations.planSource })
+      .from(schema.organizations)
+      .where(eq(schema.organizations.id, org.id));
+    expect(freshOrg.plan).toBe('growth');
+    expect(freshOrg.planSource).toBe('stripe');
+  });
+
+  it('a replayed delivery leaves one row, not two', async () => {
+    const org = await makeOrg();
+    const sub = fakeSubscription({ id: `sub_${randomUUID()}`, customer: org.stripeCustomerId });
+    const stripe = fakeStripeClient({ [sub.id]: sub });
+    const event = {
+      id: `evt_${randomUUID()}`,
+      type: 'customer.subscription.updated' as const,
+      created: Math.floor(Date.now() / 1000),
+      data: { object: { id: sub.id, customer: org.stripeCustomerId } },
+    };
+
+    const first = await applyStripeEvent(getDb(), stripe, event);
+    expect(first.outcome).toBe('applied');
+    const second = await applyStripeEvent(getDb(), stripe, event);
+    expect(second.outcome).toBe('duplicate');
+
+    const rows = await getDb()
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.organizationId, org.id));
+    expect(rows).toHaveLength(1);
+    const eventRows = await getDb()
+      .select()
+      .from(schema.stripeEvents)
+      .where(eq(schema.stripeEvents.id, event.id));
+    expect(eventRows).toHaveLength(1);
+  });
+
+  it('an out-of-order update does not move current_period_end backwards', async () => {
+    const org = await makeOrg();
+    const subscriptionId = `sub_${randomUUID()}`;
+    const now = Math.floor(Date.now() / 1000);
+    const later = fakeSubscription({
+      id: subscriptionId,
+      customer: org.stripeCustomerId,
+      currentPeriodEnd: now + 60 * 24 * 60 * 60,
+    });
+    const earlier = fakeSubscription({
+      id: subscriptionId,
+      customer: org.stripeCustomerId,
+      currentPeriodEnd: now + 10 * 24 * 60 * 60,
+      status: 'past_due',
+    });
+
+    const first = await applyStripeEvent(getDb(), fakeStripeClient({ [subscriptionId]: later }), {
+      id: `evt_${randomUUID()}`,
+      type: 'customer.subscription.updated',
+      created: now,
+      data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+    });
+    expect(first.outcome).toBe('applied');
+
+    const second = await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({ [subscriptionId]: earlier }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'customer.subscription.updated',
+        created: now - 1,
+        data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+    expect(second.outcome).toBe('stale');
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.organizationId, org.id));
+    // The stale (earlier) event's status never overwrote the later one's.
+    expect(row.status).toBe('active');
+    expect(row.currentPeriodEnd.getTime()).toBe(later.items.data[0].current_period_end * 1000);
+  });
+
+  it('an event for an unknown customer is recorded and skipped rather than throwing', async () => {
+    const stranger = `cus_${randomUUID()}`;
+    const sub = fakeSubscription({ id: `sub_${randomUUID()}`, customer: stranger });
+    const stripe = fakeStripeClient({ [sub.id]: sub });
+    const eventId = `evt_${randomUUID()}`;
+
+    await expect(
+      applyStripeEvent(getDb(), stripe, {
+        id: eventId,
+        type: 'customer.subscription.updated',
+        created: Math.floor(Date.now() / 1000),
+        data: { object: { id: sub.id, customer: stranger } },
+      }),
+    ).resolves.toEqual({ outcome: 'unknown-customer', detail: stranger });
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.stripeEvents)
+      .where(eq(schema.stripeEvents.id, eventId));
+    expect(row).toBeDefined();
+    expect(row.processedAt).not.toBeNull();
+  });
+
+  it('a subscription deletion drops the org to free with its other data intact', async () => {
+    const org = await makeOrg({ plan: 'growth', planSource: 'stripe' });
+    const sub = fakeSubscription({ id: `sub_${randomUUID()}`, customer: org.stripeCustomerId });
+    // Seed the row the deletion is expected to remove.
+    await applyStripeEvent(getDb(), fakeStripeClient({ [sub.id]: sub }), {
+      id: `evt_${randomUUID()}`,
+      type: 'customer.subscription.updated',
+      created: Math.floor(Date.now() / 1000),
+      data: { object: { id: sub.id, customer: org.stripeCustomerId } },
+    });
+
+    const result = await applyStripeEvent(getDb(), fakeStripeClient({}), {
+      id: `evt_${randomUUID()}`,
+      type: 'customer.subscription.deleted',
+      created: Math.floor(Date.now() / 1000),
+      data: { object: { id: sub.id, customer: org.stripeCustomerId } },
+    });
+    expect(result.outcome).toBe('applied');
+
+    const [freshOrg] = await getDb()
+      .select()
+      .from(schema.organizations)
+      .where(eq(schema.organizations.id, org.id));
+    expect(freshOrg.plan).toBe('free');
+    expect(freshOrg.planSource).toBe('stripe');
+    expect(freshOrg.stripeCustomerId).toBe(org.stripeCustomerId); // data intact
+    expect(freshOrg.slug).toContain('billing-webhook-test');
+
+    const rows = await getDb()
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.organizationId, org.id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('a grant survives a deletion event', async () => {
+    const org = await makeOrg({ plan: 'scale', planSource: 'grant' });
+    const sub = fakeSubscription({ id: `sub_${randomUUID()}`, customer: org.stripeCustomerId });
+
+    const result = await applyStripeEvent(getDb(), fakeStripeClient({}), {
+      id: `evt_${randomUUID()}`,
+      type: 'customer.subscription.deleted',
+      created: Math.floor(Date.now() / 1000),
+      data: { object: { id: sub.id, customer: org.stripeCustomerId } },
+    });
+    expect(result.outcome).toBe('applied');
+    expect(result.detail).toBe('grant preserved');
+
+    const [freshOrg] = await getDb()
+      .select()
+      .from(schema.organizations)
+      .where(eq(schema.organizations.id, org.id));
+    expect(freshOrg.plan).toBe('scale');
+    expect(freshOrg.planSource).toBe('grant');
+  });
+
+  it("maps a real Stripe product's metadata (growth) to org_subscriptions limits", async () => {
+    const secretKey = readFileSync(
+      join(homedir(), '.config/pitchbox-stripe-test.key'),
+      'utf8',
+    ).trim();
+    const stripe = createStripeClient(secretKey);
+    const price = await stripe.getPriceByLookupKey('pitchbox_growth_monthly');
+    expect(price).not.toBeNull();
+    const productId = typeof price!.product === 'string' ? price!.product : price!.product.id;
+    const product = await stripe.getProduct(productId);
+    expect(product.metadata.plan).toBe('growth');
+
+    const limits = limitsFromProductMetadata(product.metadata);
+    expect(limits).toEqual({
+      planId: 'growth',
+      limitRuns: 2000,
+      limitSuggestions: 2000,
+      limitProjects: 10,
+      limitSeats: 3,
+      limitDevices: 10,
+      limitConcurrency: 4,
+      limitBudgetUsd: '30.00',
+      limitRetentionDays: 90,
+      limitPremiumModels: true,
+    });
+  });
+});

--- a/shared/tests/plans.test.ts
+++ b/shared/tests/plans.test.ts
@@ -75,6 +75,7 @@ describe('resolveEntitlements', () => {
       stripeSubscriptionId: `sub_test_${randomUUID()}`,
       planId: 'solo',
       status: 'active',
+      currentPeriodStart: new Date(),
       currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
       limitRuns: PLAN_CATALOGUE.solo.runsPerMonth,
       limitSuggestions: PLAN_CATALOGUE.solo.suggestionsPerMonth,

--- a/shared/tests/stripe-signature.test.ts
+++ b/shared/tests/stripe-signature.test.ts
@@ -1,0 +1,60 @@
+// verifyStripeSignature is the whole boundary the webhook route trusts
+// before it ever reads the body as JSON or touches the database - every
+// failure mode here must return false, never throw, and never make it
+// look like an accident whether the signature or the timestamp failed.
+import { createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { verifyStripeSignature } from '../src/stripe/signature.js';
+
+const SECRET = 'whsec_test_secret';
+
+function sign(body: string, secret: string, timestamp: number): string {
+  const signed = createHmac('sha256', secret).update(`${timestamp}.${body}`, 'utf8').digest('hex');
+  return `t=${timestamp},v1=${signed}`;
+}
+
+describe('verifyStripeSignature', () => {
+  it('accepts a header computed with the right secret over the exact body', () => {
+    const body = '{"id":"evt_1","type":"customer.subscription.updated"}';
+    const header = sign(body, SECRET, Math.floor(Date.now() / 1000));
+    expect(verifyStripeSignature(body, header, SECRET)).toBe(true);
+  });
+
+  it('rejects a body that does not match what was signed', () => {
+    const signedBody = '{"id":"evt_1"}';
+    const tamperedBody = '{"id":"evt_2"}';
+    const header = sign(signedBody, SECRET, Math.floor(Date.now() / 1000));
+    expect(verifyStripeSignature(tamperedBody, header, SECRET)).toBe(false);
+  });
+
+  it('rejects a header signed with the wrong secret', () => {
+    const body = '{"id":"evt_1"}';
+    const header = sign(body, 'whsec_wrong_secret', Math.floor(Date.now() / 1000));
+    expect(verifyStripeSignature(body, header, SECRET)).toBe(false);
+  });
+
+  it('rejects a stale timestamp outside the tolerance window', () => {
+    const body = '{"id":"evt_1"}';
+    const staleTimestamp = Math.floor(Date.now() / 1000) - 10 * 60; // 10 minutes old
+    const header = sign(body, SECRET, staleTimestamp);
+    expect(verifyStripeSignature(body, header, SECRET, 300)).toBe(false);
+  });
+
+  it('rejects a missing header', () => {
+    expect(verifyStripeSignature('{}', null, SECRET)).toBe(false);
+  });
+
+  it('rejects a header with no v1 entry', () => {
+    const header = `t=${Math.floor(Date.now() / 1000)}`;
+    expect(verifyStripeSignature('{}', header, SECRET)).toBe(false);
+  });
+
+  it('accepts when a rotated secret adds a second v1 entry and only the new one matches', () => {
+    const body = '{"id":"evt_1"}';
+    const timestamp = Math.floor(Date.now() / 1000);
+    const oldSig = sign(body, 'whsec_old_secret', timestamp).split(',v1=')[1];
+    const newHeader = sign(body, SECRET, timestamp);
+    const combined = `${newHeader},v1=${oldSig}`;
+    expect(verifyStripeSignature(body, combined, SECRET)).toBe(true);
+  });
+});

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -108,6 +108,12 @@ function isInternalDispatchRequest(event: { request: Request; url: URL }): boole
 function isExemptPath(pathname: string): boolean {
   return (
     pathname.startsWith('/api/extension/') ||
+    // The Stripe webhook (#551) is a signed, unauthenticated-by-cookie
+    // delivery from Stripe's own servers - it verifies `Stripe-Signature`
+    // itself (shared/src/stripe/signature.ts) instead of a session, and
+    // must be reachable with auth on or off since the signing secret, not
+    // a Pitchbox account, is the boundary.
+    pathname.startsWith('/api/stripe/webhook') ||
     pathname.startsWith('/login') ||
     // A visitor with no session has to be able to reach both halves of
     // sign-up too (#504): /register itself, and /invite/<token>'s own
@@ -165,6 +171,9 @@ const TRUSTED_ORIGIN_SET = trustedOriginSet();
 function blocksCrossOriginMutation(event: { request: Request; url: URL }): boolean {
   if (!event.url.pathname.startsWith('/api/')) return false;
   if (event.url.pathname.startsWith('/api/extension/')) return false;
+  // Same reasoning as `isExemptPath` above: Stripe never sends an `Origin`
+  // header a browser would, but explicit beats "happens to fall through".
+  if (event.url.pathname.startsWith('/api/stripe/webhook')) return false;
   if (!MUTATING_METHODS.has(event.request.method)) return false;
   const origin = event.request.headers.get('origin');
   if (!origin) return false;

--- a/web/src/routes/api/billing/checkout/+server.ts
+++ b/web/src/routes/api/billing/checkout/+server.ts
@@ -1,0 +1,54 @@
+// A Stripe customer per org, and a Checkout session per plan (#550). This
+// route never writes a plan - the webhook (`/api/stripe/webhook`, #551) is
+// the only writer, and this route's own job ends the moment it hands back a
+// session URL.
+import { error, json, type RequestEvent } from '@sveltejs/kit';
+import { z } from 'zod';
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId, requireRole } from '$lib/server/auth.js';
+import { loadStripeEnv } from '@pitchbox/shared/stripe/env';
+import { createStripeClient } from '@pitchbox/shared/stripe/client';
+import { createCheckoutSession, UnknownPriceError } from '@pitchbox/shared/billing/checkout';
+import { PLAN_IDS } from '@pitchbox/shared/plans';
+
+const Body = z.object({
+  plan: z.enum(PLAN_IDS),
+  interval: z.enum(['month', 'year']),
+});
+
+export async function POST(event: RequestEvent) {
+  const stripeEnv = loadStripeEnv();
+  // Same posture `/api/auth/*` takes when auth is off (docs #550): billing
+  // off, or self-host with no Stripe key, means this route does not exist.
+  if (!stripeEnv.enabled) throw error(404, 'billing_disabled');
+
+  const orgId = await requireOrgId(event);
+  requireRole(event, 'admin');
+
+  const raw = await event.request.json().catch(() => null);
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return json({ error: 'invalid_body', issues: parsed.error.issues }, { status: 400 });
+  }
+
+  const db = getDb();
+  const stripe = createStripeClient(stripeEnv.secretKey);
+  try {
+    const session = await createCheckoutSession(db, stripe, {
+      orgId,
+      planId: parsed.data.plan,
+      interval: parsed.data.interval,
+      successUrl: `${event.url.origin}/settings/billing?checkout=success`,
+      cancelUrl: `${event.url.origin}/settings/billing?checkout=cancelled`,
+    });
+    return json(session);
+  } catch (err) {
+    // Free has no Stripe price, and a lookup key resolving nothing is a
+    // catalogue drift between this deployment and its Stripe account -
+    // both are the caller's problem, not a 500.
+    if (err instanceof UnknownPriceError) {
+      return json({ error: 'unknown_price' }, { status: 400 });
+    }
+    throw err;
+  }
+}

--- a/web/src/routes/api/billing/portal/+server.ts
+++ b/web/src/routes/api/billing/portal/+server.ts
@@ -1,0 +1,36 @@
+// The customer portal is where a plan changes and a card is updated (#552).
+// Every change made there comes back as a webhook (#551); this route
+// writes nothing.
+import { error, json, type RequestEvent } from '@sveltejs/kit';
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId, requireRole } from '$lib/server/auth.js';
+import { loadStripeEnv } from '@pitchbox/shared/stripe/env';
+import { createStripeClient } from '@pitchbox/shared/stripe/client';
+import { createPortalSession, NoStripeCustomerError } from '@pitchbox/shared/billing/portal';
+
+export async function POST(event: RequestEvent) {
+  const stripeEnv = loadStripeEnv();
+  if (!stripeEnv.enabled) throw error(404, 'billing_disabled');
+
+  const orgId = await requireOrgId(event);
+  requireRole(event, 'admin');
+
+  const db = getDb();
+  const stripe = createStripeClient(stripeEnv.secretKey);
+  try {
+    const session = await createPortalSession(db, stripe, {
+      orgId,
+      returnUrl: `${event.url.origin}/settings/billing`,
+      portalConfiguration: stripeEnv.portalConfiguration,
+    });
+    return json(session);
+  } catch (err) {
+    // An org with no Stripe customer yet is the free-plan case (#552): the
+    // button offers checkout instead, and that decision belongs to the
+    // caller, not a 500 here.
+    if (err instanceof NoStripeCustomerError) {
+      return json({ error: 'no_customer' }, { status: 400 });
+    }
+    throw err;
+  }
+}

--- a/web/src/routes/api/stripe/webhook/+server.ts
+++ b/web/src/routes/api/stripe/webhook/+server.ts
@@ -1,0 +1,42 @@
+// The Stripe webhook is the only writer of subscription state (#551).
+// Exempt from the auth hook and CSRF (web/src/hooks.server.ts) - Stripe
+// signs the request itself, and this route verifies that signature against
+// the raw body before it is read any other way.
+import { error, json, type RequestEvent } from '@sveltejs/kit';
+import { getDb } from '$lib/server/db.js';
+import { loadStripeEnv } from '@pitchbox/shared/stripe/env';
+import {
+  createStripeClient,
+  InvalidStripeEventError,
+  parseStripeEvent,
+} from '@pitchbox/shared/stripe/client';
+import { verifyStripeSignature } from '@pitchbox/shared/stripe/signature';
+import { applyStripeEvent } from '@pitchbox/shared/billing/webhook';
+
+export async function POST(event: RequestEvent) {
+  const stripeEnv = loadStripeEnv();
+  if (!stripeEnv.enabled || !stripeEnv.webhookSecret) throw error(404, 'billing_disabled');
+
+  // The raw bytes, not `request.json()`: the signature is computed over the
+  // exact body Stripe sent, and reading it as JSON first would both parse
+  // before verifying and risk losing byte-for-byte fidelity to whitespace/
+  // key order that a re-serialization does not preserve.
+  const rawBody = await event.request.text();
+  const signatureHeader = event.request.headers.get('stripe-signature');
+  if (!verifyStripeSignature(rawBody, signatureHeader, stripeEnv.webhookSecret)) {
+    throw error(400, 'invalid_signature');
+  }
+
+  let stripeEvent;
+  try {
+    stripeEvent = parseStripeEvent(rawBody);
+  } catch (err) {
+    if (err instanceof InvalidStripeEventError) throw error(400, 'invalid_event');
+    throw err;
+  }
+
+  const db = getDb();
+  const stripe = createStripeClient(stripeEnv.secretKey);
+  const result = await applyStripeEvent(db, stripe, stripeEvent);
+  return json({ received: true, outcome: result.outcome });
+}

--- a/web/tests/billing-routes-gating.test.ts
+++ b/web/tests/billing-routes-gating.test.ts
@@ -1,0 +1,132 @@
+// #550/#552: the checkout and portal routes' own guards - disabled when
+// billing is off, admin-or-owner only, and the specific refusals that must
+// answer with a clean 4xx rather than a 500 (no Stripe price for a plan
+// with none, no Stripe customer yet on the free plan). None of these paths
+// reach the real Stripe network: the plan/role/customer checks all run
+// before this route would ever call it.
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { POST as checkoutPost } from '../src/routes/api/billing/checkout/+server.js';
+import { POST as portalPost } from '../src/routes/api/billing/portal/+server.js';
+
+const savedEnv: Record<string, string | undefined> = {};
+
+function withEnv(vars: Record<string, string | undefined>) {
+  for (const [key, value] of Object.entries(vars)) {
+    if (!(key in savedEnv)) savedEnv[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function billingOn() {
+  withEnv({ PITCHBOX_BILLING: 'on', STRIPE_SECRET_KEY: 'sk_test_dummy' });
+}
+
+function checkoutEvent(locals: Record<string, unknown>, body: unknown): RequestEvent {
+  return {
+    locals,
+    url: new URL('https://app.pitchbox.app/api/billing/checkout'),
+    request: new Request('https://app.pitchbox.app/api/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as RequestEvent;
+}
+
+function portalEvent(locals: Record<string, unknown>): RequestEvent {
+  return {
+    locals,
+    url: new URL('https://app.pitchbox.app/api/billing/portal'),
+    request: new Request('https://app.pitchbox.app/api/billing/portal', { method: 'POST' }),
+  } as unknown as RequestEvent;
+}
+
+let orgId: number;
+
+beforeAll(async () => {
+  const [org] = await getDb()
+    .insert(schema.organizations)
+    .values({ slug: `billing-gating-test-${Date.now()}`, name: 'billing-gating-test' })
+    .returning();
+  orgId = org.id;
+});
+
+afterAll(async () => {
+  await getDb().delete(schema.organizations).where(eq(schema.organizations.id, orgId));
+});
+
+function adminLocals() {
+  return { org: { id: orgId, slug: 'x', role: 'admin' } };
+}
+function memberLocals() {
+  return { org: { id: orgId, slug: 'x', role: 'member' } };
+}
+
+describe('POST /api/billing/checkout', () => {
+  it('404s when billing is disabled', async () => {
+    withEnv({ PITCHBOX_BILLING: undefined, STRIPE_SECRET_KEY: undefined });
+    await expect(
+      checkoutPost(checkoutEvent(adminLocals(), { plan: 'growth', interval: 'month' })),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('refuses a member (admin or owner only)', async () => {
+    billingOn();
+    await expect(
+      checkoutPost(checkoutEvent(memberLocals(), { plan: 'growth', interval: 'month' })),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('rejects a malformed body for an admin before ever reaching Stripe', async () => {
+    billingOn();
+    const res = await checkoutPost(
+      checkoutEvent(adminLocals(), { plan: 'not-a-real-plan', interval: 'month' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_body');
+  });
+
+  it('rejects a request naming a price id instead of a plan/interval', async () => {
+    billingOn();
+    const res = await checkoutPost(
+      checkoutEvent(adminLocals(), { priceId: 'price_attacker_supplied', plan: 'growth' }),
+    );
+    // `interval` is still missing - the schema has no field for a raw
+    // price id at all, so supplying one is simply ignored input, and the
+    // body is invalid regardless.
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/billing/portal', () => {
+  it('404s when billing is disabled', async () => {
+    withEnv({ PITCHBOX_BILLING: undefined, STRIPE_SECRET_KEY: undefined });
+    await expect(portalPost(portalEvent(adminLocals()))).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('refuses a member (admin or owner only)', async () => {
+    billingOn();
+    await expect(portalPost(portalEvent(memberLocals()))).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('answers 400 no_customer for an org with no Stripe customer yet, not a 500', async () => {
+    billingOn();
+    // The org created in beforeAll has no `stripe_customer_id` set - the
+    // free-plan case docs/billing.md #552 describes ("the button offers
+    // checkout instead").
+    const res = await portalPost(portalEvent(adminLocals()));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('no_customer');
+  });
+});

--- a/web/tests/stripe-webhook-route.test.ts
+++ b/web/tests/stripe-webhook-route.test.ts
@@ -1,0 +1,121 @@
+// #551: the webhook route itself - reachable with no session even though
+// the real hook forces PITCHBOX_AUTH=on (proves the web/src/hooks.server.ts
+// exemption actually applies, the same regression class #132 documents for
+// hand-injected locals.org), a bad signature refused before anything is
+// written, and a valid one accepted end to end.
+import { createHmac, randomUUID } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { POST as webhookPost } from '../src/routes/api/stripe/webhook/+server.js';
+import { runThroughHandle, type CookieJar } from './helpers/handle-harness.js';
+
+const WEBHOOK_SECRET = 'whsec_test_route_secret';
+const savedEnv: Record<string, string | undefined> = {};
+
+function withEnv(vars: Record<string, string | undefined>) {
+  for (const [key, value] of Object.entries(vars)) {
+    if (!(key in savedEnv)) savedEnv[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function sign(body: string, secret: string): string {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signed = createHmac('sha256', secret).update(`${timestamp}.${body}`, 'utf8').digest('hex');
+  return `t=${timestamp},v1=${signed}`;
+}
+
+function jar(): CookieJar {
+  return { store: new Map() };
+}
+
+async function postWebhook(
+  body: string,
+  signatureHeader: string | null,
+  origin?: string,
+): Promise<Response> {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (signatureHeader) headers['stripe-signature'] = signatureHeader;
+  if (origin) headers.origin = origin;
+  const request = new Request('https://app.pitchbox.app/api/stripe/webhook', {
+    method: 'POST',
+    headers,
+    body,
+  });
+  return runThroughHandle(request, jar(), (event) => webhookPost(event as never));
+}
+
+describe('POST /api/stripe/webhook', () => {
+  it('404s when billing is disabled', async () => {
+    withEnv({ PITCHBOX_BILLING: undefined });
+    await expect(postWebhook('{}', null)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('rejects a bad signature with 400 and writes nothing, even with no session and a foreign Origin', async () => {
+    withEnv({
+      PITCHBOX_BILLING: 'on',
+      STRIPE_SECRET_KEY: 'sk_test_dummy',
+      STRIPE_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    });
+    const eventId = `evt_route_test_${randomUUID()}`;
+    const body = JSON.stringify({
+      id: eventId,
+      type: 'customer.subscription.trial_will_end',
+      created: Math.floor(Date.now() / 1000),
+      data: { object: {} },
+    });
+    const badSignature = sign(body, 'whsec_wrong_secret');
+    await expect(postWebhook(body, badSignature, 'https://evil.example')).rejects.toMatchObject({
+      status: 400,
+    });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.stripeEvents)
+      .where(eq(schema.stripeEvents.id, eventId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('rejects a missing signature header the same way', async () => {
+    withEnv({
+      PITCHBOX_BILLING: 'on',
+      STRIPE_SECRET_KEY: 'sk_test_dummy',
+      STRIPE_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    });
+    await expect(postWebhook('{}', null)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('accepts a validly signed no-op event with no session, through the real hook', async () => {
+    withEnv({
+      PITCHBOX_BILLING: 'on',
+      STRIPE_SECRET_KEY: 'sk_test_dummy',
+      STRIPE_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    });
+    const eventId = `evt_route_test_${randomUUID()}`;
+    const body = JSON.stringify({
+      id: eventId,
+      type: 'customer.subscription.trial_will_end',
+      created: Math.floor(Date.now() / 1000),
+      data: { object: {} },
+    });
+    const res = await postWebhook(body, sign(body, WEBHOOK_SECRET), 'https://evil.example');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true, outcome: 'no-op' });
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.stripeEvents)
+      .where(eq(schema.stripeEvents.id, eventId));
+    expect(row).toBeDefined();
+    expect(row.processedAt).not.toBeNull();
+  });
+});


### PR DESCRIPTION
A Stripe customer per organization, a Checkout session per plan, the webhook as the only writer of subscription state, and the customer portal.

## What changed

- **`organizations.stripe_customer_id`** (migration 0028): a Stripe customer created lazily on first checkout, per org (not per user). I put it on `organizations` rather than `org_subscriptions` because `org_subscriptions.stripe_customer_id` is `NOT NULL` and that row *is* the subscription - it gets deleted wholesale when Stripe's subscription does, so a customer that exists before any subscription (or that survives after one is cancelled) has nowhere to live there.
- **`shared/src/stripe/{env,client,signature}.ts`**: a Stripe client keyed from `STRIPE_SECRET_KEY`, absent when `PITCHBOX_BILLING` is off or no key is set (mirrors `shared/src/mail/env.ts`'s half-configured-provider rule). Talks to Stripe over raw `fetch`, matching `scripts/stripe-setup.ts`'s own convention rather than adding the `stripe` npm package. Pinned to `2025-03-31.basil`. Webhook signature verification is HMAC-SHA256 over `node:crypto`, Stripe's own documented algorithm.
- **`shared/src/billing/{customer,checkout,portal,webhook}.ts`**: the actual logic, thin routes on top (`web/src/routes/api/billing/{checkout,portal}` and `web/src/routes/api/stripe/webhook`).
- **The webhook is the only writer of `org_subscriptions`/`organizations.plan`.** Signature verified against `STRIPE_WEBHOOK_SECRET` before the raw body is read. `stripe_events` (new table) is the idempotency ledger: `id` (Stripe's event id) inserted with `onConflictDoNothing` first; a row whose `processed_at` is still null means a prior delivery crashed mid-handler and gets reprocessed, one whose `processed_at` is set is a true replay and is left untouched.
- Every subscription-touching event (`checkout.session.completed`, `customer.subscription.created/updated`, `invoice.paid`, `invoice.payment_failed`) refetches the live Subscription from Stripe rather than trusting the event's embedded snapshot - Stripe's own recommendation, since delivery order isn't guaranteed. `invoice.paid`/`invoice.payment_failed` just trigger that same refetch: Stripe itself flips the subscription's `status` to `past_due`/back before or alongside those events, so there's no separate status-guessing logic.
- Out-of-order guard: the subscription item's own `current_period_end` (not `event.created`, which two updates can share a second on). An incoming value strictly less than what's already stored is ignored.
- `customer.subscription.deleted` drops the org to free, `org_subscriptions` row removed, org's other data untouched. A `plan_source='grant'` org is never touched by any of this (verified by breaking the guard and watching the exact test fail, see below).
- An event for a customer with no matching org is recorded (for the idempotency ledger) and skipped, never thrown.
- Product metadata's `limit_*` follows the `'0'` string → real SQL `NULL` convention `scripts/stripe-setup.ts` already uses.

## A version surprise worth flagging

`2025-03-31.basil` **removed `current_period_start`/`current_period_end` from the top-level Subscription object** and moved them onto each subscription item (confirmed against the real test account - `docs/billing.md` didn't know this, since it predates pinning that version here). That's also what I use as the out-of-order marker.

## Managed Payments constraints, verified against the real test account (not just the docs)

I created real test-mode Checkout Sessions against `pitchbox_growth_monthly` to check which documented "rejected" parameters actually reject, and updated `docs/billing.md` with what I found:

- **Reject outright**, verified with the exact Stripe error: `payment_method_types` ("Managed Payments handles this parameter for you"), `shipping_address_collection` ("You cannot use shipping parameters with Managed Payments"), `subscription_data.invoice_settings` ("You cannot use subscription_data.invoice_settings with Managed Payments").
- **A narrower case than "rejected"**: `automatic_tax[enabled]` and `tax_id_collection[enabled]` are pinned to `true` by Managed Payments - passing `true` is silently accepted (it's the forced default), only `false` errors ("must be true when Managed Payments is enabled"). The app omits both.
- **Did not error at all** in this test-mode run, despite being on Stripe's own unsupported-parameter list: `customer_update[name]` and `customer_update[address]`. Noted in the doc as a discrepancy worth knowing about; the app never sets either regardless.

None of these are set by `createCheckoutSession` - it only ever sends `mode`, `customer`, `line_items`, `client_reference_id`, `subscription_data.metadata`, `allow_promotion_codes`, `managed_payments[enabled]`, `success_url`, `cancel_url`.

## What I deliberately did not do

- No live-mode anything. No dashboard changes, no account activation.
- No UI for `/settings/billing` - not asked for, and the acceptance criteria for these three issues is entirely server-side.
- No reconciliation/polling job for a subscription Stripe deletes without ever sending `customer.subscription.deleted` - the seven events list is what's specified, and Stripe's own data-deletion flow does fire that event in practice.

## Verification

Ran against a dedicated `pitchbox_test_stripe` database (isolated per this wave's convention) and, for network calls, the real Stripe test account (key at `~/.config/pitchbox-stripe-test.key`, never printed or committed).

```
export DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5434/pitchbox_test_stripe
pnpm exec vitest run shared/tests/stripe-signature.test.ts shared/tests/billing-webhook.test.ts \
  shared/tests/billing-checkout-portal.test.ts shared/tests/plans.test.ts \
  web/tests/stripe-webhook-route.test.ts web/tests/billing-routes-gating.test.ts
# 6 files, 34 tests, all passing
pnpm -F @pitchbox/shared typecheck
pnpm -F web check
npx eslint <changed files>
npx prettier --check <changed files>
```

- `maps a real Stripe product's metadata (growth) to org_subscriptions limits`: fetches `pitchbox_growth_monthly`'s real product/metadata from the test account and asserts the exact mapping (`limit_budget_usd: '30'` → `'30.00'`, `limit_devices: '10'` → `10`, etc.) - not a hand-written fixture.
- `starts a real test-mode Checkout session for growth/month with Managed Payments enabled` and the portal equivalent: real network calls, asserting on `checkout.stripe.com`/`billing.stripe.com` URLs.
- The five webhook refusals the issue calls out are each their own test, asserted against the database: a replayed delivery leaves one `org_subscriptions` row and one `stripe_events` row, not two; an out-of-order update doesn't move `current_period_end` backwards; an unsigned/badly-signed request is a 400 with zero `stripe_events` rows written; an event for an unknown customer is recorded and skipped, not thrown; a subscription deletion drops the org to free with `slug`/`stripe_customer_id` intact; a grant survives the same deletion.
- **Proved each of those four guards (signature check, idempotency check, out-of-order check, grant-preserving check) actually bites**, by commenting each one out in turn and re-running the suite: watched exactly the matching test fail each time (and only that test), then restored the file and confirmed the diff was clean again.
- Migration 0028 applied cleanly against a database that already had the previous 27; verified with `psql`/`docker exec` that `organizations.stripe_customer_id`, `org_subscriptions.current_period_start` and `stripe_events` all exist with the right types, and `drizzle.__drizzle_migrations` shows 28 rows.

Not run: `pnpm test` (full suite), `pnpm run lint` (whole repo) - out of scope per this wave's constraints.

## Coordination note

`org_subscriptions.current_period_start` was added at PlanLimits' request (#545 needs a billing-period start for its spend-window calculation) - agreed over `hub` before I generated the migration, so there's exactly one migration this wave rather than two racing.
