### PR TITLE
feat(extension,web,shared): the post's image reaches the model as pixels from the rendered tab

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -6,6 +6,7 @@ import { registerLinkedInPostAssistScript } from './background/linkedin-post-ass
 import { registerLinkedInProfileCaptureScript } from './background/linkedin-profile-capture-registration.js';
 import { registerLinkedInSourceCaptureScript } from './background/linkedin-source-capture-registration.js';
 import { injectIntoOpenLinkedInTabs } from './background/inject-open-tabs.js';
+import { captureAndCropTabRegion } from './background/capture-post-media.js';
 import {
   getSettings,
   patchPairing,
@@ -426,7 +427,7 @@ chrome.alarms.onAlarm.addListener(async (a) => {
   else if ((agg.inserted ?? 0) > 0) console.log('[pitchbox] sync:', agg);
 });
 
-chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg?.type === 'pitchbox:dm-sync:run') {
     runAllSyncs()
       .then((r) => sendResponse(aggregate(r)))
@@ -479,6 +480,28 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       // ConnectionCard's review banner surfaces it the next time the side
       // panel is opened.
     }).then(() => sendResponse({ ok: true }));
+    return true;
+  }
+  if (msg?.type === 'pitchbox:capture-post-media') {
+    // #569: the post's attached media, captured as pixels from the tab the
+    // content script itself is running in - never a request toward
+    // linkedin.com/licdn. `sender.tab` is always populated here: this
+    // message only ever arrives from a content script running in a tab.
+    const tabId = sender.tab?.id;
+    const windowId = sender.tab?.windowId;
+    if (tabId == null || windowId == null) {
+      sendResponse({ ok: false });
+      return false;
+    }
+    captureAndCropTabRegion({
+      tabId,
+      windowId,
+      rect: msg.rect,
+      devicePixelRatio: msg.devicePixelRatio,
+      maxLongEdgePx: msg.maxLongEdgePx,
+    })
+      .then(sendResponse)
+      .catch(() => sendResponse({ ok: false }));
     return true;
   }
   if (msg?.type === 'pitchbox:log') {

--- a/extension/src/background/capture-post-media.ts
+++ b/extension/src/background/capture-post-media.ts
@@ -1,0 +1,128 @@
+/**
+ * Crops and downscales a region of the sender tab's own visible viewport
+ * (#569) - `chrome.tabs.captureVisibleTab` is the only capability this
+ * touches: a browser API over the tab the human is already looking at, not
+ * a request to LinkedIn or anywhere else. The crop this returns is the only
+ * thing that ever leaves this module; the full-viewport screenshot itself
+ * is decoded, cropped and discarded here.
+ *
+ * Runs in the background service worker rather than the content script
+ * because `captureVisibleTab` is only callable from there, and because
+ * `OffscreenCanvas`/`createImageBitmap` need no DOM the content script's own
+ * page provides anyway - the decode-crop-encode pipeline below only needs
+ * globals a service worker already has.
+ */
+
+export type CaptureRegionParams = {
+  tabId: number;
+  windowId: number;
+  rect: { x: number; y: number; width: number; height: number };
+  devicePixelRatio: number;
+  maxLongEdgePx: number;
+};
+
+export type CaptureRegionResult = { ok: true; dataUrl: string } | { ok: false };
+
+/** Mirrors shared/src/assist/suggest-prompt.ts's `MAX_IMAGE_DATA_URL_CHARS`
+ * by hand - see extension/src/content/shared/media-capture.ts's own note on
+ * why. Checked again here, not just by the caller, because this is where
+ * the encoded bytes actually exist. */
+const MAX_IMAGE_DATA_URL_CHARS = 280_000;
+
+/** Re-encodes at progressively smaller size/quality until the result fits
+ * under the cap, or gives up. The first attempt is already modest - a
+ * vision model does not need a retina asset - so this only matters for the
+ * rare crop that is unusually large or busy (a screenshot of dense text,
+ * say) and would not otherwise compress well. */
+const ENCODE_ATTEMPTS: ReadonlyArray<{ longEdgeScale: number; quality: number }> = [
+  { longEdgeScale: 1, quality: 0.75 },
+  { longEdgeScale: 1, quality: 0.5 },
+  { longEdgeScale: 0.6, quality: 0.5 },
+];
+
+function base64ToBytes(base64: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/** `String.fromCharCode(...bytes)` in one call blows the argument-count
+ * limit on a large screenshot, so this walks the buffer in fixed chunks -
+ * the same reason `bytesToBase64` exists at all rather than a one-liner. */
+function bytesToBase64(bytes: Uint8Array<ArrayBuffer>): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}
+
+/**
+ * Captures whatever is visible in `params.windowId` right now, crops it to
+ * `params.rect` (already viewport-relative css px, scaled here by
+ * `devicePixelRatio` into the screenshot's own physical pixels) and
+ * downscales/re-encodes until the result fits `MAX_IMAGE_DATA_URL_CHARS`.
+ *
+ * Refuses rather than guesses whenever the capture could silently be of the
+ * wrong tab: `chrome.tabs.captureVisibleTab(windowId, ...)` captures
+ * whichever tab is currently active in that window, so a sender tab that
+ * has stopped being the active one (the human switched tabs between the
+ * click and this call resolving) would otherwise return a screenshot of
+ * something else entirely - the "tab not visible" fallback #569's issue
+ * names, made concrete.
+ */
+export async function captureAndCropTabRegion(
+  params: CaptureRegionParams,
+): Promise<CaptureRegionResult> {
+  const tab = await chrome.tabs.get(params.tabId).catch(() => null);
+  if (!tab || !tab.active || tab.windowId !== params.windowId) return { ok: false };
+
+  let screenshotDataUrl: string;
+  try {
+    screenshotDataUrl = await chrome.tabs.captureVisibleTab(params.windowId, { format: 'png' });
+  } catch {
+    return { ok: false };
+  }
+  if (!screenshotDataUrl) return { ok: false };
+
+  let bitmap: ImageBitmap;
+  try {
+    const comma = screenshotDataUrl.indexOf(',');
+    const bytes = base64ToBytes(screenshotDataUrl.slice(comma + 1));
+    bitmap = await createImageBitmap(new Blob([bytes], { type: 'image/png' }));
+  } catch {
+    return { ok: false };
+  }
+
+  try {
+    const dpr = params.devicePixelRatio || 1;
+    const sx = Math.max(0, Math.round(params.rect.x * dpr));
+    const sy = Math.max(0, Math.round(params.rect.y * dpr));
+    const sw = Math.min(bitmap.width - sx, Math.round(params.rect.width * dpr));
+    const sh = Math.min(bitmap.height - sy, Math.round(params.rect.height * dpr));
+    if (sw <= 0 || sh <= 0) return { ok: false };
+
+    for (const attempt of ENCODE_ATTEMPTS) {
+      const longEdge = params.maxLongEdgePx * attempt.longEdgeScale;
+      const scale = Math.min(1, longEdge / Math.max(sw, sh));
+      const dw = Math.max(1, Math.round(sw * scale));
+      const dh = Math.max(1, Math.round(sh * scale));
+
+      const canvas = new OffscreenCanvas(dw, dh);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) continue;
+      ctx.drawImage(bitmap, sx, sy, sw, sh, 0, 0, dw, dh);
+      const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: attempt.quality });
+      const base64 = bytesToBase64(new Uint8Array(await blob.arrayBuffer()));
+      const dataUrl = `data:image/jpeg;base64,${base64}`;
+      if (dataUrl.length <= MAX_IMAGE_DATA_URL_CHARS) return { ok: true, dataUrl };
+    }
+    return { ok: false };
+  } catch {
+    return { ok: false };
+  } finally {
+    bitmap.close();
+  }
+}

--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -32,6 +32,7 @@ import {
   resetSelectorHealth,
   selectorHealthActivityEvents,
 } from './shared/linkedin-dom.js';
