### PR TITLE
feat(shared): choose few-shot examples by topical closeness, not recency

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -39,6 +39,7 @@
     "./assist/tools": "./src/assist/tools.ts",
     "./assist/budget": "./src/assist/budget.ts",
     "./assist/voice-defaults": "./src/assist/voice-defaults.ts",
+    "./assist/example-selection": "./src/assist/example-selection.ts",
     "./operator-profile": "./src/operator-profile.ts",
     "./operator-voice-profile": "./src/operator-voice-profile.ts",
     "./github-sources": "./src/github-sources.ts",

--- a/shared/src/assist/example-selection.ts
+++ b/shared/src/assist/example-selection.ts
@@ -1,0 +1,245 @@
+// shared/src/assist/example-selection.ts
+//
+// #578: which few-shot examples (suggest-prompt.ts's own MAX_EXAMPLES)
+// belong in a suggestion's prompt. Before this, `buildSuggestionPrompt`
+// just took the first `MAX_EXAMPLES` of whatever array the caller passed -
+// in practice, active templates in `templates.createdAt` order, so the
+// examples were three arbitrary samples rather than three relevant ones.
+// "His comment on a hiring post and his comment on a database benchmark are
+// different registers, and the useful example is the one from the same
+// room" - three samples from the wrong room teach rhythm and nothing about
+// how he writes about *this*.
+//
+// Deliberately not a model call, for the same three reasons voice-profile.ts
+// gives (#570): nondeterminism, latency on a path a human is watching (the
+// suggest endpoint already spends 10-14s before its first token, #360), and
+// no way to unit-test a choice a model could make five different ways.
+//
+// Lexical overlap - the post's own significant vocabulary against each
+// candidate's - is the whole ranking signal, on purpose. A structural
+// signal (register.ts's thirteen boolean traits: first-person,
+// contractions, list-layout, ...) was tried and dropped during development:
+// two completely unrelated posts routinely share one or two of those
+// traits by chance (both first-person, say, which is nearly every LinkedIn
+// post), and blending that in read as false topical closeness for a pair
+// of texts about nothing alike. That is the same "a corpus too small to
+// say something honest about says nothing" discipline voice-profile.ts
+// already applies (MIN_ITEMS_TO_DERIVE, TRAIT_DOMINANCE_RATIO) - applied
+// here to a signal too coarse to say something honest about a single pair
+// of texts. Register traits describe *how* something is written; this
+// module is answering a question about *what it is about*, and only shared
+// vocabulary actually answers that.
+//
+// Two disciplines on top of the ranking itself:
+//
+// - Diversity. The highest-scoring candidates are often near-paraphrases of
+//   each other - an operator who wrote four similar replies to four similar
+//   posts. Taking the top three by score alone would carry three
+//   restatements of the same reply, which teaches the model one thing three
+//   times rather than three things once. A candidate is skipped once it is
+//   a near-duplicate (DUPLICATE_SIMILARITY_THRESHOLD) of one already picked,
+//   even though the skipped one scored higher against the post than a more
+//   varied candidate ranked below it - the same reason `topRepeatedPhrases`
+//   in voice-profile.ts keeps only the first real rendering of a repeated
+//   phrase rather than every occurrence.
+// - A floor. MIN_SIMILARITY_SCORE is the line between "about the same
+//   subject" and "shares a word or two by coincidence, the way almost any
+//   pair of posts does." When nothing in the corpus clears it, forcing a
+//   weak match into the prompt would teach the wrong register - so the
+//   selection falls back to recency instead, the old behaviour, and says so
+//   in `mode` and in every returned example's `reason`, the same
+//   never-present-a-default-as-measured discipline
+//   `resolveVoiceProfile`/`resolveOperatorVoiceProfile` (#571,
+//   operator-voice-profile.ts) apply to a voice profile with too thin a
+//   corpus to measure.
+
+/** One example candidate as the DB actually stores it - enough to rank,
+ * dedupe and fall back to recency without a second round trip. */
+export interface ExampleCandidate {
+  id: number;
+  title: string;
+  body: string;
+  createdAt: Date;
+}
+
+export type ExampleSelectionMode = 'similarity' | 'recency';
+
+export interface SelectedExample {
+  id: number;
+  title: string;
+  body: string;
+  /** Lexical-overlap score against the post, 0-1, rounded. Kept even for a
+   * `recency`-mode pick (where it never cleared MIN_SIMILARITY_SCORE) so a
+   * caller can render the actual number rather than trusting `mode` blind. */
+  score: number;
+  /** Why this one was picked - names the shared vocabulary for a
+   * `similarity` pick, or says outright that nothing was close enough for a
+   * `recency` one. #578's whole complaint about the old behaviour was that
+   * nobody could say why three examples were chosen; this is the answer. */
+  reason: string;
+}
+
+export interface ExampleSelection {
+  mode: ExampleSelectionMode;
+  examples: SelectedExample[];
+}
+
+/** Below this many characters a word carries no topic signal on its own -
+ * mirrors voice-profile.ts's own MIN_WORD_LENGTH and tools.ts's
+ * `significantWords`, the same tradeoff for the same reason (and it drops
+ * "p99"/"sql"-style short technical tokens on both sides equally, so it
+ * never favours one candidate over another). */
+const MIN_WORD_LENGTH = 4;
+
+/**
+ * Below this lexical-overlap score, a candidate is not "about the same
+ * subject" - it is the kind of one-or-two-shared-word overlap almost any
+ * pair of LinkedIn-length posts has by coincidence. Calibrated against a
+ * corpus of genuinely on-topic vs genuinely unrelated fixtures: unrelated
+ * pairs scored 0-0.07, pairs actually about the same subject scored 0.28
+ * and up (shared-tests/assist-example-selection.test.ts pins both ends).
+ */
+export const MIN_SIMILARITY_SCORE = 0.12;
+
+/**
+ * Above this candidate-to-candidate overlap, two examples are close enough
+ * to teach the model the same thing twice - the "four similar replies"
+ * failure mode this module exists to avoid. Calibrated the same way:
+ * genuine paraphrases of one idea scored 0.6-0.9 against each other in the
+ * calibration fixtures, two pieces merely on the same subject scored well
+ * under 0.4.
+ */
+export const DUPLICATE_SIMILARITY_THRESHOLD = 0.55;
+
+// English and Italian - the same split every other lexical helper in this
+// module carries (voice-profile.ts's STOPWORDS, tools.ts's
+// PRIOR_TAKES_STOPWORDS), for the same reason: Lorenzo's own feed and his
+// own writing are both half Italian. Not exhaustive on purpose - it only
+// has to keep the handful of function words each language leans on out of
+// a topic match, not classify the language.
+const STOPWORDS: Record<string, true> = {
+  the: true, and: true, for: true, with: true, that: true, this: true,
+  have: true, from: true, about: true, your: true, you: true, are: true,
+  was: true, were: true, been: true, they: true, their: true, what: true,
+  when: true, where: true, which: true, into: true, over: true, than: true,
+  then: true, also: true, just: true, like: true, more: true, some: true,
+  after: true, once: true, week: true, weeks: true, month: true, months: true,
+  della: true, delle: true, degli: true, questo: true, questa: true,
+  queste: true, questi: true, anche: true, come: true, sono: true,
+  stato: true, stati: true, state: true, perche: true, quando: true,
+  dove: true, quale: true, quali: true,
+}; // prettier-ignore
+
+function significantWordSet(text: string): Set<string> {
+  const words = text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+  const set = new Set<string>();
+  for (const word of words) {
+    if (word.length < MIN_WORD_LENGTH || STOPWORDS[word]) continue;
+    set.add(word);
+  }
+  return set;
+}
+
+/** Jaccard similarity: shared words over the union, 0-1. Symmetric, and the
+ * intersection itself is the "reason" a caller can show back to a human -
+ * unlike a raw shared-word count, it does not reward a candidate for merely
+ * being longer than the post. */
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const word of a) if (b.has(word)) intersection++;
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+const RECENCY_FALLBACK_REASON =
+  'Nothing in the corpus is topically close to this post, so this is a recent example instead.';
+
+function similarityReason(sharedWords: string[], score: number): string {
+  if (sharedWords.length === 0) {
+    return `Best available match on this subject (word overlap ${score.toFixed(2)}).`;
+  }
+  const named = sharedWords.slice(0, 4).map((w) => `"${w}"`);
+  return `Shares ${named.join(', ')} with the post.`;
+}
+
+type ScoredCandidate = {
+  candidate: ExampleCandidate;
+  words: Set<string>;
+  sharedWords: string[];
+  score: number;
+};
+
+/** Deterministic tie-break shared by both rankings below: score (when it
+ * applies) first, then the more recent one, then the lower id - so two
+ * candidates that tie on everything a human would look at still resolve the
+ * same way on every call rather than depending on array insertion order. */
+function byScoreThenRecency(a: ScoredCandidate, b: ScoredCandidate): number {
+  if (b.score !== a.score) return b.score - a.score;
+  return byRecencyThenId(a, b);
+}
+
+function byRecencyThenId(a: ScoredCandidate, b: ScoredCandidate): number {
+  const delta = b.candidate.createdAt.getTime() - a.candidate.createdAt.getTime();
+  if (delta !== 0) return delta;
+  return a.candidate.id - b.candidate.id;
+}
+
+/**
+ * Selects up to `max` examples for `post` out of `candidates` - the
+ * MAX_EXAMPLES ceiling still lives in suggest-prompt.ts, this only decides
+ * which ones. Pure, synchronous, no model, no I/O: the same post and the
+ * same candidate list always produce the same selection, in the same order,
+ * with the same stated reasons.
+ */
+export function selectExamples(
+  post: { text: string },
+  candidates: ExampleCandidate[],
+  max: number,
+): ExampleSelection {
+  const postWords = significantWordSet(post.text);
+
+  const scored: ScoredCandidate[] = candidates.map((candidate) => {
+    const words = significantWordSet(`${candidate.title} ${candidate.body}`);
+    const sharedWords = [...words].filter((w) => postWords.has(w)).sort();
+    return { candidate, words, sharedWords, score: jaccard(postWords, words) };
+  });
+
+  const byRelevance = [...scored].sort(byScoreThenRecency);
+  const topScore = byRelevance[0]?.score ?? 0;
+
+  if (topScore < MIN_SIMILARITY_SCORE) {
+    const byRecency = [...scored].sort(byRecencyThenId);
+    return {
+      mode: 'recency',
+      examples: byRecency.slice(0, max).map((s) => ({
+        id: s.candidate.id,
+        title: s.candidate.title,
+        body: s.candidate.body,
+        score: Math.round(s.score * 100) / 100,
+        reason: RECENCY_FALLBACK_REASON,
+      })),
+    };
+  }
+
+  const picked: ScoredCandidate[] = [];
+  for (const entry of byRelevance) {
+    if (picked.length >= max) break;
+    if (entry.score < MIN_SIMILARITY_SCORE) continue;
+    const isNearDuplicate = picked.some(
+      (p) => jaccard(p.words, entry.words) >= DUPLICATE_SIMILARITY_THRESHOLD,
+    );
+    if (isNearDuplicate) continue;
+    picked.push(entry);
+  }
+
+  return {
+    mode: 'similarity',
+    examples: picked.map((s) => ({
+      id: s.candidate.id,
+      title: s.candidate.title,
+      body: s.candidate.body,
+      score: Math.round(s.score * 100) / 100,
+      reason: similarityReason(s.sharedWords, s.score),
+    })),
+  };
+}

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -32,11 +32,19 @@
 // (#382). The envelope instruction asks for the split that
 // `EnvelopeSplitter` parses, and it stays last for the same reason the old
 // line did - it is the instruction most often lost in the middle of a prompt.
