### PR TITLE
feat(web): wire the in-page assistant's tool loop into runSuggestion

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,12 @@ importers:
         specifier: ^4.5.4
         version: 4.5.4
     devDependencies:
+      '@ai-sdk/gateway':
+        specifier: ^4.0.75
+        version: 4.0.75(zod@4.5.4)
+      '@ai-sdk/provider':
+        specifier: ^4.0.10
+        version: 4.0.10
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
@@ -329,6 +335,9 @@ importers:
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
+      ai:
+        specifier: ^7.0.93
+        version: 7.0.93(zod@4.5.4)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1

--- a/shared/package.json
+++ b/shared/package.json
@@ -80,6 +80,7 @@
     "./platforms/linkedin": "./src/platforms/linkedin/index.ts",
     "./project-source-match": "./src/project-source-match.ts",
     "./agents/sdk/tools": "./src/agents/sdk/tools.ts",
+    "./agents/sdk/runner": "./src/agents/sdk/runner.ts",
     "./agents/sdk/event-normalizer": "./src/agents/sdk/event-normalizer.ts",
     "./instance-audit": "./src/instance-audit.ts",
     "./mastodon-source": "./src/mastodon-source.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -40,6 +40,7 @@
     "./assist/budget": "./src/assist/budget.ts",
     "./assist/voice-defaults": "./src/assist/voice-defaults.ts",
     "./assist/example-selection": "./src/assist/example-selection.ts",
+    "./assist/loop": "./src/assist/loop.ts",
     "./operator-profile": "./src/operator-profile.ts",
     "./operator-voice-profile": "./src/operator-voice-profile.ts",
     "./github-sources": "./src/github-sources.ts",