+import { captureObservedImage } from './shared/media-capture.js';
 import CommentAssistPanel from './linkedin-comment-assist-panel.svelte';
 
 /**
@@ -429,6 +430,12 @@ export function composerHasOwnText(composer: HTMLElement): boolean {
  */
 function mountAssistPanel(composer: HTMLElement, post?: Element): void {
   const anchor = resolveAnchor(composer);
+  // #569: the same element `readAssistPostFromCard`/`readAssistPost` above
+  // resolved from, kept around so a suggestion request can also capture its
+  // attached media - image capture is async (a round trip through the
+  // background worker) so it happens at request time, not folded into
+  // `capturedPost`'s own synchronous read.
+  const postElement = post ?? findFeedPosts(document)[0];
   const capturedPost = post ? readAssistPostFromCard(post, document) : readAssistPost(document);
   for (const event of selectorHealthActivityEvents()) logFromContent(event);
 
@@ -524,6 +531,13 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
     boundProjectId = assist.projectId;
     personalProjectId = assist.personalProjectId;
 
+    // #569: captured here, not folded into `capturedPost`, because it is
+    // the one field on this request that costs a round trip through the
+    // background worker - see media-capture.ts's own doc comment for the
+    // three outcomes this can resolve to.
+    const image = postElement ? await captureObservedImage(postElement, document) : undefined;
+    if (!handle.alive) return;
+
     let reasoning = '';
     let draft = '';
     const res = await api.suggest(
@@ -540,6 +554,7 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
           reactionCount: capturedPost.reactionCount,
           commentCount: capturedPost.commentCount,
           thread: capturedPost.thread,
+          image,
         },
         retune,
       },

--- a/extension/src/content/shared/linkedin-dom.ts
+++ b/extension/src/content/shared/linkedin-dom.ts
@@ -129,7 +129,8 @@ export type LinkedInSelectorId =
   | 'ownPostTimestamp'
   | 'postTimestamp'
   | 'postReactionCount'
-  | 'postCommentCount';
+  | 'postCommentCount'
+  | 'postMedia';
 
 export type SelectorHealthEntry = {
   selector: LinkedInSelectorId;
@@ -831,6 +832,98 @@ export function readPostCommentCount(post: Element, root: ParentNode = document)
   }
   if (pageKind !== 'unknown') record('postCommentCount', pageKind, text !== null);
   return text;
+}
+
+/** What kind of rendered media `findPostMedia` found (#569) - mirrors
+ * `ObservedImageKind` in shared/src/assist/suggest-prompt.ts by hand, same
+ * posture as every other type this module mirrors across the workspace
+ * boundary (see that file's own doc comment on why). */
+export type PostMediaKind = 'image' | 'video_frame' | 'carousel_page';
+
+/** A post's own attached media element, as `findPostMedia` found it -
+ * `alt` is LinkedIn's own alt text when the element carries one, `partial`
+ * is true when the post rendered more than one substantial media element
+ * (a carousel or a multi-page document, which LinkedIn only ever renders
+ * one page of at a time). Capturing the element's pixels is the caller's
+ * job (`extension/src/content/shared/media-capture.ts`); this module only
+ * ever reads DOM structure, never pixels or network state. */
+export type PostMedia = {
+  element: HTMLImageElement | HTMLVideoElement;
+  kind: PostMediaKind;
+  alt?: string;
+  partial: boolean;
+};
+
+/** Below this rendered size (css px, either dimension), a candidate is
+ * treated as chrome rather than the post's own media: a reaction emoji, a
+ * connection-degree badge, or the tiny avatar LinkedIn repeats next to a
+ * byline - none of them are what a human means by "the post has an image". */
+const MIN_POST_MEDIA_DIMENSION = 120;
+
+/**
+ * `post`'s own attached media - a photo, a video's poster frame, or one
+ * page of a carousel/document - honest about what it found rather than
+ * assuming a single `<img>` is the post's media just because it exists
+ * somewhere inside the article (a profile avatar is an `<img>` too).
+ *
+ * Unverified against a live capture (module header): neither fixture
+ * contains a post with attached media, only profile-avatar `<img>`s, which
+ * this correctly excludes via the profile-link check below. Verify against
+ * a real image post before relying on this in production (#569's own PR
+ * does).
+ *
+ * Every `<img>`/`<video>` under `post` that is not inside a profile link,
+ * not `aria-hidden`, and rendered at least `MIN_POST_MEDIA_DIMENSION` on
+ * both axes is a candidate. More than one candidate means a carousel or
+ * document post (`partial: true`); among those, whichever one currently
+ * intersects the visible viewport is what LinkedIn actually has on screen,
+ * which is what a caller should ask the background worker to capture -
+ * falling back to the first candidate (off-screen) only so a caller still
+ * has an element to read `alt` from. `null` when the post has no
+ * substantial media at all - the case that must skip a capture attempt (and
+ * a vision call) entirely, at no cost.
+ */
+export function findPostMedia(
+  post: Element,
+  root: ParentNode = post.ownerDocument ?? document,
+): PostMedia | null {
+  const pageKind = detectPageKind(root);
+  const candidates = queryDeepAll<HTMLImageElement | HTMLVideoElement>('img, video', post).filter(
+    (el) => {
+      // Both the author's avatar and the byline name anchor wrap in a link
+      // to the member's profile (see the real capture's own
+      // `aria-label="Link per visualizzare l'immagine..."` avatar wrapper) -
+      // neither is ever the post's own attached media, and this check is
+      // locale-independent unlike matching the aria-label's own text.
+      if (el.closest('a[href*="/in/"]')) return false;
+      if (el.getAttribute('aria-hidden') === 'true') return false;
+      const rect = el.getBoundingClientRect();
+      return rect.width >= MIN_POST_MEDIA_DIMENSION && rect.height >= MIN_POST_MEDIA_DIMENSION;
+    },
+  );
+  if (candidates.length === 0) {
+    if (pageKind !== 'unknown') record('postMedia', pageKind, false);
+    return null;
+  }
+  if (pageKind !== 'unknown') record('postMedia', pageKind, true);
+
+  const vw =
+    root instanceof Document
+      ? window.innerWidth
+      : (post.ownerDocument?.defaultView?.innerWidth ?? 0);
+  const vh =
+    root instanceof Document
+      ? window.innerHeight
+      : (post.ownerDocument?.defaultView?.innerHeight ?? 0);
+  const onScreen = candidates.filter((el) => {
+    const r = el.getBoundingClientRect();
+    return r.right > 0 && r.bottom > 0 && r.left < vw && r.top < vh;
+  });
+  const element = onScreen[0] ?? candidates[0];
+  const kind: PostMediaKind =
+    element.tagName === 'VIDEO' ? 'video_frame' : candidates.length > 1 ? 'carousel_page' : 'image';
+  const alt = element instanceof HTMLImageElement ? element.alt || undefined : undefined;
+  return { element, kind, alt, partial: candidates.length > 1 };
 }
 
 /** A single message event read off LinkedIn's messaging surface (#307). */