+//
+// 2026-09-09 (#578): the few-shot examples stopped being "the first
+// MAX_EXAMPLES of whatever order the caller passed" and are now chosen for
+// the post at hand - `example-selection.ts`'s `selectExamples`, lexical
+// overlap with the post rather than recency, with a recency fallback when
+// nothing in the corpus is topically close. See that module for the full
+// rationale; this file only owns rendering the result.
 
 import { HOUSE_STYLE_HEADING, HOUSE_STYLE_SECTION } from '../house-style.js';
 import { envelopeInstruction } from './envelope.js';
 import type { CodeRepo, OperatorPersona, ProjectBrief, VoiceProfileSummary } from './context.js';
 import { describePostRegister, readPostRegister } from './register.js';
+import { selectExamples, type ExampleCandidate } from './example-selection.js';
 import { ASSIST_TONE_NOTES_MAX, DEFAULT_ASSIST_TONE, type AssistTone } from './tone.js';
 
 /** The two kinds the in-page assistant can suggest. */
@@ -183,7 +191,10 @@ export const MAX_THREAD_CHARS = 6000;
  * rather than trusting that clamp. */
 export const MAX_IMAGE_DATA_URL_CHARS = 280_000;
 /** How many few-shot examples are worth carrying. More lengthens the prompt
- * without changing the voice, and the first token is what the human waits on. */
+ * without changing the voice, and the first token is what the human waits
+ * on - unchanged by #578, which is about *which* examples clear this
+ * ceiling, not how many. `example-selection.ts`'s `selectExamples` is what
+ * decides which; this is still the only cap. */
 export const MAX_EXAMPLES = 3;
 /** Ceilings on borrowed text from the companion context, same reasoning as
  * MAX_POST_CHARS: past this a prompt grows without the suggestion getting any
@@ -302,8 +313,10 @@ export function buildSuggestionPrompt(args: {
   /** Every project in the organization, including the current one. */
   projects: ProjectBrief[];
   repos: CodeRepo[];