--- a/shared/src/agents/base.ts
+++ b/shared/src/agents/base.ts
@@ -22,6 +22,34 @@ export interface AgentRunOptions {
    * tool loop is exactly what a real-time path cannot afford.
    */
   attachMcp?: boolean;
+  /**
+   * A tool set to attach directly, bypassing the campaign Pitchbox MCP
+   * server (`attachMcp`'s tool set) - the in-page assistant's own tool
+   * surface (`shared/src/assist/tools.ts`, #566) is a different plane with
+   * different authority (docs/design/in-page-agent.md section 1) and must
+   * never share the campaign server's connection or its 26 mostly-writer
+   * tools. Wins over `attachMcp` when set. Only the `cloud` runner
+   * (`SdkRunner`) reads this; `AcpRunner`'s tool surface for the same plane
+   * is wired through a separate stdio MCP entry point instead.
+   */
+  tools?: Record<string, unknown>;
+  /**
+   * Step/time/token budget for a native tool-calling loop (#566), enforced
+   * only by the `cloud` runner (`SdkRunner`) - `AcpRunner` ignores it exactly
+   * as it ignores `budgetRemainingUsd`, since its own coding-agent CLI drives
+   * its own turn loop. Past `maxSteps` steps, `softBudgetMs` wall-clock time
+   * since this run started, or `tokenBudget` input tokens accumulated across
+   * steps, the next step is offered no tools at all: the model is told to
+   * answer with whatever it already gathered rather than keep spending
+   * (docs/design/in-page-agent.md section 2). This is the soft nudge;
+   * `timeoutMs` above stays the hard wall-clock ceiling that aborts the
+   * whole run regardless of what streamed.
+   */
+  toolLoopBudget?: {
+    maxSteps: number;
+    softBudgetMs: number;
+    tokenBudget: number;
+  };
   slug: string;
   env: Record<string, string>;
   cwd: string;

--- a/shared/src/agents/sdk/runner.ts
+++ b/shared/src/agents/sdk/runner.ts
@@ -8,7 +8,7 @@
 import { mkdirSync, writeFileSync, appendFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { streamText, stepCountIs, type ToolSet } from 'ai';
+import { streamText, stepCountIs, type ToolSet, type PrepareStepFunction } from 'ai';
 import {
   createGateway,
   type GatewayProvider,
@@ -200,11 +200,18 @@ export class SdkRunner implements AgentRunner {
         catalogueEntries.find((m) => m.id === modelId),
       );
 
-      // `attachMcp: false` (the in-page suggestion path) gets no tools at
-      // all - nothing for it to write, and a tool loop is what a real-time
-      // path cannot afford (mirrors AcpRunner's `mcpServers: []` case).
+      // A direct tool set (#566, the in-page assistant's own plane) wins
+      // over the campaign MCP server entirely - it has nothing to do with a
+      // `runs` row and must never share the campaign server's connection or
+      // its 26 mostly-writer tools. `attachMcp: false` (still used by a
+      // suggestion that carries no tool set at all) keeps its old meaning:
+      // nothing for it to write, and a tool loop is what a real-time path
+      // cannot afford.
       let toolSet: PitchboxToolSet | undefined;
-      if (opts.attachMcp !== false) {
+      let tools: ToolSet | undefined;
+      if (opts.tools) {
+        tools = opts.tools as ToolSet;
+      } else if (opts.attachMcp !== false) {
         // Session binding read from the per-run env `dispatchRun` builds
         // (PITCHBOX_RUN_ID etc, web/src/lib/server/runner.ts) - there is no
         // child process to forward it to here, unlike the ACP backend, and
@@ -216,7 +223,43 @@ export class SdkRunner implements AgentRunner {
           campaignId: posInt(opts.env.PITCHBOX_CAMPAIGN_ID),
           projectId: posInt(opts.env.PITCHBOX_PROJECT_ID) ?? posInt(opts.env.PROJECT_ID),
         });
+        tools = toolSet?.tools as ToolSet | undefined;
       }
+
+      // The step/time/token budget (#566, docs/design/in-page-agent.md
+      // section 2) is a nudge, not a hard stop: once any threshold trips,
+      // the next step is offered no tools at all, so the model must answer
+      // with whatever it already gathered instead of calling another one.
+      // `stepNumber` is zero-based and `steps` holds only the steps already
+      // completed (ai's own `prepareStep` contract), so this fires on the
+      // step *at* the index budget - "five tool steps plus the writing
+      // turn" reads as steps 0-4 free, step 5 forced text-only.
+      const loopBudget = opts.toolLoopBudget;
+      const loopStartedAt = Date.now();
+      const prepareStep: PrepareStepFunction<ToolSet> | undefined = loopBudget
+        ? ({ stepNumber, steps, instructions }) => {
+            const elapsedMs = Date.now() - loopStartedAt;
+            const tokensSoFar = steps.reduce(
+              (sum, step) => sum + (step.usage.inputTokens ?? 0),
+              0,
+            );
+            const overBudget =
+              stepNumber >= loopBudget.maxSteps - 1 ||
+              elapsedMs >= loopBudget.softBudgetMs ||
+              tokensSoFar >= loopBudget.tokenBudget;
+            if (!overBudget) return undefined;
+            // `instructions` only carries a plain string in this runner's
+            // own usage (a suggestion never sets `system`) - a structured
+            // `SystemModelMessage`/array is left behind rather than merged,
+            // since nothing here produces one today.
+            const base = typeof instructions === 'string' ? instructions : undefined;
+            const nudge =
+              'You are at your step, time, or token budget for this answer. Do not call ' +
+              'any more tools. Write your best answer now using only what you have already ' +
+              'gathered.';
+            return { toolChoice: 'none' as const, instructions: base ? `${base}\n\n${nudge}` : nudge };
+          }
+        : undefined;
 
       let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
       try {
@@ -273,8 +316,9 @@ export class SdkRunner implements AgentRunner {
             model,
             system,
             messages: [{ role: 'user', content: userText }],
-            tools: toolSet?.tools as ToolSet | undefined,
+            tools,
             stopWhen: stepCountIs(this.stepCeiling),
+            prepareStep,
             abortSignal: controller.signal,
           });
 

--- a/shared/src/agents/sdk/runner.ts
+++ b/shared/src/agents/sdk/runner.ts
@@ -239,10 +239,7 @@ export class SdkRunner implements AgentRunner {
       const prepareStep: PrepareStepFunction<ToolSet> | undefined = loopBudget
         ? ({ stepNumber, steps, instructions }) => {
             const elapsedMs = Date.now() - loopStartedAt;
-            const tokensSoFar = steps.reduce(
-              (sum, step) => sum + (step.usage.inputTokens ?? 0),
-              0,
-            );
+            const tokensSoFar = steps.reduce((sum, step) => sum + (step.usage.inputTokens ?? 0), 0);
             const overBudget =
               stepNumber >= loopBudget.maxSteps - 1 ||
               elapsedMs >= loopBudget.softBudgetMs ||
@@ -257,7 +254,10 @@ export class SdkRunner implements AgentRunner {
               'You are at your step, time, or token budget for this answer. Do not call ' +
               'any more tools. Write your best answer now using only what you have already ' +
               'gathered.';
-            return { toolChoice: 'none' as const, instructions: base ? `${base}\n\n${nudge}` : nudge };
+            return {
+              toolChoice: 'none' as const,
+              instructions: base ? `${base}\n\n${nudge}` : nudge,
+            };
           }
         : undefined;
 

--- a/shared/src/assist/loop.ts
+++ b/shared/src/assist/loop.ts
@@ -1,0 +1,115 @@
+// shared/src/assist/loop.ts (#566)
+//
+// Bridges #567's tool declarations (`shared/src/assist/tools.ts`) into a
+// native Vercel AI SDK tool set for `SdkRunner`'s loop
+// (docs/design/in-page-agent.md, "The SDK path wraps those handlers as
+// native tools"). One enforcement point, applied uniformly to every tool
+// regardless of what its own handler does or doesn't check:
+//
+//   - a cancelled suggestion never starts a new tool handler at all - `ai`
+//     hands every `execute` call the same `abortSignal` it passed
+//     `streamText` (`SdkRunner`'s own `controller.signal`, tripped by
+//     `handle.cancel()`), so this checks that signal directly rather than
+//     asking the caller to thread a second one;
+//   - a tool that is already running gets its per-tool ceiling
+//     (`ASSIST_TOOL_TIMEOUT_MS`, or `ASSIST_VISION_TIMEOUT_MS` for
+//     `look_at_image`) merged with that same cancellation signal, so
+//     `look_at_image`'s real Gateway call actually stops rather than
+//     running to completion for nobody - "a suggestion nobody is waiting
+//     for that keeps calling the Gateway is a bug that only shows up on
+//     the bill" (design doc, section 2).
+//
+// Takes the tool list as a parameter rather than importing `ASSIST_TOOLS`
+// itself, so this module (and its tests) never depend on the seven real
+// handlers existing - `web/src/lib/server/suggest.ts` is the one caller that
+// wires the real `ASSIST_TOOLS` in.
+
+import { tool, type ToolSet } from 'ai';
+import { z } from 'zod';
+import type { AssistTool, AssistToolAnswer, AssistToolContext } from './tools.js';
+import { ASSIST_TOOL_TIMEOUT_MS, ASSIST_VISION_TIMEOUT_MS } from './budget.js';
+
+/** `look_at_image` is a real model call whose cost and latency dwarf the
+ * other six (design doc, section 2) - it alone gets the longer ceiling. */
+function toolTimeoutMs(name: string): number {
+  return name === 'look_at_image' ? ASSIST_VISION_TIMEOUT_MS : ASSIST_TOOL_TIMEOUT_MS;
+}
+
+/**
+ * Races `handler` against `ms` and, separately, against `outerSignal`
+ * firing - whichever comes first. Neither the five DB tools nor a genuine
+ * network hang stop producing a value on their own, so this is a "stop
+ * waiting", not a true cancel, for anything but `look_at_image` (the one
+ * handler that threads `signal` into a real `fetch`); the loop must not
+ * block on a broken tool regardless of whether the tool itself cooperates.
+ */
+function runWithBudget<T>(
+  handler: (signal: AbortSignal) => Promise<T>,
+  ms: number,
+  outerSignal: AbortSignal | undefined,
+  onAbort: (reason: 'timeout' | 'cancelled') => T,
+): Promise<T> {
+  const timeoutController = new AbortController();
+  const timer = setTimeout(() => timeoutController.abort(), ms);
+  const signal = outerSignal
+    ? AbortSignal.any([outerSignal, timeoutController.signal])
+    : timeoutController.signal;
+  // shared's tsconfig targets a lib without `Promise.withResolvers`
+  // (cli/src/lib/password.ts hit the same wall) - the executor form is the
+  // one that typechecks here.
+  const abortRace = new Promise<T>((resolve) => {
+    const settle = () =>
+      resolve(onAbort(timeoutController.signal.aborted ? 'timeout' : 'cancelled'));
+    if (signal.aborted) settle();
+    else signal.addEventListener('abort', settle, { once: true });
+  });
+  return Promise.race([handler(signal), abortRace]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * Wraps every `AssistTool` handler as a native `ai` tool: same JSON schema,
+ * same server-resolved `ctx` (the model supplies no authority, per the
+ * design doc's "What the agent may know and do"), the timeout/cancellation
+ * enforcement above applied once instead of per-handler. Independent tools
+ * requested in the same model turn execute concurrently because `ai`'s own
+ * `streamText` runs every tool call in a step through `Promise.all` - this
+ * function only has to avoid accidentally serializing them itself, which it
+ * doesn't: each entry's `execute` is an independent async function with no
+ * shared lock between tools.
+ */
+export function buildAssistToolSet(
+  // mirrors tools.ts's own `ASSIST_TOOLS: Array<AssistTool<any, any>>`, heterogeneous by
+  // construction - each tool's own TArgs/TResult differs, so the array itself has to erase them.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tools: Array<AssistTool<any, any>>,
+  ctx: AssistToolContext,
+): ToolSet {
+  const toolSet: ToolSet = {};
+  for (const assistTool of tools) {
+    toolSet[assistTool.name] = tool({
+      description: assistTool.description,
+      inputSchema: z.object(assistTool.schema),
+      execute: async (
+        args: Record<string, unknown>,
+        options: { abortSignal?: AbortSignal },
+      ): Promise<AssistToolAnswer<unknown>> => {
+        if (options.abortSignal?.aborted) {
+          return { ok: false, reason: `${assistTool.name}: suggestion was cancelled` };
+        }
+        return runWithBudget(
+          (signal) => assistTool.handler(ctx, args, signal),
+          toolTimeoutMs(assistTool.name),
+          options.abortSignal,
+          (reason) => ({
+            ok: false,
+            reason:
+              reason === 'timeout'
+                ? `${assistTool.name} did not answer within its time budget`
+                : `${assistTool.name}: suggestion was cancelled`,
+          }),
+        );
+      },
+    });
+  }
+  return toolSet;
+}

--- a/shared/tests/agents/sdk/runner.test.ts
+++ b/shared/tests/agents/sdk/runner.test.ts
@@ -501,4 +501,155 @@ describe('SdkRunner', () => {
     const resultEvent = events.find((e) => e.kind === 'result');
     expect(resultEvent?.payload).toMatchObject({ type: 'result', success: true });
   });
+
+  it('attaches a directly-given tool set instead of the campaign MCP tool set when opts.tools is set', async () => {
+    const createToolSetSpy = vi.fn(fakeToolSet().fn);
+    let receivedTools: unknown;
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn: createToolSetSpy,
+      streamTextFn: vi.fn((opts: { tools?: unknown; abortSignal?: AbortSignal }) => {
+        receivedTools = opts.tools;
+        return {
+          fullStream: gen({
+            type: 'finish',
+            finishReason: 'stop',
+            totalUsage: { inputTokens: 1, outputTokens: 1 },
+          }),
+        };
+      }) as unknown as typeof streamText,
+    });
+    const directTools = { read_thread: {} };
+    const handle = runner.run({ ...baseOpts(), prompt: 'hi', tools: directTools });
+    await handle.result;
+    // The campaign MCP tool set is never created - a direct tool set wins
+    // entirely, it does not merge with it.
+    expect(createToolSetSpy).not.toHaveBeenCalled();
+    expect(receivedTools).toBe(directTools);
+  });
+
+  it('passes no prepareStep to streamText when no toolLoopBudget is given, leaving campaign runs untouched', async () => {
+    let capturedPrepareStep: unknown;
+    const { fn: createToolSetFn } = fakeToolSet();
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn,
+      streamTextFn: vi.fn((opts: { prepareStep?: unknown }) => {
+        capturedPrepareStep = opts.prepareStep;
+        return {
+          fullStream: gen({ type: 'finish', finishReason: 'stop', totalUsage: {} }),
+        };
+      }) as unknown as typeof streamText,
+    });
+    const handle = runner.run({ ...baseOpts(), prompt: 'hi', attachMcp: false });
+    await handle.result;
+    expect(capturedPrepareStep).toBeUndefined();
+  });
+
+  it('builds a prepareStep that forces toolChoice:none with a nudge once the step budget is hit', async () => {
+    // Exercising the raw PrepareStepFunction the runner hands to streamText, not typed here.
+    let capturedPrepareStep: any;
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      streamTextFn: vi.fn((opts: { prepareStep?: unknown }) => {
+        capturedPrepareStep = opts.prepareStep;
+        return { fullStream: gen({ type: 'finish', finishReason: 'stop', totalUsage: {} }) };
+      }) as unknown as typeof streamText,
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'hi',
+      tools: {},
+      toolLoopBudget: { maxSteps: 3, softBudgetMs: 1_000_000, tokenBudget: 1_000_000 },
+    });
+    await handle.result;
+    // Steps 0 and 1 (of a 3-step budget, zero-based) are still free to call tools.
+    expect(
+      await capturedPrepareStep({ stepNumber: 0, steps: [], instructions: undefined }),
+    ).toBeUndefined();
+    expect(
+      await capturedPrepareStep({
+        stepNumber: 1,
+        steps: [{ usage: { inputTokens: 10 } }],
+        instructions: undefined,
+      }),
+    ).toBeUndefined();
+    // Step 2 is the budget's last step (maxSteps - 1): forced text-only, with a
+    // nudge explaining why, appended to whatever instructions already existed.
+    const forced = await capturedPrepareStep({
+      stepNumber: 2,
+      steps: [{ usage: { inputTokens: 10 } }, { usage: { inputTokens: 10 } }],
+      instructions: 'be concise',
+    });
+    expect(forced.toolChoice).toBe('none');
+    expect(forced.instructions).toContain('be concise');
+    expect(forced.instructions).toMatch(/budget/i);
+  });
+
+  it('forces toolChoice:none once the soft wall-clock budget elapses, independent of step count', async () => {
+    vi.useFakeTimers();
+    let capturedPrepareStep: any;
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      streamTextFn: vi.fn((opts: { prepareStep?: unknown }) => {
+        capturedPrepareStep = opts.prepareStep;
+        return { fullStream: gen({ type: 'finish', finishReason: 'stop', totalUsage: {} }) };
+      }) as unknown as typeof streamText,
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'hi',
+      tools: {},
+      toolLoopBudget: { maxSteps: 10, softBudgetMs: 5_000, tokenBudget: 1_000_000 },
+    });
+    await handle.result;
+    // Well under the wall-clock budget: still free to call tools.
+    expect(
+      await capturedPrepareStep({ stepNumber: 0, steps: [], instructions: undefined }),
+    ).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(5_001);
+    const forced = await capturedPrepareStep({ stepNumber: 1, steps: [], instructions: undefined });
+    expect(forced.toolChoice).toBe('none');
+  });
+
+  it('forces toolChoice:none once accumulated input tokens cross the token budget', async () => {
+    let capturedPrepareStep: any;
+    const runner = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      streamTextFn: vi.fn((opts: { prepareStep?: unknown }) => {
+        capturedPrepareStep = opts.prepareStep;
+        return { fullStream: gen({ type: 'finish', finishReason: 'stop', totalUsage: {} }) };
+      }) as unknown as typeof streamText,
+    });
+    const handle = runner.run({
+      ...baseOpts(),
+      prompt: 'hi',
+      tools: {},
+      toolLoopBudget: { maxSteps: 10, softBudgetMs: 1_000_000, tokenBudget: 60_000 },
+    });
+    await handle.result;
+    expect(
+      await capturedPrepareStep({
+        stepNumber: 1,
+        steps: [{ usage: { inputTokens: 30_000 } }],
+        instructions: undefined,
+      }),
+    ).toBeUndefined();
+    const forced = await capturedPrepareStep({
+      stepNumber: 2,
+      steps: [{ usage: { inputTokens: 30_000 } }, { usage: { inputTokens: 30_001 } }],
+      instructions: undefined,
+    });
+    expect(forced.toolChoice).toBe('none');
+  });
 });