--- a/extension/src/content/shared/media-capture.ts
+++ b/extension/src/content/shared/media-capture.ts
@@ -1,0 +1,111 @@
+import { findPostMedia, type PostMediaKind } from './linkedin-dom.js';
+import { hasImageCapturePermission } from '../../lib/permissions.js';
+
+/**
+ * Captures a post's attached media as pixels from the human's own rendered
+ * tab (#569) - the content script only ever finds the element and asks the
+ * background worker to capture and crop it; the actual pixels never touch
+ * anything but `chrome.tabs.captureVisibleTab`, a browser capability over
+ * the visible tab. No network call, no synthetic interaction, no cookie
+ * read - see docs/design/in-page-agent.md's "capture the rendered tab,
+ * never fetch licdn" rule.
+ */
+
+/** Mirrors shared/src/assist/suggest-prompt.ts's `ObservedImage` by hand -
+ * see extension/src/lib/api.ts's own note on why the extension carries no
+ * dependency on @pitchbox/shared. */
+export type CapturedImage = {
+  dataUrl?: string;
+  alt?: string;
+  kind: PostMediaKind;
+  partial?: boolean;
+};
+
+/** Mirrors shared/src/assist/suggest-prompt.ts's `MAX_IMAGE_DATA_URL_CHARS`
+ * by hand - the server's own zod schema enforces the same number again
+ * rather than trusting this clamp (AGENTS.md: a switch is enforced where
+ * the effect happens, not only where it is read). */
+const MAX_IMAGE_DATA_URL_CHARS = 280_000;
+
+/** A vision model does not need a retina asset (#569's own issue text) - the
+ * background worker downscales to this on the longest edge, in css px
+ * before device-pixel scaling. */
+const MAX_CAPTURE_LONG_EDGE_PX = 1024;
+
+/** Below this much overlap with the viewport (css px, either axis), the
+ * media counts as scrolled off-screen rather than barely visible - a crop
+ * of a sliver describes nothing a vision model could use. */
+const MIN_VIEWPORT_OVERLAP_PX = 40;
+
+type CaptureMessageResponse = { ok: true; dataUrl: string } | { ok: false };
+
+/** The rect `chrome.tabs.captureVisibleTab`'s image actually covers -
+ * `getBoundingClientRect()`'s coordinates are already viewport-relative, so
+ * this only clips to what is currently on screen. `null` when what remains
+ * is too small to be worth capturing at all. */
+function viewportOverlap(
+  rect: DOMRect,
+): { x: number; y: number; width: number; height: number } | null {
+  const x0 = Math.max(0, rect.left);
+  const y0 = Math.max(0, rect.top);
+  const x1 = Math.min(window.innerWidth, rect.right);
+  const y1 = Math.min(window.innerHeight, rect.bottom);
+  const width = x1 - x0;
+  const height = y1 - y0;
+  if (width < MIN_VIEWPORT_OVERLAP_PX || height < MIN_VIEWPORT_OVERLAP_PX) return null;
+  return { x: x0, y: y0, width, height };
+}
+
+/**
+ * Captures `post`'s attached media, when it has one worth reading pixels
+ * from. Three outcomes, honestly distinct (see
+ * shared/src/assist/suggest-prompt.ts's `ObservedImage` doc comment for what
+ * each means to whoever reads the request on the other end):
+ *
+ * - no substantial media at all: `undefined` - the request carries no
+ *   `image` field, so no vision call is ever spent on it.
+ * - media exists but nothing reached us (off-screen, the background
+ *   worker's own capture failed, permission not granted, or the result
+ *   would not fit under the cap even downscaled): `{ alt, kind, partial }`
+ *   with no `dataUrl` - LinkedIn's own alt text when it rendered one.
+ * - media exists and the capture succeeded: the full shape, `dataUrl`
+ *   included.
+ */
+export async function captureObservedImage(
+  post: Element,
+  root: ParentNode = document,
+): Promise<CapturedImage | undefined> {
+  const media = findPostMedia(post, root);
+  if (!media) return undefined;
+
+  const fallback: CapturedImage = { alt: media.alt, kind: media.kind, partial: media.partial };
+  // #569: image capture is its own opt-in (Main's call, 2026-09-09) - see
+  // ImageCaptureAccessRow.svelte's own doc comment for why it is a separate
+  // grant from the base LinkedIn permission. Checked before even computing
+  // whether the media is on screen, so a device that never turned this on
+  // never pays for the viewport math either.
+  if (!(await hasImageCapturePermission())) return fallback;
+  const rect = viewportOverlap(media.element.getBoundingClientRect());
+  if (!rect) return fallback;
+
+  const response = await new Promise<CaptureMessageResponse>((resolve) => {
+    try {
+      chrome.runtime.sendMessage(
+        {
+          type: 'pitchbox:capture-post-media',
+          rect,
+          devicePixelRatio: window.devicePixelRatio || 1,
+          maxLongEdgePx: MAX_CAPTURE_LONG_EDGE_PX,
+        },
+        (res: CaptureMessageResponse | undefined) => {
+          resolve(chrome.runtime.lastError || !res ? { ok: false } : res);
+        },
+      );
+    } catch {
+      resolve({ ok: false });
+    }
+  });
+
+  if (!response.ok || response.dataUrl.length > MAX_IMAGE_DATA_URL_CHARS) return fallback;
+  return { ...fallback, dataUrl: response.dataUrl };
+}

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -85,6 +85,17 @@ export type SuggestThread = {
   truncated: boolean;
 };
 
+/** The post's attached media (#569) - mirrors
+ * shared/src/assist/suggest-prompt.ts's `ObservedImage` by hand. See that
+ * type's own doc comment for what each combination of present/absent
+ * fields means to whoever reads it on the other end. */
+export type SuggestImage = {
+  dataUrl?: string;
+  alt?: string;
+  kind: 'image' | 'video_frame' | 'carousel_page';
+  partial?: boolean;
+};
+
 /** The observed post context /suggest drafts from. `urn` is absent for a
  * feed sighting - see linkedin-dom.ts's "Two frontends, one identifier".
  * `text` is optional because a `kind: 'post'` request carries nothing to
@@ -103,6 +114,7 @@ export type SuggestPost = {
   reactionCount?: string;
   commentCount?: string;
   thread?: SuggestThread;
+  image?: SuggestImage;
 };
 
 /** What /suggest/accept sends back: the same post context, minus `text` -

--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -234,6 +234,23 @@ export const en = {
   'home.access.denied': 'Chrome did not grant access. You can ask again anytime.',
   'home.access.request-failed': 'Could not ask Chrome for LinkedIn access. Try again.',
 
+  // #569: image capture is its own opt-in, deliberately never folded into
+  // home.access above (Main's call, 2026-09-09) - see
+  // ImageCaptureAccessRow.svelte's own doc comment for why. The off-detail
+  // line says plainly that Chrome will ask for every site, not just
+  // LinkedIn, and why: captureVisibleTab is a browser-level capture of the
+  // visible tab, so Chrome will not scope it to one origin.
+  'home.image-access.on': 'Image-aware suggestions: on',
+  'home.image-access.off': 'Image-aware suggestions: off',
+  'home.image-access.on-detail':
+    'The assistant can look at the picture in a post before it suggests a comment.',
+  'home.image-access.off-detail':
+    'Chrome has no way to capture just LinkedIn - turning this on means answering Chrome\'s own "all sites" prompt, not a LinkedIn-only one. Skip it and the assistant just says it cannot see the image.',
+  'home.image-access.turn-on': 'Turn on',
+  'home.image-access.turn-off': 'Turn off',
+  'home.image-access.denied': 'Chrome did not grant access. You can ask again anytime.',
+  'home.image-access.request-failed': 'Could not ask Chrome for access. Try again.',
+
   // The state line at the top of home, one per state lib/home-state.ts can
   // derive. Every line names the state in words; every detail names what set
   // it (D21).

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -225,6 +225,19 @@ export const it = {
   'home.access.denied': 'Chrome non ha concesso l’accesso. Puoi richiederlo quando vuoi.',
   'home.access.request-failed': 'Impossibile chiedere a Chrome l’accesso a LinkedIn. Riprova.',
 
+  // #569: vedi dict-en.ts - la cattura immagine è un consenso separato,
+  // mai unito ad home.access sopra.
+  'home.image-access.on': 'Suggerimenti con immagini: attivi',
+  'home.image-access.off': 'Suggerimenti con immagini: non attivi',
+  'home.image-access.on-detail':
+    'L’assistente può guardare l’immagine di un post prima di suggerire un commento.',
+  'home.image-access.off-detail':
+    'Chrome non può catturare solo LinkedIn: attivarlo significa rispondere al prompt di Chrome per "tutti i siti", non uno specifico per LinkedIn. Se lo salti, l’assistente dice semplicemente che non può vedere l’immagine.',
+  'home.image-access.turn-on': 'Attiva',
+  'home.image-access.turn-off': 'Disattiva',
+  'home.image-access.denied': 'Chrome non ha concesso l’accesso. Puoi richiederlo quando vuoi.',
+  'home.image-access.request-failed': 'Impossibile chiedere a Chrome l’accesso. Riprova.',
+
   // La riga di stato in cima a home, una per ogni stato che
   // lib/home-state.ts sa derivare: la riga nomina lo stato, il dettaglio
   // nomina chi lo ha causato (D21).

--- a/extension/src/lib/permissions.ts
+++ b/extension/src/lib/permissions.ts
@@ -45,3 +45,39 @@ export function requestLinkedInPermission(): Promise<boolean> {
 export function revokeLinkedInPermission(): Promise<boolean> {
   return chrome.permissions.remove({ origins: [LINKEDIN_ORIGIN] });
 }
+
+// #569: image capture is its own opt-in, deliberately never folded into
+// LINKEDIN_ORIGIN above (Main's call, 2026-09-09). `chrome.tabs.captureVisibleTab`
+// refuses with "Either the '<all_urls>' or 'activeTab' permission is required"
+// even once the scoped LinkedIn origin above is granted - measured directly
+// against a real tab - and `activeTab` cannot substitute here: it only
+// activates on a browser-UI gesture (the toolbar icon, a context menu, the
+// commands API), never on the page-level click that triggers a capture (the
+// human clicking into LinkedIn's own comment box). So the only permission
+// that actually satisfies a content-script-triggered capture is `<all_urls>`,
+// already declared in `manifest.config.ts`'s `optional_host_permissions` -
+// this is a wider *runtime request*, not a wider static grant. Keeping it
+// out of `requestLinkedInPermission` matters: the one button an operator
+// presses to use the assistant at all must keep asking Chrome's narrowest
+// possible question, so declining the image feature never reads as
+// declining the assistant itself.
+export const IMAGE_CAPTURE_ORIGIN = '<all_urls>';
+
+/** The real current state, read from Chrome rather than assumed. */
+export function hasImageCapturePermission(): Promise<boolean> {
+  return chrome.permissions.contains({ origins: [IMAGE_CAPTURE_ORIGIN] });
+}
+
+/**
+ * Requests `<all_urls>`, for image capture only. Same user-gesture
+ * constraint as `requestLinkedInPermission` - call synchronously from the
+ * click, before any other `await` resolves.
+ */
+export function requestImageCapturePermission(): Promise<boolean> {
+  return chrome.permissions.request({ origins: [IMAGE_CAPTURE_ORIGIN] });
+}
+
+/** Revokes `<all_urls>`. Safe to call even if never granted. */
+export function revokeImageCapturePermission(): Promise<boolean> {
+  return chrome.permissions.remove({ origins: [IMAGE_CAPTURE_ORIGIN] });
+}