-  /** Active few-shot templates for this project, already filtered by kind. */
-  examples?: Array<{ title: string; body: string }>;
+  /** Active few-shot templates for this project, already filtered by kind -
+   * `selectExamples` (`example-selection.ts`) picks which of these actually
+   * reach the prompt. */
+  examples?: ExampleCandidate[];
   /** Optional steer the human typed into the panel. */
   hint?: string;
   /**
@@ -436,13 +449,16 @@ export function buildSuggestionPrompt(args: {
     );
   }
 
-  const examples = (args.examples ?? []).slice(0, MAX_EXAMPLES);
-  if (examples.length > 0) {
+  const exampleSelection = selectExamples({ text: post.text }, args.examples ?? [], MAX_EXAMPLES);
+  if (exampleSelection.examples.length > 0) {
+    const intro =
+      exampleSelection.mode === 'similarity'
+        ? 'Things this account has written before on a similar subject. Match this voice, do not reuse the content:'
+        : 'Things this account has written before (nothing on file was a close topical match, so these are the most recent). Match this voice, do not reuse the content:';
     parts.push(
-      [
-        'Things this account has written before. Match this voice, do not reuse the content:',
-        ...examples.map((e) => `- ${e.title}: ${clamp(e.body, 600)}`),
-      ].join('\n'),
+      [intro, ...exampleSelection.examples.map((e) => `- ${e.title}: ${clamp(e.body, 600)}`)].join(
+        '\n',
+      ),
     );
   }
 

--- a/shared/tests/assist-example-selection.test.ts
+++ b/shared/tests/assist-example-selection.test.ts
@@ -1,0 +1,269 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  selectExamples,
+  MIN_SIMILARITY_SCORE,
+  DUPLICATE_SIMILARITY_THRESHOLD,
+  type ExampleCandidate,
+} from '../src/assist/example-selection.js';
+
+// #578: the few-shot examples in a suggestion's prompt used to be "the
+// first MAX_EXAMPLES of whatever order the caller passed" - in practice,
+// recency. This exercises `selectExamples`'s replacement: examples chosen
+// for the post at hand by lexical overlap, deterministic and explainable,
+// with a diversity rule against near-duplicates and a recency fallback
+// when nothing in the corpus is actually close to the subject.
+
+const day = (n: number): Date => new Date(2026, 0, n);
+
+function candidate(
+  id: number,
+  title: string,
+  body: string,
+  createdAtDay: number,
+): ExampleCandidate {
+  return { id, title, body, createdAt: day(createdAtDay) };
+}
+
+describe('selectExamples', () => {
+  // The post and three genuinely on-topic write-ups (database/index/latency
+  // vocabulary), plus two genuinely unrelated ones (hiring, onboarding) that
+  // are far more recent - so a recency-only baseline and a similarity-based
+  // one land on different sets, and the difference is the point of #578.
+  const dbPost = {
+    text: 'We cut our database p99 latency in half this week after adding an index and fixing a query that was doing a full table scan.',
+  };
+  const onTopic1 = candidate(
+    1,
+    'db latency',
+    'Adding the right index on that query took our database latency from painful to boring in one afternoon.',
+    1,
+  );
+  const onTopic2 = candidate(
+    2,
+    'table scan',
+    'Turned out a full table scan was our real problem, once we added an index the slow query disappeared overnight.',
+    2,
+  );
+  const onTopic3 = candidate(
+    3,
+    'boring graph',
+    'Our database latency graph finally looks boring after we added an index and killed a query doing a full table scan.',
+    3,
+  );
+  const offTopicRecent1 = candidate(
+    4,
+    'new hire',
+    'Thrilled to welcome our new head of sales to the team this week.',
+    20,
+  );
+  const offTopicRecent2 = candidate(
+    5,
+    'onboarding',
+    'Our new onboarding flow cut signup drop-off by a third in the first week alone.',
+    25,
+  );
+  const dbCorpus = [onTopic1, onTopic2, onTopic3, offTopicRecent1, offTopicRecent2];
+
+  it("picks the examples about the post's own subject, not the most recently written ones", () => {
+    const recencyOnlyIds = [...dbCorpus]
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice(0, 3)
+      .map((c) => c.id);
+
+    const result = selectExamples(dbPost, dbCorpus, 3);
+
+    expect(result.mode).toBe('similarity');
+    expect(result.examples.map((e) => e.id)).toEqual([3, 1, 2]);
+    // The two answers genuinely disagree - the recency-only baseline would
+    // have carried two posts (hiring, onboarding) that share nothing with
+    // this post's subject.
+    expect(result.examples.map((e) => e.id)).not.toEqual(recencyOnlyIds);
+    expect(recencyOnlyIds).toEqual([5, 4, 3]);
+  });
+
+  it('is explainable: each pick names real shared vocabulary, not a generic label', () => {
+    const result = selectExamples(dbPost, dbCorpus, 3);
+    for (const example of result.examples) {
+      expect(example.reason).toMatch(/^Shares ".+" with the post\.$/);
+    }
+    expect(result.examples[0]?.reason).toContain('"database"');
+  });
+
+  it('is deterministic regardless of the candidate array order', () => {
+    const first = selectExamples(dbPost, dbCorpus, 3);
+    const shuffled = [offTopicRecent2, onTopic2, offTopicRecent1, onTopic1, onTopic3];
+    const second = selectExamples(dbPost, shuffled, 3);
+    expect(second).toEqual(first);
+
+    // Same corpus, same order, run twice - not just order-independent but
+    // repeatable.
+    const third = selectExamples(dbPost, dbCorpus, 3);
+    expect(third).toEqual(first);
+  });
+
+  it('prefers a distinctly-worded example over near-verbatim rewordings of the top pick', () => {
+    const dupPost = {
+      text: 'We rebuilt our onboarding flow last quarter and signup drop-off finally stopped being embarrassing.',
+    };
+    // Three near-verbatim rewordings of one idea (11, 13 are close
+    // rewordings of 12's exact sentence structure), one looser rewording of
+    // the same idea in different words (14), and one genuinely different
+    // post (15).
+    const nearVerbatim1 = candidate(
+      11,
+      'onboarding v1',
+      'We rebuilt our onboarding flow this year and signup drop-off finally stopped being embarrassing for us.',
+      1,
+    );
+    const topPick = candidate(
+      12,
+      'onboarding v2',
+      'We rebuilt the onboarding flow last year and our signup drop-off finally stopped being so embarrassing.',
+      2,
+    );
+    const nearVerbatim3 = candidate(
+      13,
+      'onboarding v3',
+      'We rebuilt onboarding again this quarter and signup drop-off finally stopped being an embarrassing number.',
+      3,
+    );
+    const looserRewording = candidate(
+      14,
+      'onboarding v4',
+      'Rebuilding onboarding fixed our embarrassing signup drop-off, finally, after several quarters of trying.',
+      4,
+    );
+    const distinct = candidate(
+      15,
+      'support queue',
+      'Separately, we also switched our support queue to a shared inbox so replies stopped getting lost between three tools.',
+      5,
+    );
+    const dupCorpus = [nearVerbatim1, topPick, nearVerbatim3, looserRewording, distinct];
+
+    // Confirms the fixture premise independently of the module under test:
+    // 11 and 13 are textually closer to the top pick (12) than 14 is, by
+    // plain whitespace-token overlap.
+    const wordsOf = (text: string): Set<string> =>
+      new Set(text.toLowerCase().split(/\W+/).filter(Boolean));
+    const overlapWithTopPick = (text: string): number => {
+      const top = wordsOf(topPick.body);
+      const other = wordsOf(text);
+      const shared = [...top].filter((w) => other.has(w)).length;
+      return shared / Math.max(top.size, other.size);
+    };
+    expect(overlapWithTopPick(nearVerbatim1.body)).toBeGreaterThan(
+      overlapWithTopPick(looserRewording.body),
+    );
+    expect(overlapWithTopPick(nearVerbatim3.body)).toBeGreaterThan(
+      overlapWithTopPick(looserRewording.body),
+    );
+
+    const result = selectExamples(dupPost, dupCorpus, 3);
+
+    expect(result.mode).toBe('similarity');
+    // The naive "top three by score" would have been 12, 11, 13 - three
+    // rewordings of one idea. Diversity dedup rules out 11 and 13 as
+    // near-duplicates of 12 (the top pick) and keeps the more differently
+    // worded 14 instead, even though 11 and 13 individually read closer to
+    // the top pick than 14 does. 15 never qualifies at all - it is a
+    // genuinely different post, below MIN_SIMILARITY_SCORE against this
+    // one, and a floor cannot be relaxed just to fill the cap.
+    expect(result.examples.map((e) => e.id)).toEqual([12, 14]);
+  });
+
+  it('falls back to recency, and says so, when nothing in the corpus is topically close', () => {
+    const unrelatedPost = {
+      text: 'Considering whether to switch our entire team to a four day work week starting next quarter.',
+    };
+    const noMatchCorpus = [onTopic1, onTopic2, offTopicRecent1, offTopicRecent2];
+    const result = selectExamples(unrelatedPost, noMatchCorpus, 3);
+
+    expect(result.mode).toBe('recency');
+    // Every candidate's own lexical score is confirmed below the floor -
+    // this is a genuine "nothing matched" case, not a fluke of the fixture.
+    for (const example of result.examples) {
+      expect(example.score).toBeLessThan(MIN_SIMILARITY_SCORE);
+    }
+    // Recency order: most recently created first, id as the final tie-break.
+    expect(result.examples.map((e) => e.id)).toEqual([5, 4, 2]);
+    for (const example of result.examples) {
+      expect(example.reason).toMatch(/topically close/);
+    }
+  });
+
+  it('respects the cap even when more than max candidates qualify and none are duplicates', () => {
+    const diverseOnTopic = [
+      onTopic1,
+      onTopic2,
+      onTopic3,
+      candidate(
+        6,
+        'checkout latency',
+        'A missing index on the orders table was the whole story - once we added it the database stopped complaining about latency during checkout.',
+        6,
+      ),
+      candidate(
+        7,
+        'unindexed fk',
+        'We finally profiled the slow endpoint and found an unindexed foreign key column causing the database to scan the entire table on every request.',
+        7,
+      ),
+      candidate(
+        8,
+        'query planner',
+        'Query planner showed a sequential scan instead of an index lookup, so we added one and database response time dropped immediately.',
+        8,
+      ),
+    ];
+    const result = selectExamples(dbPost, diverseOnTopic, 3);
+    expect(result.mode).toBe('similarity');
+    expect(result.examples).toHaveLength(3);
+  });
+
+  it('returns nothing for an empty corpus rather than throwing', () => {
+    const result = selectExamples(dbPost, [], 3);
+    expect(result.examples).toEqual([]);
+  });
+
+  it('DUPLICATE_SIMILARITY_THRESHOLD and MIN_SIMILARITY_SCORE are ordered sensibly', () => {
+    // A candidate can never simultaneously be "not similar enough to the
+    // post to count" and "so similar to another pick it has to be dropped
+    // as a duplicate" in a way that breaks the floor check - the duplicate
+    // threshold is the higher bar, as it must be to mean anything.
+    expect(DUPLICATE_SIMILARITY_THRESHOLD).toBeGreaterThan(MIN_SIMILARITY_SCORE);
+  });
+});
+
+// #578's acceptance, matching #570's own test for the same claim
+// (assist-voice-profile.test.ts): no model call anywhere in the selection
+// path. Asserted by scanning the real source text, so a future import of a
+// model client or a Gateway call fails this test immediately rather than
+// being caught by review.
+describe('no model call in the selection path', () => {
+  const FORBIDDEN_PATTERNS = [
+    /\bfrom\s+['"]ai['"]/i,
+    /@ai-sdk/i,
+    /streamText/,
+    /generateText/,
+    /AI_GATEWAY/,
+    /gateway-catalogue/i,
+    /agents\/sdk/i,
+    /completion\(/,
+    /\bfetch\(/,
+  ];
+
+  const FILES = ['../src/assist/example-selection.ts'];
+
+  for (const relativePath of FILES) {
+    it(`${relativePath} never imports or calls a model`, () => {
+      const path = fileURLToPath(new URL(relativePath, import.meta.url));
+      const source = readFileSync(path, 'utf8');
+      for (const pattern of FORBIDDEN_PATTERNS) {
+        expect(source).not.toMatch(pattern);
+      }
+    });
+  }
+});

--- a/shared/tests/suggest-prompt.test.ts
+++ b/shared/tests/suggest-prompt.test.ts
@@ -145,9 +145,14 @@ describe('buildSuggestionPrompt', () => {
   });
 
   it('caps the few-shot examples', () => {
+    // None of these bodies share vocabulary with `post.text`, so this also
+    // exercises the recency fallback (example-selection.ts) - the property
+    // this test pins is still just the cap, not the mode.
     const examples = Array.from({ length: MAX_EXAMPLES + 4 }, (_, i) => ({
+      id: i + 1,
       title: `ex-${i}`,
       body: `body ${i}`,
+      createdAt: new Date(2026, 0, i + 1),
     }));
     const prompt = buildSuggestionPrompt({
       kind: 'post_comment',

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -26,6 +26,7 @@ import type {
   ProjectBrief,
   VoiceProfileSummary,
 } from '@pitchbox/shared/assist/context';
+import type { ExampleCandidate } from '@pitchbox/shared/assist/example-selection';
 import type { AssistTone } from '@pitchbox/shared/assist/tone';
 import type { AgentRunner } from '@pitchbox/shared/agents';
 import {
@@ -191,7 +192,7 @@ export function runSuggestion(args: {
   voiceProfile: VoiceProfileSummary | null;
   projects: ProjectBrief[];
   repos: CodeRepo[];
-  examples?: Array<{ title: string; body: string }>;
+  examples?: ExampleCandidate[];
   hint?: string;
   /**
    * A retune direction (#409): the panel's own regenerate-in-a-direction

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -317,12 +317,16 @@ export async function POST(event: RequestEvent) {
     groundedPost = { ...body.post, text: body.post.text as string };
   }
 
+  // #578: id and createdAt travel too, not just title/body -
+  // `buildSuggestionPrompt` (`shared/src/assist/example-selection.ts`) picks
+  // which of these actually reach the prompt, by topical closeness to
+  // `groundedPost` rather than by this array's order.
   const examples = (
     await loadActiveTemplates(db, {
       projectId: project.id,
       kind: body.kind === 'post' ? 'post' : 'comment',
     })
-  ).map((t) => ({ title: t.title, body: t.body }));
+  ).map((t) => ({ id: t.id, title: t.title, body: t.body, createdAt: t.createdAt }));
 
   // Everything the companion is allowed to know beyond this one post:
   // the operator's own persona and voice, every project in the org, and the

--- a/web/tests/extension-suggest-voice.test.ts
+++ b/web/tests/extension-suggest-voice.test.ts
@@ -183,7 +183,7 @@ describe('per-project voice (#408)', () => {
     });
     const examples = (
       await loadActiveTemplates(db, { projectId: project.id, kind: 'comment' })
-    ).map((t) => ({ title: t.title, body: t.body }));
+    ).map((t) => ({ id: t.id, title: t.title, body: t.body, createdAt: t.createdAt }));
     const expected = buildSuggestionPrompt({
       kind: 'post_comment',
       post: POST_BODY.post,


### PR DESCRIPTION
## What changed

`MAX_EXAMPLES` was still three, but `buildSuggestionPrompt` just took the first three of whatever order the caller passed - in practice the `templates` table's own `createdAt` order, so a suggestion's few-shot examples were three arbitrary samples rather than three relevant ones. His comment on a hiring post and his comment on a database benchmark are different registers, and the useful example is the one from the same room.

`shared/src/assist/example-selection.ts` (new) picks examples for the post at hand by lexical overlap: significant-word Jaccard similarity between the post and each candidate, deterministic and synchronous, no model call, in the spirit of `voice-profile.ts` (#570). I tried blending in a structural signal built from `register.ts`'s trait vocabulary during development and dropped it: two completely unrelated posts routinely share one or two of its thirteen boolean traits by chance (both first-person, say), which read as false topical closeness. That reasoning is in the module's own header comment.

Two disciplines on top of the ranking:

- **Diversity.** A candidate is skipped once it is a near-duplicate (`DUPLICATE_SIMILARITY_THRESHOLD`) of one already picked, even when it outscores a more varied candidate ranked below it - so four similar replies do not become three copies of the same example in the prompt.
- **A floor.** Below `MIN_SIMILARITY_SCORE` nothing in the corpus is genuinely about the same subject, so the selection falls back to recency instead of forcing a weak match - the old behavior - and says so, in the returned `mode` and in every example's `reason`.

`buildSuggestionPrompt` now calls `selectExamples` and varies its intro line by mode. The example candidate type widened from `{title, body}` to `{id, title, body, createdAt}` (recency and dedup both need it); `runSuggestion`'s type in `web/src/lib/server/suggest.ts` widened to match - a type-only change, coordinated with `AssistLoopFinish`/#566 over IRC before touching it, and the passthrough line (`examples: args.examples`) itself is unchanged - and the suggest route now carries `id`/`createdAt` when mapping `loadActiveTemplates` rows.

## Verified

- `pnpm exec vitest run shared/tests/assist-example-selection.test.ts shared/tests/suggest-prompt.test.ts web/tests/extension-suggest-voice.test.ts web/tests/extension-suggest.test.ts` - 63 passed
- `pnpm -F @pitchbox/shared typecheck` and `pnpm -F web check` - both clean
- `npx eslint` + `npx prettier --check` on every touched file - clean
- Runtime measured with a throwaway script (not a persisted test - no runtime-assertion precedent exists in this codebase and a wall-clock assertion in CI would be flaky): sub-millisecond per call up to a 200-candidate corpus, well past what a single project's template list holds in practice, against the 10-14s the suggest path already spends before its first token (#360).

## Acceptance, against the issue

- A fixture corpus where the recency answer and the similarity answer genuinely differ, asserting the chosen set - `assist-example-selection.test.ts`'s first test.
- Determinism asserted (shuffled candidate order, repeated calls) rather than assumed.
- The diversity rule proved with a corpus of near-verbatim rewordings plus one genuinely distinct post.
- The fallback proved with a corpus that matches nothing, including the mode label and per-example reason.
- A test that fails if a model call is introduced into the selection path, matching #570's own test for the same claim.

## Left out on purpose

- Exposing the per-example `reason` through the assist tool surface (`tools.ts`, #567, the `operator_voice` tool the issue mentions) - that file is merged and owned elsewhere; not mine to touch this round.
- The stylometric-distance evaluation the original issue text references against a numbered eval-set issue - that number does not correspond to any real issue in this repo's GitHub numbering (I checked; it's an unrelated, long-merged PR), and Main's scoped task for this PR dropped it from the acceptance criteria. Flagging here rather than silently dropping it.

Closes #578