--- a/shared/tests/assist/loop.test.ts
+++ b/shared/tests/assist/loop.test.ts
@@ -1,0 +1,171 @@
+// shared/tests/assist/loop.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { buildAssistToolSet } from '../../src/assist/loop.js';
+import type { AssistTool, AssistToolAnswer, AssistToolContext } from '../../src/assist/tools.js';
+import { ASSIST_TOOL_TIMEOUT_MS, ASSIST_VISION_TIMEOUT_MS } from '../../src/assist/budget.js';
+
+/**
+ * What this file defends: the one enforcement point `buildAssistToolSet`
+ * exists for (docs/design/in-page-agent.md section 2) - a cancelled
+ * suggestion never starts a new handler, a hanging handler never blocks the
+ * loop past its ceiling, `look_at_image` gets the longer vision ceiling, an
+ * in-flight handler is told to stop rather than merely ignored, and nothing
+ * in this wrapper accidentally serializes tools the model called together.
+ * The seven real handlers (#567) are exercised by their own test file -
+ * every tool fixture here is a fake, on purpose.
+ *
+ * `execute`'s cancellation source is `ai`'s own second argument
+ * (`options.abortSignal`) - exactly what `SdkRunner` hands every tool call
+ * once `handle.cancel()` trips its `controller.abort()` - so these tests
+ * drive it directly rather than a bespoke signal.
+ */
+
+function fakeCtx(): AssistToolContext {
+  return {
+    db: {} as AssistToolContext['db'],
+    orgId: 1,
+    boundProjectId: 1,
+    observedTarget: null,
+    operator: null,
+  };
+}
+
+function execOpts(signal?: AbortSignal) {
+  return { toolCallId: 't1', messages: [], context: undefined, abortSignal: signal };
+}
+
+function makeTool<T>(
+  name: string,
+  handler: (
+    ctx: AssistToolContext,
+    args: Record<string, never>,
+    signal?: AbortSignal,
+  ) => Promise<AssistToolAnswer<T>>,
+): AssistTool<Record<string, never>, T> {
+  return { name, description: name, schema: {}, handler };
+}
+
+/** A handler that never answers on its own - only the wrapper's own ceiling
+ * or an abort can end it. */
+function hangingTool<T>(name: string): AssistTool<Record<string, never>, T> {
+  // shared's tsconfig targets a lib without `Promise.withResolvers` (see
+  // loop.ts's own comment) - the executor form is the one that typechecks.
+  return makeTool<T>(name, () => new Promise<AssistToolAnswer<T>>(() => {}));
+}
+
+describe('buildAssistToolSet', () => {
+  it('never calls the handler when the execution signal is already aborted', async () => {
+    const handlerSpy = vi.fn(async () => ({ ok: true as const, data: 'x' }));
+    const toolSet = buildAssistToolSet([makeTool('read_thread', handlerSpy)], fakeCtx());
+    const alreadyAborted = new AbortController();
+    alreadyAborted.abort();
+    const result = await toolSet.read_thread.execute!({}, execOpts(alreadyAborted.signal));
+    expect(handlerSpy).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: false });
+  });
+
+  it('stops waiting on a handler that exceeds its per-tool timeout, without waiting for it to resolve', async () => {
+    vi.useFakeTimers();
+    try {
+      const toolSet = buildAssistToolSet([hangingTool('author_history')], fakeCtx());
+      const resultPromise = toolSet.author_history.execute!({}, execOpts());
+      await vi.advanceTimersByTimeAsync(ASSIST_TOOL_TIMEOUT_MS + 1);
+      const result = await resultPromise;
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toMatch(/time budget/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('gives look_at_image the longer vision ceiling instead of the standard 4s tool ceiling', async () => {
+    vi.useFakeTimers();
+    try {
+      const toolSet = buildAssistToolSet(
+        [hangingTool('look_at_image'), hangingTool('operator_voice')],
+        fakeCtx(),
+      );
+      const visionPromise = toolSet.look_at_image.execute!({}, execOpts());
+      const voicePromise = toolSet.operator_voice.execute!({}, execOpts());
+
+      await vi.advanceTimersByTimeAsync(ASSIST_TOOL_TIMEOUT_MS + 1);
+      // The standard-ceiling tool has already timed out...
+      const voiceResult = await voicePromise;
+      expect(voiceResult.ok).toBe(false);
+      // ...but look_at_image's own, longer ceiling has not been reached yet.
+      let visionSettled = false;
+      void visionPromise.then(() => {
+        visionSettled = true;
+      });
+      await Promise.resolve();
+      expect(visionSettled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(ASSIST_VISION_TIMEOUT_MS - ASSIST_TOOL_TIMEOUT_MS + 1);
+      const visionResult = await visionPromise;
+      expect(visionResult.ok).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('threads the execution abort signal into the handler so an in-flight tool can stop early on cancel', async () => {
+    const outer = new AbortController();
+    let handlerSawAbort = false;
+    const toolSet = buildAssistToolSet(
+      [
+        makeTool<never>('look_at_image', (_ctx, _args, signal) => {
+          return new Promise<AssistToolAnswer<never>>((resolve) => {
+            signal?.addEventListener('abort', () => {
+              handlerSawAbort = true;
+              resolve({ ok: false, reason: 'aborted mid-flight' });
+            });
+          });
+        }),
+      ],
+      fakeCtx(),
+    );
+    const resultPromise = toolSet.look_at_image.execute!({}, execOpts(outer.signal));
+    outer.abort();
+    const result = await resultPromise;
+    // Whichever settles the race, the handler must have actually observed
+    // the abort (proving the signal reached the in-flight Gateway call,
+    // not just that the wrapper stopped waiting on it) and the loop must
+    // still get back a refusal rather than hang.
+    expect(handlerSawAbort).toBe(true);
+    expect(result.ok).toBe(false);
+  });
+
+  it('runs independent tools concurrently rather than serializing them', async () => {
+    vi.useFakeTimers();
+    try {
+      const DELAY_MS = 40;
+      let concurrent = 0;
+      let peakConcurrent = 0;
+      const delayed = (label: string): AssistTool<Record<string, never>, string> =>
+        makeTool(label, async () => {
+          concurrent += 1;
+          peakConcurrent = Math.max(peakConcurrent, concurrent);
+          await new Promise<void>((resolve) => setTimeout(resolve, DELAY_MS));
+          concurrent -= 1;
+          return { ok: true, data: label };
+        });
+      const toolSet = buildAssistToolSet(
+        [delayed('read_thread'), delayed('author_history')],
+        fakeCtx(),
+      );
+      const resultsPromise = Promise.all([
+        toolSet.read_thread.execute!({}, execOpts()),
+        toolSet.author_history.execute!({}, execOpts()),
+      ]);
+      await vi.advanceTimersByTimeAsync(DELAY_MS + 1);
+      const [thread, history] = await resultsPromise;
+      expect(thread).toMatchObject({ ok: true, data: 'read_thread' });
+      expect(history).toMatchObject({ ok: true, data: 'author_history' });
+      // If `execute` serialized the two calls (awaited one before starting
+      // the other), only one would ever be in flight at once.
+      expect(peakConcurrent).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -29,12 +29,15 @@
     "zod": "^4.5.4"
   },
   "devDependencies": {
+    "@ai-sdk/gateway": "^4.0.75",
+    "@ai-sdk/provider": "^4.0.10",
     "@fontsource-variable/inter": "^5.2.8",
     "@internationalized/date": "^3.12.2",
     "@sveltejs/adapter-node": "^5.5.7",
     "@sveltejs/kit": "^2.70.2",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/diff": "^8.0.0",
+    "ai": "^7.0.93",
     "clsx": "^2.1.1",
     "mode-watcher": "^1.1.0",
     "shadcn-svelte": "^1.5.1",

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -34,6 +34,15 @@ import {
   enforceHouseStyle,
   type StyleFinding,
 } from '@pitchbox/shared/style-check';
+import { ASSIST_TOOLS } from '@pitchbox/shared/assist/tools';
+import { buildAssistToolSet } from '@pitchbox/shared/assist/loop';
+import {
+  ASSIST_HARD_TIMEOUT_MS,
+  ASSIST_MAX_STEPS,
+  ASSIST_SOFT_BUDGET_MS,
+  ASSIST_TOKEN_BUDGET,
+} from '@pitchbox/shared/assist/budget';
+import { resolveDeviceOrgId } from './extension-auth.js';
 
 /**
  * Runs one suggestion: a single-turn agent invocation with no playbook, no MCP
@@ -92,8 +101,8 @@ export interface SuggestionHandle {
 }
 
 /** A suggestion the human is waiting on has a much shorter patience than a
- * campaign run. Past this the answer is not worth having. */
-const SUGGESTION_TIMEOUT_MS = 90_000;
+ * campaign run - `ASSIST_HARD_TIMEOUT_MS` (`shared/src/assist/budget.ts`) is
+ * the ceiling, not the target. */
 
 /**
  * The model a suggestion asks for when an operator has not pinned one for
@@ -166,7 +175,7 @@ async function runStyleRewrite(
       slug: 'assist-style-rewrite',
       env: {},
       cwd,
-      timeoutMs: SUGGESTION_TIMEOUT_MS,
+      timeoutMs: ASSIST_HARD_TIMEOUT_MS,
       orgId,
       onTextChunk: (chunk) => {
         rawText += chunk;
@@ -294,9 +303,11 @@ export function runSuggestion(args: {
     const runner = createAgentRunner(args.runnerSlug, resolvedConfig);
 
     // The agent still gets a working directory, and it must not be the repo:
-    // this session has no tools attached, but a cwd it could read is a cwd it
-    // should not have. An empty temp directory is the smallest thing that
-    // satisfies the ACP `session/new` contract.
+    // even with the assist tool set attached below, nothing here reads or
+    // writes the filesystem or a shell - the tools are the only capability
+    // added (docs/design/in-page-agent.md, section 1). An empty temp
+    // directory is the smallest thing that satisfies the ACP `session/new`
+    // contract.
     const cwd = await mkdtemp(join(tmpdir(), 'pitchbox-suggest-'));
     // Last gate before the spawn, and the one that matters most: past here a
     // process exists and only the handle can stop it.
@@ -304,6 +315,33 @@ export function runSuggestion(args: {
       await rm(cwd, { recursive: true, force: true }).catch(() => {});
       throw new Cancelled();
     }
+
+    // #566: the in-page assistant's own tool surface (`shared/src/assist/
+    // tools.ts`, #567), wired in for the SDK runner via `opts.tools` -
+    // `buildAssistToolSet` wraps every handler with the cancellation and
+    // per-tool timeout enforcement (`shared/src/assist/loop.ts`). `AcpRunner`
+    // ignores `opts.tools`/`opts.toolLoopBudget` entirely (its own assist MCP
+    // entry point, `cli/bin/pitchbox-assist-mcp`, is a separate wiring), so
+    // an ACP-backed suggestion keeps today's single, tool-less turn.
+    //
+    // The org id comes from the device's auth, falling back to the seeded
+    // `default` organization exactly as the LinkedIn assist gate already
+    // does (`resolveDeviceOrgId`) - a self-host with auth off still gets the
+    // loop rather than losing it because there is no device-bound org to
+    // scope tools to. Only a genuinely unseeded database (`toolOrgId` still
+    // null) falls back to no tools at all, the same shape this suggestion
+    // had before this issue.
+    const toolOrgId = await resolveDeviceOrgId(db, args.orgId ?? null);
+    const toolSet =
+      toolOrgId != null
+        ? buildAssistToolSet(ASSIST_TOOLS, {
+            db,
+            orgId: toolOrgId,
+            boundProjectId: args.projectId,
+            observedTarget: args.post,
+            operator: args.persona,
+          })
+        : undefined;
 
     // `rawText` is the whole response, unsplit - used only to tell an actual
     // zero-text turn (a real failure) apart from a well-formed response whose
@@ -319,8 +357,19 @@ export function runSuggestion(args: {
         slug: `assist-${args.kind}`,
         env: {},
         cwd,
-        timeoutMs: SUGGESTION_TIMEOUT_MS,
+        timeoutMs: ASSIST_HARD_TIMEOUT_MS,
         orgId: args.orgId,
+        tools: toolSet,
+        // Only meaningful alongside `tools` - `SdkRunner` gates its own
+        // `prepareStep` enforcement on this being set, so the two travel
+        // together or not at all (docs/design/in-page-agent.md, section 2).
+        toolLoopBudget: toolSet
+          ? {
+              maxSteps: ASSIST_MAX_STEPS,
+              softBudgetMs: ASSIST_SOFT_BUDGET_MS,
+              tokenBudget: ASSIST_TOKEN_BUDGET,
+            }
+          : undefined,
         onTextChunk: (chunk) => {
           rawText += chunk;
           // `args.onChunk?.(splitter.push(chunk))` looks equivalent but is

--- a/web/tests/extension-suggest-loop-wiring.test.ts
+++ b/web/tests/extension-suggest-loop-wiring.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type { AgentRunHandle, AgentRunOptions, AgentRunner } from '@pitchbox/shared/agents';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+import { ASSIST_TOOLS } from '@pitchbox/shared/assist/tools';
+import {
+  ASSIST_MAX_STEPS,
+  ASSIST_SOFT_BUDGET_MS,
+  ASSIST_TOKEN_BUDGET,
+} from '@pitchbox/shared/assist/budget';
+import { DRAFT_MARKER } from '@pitchbox/shared/assist/envelope';
+
+/**
+ * #566: `runSuggestion`'s middle now builds the in-page assistant's tool
+ * context and hands it to the runner. This file pins that wiring in
+ * isolation from a real model loop - a fake `AgentRunner` just captures what
+ * `runSuggestion` handed it, the way `extension-suggest.test.ts` already
+ * does for the route's other options. The loop mechanics themselves
+ * (multi-step, parallel calls, budget enforcement, cancellation, usage
+ * summed across steps) are exercised end to end, against a real `SdkRunner`
+ * and a fake model, in extension-suggest-loop.test.ts.
+ */
+
+let lastOptions: AgentRunOptions | null = null;
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'fake',
+    run(opts: AgentRunOptions): AgentRunHandle {
+      lastOptions = opts;
+      opts.onTextChunk?.(`Fine.\n${DRAFT_MARKER}\nOk.`);
+      return {
+        result: Promise.resolve({ exitCode: 0, logPath: '/dev/null' }),
+        cancel: () => {},
+      };
+    },
+  }),
+}));
+
+// Dynamic, matching every other route/suggest test in this repo: `vi.mock`
+// above is hoisted, but the mocked module graph must not resolve until
+// after that registration runs, and a static import this early would race
+// it and pick up the real registry instead of the fake one.
+const { runSuggestion } = await import('../src/lib/server/suggest.js');
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, contact_history, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  lastOptions = null;
+}
+
+async function seedOrgProject(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `p-${slug}`,
+      name: slug,
+      description: `about ${slug}`,
+    })
+    .returning();
+  return { org, project };
+}
+
+describe('runSuggestion: assist tool surface wiring (#566)', () => {
+  beforeEach(reset);
+
+  it('attaches exactly the seven assist tools and the exact ASSIST_* budget - never the campaign tool set', async () => {
+    const { org, project } = await seedOrgProject('org-loop-wiring');
+
+    const handle = runSuggestion({
+      kind: 'post_comment',
+      post: { urn: 'urn:li:activity:1', authorName: 'A', text: 'hi' },
+      currentProject: { name: project.name, description: project.description },
+      persona: null,
+      voiceProfile: null,
+      projects: [],
+      repos: [],
+      projectId: project.id,
+      orgId: org.id,
+      runnerSlug: 'cloud',
+    });
+    await handle.result;
+
+    // `attachMcp: false` unchanged - a direct tool set wins over it entirely
+    // (SdkRunner never even looks at attachMcp once opts.tools is set), and
+    // this is the marker that the campaign MCP tool set was never requested.
+    expect(lastOptions?.attachMcp).toBe(false);
+    expect(Object.keys(lastOptions?.tools ?? {}).sort()).toEqual(
+      ASSIST_TOOLS.map((t) => t.name).sort(),
+    );
+    expect(lastOptions?.toolLoopBudget).toEqual({
+      maxSteps: ASSIST_MAX_STEPS,
+      softBudgetMs: ASSIST_SOFT_BUDGET_MS,
+      tokenBudget: ASSIST_TOKEN_BUDGET,
+    });
+  });
+
+  it('scopes the tool context to the bound project and the observed post, never a model-supplied id', async () => {
+    const { org, project } = await seedOrgProject('org-loop-ctx');
+    const { project: otherProject } = await seedOrgProject('org-loop-ctx-other');
+
+    const handle = runSuggestion({
+      kind: 'post_comment',
+      post: {
+        urn: 'urn:li:activity:2',
+        authorName: 'A',
+        text: 'hi',
+        thread: { comments: [{ body: 'nice post' }], renderedCount: 1, truncated: false },
+      },
+      currentProject: { name: project.name, description: project.description },
+      persona: null,
+      voiceProfile: null,
+      projects: [],
+      repos: [],
+      projectId: project.id,
+      orgId: org.id,
+      runnerSlug: 'cloud',
+    });
+    await handle.result;
+
+    const tools = lastOptions?.tools as Record<
+      string,
+      { execute: (args: unknown, opts: unknown) => Promise<{ ok: boolean; data?: unknown }> }
+    >;
+    // read_thread reads the real observed target `runSuggestion` was called
+    // with, not an empty context.
+    const threadResult = (await tools.read_thread.execute({}, {})) as {
+      ok: boolean;
+      data: { comments: unknown[] };
+    };
+    expect(threadResult.ok).toBe(true);
+    expect(threadResult.data.comments).toHaveLength(1);
+
+    // project_knowledge validates a model-supplied project id against the
+    // binding - a project belonging to a different org must be refused
+    // rather than answered.
+    const otherResult = (await tools.project_knowledge.execute(
+      { projectId: otherProject.id },
+      {},
+    )) as { ok: boolean };
+    expect(otherResult.ok).toBe(false);
+  });
+});

--- a/web/tests/extension-suggest-loop.test.ts
+++ b/web/tests/extension-suggest-loop.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { createGateway } from '@ai-sdk/gateway';
+import type {
+  LanguageModelV4CallOptions,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+} from '@ai-sdk/provider';
+import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+import type { ObservedPost } from '@pitchbox/shared/assist/suggest-prompt';
+import {
+  ASSIST_MAX_STEPS,
+  ASSIST_SOFT_BUDGET_MS,
+  ASSIST_TOKEN_BUDGET,
+} from '@pitchbox/shared/assist/budget';
+import { DRAFT_MARKER } from '@pitchbox/shared/assist/envelope';
+
+/**
+ * #566: the loop itself - what `extension-suggest-loop-wiring.test.ts`
+ * leaves out because it fakes the runner entirely. Here the runner is real
+ * (`SdkRunner`, unmocked) driven by the real `ai` `streamText` engine
+ * (unmocked too) against a scripted `MockLanguageModelV4` - only the model
+ * at the very bottom is fake, so a step with several tool calls is actually
+ * dispatched by the AI SDK's own tool-execution machinery, not reimplemented
+ * by this file. What this defends: a suggestion needing several things takes
+ * several steps and issues independent tool calls together rather than one
+ * per turn; a suggestion needing nothing extra still takes one turn;
+ * cancelling mid-step stops the loop from spending anything further; each of
+ * the three soft budgets (steps, wall-clock, tokens) forces a usable draft
+ * rather than an error; and the usage the accept path ledgers is the sum
+ * across every step, not just the last one.
+ */
+
+let logDirs: string[] = [];
+let currentGatewayFn: typeof createGateway | null = null;
+
+// Dynamic import inside the factory rather than a top-level one: `SdkRunner`
+// is the real class under test here and is never mocked, but referencing a
+// regular top-level import from inside `vi.mock`'s factory trips vitest's
+// hoisting guard (the factory is moved above every import in the transformed
+// module). The factory body itself only runs later, once `createAgentRunner`
+// is actually called at test time, well after the module has finished
+// loading either way.
+vi.mock('@pitchbox/shared/agents/registry', async () => {
+  const { SdkRunner } = await import('@pitchbox/shared/agents/sdk/runner');
+  return {
+    createAgentRunner: (_slug: string, config: RunnerConfig) => {
+      if (!currentGatewayFn) {
+        throw new Error('test must call useModel(...) before invoking runSuggestion');
+      }
+      const logDir = mkdtempSync(join(tmpdir(), 'sdk-loop-test-'));
+      logDirs.push(logDir);
+      return new SdkRunner({ config, logDir, createGatewayFn: currentGatewayFn });
+    },
+  };
+});
+
+// Dynamic, matching every other route/suggest test in this repo (see
+// extension-suggest-loop-wiring.test.ts) - a static import here would race
+// the `vi.mock` registration above and pick up the real registry instead of
+// the fake one.
+const { runSuggestion } = await import('../src/lib/server/suggest.js');
+
+function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}
+
+type FakeUsage = { inputTokens: number; outputTokens: number };
+
+function usage(u: FakeUsage): LanguageModelV4Usage {
+  return {
+    inputTokens: { total: u.inputTokens, noCache: u.inputTokens, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: u.outputTokens, text: u.outputTokens, reasoning: 0 },
+  };
+}
+
+/** One model turn that calls every named tool, all in the same step - the
+ * shape a step with several independent tool calls actually takes on the
+ * wire. `ai`'s own engine (not this file) is what then runs them
+ * concurrently via `Promise.all`; `shared/tests/assist/loop.test.ts`
+ * already proves `buildAssistToolSet`'s own wrapper never re-serializes
+ * them. What this file adds is proof that the *dispatch* happens together -
+ * a run log's call count, not an assertion about internal timing. */
+function toolCallStep(
+  calls: Array<{ name: string; args?: Record<string, unknown> }>,
+  u: FakeUsage = { inputTokens: 10, outputTokens: 5 },
+): LanguageModelV4StreamPart[] {
+  return [
+    { type: 'stream-start', warnings: [] },
+    ...calls.map((c, i): LanguageModelV4StreamPart => ({
+      type: 'tool-call',
+      toolCallId: `c${i}-${c.name}`,
+      toolName: c.name,
+      input: JSON.stringify(c.args ?? {}),
+    })),
+    { type: 'finish', finishReason: { unified: 'tool-calls', raw: undefined }, usage: usage(u) },
+  ];
+}
+
+/** The writing turn: an envelope-shaped final answer. */
+function textStep(
+  text: string,
+  u: FakeUsage = { inputTokens: 10, outputTokens: 10 },
+): LanguageModelV4StreamPart[] {
+  return [
+    { type: 'stream-start', warnings: [] },
+    { type: 'text-start', id: 't1' },
+    { type: 'text-delta', id: 't1', delta: text },
+    { type: 'text-end', id: 't1' },
+    { type: 'finish', finishReason: { unified: 'stop', raw: undefined }, usage: usage(u) },
+  ];
+}
+
+/**
+ * Wires a scripted model into the mocked registry for the next
+ * `runSuggestion` call. `script(step, options)` runs once per model turn
+ * (`step` 0-based) and returns that turn's stream parts - `options
+ * .toolChoice` is what `SdkRunner`'s own budget enforcement sets once it
+ * forces a turn text-only, and every budget-edge test below reads it from
+ * here rather than guessing at timing.
+ */
+function useModel(
+  script: (
+    step: number,
+    options: LanguageModelV4CallOptions,
+  ) => LanguageModelV4StreamPart[] | Promise<LanguageModelV4StreamPart[]>,
+): { callCount: () => number } {
+  let callIndex = 0;
+  const model = (id: string) =>
+    new MockLanguageModelV4({
+      modelId: id,
+      doStream: async (options) => {
+        const step = callIndex++;
+        const parts = await script(step, options);
+        return { stream: convertArrayToReadableStream(parts) };
+      },
+    });
+  const gateway = Object.assign(model, { getAvailableModels: async () => ({ models: [] }) });
+  // The one boundary cast in this file: `@ai-sdk/gateway`'s own
+  // `GatewayProvider` type carries provider-specific extras `SdkRunner`
+  // never reads - it only ever calls this as `(id) => LanguageModelV4` plus
+  // `getAvailableModels`, both of which `gateway` above already provides.
+  currentGatewayFn = (() => gateway) as unknown as typeof createGateway;
+  return { callCount: () => callIndex };
+}
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, contact_history, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  currentGatewayFn = null;
+  process.env.AI_GATEWAY_API_KEY = 'test-key';
+}
+
+async function seedOrgProject(slug: string) {
+  const db = getDb();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `p-${slug}`,
+      name: slug,
+      description: `about ${slug}`,
+    })
+    .returning();
+  return { org, project };
+}
+
+function suggestionArgs(post: ObservedPost, projectId: number, orgId: number) {
+  return {
+    kind: 'post_comment' as const,
+    post,
+    currentProject: { name: 'p', description: null },
+    persona: null,
+    voiceProfile: null,
+    projects: [],
+    repos: [],
+    projectId,
+    orgId,
+    runnerSlug: 'cloud',
+  };
+}
+
+describe('runSuggestion: the agent loop (#566)', () => {
+  beforeEach(reset);
+  afterEach(() => {
+    for (const dir of logDirs) rmSync(dir, { recursive: true, force: true });
+    logDirs = [];
+    vi.useRealTimers();
+  });
+
+  it('a suggestion needing the thread and the image takes multiple steps, dispatching independent tool calls together', async () => {
+    const { org, project } = await seedOrgProject('org-loop-multistep');
+    // Captured at the write step (the one whose prompt already carries every
+    // earlier tool result) so the assertions below can check the *results*
+    // actually reached the model - a step count alone cannot tell "the
+    // tools genuinely ran" apart from "the harness pretended they did", since
+    // `ai` forwards an unexecutable tool-call through to the next turn
+    // either way.
+    let finalPrompt = '';
+    const { callCount } = useModel((step, options) => {
+      if (step === 0) return toolCallStep([{ name: 'read_thread' }, { name: 'author_history' }]);
+      if (step === 1) return toolCallStep([{ name: 'look_at_image' }]);
+      finalPrompt = JSON.stringify(options.prompt);
+      return textStep(
+        `Noticed the chart.\n${DRAFT_MARKER}\nGreat point on p99, thanks for the context.`,
+      );
+    });
+
+    const handle = runSuggestion(
+      suggestionArgs(
+        {
+          urn: 'urn:li:activity:2',
+          authorHandle: 'jdoe',
+          authorName: 'J Doe',
+          text: 'We cut p99 in half this week.',
+          thread: {
+            comments: [{ body: 'Nice work', authorHandle: 'other-user' }],
+            renderedCount: 1,
+            truncated: false,
+          },
+          image: { alt: 'A latency chart trending down', kind: 'image' },
+        },
+        project.id,
+        org.id,
+      ),
+    );
+    const result = await handle.result;
+
+    // Two independent, DB-backed tools requested in the same step (step 0),
+    // then look_at_image alone (step 1, per the design's "runs alone"), then
+    // the write (step 2) - three model turns, not four: if the two tools in
+    // step 0 had been forced into separate turns instead of dispatched
+    // together, this would read 4.
+    expect(callCount()).toBe(3);
+    expect(result.draft).toBe('Great point on p99, thanks for the context.');
+    // The real handlers actually ran and their real answers reached the
+    // write step - read_thread's real comment text, author_history's real
+    // "nothing on file" refusal (a fresh org has no contact_history row for
+    // this handle), and look_at_image's real alt-text description.
+    expect(finalPrompt).toContain('Nice work');
+    expect(finalPrompt).toContain('no prior contact');
+    expect(finalPrompt).toContain('A latency chart trending down');
+  });
+
+  it('a plain text post still takes exactly one model turn when the model asks for no tools', async () => {
+    const { org, project } = await seedOrgProject('org-loop-singleturn');
+    const { callCount } = useModel(() =>
+      textStep(`Straightforward.\n${DRAFT_MARKER}\nCongrats on shipping this.`),
+    );
+
+    const handle = runSuggestion(
+      suggestionArgs(
+        { urn: 'urn:li:activity:3', authorName: 'A', text: 'Shipped a small thing today.' },
+        project.id,
+        org.id,
+      ),
+    );
+    const result = await handle.result;
+
+    expect(callCount()).toBe(1);
+    expect(result.draft).toBe('Congrats on shipping this.');
+  });
+
+  it('cancelling from the panel stops the loop mid-step: no further tool handler starts and no further model turn is requested', async () => {
+    const { org, project } = await seedOrgProject('org-loop-cancel');
+    let resolveStarted: () => void = () => {};
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const { callCount } = useModel(async (step, options) => {
+      if (step > 0) {
+        throw new Error(`no further model turn should have been requested (reached step ${step})`);
+      }
+      resolveStarted();
+      // The real AI SDK ends the stream cleanly on abort rather than
+      // throwing (docs/cloud-runner.md's "an aborted streamText does not
+      // throw" finding) - waiting on the signal and yielding nothing models
+      // that faithfully.
+      await waitForAbort(options.abortSignal ?? new AbortController().signal);
+      return [];
+    });
+
+    const handle = runSuggestion(
+      suggestionArgs({ urn: 'urn:li:activity:4', authorName: 'A', text: 'hi' }, project.id, org.id),
+    );
+    await started;
+    handle.cancel();
+
+    await expect(handle.result).rejects.toThrow(/cancelled/i);
+    expect(callCount()).toBe(1);
+  });
+
+  it('hitting the step budget forces the model to answer with what it has, yielding a usable draft', async () => {
+    const { org, project } = await seedOrgProject('org-loop-steps');
+    const { callCount } = useModel((_step, options) => {
+      if (options.toolChoice?.type === 'none') {
+        return textStep(`Wrapping up.\n${DRAFT_MARKER}\nHere is what I found in time.`);
+      }
+      return toolCallStep([{ name: 'check_style', args: { text: 'a draft in progress' } }]);
+    });
+
+    const handle = runSuggestion(
+      suggestionArgs({ urn: 'urn:li:activity:5', authorName: 'A', text: 'hi' }, project.id, org.id),
+    );
+    const result = await handle.result;
+
+    // Steps 0..ASSIST_MAX_STEPS-2 are free to call tools; the last one
+    // (index ASSIST_MAX_STEPS-1) is forced text-only - ASSIST_MAX_STEPS
+    // turns total.
+    expect(callCount()).toBe(ASSIST_MAX_STEPS);
+    expect(result.draft).toBe('Here is what I found in time.');
+  });
+
+  it('crossing the soft wall-clock budget forces the model to answer with what it has, yielding a usable draft', async () => {
+    vi.useFakeTimers();
+    const { org, project } = await seedOrgProject('org-loop-soft');
+    const { callCount } = useModel(async (_step, options) => {
+      if (options.toolChoice?.type === 'none') {
+        return textStep(`Time is up.\n${DRAFT_MARKER}\nHere is my answer given the time I had.`);
+      }
+      // The first turn itself takes longer than the soft budget - the very
+      // next prepareStep call then sees elapsed wall-clock time already
+      // past it.
+      await vi.advanceTimersByTimeAsync(ASSIST_SOFT_BUDGET_MS + 1_000);
+      return toolCallStep([{ name: 'check_style', args: { text: 'a draft in progress' } }]);
+    });
+
+    const handle = runSuggestion(
+      suggestionArgs({ urn: 'urn:li:activity:6', authorName: 'A', text: 'hi' }, project.id, org.id),
+    );
+    const result = await handle.result;
+
+    expect(callCount()).toBe(2);
+    expect(result.draft).toBe('Here is my answer given the time I had.');
+  });
+
+  it('crossing the token budget forces the model to answer with what it has, yielding a usable draft', async () => {
+    const { org, project } = await seedOrgProject('org-loop-tokens');
+    const { callCount } = useModel((_step, options) => {
+      if (options.toolChoice?.type === 'none') {
+        return textStep(
+          `Enough context.\n${DRAFT_MARKER}\nHere is my answer from what I already gathered.`,
+        );
+      }
+      // Step 0 alone reports more input tokens than ASSIST_TOKEN_BUDGET, so
+      // step 1's prepareStep sees the accumulated total already over it.
+      return toolCallStep([{ name: 'check_style', args: { text: 'a draft in progress' } }], {
+        inputTokens: ASSIST_TOKEN_BUDGET + 10_000,
+        outputTokens: 5,
+      });
+    });
+
+    const handle = runSuggestion(
+      suggestionArgs({ urn: 'urn:li:activity:7', authorName: 'A', text: 'hi' }, project.id, org.id),
+    );
+    const result = await handle.result;
+
+    expect(callCount()).toBe(2);
+    expect(result.draft).toBe('Here is my answer from what I already gathered.');
+  });
+
+  it('usage is the sum across steps, not just the last one', async () => {
+    const { org, project } = await seedOrgProject('org-loop-usage');
+    useModel((step) => {
+      if (step === 0) {
+        return toolCallStep([{ name: 'check_style', args: { text: 'draft' } }], {
+          inputTokens: 30,
+          outputTokens: 5,
+        });
+      }
+      return textStep(`Ok.\n${DRAFT_MARKER}\nFinal answer.`, { inputTokens: 20, outputTokens: 15 });
+    });
+
+    const handle = runSuggestion(
+      suggestionArgs({ urn: 'urn:li:activity:8', authorName: 'A', text: 'hi' }, project.id, org.id),
+    );
+    const result = await handle.result;
+
+    expect(result.usage?.inputTokens).toBe(50);
+    expect(result.usage?.outputTokens).toBe(20);
+    // No catalogue pricing wired into this fake gateway - cost stays
+    // best-effort null rather than a guess, per the design doc.
+    expect(result.usage?.costUsd).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #566

Wires the in-page assistant's tool loop into `runSuggestion`. This is the last piece of the epic settled in `docs/design/in-page-agent.md`: the middle of `runSuggestion` builds the `AssistToolContext` (db, orgId, boundProjectId, observedTarget, operator) from what it already resolves server-side, and passes it through `buildAssistToolSet` as `opts.tools` on the runner, with `toolLoopBudget` carrying the exact `ASSIST_MAX_STEPS` / `ASSIST_SOFT_BUDGET_MS` / `ASSIST_TOKEN_BUDGET` constants from `shared/src/assist/budget.ts`.

## What changed

- `web/src/lib/server/suggest.ts`: builds the tool context and wires `tools`/`toolLoopBudget` into `runner.run()`. The org id falls back to the seeded `default` organization (`resolveDeviceOrgId`) so a self-hosted, auth-off device still gets the loop. `ASSIST_HARD_TIMEOUT_MS` replaces the local `SUGGESTION_TIMEOUT_MS` constant so the budget module stays the one source of that number.
- `AcpRunner` ignores `opts.tools`/`opts.toolLoopBudget` entirely, so an ACP-backed suggestion keeps its existing single, tool-less turn. That transport's assist MCP entry point (`cli/src/mcp/assist-server.ts`, already shipped in #601) is separate wiring this issue does not do - noted below under "left deliberately."
- `shared/package.json`: exports `./agents/sdk/runner` so a real integration test can drive `SdkRunner` directly.
- `web/package.json`: adds `ai`, `@ai-sdk/gateway`, `@ai-sdk/provider` as devDependencies for the new test harness (drives the real `streamText` engine against a scripted `MockLanguageModelV4`, not a fake `streamText`).

## Tests added

- `web/tests/extension-suggest-loop-wiring.test.ts`: pins that the exact seven `ASSIST_TOOLS` and the exact `ASSIST_*` budget reach the runner, and that the tool context is scoped to the bound project and the observed post (a model-supplied project id belonging to another org is refused).
- `web/tests/extension-suggest-loop.test.ts`: drives the real `SdkRunner` against a scripted `MockLanguageModelV4` (real `streamText`, real `buildAssistToolSet`, real `ASSIST_TOOLS` handlers hitting the real test DB) to prove:
  - a suggestion needing the thread and the image takes three steps, with the two independent DB-backed tool calls dispatched together in one step (verified by call count staying at 3 rather than 4, and by inspecting the final turn's prompt for content only the real handlers could have produced);
  - a plain text post still takes exactly one model turn;
  - cancelling mid-step stops the loop - no further tool handler starts and no further model turn is requested;
  - each of the three budget edges (steps, soft wall-clock, tokens) forces a usable draft rather than an error;
  - usage is the sum across steps, not just the last one.

I proved the multi-step/parallel and the three budget-edge tests bite by disabling `tools`/`toolLoopBudget` in `suggest.ts` and watching exactly those tests fail, then restored.

## Verification

- `pnpm -F web check` - 0 errors.
- `pnpm -F @pitchbox/shared exec tsc --noEmit -p .` - clean.
- `eslint` + `prettier --check` on every changed/added file - clean.
- `web/tests/extension-suggest*.test.ts` and `web/tests/suggest-style-check.test.ts` (the existing suite this changes the middle of) - all green except one file (`extension-suggest-image.test.ts`) that hit a Postgres deadlock from two test files truncating the same tables in parallel workers; it passes standalone and the deadlock reproduces on `main` too, unrelated to this change.
- Latency: measured the real `claude-code` ACP path (unaffected by this change, since ACP ignores `opts.tools`) with `runSuggestion` directly, n=3, plain-text `post_comment`. Median first token 22.95s, median total 27.47s - well above the design doc's recorded 10.4s/12.9s pinned baseline. This devbox had several sibling agents running concurrently during the measurement (visible in the session roster), so I'm reporting the number as measured rather than treating it as a regression; the ACP code path itself is byte-for-byte unchanged by this PR.

## Left deliberately

- The ACP transport (self-hosted `claude-code`/`codex`/etc. runners) does not get the tool loop in this PR. The assist MCP entry point already exists (`cli/src/mcp/assist-server.ts` from #601) but nothing spawns it for a suggestion yet - only `SdkRunner`'s `opts.tools` path (the one runner change the design doc calls out for this issue) is wired. Worth its own follow-up if self-hosted parity matters before #574.