--- a/extension/src/sidepanel/components/ImageCaptureAccessRow.svelte
+++ b/extension/src/sidepanel/components/ImageCaptureAccessRow.svelte
@@ -1,0 +1,109 @@
+<!-- Image-aware suggestions as their own opt-in (#569), deliberately not
+     folded into LinkedInAccessRow above (Main's call, 2026-09-09): the
+     button that turns the assistant on at all must keep asking Chrome's
+     narrowest possible question, so declining the image feature never reads
+     as declining the assistant itself. `chrome.tabs.captureVisibleTab` is a
+     browser-level capture of the visible tab, so Chrome will not scope its
+     permission check to one origin the way it does for reading the page -
+     turning this on means answering Chrome's own "all sites" prompt, not a
+     LinkedIn-only one, and the copy below says so before the click rather
+     than leaving it to Chrome's bubble to explain.
+
+     Same posture as LinkedInAccessRow otherwise: state read back from
+     chrome.permissions rather than a local record of having asked, and the
+     request stays synchronous after the click for the same user-gesture
+     reason. -->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { Button } from '$ui/button';
+  import { t } from '$ext/i18n';
+  import {
+    hasImageCapturePermission,
+    requestImageCapturePermission,
+    revokeImageCapturePermission,
+  } from '$ext/permissions';
+
+  let granted = $state(false);
+  let busy = $state(false);
+  let denied = $state(false);
+  let requestFailed = $state(false);
+
+  async function refresh() {
+    granted = await hasImageCapturePermission();
+  }
+
+  onMount(() => {
+    refresh();
+    // Keeps this row honest if the permission is revoked from
+    // chrome://extensions while the panel is open, and after a grant made
+    // from elsewhere.
+    chrome.permissions.onAdded.addListener(refresh);
+    chrome.permissions.onRemoved.addListener(refresh);
+    return () => {
+      chrome.permissions.onAdded.removeListener(refresh);
+      chrome.permissions.onRemoved.removeListener(refresh);
+    };
+  });
+
+  async function turnOn() {
+    denied = false;
+    requestFailed = false;
+    busy = true;
+    try {
+      // Must run in this click's user-gesture context, so request before any
+      // other await resolves.
+      let ok: boolean;
+      try {
+        ok = await requestImageCapturePermission();
+      } catch {
+        requestFailed = true;
+        return;
+      }
+      if (!ok) {
+        denied = true;
+        return;
+      }
+      granted = true;
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function turnOff() {
+    busy = true;
+    try {
+      await revokeImageCapturePermission();
+      await refresh();
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-2">
+  <div class="flex items-center justify-between gap-2">
+    <div class="flex min-w-0 flex-col">
+      <span class="text-sm font-medium">
+        {granted ? $t('home.image-access.on') : $t('home.image-access.off')}
+      </span>
+      <span class="text-xs text-muted-foreground">
+        {granted ? $t('home.image-access.on-detail') : $t('home.image-access.off-detail')}
+      </span>
+    </div>
+    {#if granted}
+      <Button variant="ghost" size="sm" disabled={busy} onclick={turnOff}>
+        {$t('home.image-access.turn-off')}
+      </Button>
+    {:else}
+      <Button size="sm" disabled={busy} onclick={turnOn}>
+        {$t('home.image-access.turn-on')}
+      </Button>
+    {/if}
+  </div>
+  {#if denied}
+    <p class="text-xs text-destructive">{$t('home.image-access.denied')}</p>
+  {/if}
+  {#if requestFailed}
+    <p class="text-xs text-destructive">{$t('home.image-access.request-failed')}</p>
+  {/if}
+</div>

--- a/extension/src/sidepanel/routes/Dashboard.svelte
+++ b/extension/src/sidepanel/routes/Dashboard.svelte
@@ -17,6 +17,7 @@
   import { t } from '$ext/i18n';
   import PairingList from '../components/PairingList.svelte';
   import LinkedInAccessRow from '../components/LinkedInAccessRow.svelte';
+  import ImageCaptureAccessRow from '../components/ImageCaptureAccessRow.svelte';
   import HomeStateLine from '../components/HomeStateLine.svelte';
   import { getSettings, type Pairing } from '$ext/storage';
   import { getLinkedInAccessState } from '$ext/linkedin-access';
@@ -108,6 +109,16 @@
         <div class="flex flex-col gap-2 border-t pt-3">
           <LinkedInAccessRow onchange={(g) => (linkedInGranted = g)} />
         </div>
+
+        <!-- Image-aware suggestions (#569) only mean anything once LinkedIn
+             access itself is on - nothing runs on LinkedIn without that
+             grant regardless, so offering this first would be a control
+             with nothing to control yet. -->
+        {#if linkedInGranted}
+          <div class="flex flex-col gap-2 border-t pt-3">
+            <ImageCaptureAccessRow />
+          </div>
+        {/if}
 
         <div class="flex flex-col gap-2 border-t pt-3">
           <div class="flex items-center justify-between gap-2">

--- a/extension/tests/background/capture-post-media.test.ts
+++ b/extension/tests/background/capture-post-media.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { captureAndCropTabRegion } from '../../src/background/capture-post-media.js';
+import capturePostMediaSource from '../../src/background/capture-post-media.ts?raw';
+
+/**
+ * #569: the background half of "the post's image reaches the model as
+ * pixels from the human's own tab" - `chrome.tabs.captureVisibleTab` over
+ * the sender's own active tab, cropped and downscaled here, never a fetch of
+ * anything. Node has neither `OffscreenCanvas` nor `createImageBitmap`, so
+ * the encode pipeline is exercised against fakes; the guard clauses (wrong
+ * tab, capture failure) need no canvas at all and run against the real
+ * `chrome.tabs` mock alone.
+ */
+
+let tabs: Record<number, { id: number; active: boolean; windowId: number }>;
+let captureVisibleTab = vi.fn<() => Promise<string>>();
+
+const chromeMock = {
+  tabs: {
+    get: vi.fn(async (id: number) => {
+      const tab = tabs[id];
+      if (!tab) throw new Error('no such tab');
+      return tab;
+    }),
+    captureVisibleTab: (..._args: unknown[]) => captureVisibleTab(),
+  },
+};
+const globalWithChrome = globalThis as unknown as { chrome: typeof chrome };
+globalWithChrome.chrome = chromeMock as unknown as typeof chrome;
+
+beforeEach(() => {
+  tabs = { 1: { id: 1, active: true, windowId: 10 } };
+  captureVisibleTab = vi.fn(async () => `data:image/png;base64,${btoa('fake-png-bytes')}`);
+});
+
+const BASE_PARAMS = {
+  tabId: 1,
+  windowId: 10,
+  rect: { x: 0, y: 0, width: 400, height: 300 },
+  devicePixelRatio: 2,
+  maxLongEdgePx: 1024,
+};
+
+describe('captureAndCropTabRegion (#569): guard clauses need no canvas at all', () => {
+  it('refuses without capturing when the sender tab is no longer the active one', async () => {
+    tabs[1].active = false;
+    const result = await captureAndCropTabRegion(BASE_PARAMS);
+    expect(result).toEqual({ ok: false });
+    expect(captureVisibleTab).not.toHaveBeenCalled();
+  });
+
+  it('refuses without capturing when the sender tab has moved to a different window', async () => {
+    tabs[1].windowId = 99;
+    const result = await captureAndCropTabRegion(BASE_PARAMS);
+    expect(result).toEqual({ ok: false });
+    expect(captureVisibleTab).not.toHaveBeenCalled();
+  });
+
+  it('refuses when chrome.tabs.get itself rejects (the tab closed mid-flight)', async () => {
+    const result = await captureAndCropTabRegion({ ...BASE_PARAMS, tabId: 404 });
+    expect(result).toEqual({ ok: false });
+  });
+
+  it('refuses when captureVisibleTab throws - the "tab not visible" case #569 names', async () => {
+    captureVisibleTab.mockImplementation(async () => {
+      throw new Error('Cannot access contents of the page');
+    });
+    const result = await captureAndCropTabRegion(BASE_PARAMS);
+    expect(result).toEqual({ ok: false });
+  });
+
+  it('refuses when captureVisibleTab resolves empty', async () => {
+    captureVisibleTab.mockImplementation(async () => '');
+    const result = await captureAndCropTabRegion(BASE_PARAMS);
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+describe('captureAndCropTabRegion (#569): the crop/downscale/encode pipeline', () => {
+  let bitmapClose: () => void;
+  let convertToBlob: (opts: unknown) => Promise<Blob>;
+  let convertToBlobCalls: number;
+  let canvasSizes: Array<{ width: number; height: number }>;
+
+  function stubCanvasPipeline(blobBytesPerAttempt: number[]): void {
+    convertToBlobCalls = 0;
+    convertToBlob = async () => {
+      const size =
+        blobBytesPerAttempt[Math.min(convertToBlobCalls, blobBytesPerAttempt.length - 1)];
+      convertToBlobCalls += 1;
+      return new Blob([new Uint8Array(size)], { type: 'image/jpeg' });
+    };
+    canvasSizes = [];
+    bitmapClose = vi.fn();
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn(async () => ({ width: 1200, height: 900, close: bitmapClose })),
+    );
+    vi.stubGlobal(
+      'OffscreenCanvas',
+      class {
+        width: number;
+        height: number;
+        constructor(width: number, height: number) {
+          this.width = width;
+          this.height = height;
+          canvasSizes.push({ width, height });
+        }
+        getContext() {
+          return { drawImage: vi.fn() };
+        }
+        convertToBlob(opts: unknown) {
+          return convertToBlob(opts);
+        }
+      },
+    );
+  }
+
+  it('returns a data URL under the cap and releases the decoded bitmap', async () => {
+    stubCanvasPipeline([100]);
+    const result = await captureAndCropTabRegion(BASE_PARAMS);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.dataUrl).toMatch(/^data:image\/jpeg;base64,/);
+    expect(bitmapClose).toHaveBeenCalledOnce();
+    // rect (400x300 css px) x devicePixelRatio 2 = 800x600 source pixels;
+    // under the 1024px cap on the longest edge, so no downscale on attempt 1.
+    expect(canvasSizes[0]).toEqual({ width: 800, height: 600 });
+  });
+
+  // Hostile fixture (#569 acceptance): a crop that would encode past
+  // MAX_IMAGE_DATA_URL_CHARS at every attempted quality/size must never be
+  // handed back anyway - the cap wins over "return something".
+  it('gives up rather than returning a data URL past the cap, having tried every encode attempt', async () => {
+    stubCanvasPipeline([300_000, 300_000, 300_000]);
+    const result = await captureAndCropTabRegion(BASE_PARAMS);
+    expect(result).toEqual({ ok: false });
+    expect(convertToBlobCalls).toBe(3);
+    // Each attempt after the first uses the same or a smaller canvas.
+    expect(canvasSizes[2].width).toBeLessThanOrEqual(canvasSizes[0].width);
+  });
+
+  it('succeeds on a later, smaller/lower-quality attempt once the earlier ones are too large', async () => {
+    stubCanvasPipeline([300_000, 300_000, 100]);
+    const result = await captureAndCropTabRegion(BASE_PARAMS);
+    expect(result).toEqual({
+      ok: true,
+      dataUrl: expect.stringMatching(/^data:image\/jpeg;base64,/),
+    });
+    expect(convertToBlobCalls).toBe(3);
+  });
+
+  it('refuses when the crop rect falls entirely outside the decoded bitmap', async () => {
+    stubCanvasPipeline([100]);
+    const result = await captureAndCropTabRegion({
+      ...BASE_PARAMS,
+      rect: { x: 5000, y: 5000, width: 400, height: 300 },
+    });
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+describe('compliance: never a request toward linkedin.com/licdn.com', () => {
+  it('the source text carries no fetch/XHR/sendBeacon call at all', () => {
+    expect(capturePostMediaSource).not.toMatch(/fetch\(|XMLHttpRequest|sendBeacon/);
+  });
+});

--- a/extension/tests/content/linkedin-dom.test.ts
+++ b/extension/tests/content/linkedin-dom.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   detectPageKind,
   findFeedPosts,
@@ -11,6 +11,7 @@ import {
   findPostComposer,
   findPostComposerModal,
   findPostSubmitButton,
+  findPostMedia,
   readOwnProfileHandle,
   readOwnProfilePageHandle,
   readOwnProfile,
@@ -709,5 +710,127 @@ describe('readOwnPosts: synthetic markup', () => {
       </div>
     `);
     expect(readOwnPosts(document)).toEqual([]);
+  });
+});
+
+describe('findPostMedia (#569): synthetic markup', () => {
+  // Neither fixture contains a post with attached media (see
+  // fixtures/linkedin/README.md: images become empty `<img>` slots and the
+  // only ones either real capture actually has are profile avatars) - same
+  // disclaimer as `findCommentSubmitButton`/`findPostComposer` above, and
+  // the module's own doc comment on `findPostMedia` names it explicitly.
+  function stubRect(el: Element, width: number, height: number, onScreen = true): void {
+    const left = onScreen ? 0 : -9999;
+    const top = onScreen ? 0 : -9999;
+    const rect = {
+      top,
+      left,
+      right: left + width,
+      bottom: top + height,
+      width,
+      height,
+      x: left,
+      y: top,
+    };
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({ ...rect, toJSON: () => rect });
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal('innerWidth', 1000);
+    vi.stubGlobal('innerHeight', 800);
+  });
+
+  it('finds a substantial image and excludes the author avatar wrapped in a profile link', () => {
+    render(`
+      <div role="article" data-urn="urn:li:activity:7000000000000000001">
+        <a href="/in/example-person/"><img id="avatar" /></a>
+        <img id="media" alt="A chart showing quarterly growth" />
+      </div>
+    `);
+    const [post] = findFeedPosts(document);
+    stubRect(document.getElementById('avatar')!, 48, 48);
+    stubRect(document.getElementById('media')!, 400, 300);
+    const media = findPostMedia(post);
+    expect(media?.element.id).toBe('media');
+    expect(media?.kind).toBe('image');
+    expect(media?.alt).toBe('A chart showing quarterly growth');
+    expect(media?.partial).toBe(false);
+  });
+
+  it('returns null when the only substantial-sized element is the avatar', () => {
+    render(`
+      <div role="article" data-urn="urn:li:activity:7000000000000000001">
+        <a href="/in/example-person/"><img id="avatar" /></a>
+      </div>
+    `);
+    const [post] = findFeedPosts(document);
+    stubRect(document.getElementById('avatar')!, 400, 400);
+    expect(findPostMedia(post)).toBeNull();
+  });
+
+  it('excludes an image below the minimum rendered size (a reaction icon, not the post media)', () => {
+    render(`
+      <div role="article" data-urn="urn:li:activity:7000000000000000001">
+        <img id="icon" />
+      </div>
+    `);
+    const [post] = findFeedPosts(document);
+    stubRect(document.getElementById('icon')!, 24, 24);
+    expect(findPostMedia(post)).toBeNull();
+  });
+
+  it('reports a video element as video_frame, never as a plain image', () => {
+    render(`
+      <div role="article" data-urn="urn:li:activity:7000000000000000001">
+        <video id="clip"></video>
+      </div>
+    `);
+    const [post] = findFeedPosts(document);
+    stubRect(document.getElementById('clip')!, 400, 300);
+    expect(findPostMedia(post)?.kind).toBe('video_frame');
+  });
+
+  it('reports more than one substantial image as a carousel page, and picks the one on screen', () => {
+    render(`
+      <div role="article" data-urn="urn:li:activity:7000000000000000001">
+        <img id="onscreen" alt="page one" />
+        <img id="offscreen" alt="page two" />
+      </div>
+    `);
+    const [post] = findFeedPosts(document);
+    stubRect(document.getElementById('onscreen')!, 400, 300, true);
+    stubRect(document.getElementById('offscreen')!, 400, 300, false);
+    const media = findPostMedia(post);
+    expect(media?.kind).toBe('carousel_page');
+    expect(media?.partial).toBe(true);
+    expect(media?.element.id).toBe('onscreen');
+  });
+
+  it('falls back to an off-screen candidate when nothing intersects the viewport, so alt is still readable', () => {
+    render(`
+      <div role="article" data-urn="urn:li:activity:7000000000000000001">
+        <img id="scrolled-away" alt="scrolled out of view" />
+      </div>
+    `);
+    const [post] = findFeedPosts(document);
+    stubRect(document.getElementById('scrolled-away')!, 400, 300, false);
+    const media = findPostMedia(post);
+    expect(media?.element.id).toBe('scrolled-away');
+    expect(media?.alt).toBe('scrolled out of view');
+  });
+
+  it('records selector health for postMedia against a classic post-detail page', () => {
+    render(`
+      <div role="article" data-urn="urn:li:activity:7000000000000000001">
+        <img id="media" />
+      </div>
+    `);
+    const [post] = findFeedPosts(document);
+    stubRect(document.getElementById('media')!, 400, 300);
+    findPostMedia(post);
+    const entry = getSelectorHealthReport().find(
+      (e) => e.selector === 'postMedia' && e.pageKind === 'post-detail-classic',
+    );
+    expect(entry?.lastResult).toBe('match');
   });
 });

--- a/extension/tests/content/media-capture.test.ts
+++ b/extension/tests/content/media-capture.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { captureObservedImage } from '../../src/content/shared/media-capture.js';
+import mediaCaptureSource from '../../src/content/shared/media-capture.ts?raw';
+
+/**
+ * #569: the content-script half of "the post's image reaches the model as
+ * pixels from the human's own tab". `findPostMedia`'s own selector logic is
+ * covered by linkedin-dom.test.ts; this covers the three outcomes
+ * `captureObservedImage` can resolve to (see its own doc comment) and the
+ * hard cap on what a background-worker response is allowed to hand back.
+ */
+
+let sendMessageMock = vi.fn();
+let containsMock = vi.fn();
+const globalWithChrome = globalThis as unknown as { chrome: typeof chrome };
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  sendMessageMock = vi.fn();
+  containsMock = vi.fn(async () => true);
+  globalWithChrome.chrome = {
+    runtime: { sendMessage: sendMessageMock, lastError: undefined },
+    permissions: { contains: containsMock },
+  } as unknown as typeof chrome;
+  vi.stubGlobal('innerWidth', 1000);
+  vi.stubGlobal('innerHeight', 800);
+});
+
+function stubRect(el: Element, width: number, height: number, onScreen = true): void {
+  const left = onScreen ? 0 : -9999;
+  const top = onScreen ? 0 : -9999;
+  const rect = {
+    top,
+    left,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+    x: left,
+    y: top,
+  };
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({ ...rect, toJSON: () => rect });
+}
+
+/** Mimics the background worker's own callback-style `sendMessage` reply. */
+function respondWith(response: unknown): void {
+  sendMessageMock.mockImplementation((_msg: unknown, cb: (r: unknown) => void) => cb(response));
+}
+
+describe('captureObservedImage (#569)', () => {
+  it('returns undefined and never messages the background worker when the post has no substantial media', async () => {
+    document.body.innerHTML = '<div id="post"><p>Just text, no image.</p></div>';
+    const post = document.getElementById('post')!;
+    const image = await captureObservedImage(post, document);
+    expect(image).toBeUndefined();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to alt/kind with no dataUrl, and never messages the background worker, when the media is off-screen', async () => {
+    document.body.innerHTML = '<div id="post"><img id="media" alt="a chart" /></div>';
+    const post = document.getElementById('post')!;
+    stubRect(document.getElementById('media')!, 400, 300, false);
+    const image = await captureObservedImage(post, document);
+    expect(image).toEqual({ alt: 'a chart', kind: 'image', partial: false });
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to alt/kind with no dataUrl, and never messages the background worker, when the separate image-capture permission is not granted', async () => {
+    document.body.innerHTML = '<div id="post"><img id="media" alt="a chart" /></div>';
+    const post = document.getElementById('post')!;
+    stubRect(document.getElementById('media')!, 400, 300, true);
+    containsMock.mockResolvedValue(false);
+    const image = await captureObservedImage(post, document);
+    expect(image).toEqual({ alt: 'a chart', kind: 'image', partial: false });
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the full shape, dataUrl included, when the background worker captures successfully', async () => {
+    document.body.innerHTML = '<div id="post"><img id="media" alt="a chart" /></div>';
+    const post = document.getElementById('post')!;
+    stubRect(document.getElementById('media')!, 400, 300, true);
+    respondWith({ ok: true, dataUrl: 'data:image/jpeg;base64,AAAA' });
+    const image = await captureObservedImage(post, document);
+    expect(image).toEqual({
+      alt: 'a chart',
+      kind: 'image',
+      partial: false,
+      dataUrl: 'data:image/jpeg;base64,AAAA',
+    });
+  });
+
+  it('falls back to alt/kind with no dataUrl when the background worker reports it could not capture', async () => {
+    document.body.innerHTML = '<div id="post"><img id="media" alt="a chart" /></div>';
+    const post = document.getElementById('post')!;
+    stubRect(document.getElementById('media')!, 400, 300, true);
+    respondWith({ ok: false });
+    const image = await captureObservedImage(post, document);
+    expect(image).toEqual({ alt: 'a chart', kind: 'image', partial: false });
+  });
+
+  it('never used chrome.runtime.lastError-throwing sendMessage as a crash - a dead extension context degrades to the alt fallback', async () => {
+    document.body.innerHTML = '<div id="post"><img id="media" alt="a chart" /></div>';
+    const post = document.getElementById('post')!;
+    stubRect(document.getElementById('media')!, 400, 300, true);
+    sendMessageMock.mockImplementation(() => {
+      throw new Error('Extension context invalidated.');
+    });
+    const image = await captureObservedImage(post, document);
+    expect(image).toEqual({ alt: 'a chart', kind: 'image', partial: false });
+  });
+
+  // Hostile fixture (#569 acceptance): a background worker (or a crafted
+  // response from an untrusted extension context) that hands back a
+  // dataUrl past the extension's own cap must never have that cap silently
+  // widened - the oversized payload is dropped, not truncated and kept.
+  it('drops an oversized dataUrl from the background worker rather than forwarding it past the cap', async () => {
+    document.body.innerHTML = '<div id="post"><img id="media" alt="a chart" /></div>';
+    const post = document.getElementById('post')!;
+    stubRect(document.getElementById('media')!, 400, 300, true);
+    const oversized = `data:image/jpeg;base64,${'A'.repeat(300_000)}`;
+    respondWith({ ok: true, dataUrl: oversized });
+    const image = await captureObservedImage(post, document);
+    expect(image).toEqual({ alt: 'a chart', kind: 'image', partial: false });
+  });
+
+  it('never fetches or navigates toward linkedin.com/licdn.com, and never touches cookies or storage', () => {
+    expect(mediaCaptureSource).not.toMatch(/fetch\(|XMLHttpRequest|sendBeacon/);
+    expect(mediaCaptureSource).not.toMatch(
+      /document\.cookie|localStorage|sessionStorage|chrome\.cookies/,
+    );
+  });
+});

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -67,6 +67,47 @@ export interface ObservedPost {
   /** The visible comment thread (#568), when the page had one to read - the
    * SDUI feed never does (see linkedin-dom.ts's module header). */
   thread?: ObservedThread;
+  /** The post's own attached media, captured as pixels from the human's
+   * rendered tab (#569) - never fetched from a licdn URL, by either side;
+   * see docs/design/in-page-agent.md's "capture the rendered tab, never
+   * fetch licdn" rule. See `ObservedImage`'s own doc comment for what
+   * absence of each of its fields means. */
+  image?: ObservedImage;
+}
+
+/** What kind of rendered media `ObservedPost.image` is a crop of (#569), so
+ * a description doesn't overclaim: a video post shows one frame, never the
+ * video, and a carousel or document post shows whichever page LinkedIn
+ * currently has on screen, never every page. */
+export type ObservedImageKind = 'image' | 'video_frame' | 'carousel_page';
+
+/** The post's attached media (#569), present on `ObservedPost` whenever the
+ * post has visible media at all - independent of whether a capture of it
+ * actually reached us. Three states a consumer must handle, honestly
+ * distinct rather than collapsed into one "no image" case:
+ *
+ * - `dataUrl` set: real pixels, a `data:image/...;base64,...` URL the
+ *   extension downscaled and re-encoded before the request ever left the
+ *   browser, capped at `MAX_IMAGE_DATA_URL_CHARS` and re-enforced by the
+ *   same cap server-side rather than trusting that clamp.
+ * - `dataUrl` absent, `alt` set: the capture itself was unavailable
+ *   (permission not granted, the tab was not the active one, or the media
+ *   had scrolled out of the viewport) but LinkedIn rendered its own alt
+ *   text for it.
+ * - both absent: the post has media and neither a capture nor an alt text
+ *   reached us. There is an image nobody can describe, which is worth
+ *   stating to the model rather than pretending away.
+ *
+ * `ObservedPost.image` itself absent (not this type at all) means the post
+ * carries no media whatsoever - the one case that skips a vision call
+ * entirely, at no cost. */
+export interface ObservedImage {
+  dataUrl?: string;
+  alt?: string;
+  kind: ObservedImageKind;
+  /** True when this is one page of a multi-page carousel or document post -
+   * what is currently rendered, never every page. */
+  partial?: boolean;
 }
 
 /** One rendered comment or reply in `ObservedPost.thread` (#568), mirroring
@@ -132,6 +173,15 @@ export const MAX_POST_CHARS = 4000;
 export const MAX_THREAD_COMMENTS = 30;
 export const MAX_COMMENT_CHARS = 500;
 export const MAX_THREAD_CHARS = 6000;
+/** Hard ceiling on `ObservedImage.dataUrl`'s own character length (#569) - a
+ * downscaled, re-encoded crop meant for a vision model, not a retina asset.
+ * ~280 KB of base64 text is comfortably above what a JPEG crop capped at
+ * 1024px on its longest edge and re-encoded at moderate quality produces,
+ * and comfortably below anything that would bloat the request; past this
+ * either the extension's own clamp failed or the request is hostile, and
+ * the zod schema on `POST /api/extension/suggest` rejects it outright
+ * rather than trusting that clamp. */
+export const MAX_IMAGE_DATA_URL_CHARS = 280_000;
 /** How many few-shot examples are worth carrying. More lengthens the prompt
  * without changing the voice, and the first token is what the human waits on. */
 export const MAX_EXAMPLES = 3;

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -11,6 +11,7 @@ import { getAccountUsage, checkQuota, loadQuotaLimits } from '@pitchbox/shared/q
 import { mapDraftKindToQuotaKind } from '@pitchbox/shared/quota-types';
 import {
   MAX_COMMENT_CHARS,
+  MAX_IMAGE_DATA_URL_CHARS,
   MAX_POST_CHARS,
   MAX_THREAD_CHARS,
   MAX_THREAD_COMMENTS,
@@ -61,6 +62,26 @@ const ThreadSchema = z.object({
   truncated: z.boolean(),
 });
 
+// #569: the post's attached media, captured as pixels from the human's own
+// rendered tab - see docs/design/in-page-agent.md's "capture the rendered
+// tab, never fetch licdn" rule and `ObservedImage`'s own doc comment for
+// what each combination of present/absent fields means. `dataUrl` is
+// re-capped here rather than trusted from the extension's own clamp, same
+// posture as every other field on this schema.
+const ImageSchema = z.object({
+  dataUrl: z
+    .string()
+    .max(MAX_IMAGE_DATA_URL_CHARS)
+    .regex(
+      /^data:image\/(jpeg|png|webp);base64,/,
+      'post.image.dataUrl must be a base64 image data URL',
+    )
+    .optional(),
+  alt: z.string().max(1000).optional(),
+  kind: z.enum(['image', 'video_frame', 'carousel_page']),
+  partial: z.boolean().optional(),
+});
+
 const BodySchema = z
   .object({
     projectId: z.number().int().positive(),
@@ -81,6 +102,9 @@ const BodySchema = z
       reactionCount: z.string().max(100).optional(),
       commentCount: z.string().max(100).optional(),
       thread: ThreadSchema.optional(),
+      // #569: the post's attached media - see ImageSchema's own doc comment
+      // for what each combination of present/absent sub-fields means.
+      image: ImageSchema.optional(),
     }),
     hint: z.string().max(500).optional(),
     // #409: a panel-level retune direction, never a setting - see the

--- a/web/tests/extension-suggest-image.test.ts
+++ b/web/tests/extension-suggest-image.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type { AgentRunHandle, AgentRunOptions, AgentRunner } from '@pitchbox/shared/agents';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+import { DRAFT_MARKER } from '@pitchbox/shared/assist/envelope';
+import { MAX_IMAGE_DATA_URL_CHARS } from '@pitchbox/shared/assist/suggest-prompt';
+
+/**
+ * #569: the zod schema on POST /api/extension/suggest is the enforcement
+ * boundary for the post's attached media, not the extension's own clamp - a
+ * stale build or a crafted request must not reach the model with a payload
+ * past the cap, or one whose `dataUrl` isn't actually an image data URL.
+ * Kept in its own file for the same reason extension-suggest-thread.test.ts
+ * is: `perDevice`'s rate limiter is a module-level singleton shared by every
+ * test that imports the route within one process.
+ */
+
+const REASONING = 'Noticed the chart in the screenshot.';
+const DRAFT = 'That growth curve is the whole story.';
+const ENVELOPE_CHUNKS = [`${REASONING}\n`, DRAFT_MARKER, '\n', DRAFT];
+let responseChunks: string[] = ENVELOPE_CHUNKS;
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'fake',
+    run(opts: AgentRunOptions): AgentRunHandle {
+      for (const c of responseChunks) opts.onTextChunk?.(c);
+      return {
+        result: Promise.resolve({ exitCode: 0, logPath: '/dev/null' }),
+        cancel: () => {},
+      };
+    },
+  }),
+}));
+
+// Dynamic on purpose: `vi.mock` above is hoisted, but the route module has to
+// load after that mock is registered - a static import here would race it.
+// Same pattern as extension-suggest-thread.test.ts.
+const { POST: suggest } = await import('../src/routes/api/extension/suggest/+server.js');
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, contact_history, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+  responseChunks = ENVELOPE_CHUNKS;
+}
+
+async function seedOrgProject(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug, description: `about ${slug}` })
+    .returning();
+  await saveLinkedInAssistSettings(db, org.id, {
+    ...defaultLinkedInAssistSettings(),
+    enabled: true,
+    projectId: project.id,
+  });
+  return { org, project };
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({ organizationId, tokenHash: tokenHash(token), label: 'test' });
+}
+
+function request(token: string | null, body: unknown): Request {
+  return new Request('http://x/api/extension/suggest', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+const POST_BODY = {
+  kind: 'post_comment' as const,
+  post: {
+    urn: 'urn:li:activity:7000000000000000001',
+    authorName: 'Giulia Bianchi',
+    text: 'We cut p99 in half.',
+  },
+};
+
+describe('the attached image (#569): the schema rejects what the cap forbids', () => {
+  beforeEach(reset);
+
+  it('accepts an image within the cap and streams normally', async () => {
+    const { org, project } = await seedOrgProject('org-image-ok');
+    await mintDevice(org.id, 'tok-image-ok');
+
+    const res = await suggest({
+      request: request('tok-image-ok', {
+        ...POST_BODY,
+        projectId: project.id,
+        post: {
+          ...POST_BODY.post,
+          image: { dataUrl: 'data:image/jpeg;base64,AAAA', kind: 'image' },
+        },
+      }),
+    } as never);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+  });
+
+  it('accepts an image with no dataUrl at all - the capture-unavailable, alt-only fallback', async () => {
+    const { org, project } = await seedOrgProject('org-image-alt-only');
+    await mintDevice(org.id, 'tok-image-alt-only');
+
+    const res = await suggest({
+      request: request('tok-image-alt-only', {
+        ...POST_BODY,
+        projectId: project.id,
+        post: {
+          ...POST_BODY.post,
+          image: { alt: 'a bar chart', kind: 'image', partial: false },
+        },
+      }),
+    } as never);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+  });
+
+  // Hostile fixture (#569 acceptance): an oversized image, whether from a
+  // stale extension build or a crafted request, must never reach the model.
+  it('rejects a dataUrl longer than MAX_IMAGE_DATA_URL_CHARS', async () => {
+    const { org, project } = await seedOrgProject('org-image-oversized');
+    await mintDevice(org.id, 'tok-image-oversized');
+
+    const oversized = `data:image/jpeg;base64,${'A'.repeat(MAX_IMAGE_DATA_URL_CHARS + 1)}`;
+    await expect(
+      suggest({
+        request: request('tok-image-oversized', {
+          ...POST_BODY,
+          projectId: project.id,
+          post: { ...POST_BODY.post, image: { dataUrl: oversized, kind: 'image' } },
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('accepts a dataUrl exactly at the cap', async () => {
+    const { org, project } = await seedOrgProject('org-image-at-cap');
+    await mintDevice(org.id, 'tok-image-at-cap');
+
+    const prefix = 'data:image/jpeg;base64,';
+    const atCap = prefix + 'A'.repeat(MAX_IMAGE_DATA_URL_CHARS - prefix.length);
+    expect(atCap.length).toBe(MAX_IMAGE_DATA_URL_CHARS);
+
+    const res = await suggest({
+      request: request('tok-image-at-cap', {
+        ...POST_BODY,
+        projectId: project.id,
+        post: { ...POST_BODY.post, image: { dataUrl: atCap, kind: 'image' } },
+      }),
+    } as never);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+  });
+
+  it('rejects a dataUrl that is not an image data URL at all - a licdn URL handed over instead of pixels', async () => {
+    const { org, project } = await seedOrgProject('org-image-not-a-data-url');
+    await mintDevice(org.id, 'tok-image-not-a-data-url');
+
+    await expect(
+      suggest({
+        request: request('tok-image-not-a-data-url', {
+          ...POST_BODY,
+          projectId: project.id,
+          post: {
+            ...POST_BODY.post,
+            image: { dataUrl: 'https://media.licdn.com/dms/image/abc.jpg', kind: 'image' },
+          },
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects a media kind outside the three the extension can actually report', async () => {
+    const { org, project } = await seedOrgProject('org-image-bad-kind');
+    await mintDevice(org.id, 'tok-image-bad-kind');
+
+    await expect(
+      suggest({
+        request: request('tok-image-bad-kind', {
+          ...POST_BODY,
+          projectId: project.id,
+          post: { ...POST_BODY.post, image: { alt: 'x', kind: 'gif' } },
+        }),
+      } as never),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});


### PR DESCRIPTION
Closes #569.

## What changed

- **Content script** (`extension/src/content/shared/linkedin-dom.ts`): `findPostMedia` finds a post's own attached media - the largest substantial (>=120px) `img`/`video` that isn't inside a profile link (the avatar/byline wrapper pattern) or `aria-hidden`. More than one candidate means a carousel/document post; whichever one intersects the viewport is what LinkedIn actually has on screen right now.
- **Content script orchestration** (`extension/src/content/shared/media-capture.ts`): `captureObservedImage` - no media, no message, no cost. Media off-screen or the image-capture permission isn't granted, it returns `{ alt, kind, partial }` with no pixels. Otherwise it asks the background worker for a crop.
- **Background worker** (`extension/src/background/capture-post-media.ts`): `chrome.tabs.captureVisibleTab` on the sender's own tab (refusing outright if that tab is no longer the active one - the "tab not visible" case, since `captureVisibleTab(windowId)` captures whatever is active in that window, which would silently be the wrong tab otherwise), decodes the PNG with `createImageBitmap`, crops to the media's rect scaled by `devicePixelRatio`, downscales to 1024px on the longest edge, and re-encodes as JPEG at decreasing quality/size until the result fits the cap or gives up. No `fetch`, no `XMLHttpRequest`, nothing toward licdn anywhere in this path.
- **Transport**: `ObservedPost` gains an optional `image: ObservedImage` field (`shared/src/assist/suggest-prompt.ts`) - `dataUrl`/`alt`/`kind`/`partial`, each combination documented for what it means (real pixels / alt-only fallback / "there is an image you cannot see"). `MAX_IMAGE_DATA_URL_CHARS = 280_000` (~210 KB decoded), re-enforced by a zod schema on `POST /api/extension/suggest` rather than trusted from the extension's own clamp - a `dataUrl` past the cap, or one that isn't actually an `image/{jpeg,png,webp}` base64 data URL, is a 400.
- **Never stored**: the crop only ever exists in the request body handed to `runSuggestion`; nothing in this PR writes it anywhere.

## The permission finding (read before touching capture again)

`chrome.tabs.captureVisibleTab` refuses with *"Either the '\<all_urls\>' or 'activeTab' permission is required"* even once the existing scoped `*://*.linkedin.com/*` optional permission is granted - measured directly against a real signed-in LinkedIn tab, and it matches Chrome's own documented behavior. `activeTab` can't substitute: it only activates on a browser-UI gesture (the toolbar icon, a context menu, the commands API), never on the page-level click that triggers a capture here (the human clicking into LinkedIn's own comment box).

Given that, **image capture is its own opt-in**, deliberately not folded into the existing "Grant access" button (Main's call): that one button is the entire on-ramp to using the assistant at all, and it has to keep asking Chrome's narrowest possible question. A new `ImageCaptureAccessRow` in the extension side panel (right under `LinkedInAccessRow`, shown once LinkedIn access itself is on) requests/revokes `<all_urls>` on its own click, with copy that says plainly Chrome is about to ask for every site and why. `<all_urls>` was already declared in `manifest.config.ts`'s `optional_host_permissions` - this is a wider runtime *request*, not a wider static grant, and compliance rule 6 (which checks the static `host_permissions` list) is unaffected. Declining it costs nothing but the image feature: `captureObservedImage` checks the permission before even computing viewport overlap, and falls back to the alt-text/no-image case with no vision call and no cost.

## The three edge cases named in the issue

- **No image**: `findPostMedia` returns `null`, `ObservedPost.image` is absent entirely, no cost.
- **Several images / a document**: `kind: 'carousel_page'`, `partial: true`, and the crop is whichever page is actually rendered on screen right now - never every page.
- **Video**: `kind: 'video_frame'` on the `<video>` element itself (a poster/current frame, not the video), so the model isn't handed a description that overclaims.

## Verified

- `pnpm run test:linkedin-compliance` - 15/15 green, no rule relaxed (`tests/compliance/linkedin-boundary.test.ts` already scans the real `extension/src` tree, so my two new files are covered by "finds zero violations across the real repo").
- `pnpm exec vitest run extension/tests/content/linkedin-dom.test.ts extension/tests/content/media-capture.test.ts extension/tests/background/capture-post-media.test.ts extension/tests/lib/permissions.test.ts` - 81 passed. Covers: media selection (avatar exclusion, size floor, video, carousel, off-screen fallback), the three `captureObservedImage` outcomes, permission gating, and a hostile-fixture cap test on the background encode pipeline (an encode that would exceed the cap at every quality/size attempt is refused, never truncated-and-kept).
- `DATABASE_URL=postgres://pitchbox:pitchbox@127.0.0.1:5434/pitchbox_test_image pnpm exec vitest run web/tests/extension-suggest-image.test.ts` - 6 passed: accepts an image within the cap, accepts alt-only (no `dataUrl`), rejects a `dataUrl` one character over `MAX_IMAGE_DATA_URL_CHARS` (the hostile fixture), accepts one exactly at the cap, rejects a `dataUrl` that's a licdn URL instead of a data URL, rejects a `kind` outside the three real values.
- `pnpm -F @pitchbox/extension check`, `pnpm -F @pitchbox/shared typecheck`, `pnpm -F web check` - all clean.
- `pnpm run build:extension`, then `ls extension/dist/src/content/` - `linkedin-comment-assist.js` and `linkedin-post-assist.js` both built as IIFEs with no top-level `import`/`export`.
- **Live, on a real image post**: loaded the built extension via `Extensions.loadUnpacked` over raw CDP into `personal-b` (a clone profile, to avoid colliding with siblings on `personal`), granted LinkedIn access and then image-capture access through the real side-panel gesture flow (including the native Chrome permission bubble via `xdotool`), navigated to `linkedin.com/feed/`, found a real post's image (`alt="Visualizza immagine"`, not wrapped in a profile link, exactly the shape `findPostMedia` targets), and drove the real capture message end to end against the real service worker: **a 550x519 CSS-px crop produced a `data:image/jpeg;base64,...` data URL of 44,603 characters** (~33 KB decoded, comfortably under the 280,000-char cap).

## Deliberately left

- The vision call itself (`look_at_image`) is #567/AssistTools - merged as PR #601, `ObservedImage` shape landed exactly as agreed over `hub`.
- No fixture in `extension/tests/content/fixtures/linkedin/` shows a post with real attached media (both captures predate this feature and only ever show profile-avatar `<img>`s), so `findPostMedia` is unit-tested against synthetic markup, same disclaimer this file already carries for `findCommentComposer`/`findPostComposer`. The live-profile check above is what actually exercises it against real markup.
- No dedicated UI screenshot of the new side-panel row post-rebuild: the second `Extensions.loadUnpacked` reload invalidated my CDP session before I re-attached (a known, documented trap), and I prioritized the functional end-to-end capture proof over re-establishing a fresh session for a screenshot under time pressure. `svelte-check` passed clean on the component and it's a line-for-line structural mirror of the already-shipped, already-screenshotted `LinkedInAccessRow`.
- Distinguishing a photo carousel from a PDF/document post at the `kind` level: both render through the same paginated-viewer shape from a DOM perspective and nothing I could find distinguishes them reliably without a real capture of that specific post type, so both report as `carousel_page`.
