### PR TITLE
feat(web,shared): an onboarding you can skip, resume and start again

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -99,7 +99,8 @@
     "./billing/checkout": "./src/billing/checkout.ts",
     "./billing/portal": "./src/billing/portal.ts",
     "./billing/webhook": "./src/billing/webhook.ts",
-    "./usage": "./src/usage.ts"
+    "./usage": "./src/usage.ts",
+    "./onboarding": "./src/onboarding.ts"
   },
   "scripts": {
     "migrate": "tsx src/db/migrate.ts",

--- a/shared/src/db/migrations/0030_onboarding_state.sql
+++ b/shared/src/db/migrations/0030_onboarding_state.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "onboarding_state" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer,
+	"organization_id" integer NOT NULL,
+	"status" text DEFAULT 'not_started' NOT NULL,
+	"current_step" text,
+	"version" integer DEFAULT 1 NOT NULL,
+	"started_at" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	"skipped_at" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "onboarding_state" ADD CONSTRAINT "onboarding_state_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "onboarding_state" ADD CONSTRAINT "onboarding_state_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "onboarding_state_user_org_unique" ON "onboarding_state" USING btree ("user_id","organization_id") WHERE "onboarding_state"."user_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "onboarding_state_org_no_user_unique" ON "onboarding_state" USING btree ("organization_id") WHERE "onboarding_state"."user_id" IS NULL;

--- a/shared/src/db/migrations/meta/0030_snapshot.json
+++ b/shared/src/db/migrations/meta/0030_snapshot.json
@@ -1,0 +1,5152 @@
+{
+  "id": "b2cbdb08-a501-478f-bda3-927a7618de2f",
+  "prevId": "10643b98-43d8-4cb6-aa29-ee4af1669e82",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cookie_session": {
+          "name": "cookie_session",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_limit": {
+          "name": "weekly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_project_id_projects_id_fk": {
+          "name": "accounts_project_id_projects_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_platform_id_platforms_id_fk": {
+          "name": "accounts_platform_id_platforms_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assist_usage": {
+      "name": "assist_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assist_usage_org_created_idx": {
+          "name": "assist_usage_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assist_usage_project_created_idx": {
+          "name": "assist_usage_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assist_usage_organization_id_organizations_id_fk": {
+          "name": "assist_usage_organization_id_organizations_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_project_id_projects_id_fk": {
+          "name": "assist_usage_project_id_projects_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_device_id_extension_devices_id_fk": {
+          "name": "assist_usage_device_id_extension_devices_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "extension_devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assist_usage_platform_id_platforms_id_fk": {
+          "name": "assist_usage_platform_id_platforms_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_failures": {
+      "name": "auth_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login_attempt'"
+        }
+      },
+      "indexes": {
+        "auth_failures_identifier_idx": {
+          "name": "auth_failures_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist": {
+      "name": "blocklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocklist_platform_id_platforms_id_fk": {
+          "name": "blocklist_platform_id_platforms_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocklist_project_id_projects_id_fk": {
+          "name": "blocklist_project_id_projects_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_recommendations": {
+      "name": "campaign_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_slug": {
+          "name": "scenario_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_recommendations_project_idx": {
+          "name": "campaign_recommendations_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_recommendations_project_id_projects_id_fk": {
+          "name": "campaign_recommendations_project_id_projects_id_fk",
+          "tableFrom": "campaign_recommendations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_slug": {
+          "name": "skill_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_attempts": {
+          "name": "failure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_due_to_failures": {
+          "name": "paused_due_to_failures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_post": {
+          "name": "auto_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_platform_id_platforms_id_fk": {
+          "name": "campaigns_platform_id_platforms_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_history": {
+      "name": "contact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_handle": {
+          "name": "account_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_checked_at": {
+          "name": "reply_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_room_id": {
+          "name": "chat_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_context_url": {
+          "name": "platform_context_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uncontactable": {
+          "name": "uncontactable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uncontactable_reason": {
+          "name": "uncontactable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_history_target_idx": {
+          "name": "contact_history_target_idx",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_target_idx": {
+          "name": "messages_account_target_idx",
+          "columns": [
+            {
+              "expression": "account_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_org_idx": {
+          "name": "contact_history_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_contacted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_history_platform_id_platforms_id_fk": {
+          "name": "contact_history_platform_id_platforms_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contact_history_draft_id_drafts_id_fk": {
+          "name": "contact_history_draft_id_drafts_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_history_organization_id_organizations_id_fk": {
+          "name": "contact_history_organization_id_organizations_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_heartbeats": {
+      "name": "daemon_heartbeats",
+      "schema": "",
+      "columns": {
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tick_at": {
+          "name": "tick_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_events": {
+      "name": "draft_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_events_kind_created_idx": {
+          "name": "draft_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_events_draft_id_drafts_id_fk": {
+          "name": "draft_events_draft_id_drafts_id_fk",
+          "tableFrom": "draft_events",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_regeneration_hints": {
+      "name": "draft_regeneration_hints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint_text": {
+          "name": "hint_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_regeneration_hints_draft_id_drafts_id_fk": {
+          "name": "draft_regeneration_hints_draft_id_drafts_id_fk",
+          "tableFrom": "draft_regeneration_hints",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "fit_score": {
+          "name": "fit_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_url": {
+          "name": "compose_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_content": {
+          "name": "sent_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_comment_id": {
+          "name": "platform_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dedup_warning": {
+          "name": "dedup_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_edited": {
+          "name": "body_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_send_after": {
+          "name": "scheduled_send_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerating_run_id": {
+          "name": "regenerating_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drafting_run_id": {
+          "name": "drafting_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_reason": {
+          "name": "quality_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_model": {
+          "name": "quality_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_id": {
+          "name": "variant_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undeliverable_reason": {
+          "name": "undeliverable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drafts_state_idx": {
+          "name": "drafts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_project_idx": {
+          "name": "drafts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_run_idx": {
+          "name": "drafts_state_run_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_campaign_created_idx": {
+          "name": "drafts_state_campaign_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_variant_group_idx": {
+          "name": "drafts_variant_group_idx",
+          "columns": [
+            {
+              "expression": "variant_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_run_id_runs_id_fk": {
+          "name": "drafts_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_project_id_projects_id_fk": {
+          "name": "drafts_project_id_projects_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_platform_id_platforms_id_fk": {
+          "name": "drafts_platform_id_platforms_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_accounts_id_fk": {
+          "name": "drafts_account_id_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_regenerating_run_id_runs_id_fk": {
+          "name": "drafts_regenerating_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "regenerating_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drafts_drafting_run_id_runs_id_fk": {
+          "name": "drafts_drafting_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "drafting_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_verification_tokens_user_idx": {
+          "name": "email_verification_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_devices": {
+      "name": "extension_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unnamed device'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "extension_devices_token_hash_unique": {
+          "name": "extension_devices_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extension_devices_organization_id_organizations_id_fk": {
+          "name": "extension_devices_organization_id_organizations_id_fk",
+          "tableFrom": "extension_devices",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_pairings": {
+      "name": "extension_pairings",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extension_pairings_organization_id_organizations_id_fk": {
+          "name": "extension_pairings_organization_id_organizations_id_fk",
+          "tableFrom": "extension_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'User'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selected'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_unique": {
+          "name": "github_installations_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_organization_id_organizations_id_fk": {
+          "name": "github_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sources": {
+      "name": "github_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_language": {
+          "name": "primary_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readme_excerpt": {
+          "name": "readme_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_commits": {
+          "name": "recent_commits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_sources_org_repo_unique": {
+          "name": "github_sources_org_repo_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_sources_organization_id_organizations_id_fk": {
+          "name": "github_sources_organization_id_organizations_id_fk",
+          "tableFrom": "github_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_audit_log": {
+      "name": "instance_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_audit_log_created_idx": {
+          "name": "instance_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_watches": {
+      "name": "keyword_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_field": {
+          "name": "match_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keyword_watches_campaign_idx": {
+          "name": "keyword_watches_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_watches_project_idx": {
+          "name": "keyword_watches_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_watches_project_id_projects_id_fk": {
+          "name": "keyword_watches_project_id_projects_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keyword_watches_campaign_id_campaigns_id_fk": {
+          "name": "keyword_watches_campaign_id_campaigns_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_org_user_unique": {
+          "name": "memberships_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_from_us": {
+          "name": "is_from_us",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_platform": {
+          "name": "created_at_platform",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_contact_idx": {
+          "name": "messages_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_platform_message_unique": {
+          "name": "messages_platform_message_unique",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_contact_id_contact_history_id_fk": {
+          "name": "messages_contact_id_contact_history_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "contact_history",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_draft_id_drafts_id_fk": {
+          "name": "messages_draft_id_drafts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_platform_id_platforms_id_fk": {
+          "name": "messages_platform_id_platforms_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_unread_idx": {
+          "name": "notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_idx": {
+          "name": "notifications_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organization_id_organizations_id_fk": {
+          "name": "notifications_organization_id_organizations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observed_targets": {
+      "name": "observed_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_by_run_id": {
+          "name": "consumed_by_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "observed_targets_dedup_idx": {
+          "name": "observed_targets_dedup_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "observed_targets_project_unconsumed_idx": {
+          "name": "observed_targets_project_unconsumed_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_by_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "observed_targets_organization_id_organizations_id_fk": {
+          "name": "observed_targets_organization_id_organizations_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_project_id_projects_id_fk": {
+          "name": "observed_targets_project_id_projects_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_platform_id_platforms_id_fk": {
+          "name": "observed_targets_platform_id_platforms_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observed_targets_consumed_by_run_id_runs_id_fk": {
+          "name": "observed_targets_consumed_by_run_id_runs_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "consumed_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_state": {
+      "name": "onboarding_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_state_user_org_unique": {
+          "name": "onboarding_state_user_org_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"onboarding_state\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_state_org_no_user_unique": {
+          "name": "onboarding_state_org_no_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"onboarding_state\".\"user_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_state_user_id_users_id_fk": {
+          "name": "onboarding_state_user_id_users_id_fk",
+          "tableFrom": "onboarding_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onboarding_state_organization_id_organizations_id_fk": {
+          "name": "onboarding_state_organization_id_organizations_id_fk",
+          "tableFrom": "onboarding_state",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_profiles": {
+      "name": "operator_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiences": {
+          "name": "experiences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'linkedin_capture'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_profiles_org_unique": {
+          "name": "operator_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_profiles": {
+      "name": "operator_voice_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "openings": {
+          "name": "openings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "closings": {
+          "name": "closings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "common_words": {
+          "name": "common_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "words_per_sentence": {
+          "name": "words_per_sentence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'derived'"
+        },
+        "derived_at": {
+          "name": "derived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_profiles_org_unique": {
+          "name": "operator_voice_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_voice_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_samples": {
+      "name": "operator_voice_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_samples_org_external_unique": {
+          "name": "operator_voice_samples_org_external_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operator_voice_samples_org_idx": {
+          "name": "operator_voice_samples_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "excluded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_samples_organization_id_organizations_id_fk": {
+          "name": "operator_voice_samples_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_voice_samples_platform_id_platforms_id_fk": {
+          "name": "operator_voice_samples_platform_id_platforms_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invites": {
+      "name": "org_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_invites_org_idx": {
+          "name": "org_invites_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invites_organization_id_organizations_id_fk": {
+          "name": "org_invites_organization_id_organizations_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invites_created_by_user_id_users_id_fk": {
+          "name": "org_invites_created_by_user_id_users_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invites_token_unique": {
+          "name": "org_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_subscriptions": {
+      "name": "org_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "limit_runs": {
+          "name": "limit_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_suggestions": {
+          "name": "limit_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_projects": {
+          "name": "limit_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_seats": {
+          "name": "limit_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_devices": {
+          "name": "limit_devices",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrency": {
+          "name": "limit_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_budget_usd": {
+          "name": "limit_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_retention_days": {
+          "name": "limit_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_premium_models": {
+          "name": "limit_premium_models",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_org_unique": {
+          "name": "org_subscriptions_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_stripe_subscription_unique": {
+          "name": "org_subscriptions_stripe_subscription_unique",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_subscriptions_organization_id_organizations_id_fk": {
+          "name": "org_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "org_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_run_budget_usd": {
+          "name": "monthly_run_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_source": {
+          "name": "plan_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "plan_updated_at": {
+          "name": "plan_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organizations_stripe_customer_id_unique": {
+          "name": "organizations_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_user_idx": {
+          "name": "password_reset_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platforms": {
+      "name": "platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platforms_slug_unique": {
+          "name": "platforms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playbooks": {
+      "name": "playbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playbooks_slug_unique": {
+          "name": "playbooks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_insights": {
+      "name": "project_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary_md": {
+          "name": "summary_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_insights_project_idx": {
+          "name": "project_insights_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_insights_project_id_projects_id_fk": {
+          "name": "project_insights_project_id_projects_id_fk",
+          "tableFrom": "project_insights",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_sources": {
+      "name": "project_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_runner": {
+          "name": "default_agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "voice_tone": {
+          "name": "voice_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_tone_notes": {
+          "name": "voice_tone_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_unique": {
+          "name": "projects_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_events_run_idx": {
+          "name": "run_events_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_events_kind_created_idx": {
+          "name": "run_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'campaign'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout_log_path": {
+          "name": "stdout_log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playbook_body": {
+          "name": "playbook_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_project_kind_idx": {
+          "name": "runs_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_campaign_id_campaigns_id_fk": {
+          "name": "runs_campaign_id_campaigns_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_scout_candidates": {
+      "name": "staging_scout_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staging_scout_candidates_run_id_runs_id_fk": {
+          "name": "staging_scout_candidates_run_id_runs_id_fk",
+          "tableFrom": "staging_scout_candidates",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_project_kind_idx": {
+          "name": "templates_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_project_id_projects_id_fk": {
+          "name": "templates_project_id_projects_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_instance_admin": {
+          "name": "is_instance_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recent_idx": {
+          "name": "webhook_deliveries_recent_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_org_idx": {
+          "name": "webhook_deliveries_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_organization_id_organizations_id_fk": {
+          "name": "webhook_deliveries_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1788960000016,
       "tag": "0029_stripe_customer_and_events",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1788960000017,
+      "tag": "0030_onboarding_state",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import {
   pgTable,
   serial,
@@ -1345,5 +1346,67 @@ export const projectSources = pgTable(
   },
   (t) => ({
     byProject: index('project_sources_project_idx').on(t.projectId, t.active),
+  }),
+);
+
+// Onboarding state (#516): a per-(user, org) row rather than a jsonb blob on
+// `users`, because a person can own their own org and later join a second
+// one with a different setup state - a completed org and an empty one are
+// not the same fact about the same person, and a `users` column would
+// conflate them. `organizationId` is always set (self-host with auth off
+// still resolves the seeded `default` org - see resolveOrgId);
+// `userId` is null only for that self-host, no-login case, where there is
+// no `users` row to key on at all. The `*_no_user_unique` index below is
+// what keeps a race between two anonymous self-host requests from
+// inserting two rows for the same org - Postgres treats every NULL as
+// distinct, so an ordinary unique index on (user_id, organization_id)
+// would not catch that (same trick as `users.email`, see above).
+//
+// `status` is the explicit lifecycle `OnboardingStatus`
+// (shared/src/onboarding.ts): `not_started` -> `in_progress` -> `skipped` |
+// `completed`, with `skipped` -> `in_progress` a valid transition too (the
+// Settings "Start again" action, restartOnboarding). A skip is a recorded
+// decision, not the absence of a row: otherwise "never started" and "said
+// no thanks" are indistinguishable and the flow would come back to haunt
+// someone who deliberately dismissed it.
+//
+// `currentStep` is a navigation pointer, not a completion record - which
+// step is complete is never read from here, it is recomputed live from the
+// real state of the org (a project with a source, a connected account, a
+// paired extension device, a draft) every time a caller asks
+// (`computeOnboardingSteps`, shared/src/onboarding.ts). That is what keeps
+// this table from becoming the "said done but the underlying thing is
+// missing" failure mode the issue calls out: nothing here can go stale
+// about *whether* a step is done, only about *where the person last was*.
+//
+// `version` is the onboarding sequence version the row was started or
+// restarted under (`ONBOARDING_VERSION`). It is written, not yet compared
+// against on read - so that changing the step list later is a decision an
+// implementer makes deliberately (re-offer a stale `completed` row, or
+// leave it alone) instead of an accident silently re-triggering for every
+// existing account.
+export const onboardingState = pgTable(
+  'onboarding_state',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id').references(() => users.id, { onDelete: 'cascade' }),
+    organizationId: integer('organization_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    status: text('status').notNull().default('not_started'),
+    currentStep: text('current_step'),
+    version: integer('version').notNull().default(1),
+    startedAt: timestamp('started_at', { withTimezone: true }),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
+    skippedAt: timestamp('skipped_at', { withTimezone: true }),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    byUserOrg: uniqueIndex('onboarding_state_user_org_unique')
+      .on(t.userId, t.organizationId)
+      .where(sql`${t.userId} IS NOT NULL`),
+    byOrgNoUser: uniqueIndex('onboarding_state_org_no_user_unique')
+      .on(t.organizationId)
+      .where(sql`${t.userId} IS NULL`),
   }),
 );

--- a/shared/src/onboarding.ts
+++ b/shared/src/onboarding.ts
@@ -1,0 +1,343 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+import {
+  accounts,
+  drafts,
+  extensionDevices,
+  onboardingState,
+  organizations,
+  projects,
+  projectSources,
+  users,
+} from './db/schema.js';
+import { isEmailVerified } from './auth.js';
+import { defaultOrgName, getMemberRole } from './orgs.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Db = PgDatabase<any, any, any>;
+
+/**
+ * The onboarding sequence version. Bump this when the step list changes;
+ * `onboarding_state.version` records which version a row was started or
+ * restarted under, so a future change can decide deliberately whether a
+ * `completed`/`skipped` row written under an older version should be
+ * re-offered - nothing here does that automatically (see #516's own
+ * comment: "changing the steps later is a decision... instead of an
+ * accident").
+ */
+export const ONBOARDING_VERSION = 1;
+
+export type OnboardingStepId =
+  'organization' | 'verify_email' | 'project' | 'account' | 'extension' | 'first_draft';
+
+/** Order matters: this is the sequence the wizard walks and the order `currentStep` is picked in. */
+export const ONBOARDING_STEPS: readonly OnboardingStepId[] = [
+  'organization',
+  'verify_email',
+  'project',
+  'account',
+  'extension',
+  'first_draft',
+];
+
+export type OnboardingStatus = 'not_started' | 'in_progress' | 'skipped' | 'completed';
+
+export type OnboardingStepState = {
+  id: OnboardingStepId;
+  /** Whether this step means anything for this identity (e.g. `organization` and
+   * `verify_email` are not applicable with auth off, or to a non-owner member). */
+  applicable: boolean;
+  /** Read live from the real thing the step is about - never a stored flag. */
+  complete: boolean;
+};
+
+export type OnboardingSnapshot = {
+  status: OnboardingStatus;
+  version: number;
+  steps: OnboardingStepState[];
+  /** The single next applicable+incomplete step, or null when there is nothing left. */
+  currentStep: OnboardingStepId | null;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  skippedAt: Date | null;
+};
+
+export type OnboardingIdentity = {
+  organizationId: number;
+  /** Null only for self-host with auth off, where there is no `users` row to key on. */
+  userId: number | null;
+};
+
+export type OnboardingContext = {
+  authOn: boolean;
+  /** The signed-in caller's username, needed only to evaluate the `organization` step. */
+  username?: string | null;
+};
+
+async function findRow(db: Db, identity: OnboardingIdentity) {
+  const { organizationId, userId } = identity;
+  const condition =
+    userId == null
+      ? and(eq(onboardingState.organizationId, organizationId), isNull(onboardingState.userId))
+      : and(eq(onboardingState.organizationId, organizationId), eq(onboardingState.userId, userId));
+  const [row] = await db.select().from(onboardingState).where(condition).limit(1);
+  return row ?? null;
+}
+
+/**
+ * Live per-step completion, read from the real state of the things each
+ * step walks the operator through - a project with a source, a connected
+ * account, a paired extension device, a first draft - rather than from a
+ * copy this table keeps of its own. This is the one place that "is this
+ * step actually done" gets decided, and it is safe to call on every page
+ * load: five to six cheap indexed lookups, no writes.
+ */
+export async function computeOnboardingSteps(
+  db: Db,
+  identity: OnboardingIdentity,
+  ctx: OnboardingContext,
+): Promise<OnboardingStepState[]> {
+  const { organizationId, userId } = identity;
+  const { authOn, username } = ctx;
+
+  // organization: applicable only to the owner of an authenticated org (the
+  // one #513 derived a name for without asking) - a member has nothing to
+  // rename and self-host has no owner concept. Complete once the name on
+  // file differs from the pure-function default `defaultOrgName` would
+  // still produce for this account - a real column comparison, not a click
+  // flag.
+  let orgApplicable = false;
+  let orgComplete = true;
+  if (authOn && userId != null) {
+    const role = await getMemberRole(db, organizationId, userId);
+    orgApplicable = role === 'owner';
+    if (orgApplicable) {
+      const [org] = await db
+        .select({ name: organizations.name })
+        .from(organizations)
+        .where(eq(organizations.id, organizationId))
+        .limit(1);
+      const derivedDefault = username ? defaultOrgName(username) : null;
+      orgComplete = !org || derivedDefault == null || org.name !== derivedDefault;
+    }
+  }
+
+  // verify_email: applicable only when signed in with an address on file -
+  // self-host and a pre-#507 account with no email have nothing to prove.
+  let verifyApplicable = false;
+  let verifyComplete = true;
+  if (authOn && userId != null) {
+    const [u] = await db
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+    verifyApplicable = !!u?.email;
+    if (verifyApplicable) verifyComplete = await isEmailVerified(db, userId);
+  }
+
+  // project: at least one source, not just an empty project shell - "give
+  // the agent something to write about" is the actual bar #516 sets.
+  const [projectRow] = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .innerJoin(projectSources, eq(projectSources.projectId, projects.id))
+    .where(and(eq(projects.organizationId, organizationId), eq(projectSources.active, true)))
+    .limit(1);
+
+  // account: any active platform account on any project in the org.
+  const [accountRow] = await db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .innerJoin(projects, eq(projects.id, accounts.projectId))
+    .where(and(eq(projects.organizationId, organizationId), eq(accounts.active, true)))
+    .limit(1);
+
+  // extension: a non-revoked device paired to this org. Self-host with auth
+  // off still resolves a real org id (the seeded `default` org - see
+  // resolveOrgId/defaultOrgId in web/src/lib/server), and every pairing
+  // path (auto-pair, pairing-code redemption) writes that same real id, so
+  // this is a plain equality check with no null-org branch to carry.
+  const [deviceRow] = await db
+    .select({ id: extensionDevices.id })
+    .from(extensionDevices)
+    .where(
+      and(eq(extensionDevices.organizationId, organizationId), isNull(extensionDevices.revokedAt)),
+    )
+    .limit(1);
+
+  // first_draft: reaching a draft is the destination this step names - not
+  // "sent", which is a further, separate human decision.
+  const [draftRow] = await db
+    .select({ id: drafts.id })
+    .from(drafts)
+    .innerJoin(projects, eq(projects.id, drafts.projectId))
+    .where(eq(projects.organizationId, organizationId))
+    .limit(1);
+
+  return [
+    { id: 'organization', applicable: orgApplicable, complete: orgComplete },
+    { id: 'verify_email', applicable: verifyApplicable, complete: verifyComplete },
+    { id: 'project', applicable: true, complete: !!projectRow },
+    { id: 'account', applicable: true, complete: !!accountRow },
+    { id: 'extension', applicable: true, complete: !!deviceRow },
+    { id: 'first_draft', applicable: true, complete: !!draftRow },
+  ];
+}
+
+function firstIncomplete(steps: OnboardingStepState[]): OnboardingStepId | null {
+  return steps.find((s) => s.applicable && !s.complete)?.id ?? null;
+}
+
+function toSnapshot(
+  row: {
+    status: string;
+    version: number;
+    startedAt: Date | null;
+    completedAt: Date | null;
+    skippedAt: Date | null;
+  } | null,
+  steps: OnboardingStepState[],
+): OnboardingSnapshot {
+  return {
+    status: (row?.status as OnboardingStatus) ?? 'not_started',
+    version: row?.version ?? ONBOARDING_VERSION,
+    steps,
+    currentStep: firstIncomplete(steps),
+    startedAt: row?.startedAt ?? null,
+    completedAt: row?.completedAt ?? null,
+    skippedAt: row?.skippedAt ?? null,
+  };
+}
+
+/**
+ * Reads the current onboarding snapshot with no side effects beyond the one
+ * honest reconciliation every caller needs: an `in_progress` row whose live
+ * steps are now all satisfied gets marked `completed` right here, because
+ * that is a fact about reality becoming true, not a click being tracked. A
+ * missing row reads as `not_started` without ever being written - visiting
+ * a page must never silently create a row.
+ */
+export async function getOnboardingSnapshot(
+  db: Db,
+  identity: OnboardingIdentity,
+  ctx: OnboardingContext,
+): Promise<OnboardingSnapshot> {
+  const row = await findRow(db, identity);
+  const steps = await computeOnboardingSteps(db, identity, ctx);
+  if (row && row.status === 'in_progress' && firstIncomplete(steps) == null) {
+    const [updated] = await db
+      .update(onboardingState)
+      .set({ status: 'completed', completedAt: new Date(), updatedAt: new Date() })
+      .where(eq(onboardingState.id, row.id))
+      .returning();
+    return toSnapshot(updated, steps);
+  }
+  return toSnapshot(row, steps);
+}
+
+async function upsert(
+  db: Db,
+  identity: OnboardingIdentity,
+  values: Partial<typeof onboardingState.$inferInsert>,
+) {
+  const row = await findRow(db, identity);
+  if (row) {
+    await db
+      .update(onboardingState)
+      .set({ ...values, updatedAt: new Date() })
+      .where(eq(onboardingState.id, row.id));
+    return;
+  }
+  try {
+    await db.insert(onboardingState).values({
+      organizationId: identity.organizationId,
+      userId: identity.userId,
+      ...values,
+    });
+  } catch (e) {
+    // A concurrent first-visit raced us to the same (user, org) row - the
+    // partial unique indexes on onboarding_state caught it. Whoever lost
+    // the insert just applies the same update to the row the winner made.
+    if (e instanceof Error && /unique|duplicate key/i.test(e.message)) {
+      const winner = await findRow(db, identity);
+      if (winner) {
+        await db
+          .update(onboardingState)
+          .set({ ...values, updatedAt: new Date() })
+          .where(eq(onboardingState.id, winner.id));
+        return;
+      }
+    }
+    throw e;
+  }
+}
+
+/**
+ * First sign-in entry point: `not_started` (or no row at all) becomes
+ * `in_progress`. A row already in any other status is left untouched - this
+ * is not a resume primitive, it is "begin, once". Called from `/onboarding`'s
+ * own loader, so visiting the page for the first time is what starts it;
+ * nothing elsewhere needs to reach into this table.
+ */
+export async function startOnboarding(
+  db: Db,
+  identity: OnboardingIdentity,
+  ctx: OnboardingContext,
+): Promise<OnboardingSnapshot> {
+  const existing = await findRow(db, identity);
+  if (!existing || existing.status === 'not_started') {
+    await upsert(db, identity, {
+      status: 'in_progress',
+      startedAt: new Date(),
+      version: ONBOARDING_VERSION,
+    });
+  }
+  // getOnboardingSnapshot's own reconciliation immediately promotes this to
+  // `completed` when every applicable step already reads true - a
+  // pre-populated org (an existing self-host install, an org someone joined
+  // after everything was already set up) never sees an empty wizard with
+  // nothing left to do.
+  return getOnboardingSnapshot(db, identity, ctx);
+}
+
+/**
+ * The dashboard's dismiss action and the wizard's own "Skip for now": a
+ * recorded decision, not a lack of one. No-op when already `skipped` or
+ * `completed` (skip only means something on the way there).
+ */
+export async function skipOnboarding(
+  db: Db,
+  identity: OnboardingIdentity,
+  ctx: OnboardingContext,
+): Promise<OnboardingSnapshot> {
+  const existing = await findRow(db, identity);
+  if (!existing || existing.status === 'not_started' || existing.status === 'in_progress') {
+    await upsert(db, identity, { status: 'skipped', skippedAt: new Date() });
+  }
+  return getOnboardingSnapshot(db, identity, ctx);
+}
+
+/**
+ * The Settings "Start again" action: valid from every status, including the
+ * two terminal ones (#516: "from /settings it can be started again from any
+ * terminal state"). Bumps `version` to the sequence currently in code and
+ * clears the terminal timestamps - if every step still reads complete, the
+ * very next `getOnboardingSnapshot` call folds it straight back to
+ * `completed` with a fresh timestamp, which is the honest answer to
+ * "run it again": confirmed, not re-created.
+ */
+export async function restartOnboarding(
+  db: Db,
+  identity: OnboardingIdentity,
+  ctx: OnboardingContext,
+): Promise<OnboardingSnapshot> {
+  await upsert(db, identity, {
+    status: 'in_progress',
+    version: ONBOARDING_VERSION,
+    startedAt: new Date(),
+    completedAt: null,
+    skippedAt: null,
+  });
+  return getOnboardingSnapshot(db, identity, ctx);
+}

--- a/shared/tests/onboarding.test.ts
+++ b/shared/tests/onboarding.test.ts
@@ -1,0 +1,495 @@
+// Exercises shared/src/onboarding.ts: the skip/resume/restart state machine
+// (#516) and the live per-step reads it is built on - a step must read the
+// real thing it is about, never a stored flag of its own. Each test creates
+// its own organization (+ user where relevant, unique slug/username) rather
+// than reusing the seeded 'default' org, and cleans up via cascade delete on
+// the org - this DB is shared across test files and teardown intentionally
+// leaves data for inspection.
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, afterEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import { createUserRecord } from '../src/auth.js';
+import { createOrganization, defaultOrgName, renameOrg } from '../src/orgs.js';
+import {
+  ONBOARDING_VERSION,
+  computeOnboardingSteps,
+  getOnboardingSnapshot,
+  restartOnboarding,
+  skipOnboarding,
+  startOnboarding,
+  type OnboardingStepId,
+} from '../src/onboarding.js';
+
+const createdOrgIds: number[] = [];
+const createdUserIds: number[] = [];
+
+afterEach(async () => {
+  const db = getDb();
+  while (createdOrgIds.length > 0) {
+    // Cascades to memberships/projects/onboarding_state (all onDelete:
+    // 'cascade' off organizations in schema.ts).
+    await db.delete(schema.organizations).where(eq(schema.organizations.id, createdOrgIds.pop()!));
+  }
+  while (createdUserIds.length > 0) {
+    await db.delete(schema.users).where(eq(schema.users.id, createdUserIds.pop()!));
+  }
+});
+
+/** A fresh, self-registered-shaped org: one owner user, org named by
+ * `defaultOrgName` exactly the way #513's derivation leaves it - i.e. the
+ * `organization` step should read as NOT complete for this fixture until a
+ * test explicitly renames it. */
+async function setupOwner() {
+  const db = getDb();
+  const username = `onboarding-owner-${randomUUID()}`;
+  const userId = await createUserRecord(db, {
+    username,
+    password: 'password123',
+    email: `${username}@example.com`,
+    emailVerifiedAt: null,
+  });
+  createdUserIds.push(userId);
+  const org = await createOrganization(db, {
+    slug: `onboarding-org-${randomUUID()}`,
+    name: defaultOrgName(username),
+    ownerUserId: userId,
+  });
+  createdOrgIds.push(org.id);
+  return { orgId: org.id, userId, username };
+}
+
+async function makeProjectWithSource(orgId: number) {
+  const db = getDb();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: orgId, slug: `p-${randomUUID()}`, name: 'Project' })
+    .returning();
+  await db.insert(schema.projectSources).values({
+    projectId: project.id,
+    kind: 'website',
+    config: { url: 'https://example.com' },
+    active: true,
+  });
+  return project.id;
+}
+
+async function makeAccount(projectId: number) {
+  const db = getDb();
+  const [platform] = await db
+    .select({ id: schema.platforms.id })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'reddit'))
+    .limit(1);
+  const [account] = await db
+    .insert(schema.accounts)
+    .values({ projectId, platformId: platform.id, handle: `u-${randomUUID()}`, active: true })
+    .returning();
+  return { accountId: account.id, platformId: platform.id };
+}
+
+async function pairExtensionDevice(orgId: number) {
+  const db = getDb();
+  await db.insert(schema.extensionDevices).values({
+    organizationId: orgId,
+    label: 'Test device',
+    tokenHash: `hash-${randomUUID()}`,
+  });
+}
+
+async function makeDraft(projectId: number, accountId: number, platformId: number) {
+  const db = getDb();
+  const [run] = await db
+    .insert(schema.runs)
+    .values({ kind: 'project_extraction', projectId, trigger: 'manual', status: 'success' })
+    .returning();
+  await db.insert(schema.drafts).values({
+    runId: run.id,
+    projectId,
+    platformId,
+    accountId,
+    kind: 'post',
+    body: 'A first draft.',
+  });
+}
+
+function stepById(
+  steps: { id: OnboardingStepId; applicable: boolean; complete: boolean }[],
+  id: OnboardingStepId,
+) {
+  const step = steps.find((s) => s.id === id);
+  if (!step) throw new Error(`missing step ${id}`);
+  return step;
+}
+
+describe('computeOnboardingSteps', () => {
+  it('reads every step from real state on a fresh org: nothing applicable is complete', async () => {
+    const { orgId, userId, username } = await setupOwner();
+    const steps = await computeOnboardingSteps(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    expect(stepById(steps, 'organization')).toEqual({
+      id: 'organization',
+      applicable: true,
+      complete: false,
+    });
+    expect(stepById(steps, 'verify_email').applicable).toBe(true);
+    expect(stepById(steps, 'verify_email').complete).toBe(false);
+    expect(stepById(steps, 'project').complete).toBe(false);
+    expect(stepById(steps, 'account').complete).toBe(false);
+    expect(stepById(steps, 'extension').complete).toBe(false);
+    expect(stepById(steps, 'first_draft').complete).toBe(false);
+  });
+
+  it('the organization step reads the real name column, not a click', async () => {
+    const { orgId, userId } = await setupOwner();
+    await renameOrg(getDb(), orgId, 'A Real Company Name');
+    const steps = await computeOnboardingSteps(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username: 'irrelevant-once-renamed' },
+    );
+    expect(stepById(steps, 'organization').complete).toBe(true);
+  });
+
+  it('the organization and verify_email steps are not applicable with auth off', async () => {
+    const { orgId } = await setupOwner();
+    const steps = await computeOnboardingSteps(
+      getDb(),
+      { organizationId: orgId, userId: null },
+      { authOn: false },
+    );
+    expect(stepById(steps, 'organization').applicable).toBe(false);
+    expect(stepById(steps, 'verify_email').applicable).toBe(false);
+    // Steps that read org-level state stay applicable regardless of auth.
+    expect(stepById(steps, 'project').applicable).toBe(true);
+  });
+
+  it('a project with no source does not satisfy the project step', async () => {
+    const { orgId, userId } = await setupOwner();
+    await getDb()
+      .insert(schema.projects)
+      .values({ organizationId: orgId, slug: `bare-${randomUUID()}`, name: 'Bare' });
+    const steps = await computeOnboardingSteps(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true },
+    );
+    expect(stepById(steps, 'project').complete).toBe(false);
+  });
+
+  it('marks project/account/extension/first_draft complete once the underlying rows exist', async () => {
+    const { orgId, userId } = await setupOwner();
+    const projectId = await makeProjectWithSource(orgId);
+    const { accountId, platformId } = await makeAccount(projectId);
+    await pairExtensionDevice(orgId);
+    await makeDraft(projectId, accountId, platformId);
+
+    const steps = await computeOnboardingSteps(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true },
+    );
+    expect(stepById(steps, 'project').complete).toBe(true);
+    expect(stepById(steps, 'account').complete).toBe(true);
+    expect(stepById(steps, 'extension').complete).toBe(true);
+    expect(stepById(steps, 'first_draft').complete).toBe(true);
+  });
+
+  it('a non-owner member never sees the organization step, regardless of the org name', async () => {
+    const { orgId } = await setupOwner();
+    const memberUsername = `onboarding-member-${randomUUID()}`;
+    const memberUserId = await createUserRecord(getDb(), {
+      username: memberUsername,
+      password: 'password123',
+      email: `${memberUsername}@example.com`,
+      emailVerifiedAt: new Date(),
+    });
+    createdUserIds.push(memberUserId);
+    await getDb()
+      .insert(schema.memberships)
+      .values({ organizationId: orgId, userId: memberUserId, role: 'member' });
+
+    const steps = await computeOnboardingSteps(
+      getDb(),
+      { organizationId: orgId, userId: memberUserId },
+      { authOn: true, username: memberUsername },
+    );
+    expect(stepById(steps, 'organization').applicable).toBe(false);
+  });
+
+  it("an invited member joining an already-set-up org reads completed, never repeating the owner's work", async () => {
+    const { orgId } = await setupOwner();
+    await renameOrg(getDb(), orgId, 'Owner Set This Up Co');
+    const projectId = await makeProjectWithSource(orgId);
+    const { accountId, platformId } = await makeAccount(projectId);
+    await pairExtensionDevice(orgId);
+    await makeDraft(projectId, accountId, platformId);
+
+    const memberUsername = `onboarding-member-${randomUUID()}`;
+    const memberUserId = await createUserRecord(getDb(), {
+      username: memberUsername,
+      password: 'password123',
+      email: `${memberUsername}@example.com`,
+      // Born verified, mirroring an invite whose named address matched -
+      // see POST /api/auth/register's inviteEmailMatches branch.
+      emailVerifiedAt: new Date(),
+    });
+    createdUserIds.push(memberUserId);
+    await getDb()
+      .insert(schema.memberships)
+      .values({ organizationId: orgId, userId: memberUserId, role: 'member' });
+
+    const snapshot = await startOnboarding(
+      getDb(),
+      { organizationId: orgId, userId: memberUserId },
+      { authOn: true, username: memberUsername },
+    );
+    expect(snapshot.status).toBe('completed');
+    expect(snapshot.currentStep).toBeNull();
+  });
+});
+
+describe('the skip/resume/restart state machine', () => {
+  it('a fresh identity with no row reads not_started', async () => {
+    const { orgId, userId, username } = await setupOwner();
+    const snapshot = await getOnboardingSnapshot(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    expect(snapshot.status).toBe('not_started');
+    expect(snapshot.currentStep).toBe('organization');
+  });
+
+  it('starting moves not_started to in_progress and points at the first incomplete step', async () => {
+    const { orgId, userId, username } = await setupOwner();
+    const snapshot = await startOnboarding(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    expect(snapshot.status).toBe('in_progress');
+    expect(snapshot.currentStep).toBe('organization');
+    expect(snapshot.version).toBe(ONBOARDING_VERSION);
+    expect(snapshot.startedAt).not.toBeNull();
+  });
+
+  it('resuming after progress lands on the correct next step, not the beginning', async () => {
+    const { orgId, userId, username } = await setupOwner();
+    await startOnboarding(getDb(), { organizationId: orgId, userId }, { authOn: true, username });
+    await renameOrg(getDb(), orgId, 'Renamed Co');
+
+    const resumed = await getOnboardingSnapshot(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    expect(resumed.status).toBe('in_progress');
+    expect(stepById(resumed.steps, 'organization').complete).toBe(true);
+    expect(resumed.currentStep).toBe('verify_email');
+  });
+
+  it('a pre-populated org (everything already true) starts and immediately reads completed, never a stuck in_progress with nothing to do', async () => {
+    const { orgId } = await setupOwner();
+    await renameOrg(getDb(), orgId, 'Already Named Co');
+    const projectId = await makeProjectWithSource(orgId);
+    const { accountId, platformId } = await makeAccount(projectId);
+    await pairExtensionDevice(orgId);
+    await makeDraft(projectId, accountId, platformId);
+    // Auth off, so organization/verify_email are simply not applicable and
+    // every applicable step above is already satisfied.
+    const snapshot = await startOnboarding(
+      getDb(),
+      { organizationId: orgId, userId: null },
+      { authOn: false },
+    );
+    expect(snapshot.status).toBe('completed');
+    expect(snapshot.currentStep).toBeNull();
+    expect(snapshot.completedAt).not.toBeNull();
+  });
+
+  it('starting again while already in_progress does not reset startedAt', async () => {
+    const { orgId, userId, username } = await setupOwner();
+    const first = await startOnboarding(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    const second = await startOnboarding(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    expect(second.startedAt?.getTime()).toBe(first.startedAt?.getTime());
+  });
+
+  it('skipping records a decision distinct from never having started', async () => {
+    const { orgId, userId, username } = await setupOwner();
+    await startOnboarding(getDb(), { organizationId: orgId, userId }, { authOn: true, username });
+    const skipped = await skipOnboarding(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    expect(skipped.status).toBe('skipped');
+    expect(skipped.skippedAt).not.toBeNull();
+  });
+
+  it('a skip survives being read again - it is server state, not a one-shot flag', async () => {
+    const { orgId, userId, username } = await setupOwner();
+    await startOnboarding(getDb(), { organizationId: orgId, userId }, { authOn: true, username });
+    await skipOnboarding(getDb(), { organizationId: orgId, userId }, { authOn: true, username });
+
+    const reread = await getOnboardingSnapshot(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    expect(reread.status).toBe('skipped');
+  });
+
+  it('restarting a skipped flow moves it back to in_progress', async () => {
+    const { orgId, userId, username } = await setupOwner();
+    await startOnboarding(getDb(), { organizationId: orgId, userId }, { authOn: true, username });
+    await skipOnboarding(getDb(), { organizationId: orgId, userId }, { authOn: true, username });
+
+    const restarted = await restartOnboarding(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    expect(restarted.status).toBe('in_progress');
+    expect(restarted.skippedAt).toBeNull();
+  });
+
+  it('a completed flow can be run again and creates nothing twice', async () => {
+    const { orgId, userId, username } = await setupOwner();
+    await renameOrg(getDb(), orgId, 'Done Co');
+    const projectId = await makeProjectWithSource(orgId);
+    const { accountId, platformId } = await makeAccount(projectId);
+    await pairExtensionDevice(orgId);
+    await makeDraft(projectId, accountId, platformId);
+    // Verify the email too, so every applicable step is genuinely satisfied.
+    await getDb()
+      .update(schema.users)
+      .set({ emailVerifiedAt: new Date() })
+      .where(eq(schema.users.id, userId!));
+
+    const completedOnce = await startOnboarding(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    expect(completedOnce.status).toBe('completed');
+
+    const [projectsBefore, draftsBefore] = await Promise.all([
+      getDb().select().from(schema.projects).where(eq(schema.projects.organizationId, orgId)),
+      getDb()
+        .select()
+        .from(schema.drafts)
+        .innerJoin(schema.projects, eq(schema.projects.id, schema.drafts.projectId))
+        .where(eq(schema.projects.organizationId, orgId)),
+    ]);
+
+    const restarted = await restartOnboarding(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    // Immediately re-completes, since every applicable step already reads true.
+    expect(restarted.status).toBe('completed');
+
+    const [projectsAfter, draftsAfter] = await Promise.all([
+      getDb().select().from(schema.projects).where(eq(schema.projects.organizationId, orgId)),
+      getDb()
+        .select()
+        .from(schema.drafts)
+        .innerJoin(schema.projects, eq(schema.projects.id, schema.drafts.projectId))
+        .where(eq(schema.projects.organizationId, orgId)),
+    ]);
+    expect(projectsAfter.length).toBe(projectsBefore.length);
+    expect(draftsAfter.length).toBe(draftsBefore.length);
+  });
+
+  it('a second completion after restarting is a real, distinct transition (skipped -> in_progress -> completed)', async () => {
+    const { orgId, userId, username } = await setupOwner();
+    await startOnboarding(getDb(), { organizationId: orgId, userId }, { authOn: true, username });
+    await skipOnboarding(getDb(), { organizationId: orgId, userId }, { authOn: true, username });
+
+    await renameOrg(getDb(), orgId, 'Second Pass Co');
+    const projectId = await makeProjectWithSource(orgId);
+    const { accountId, platformId } = await makeAccount(projectId);
+    await pairExtensionDevice(orgId);
+    await makeDraft(projectId, accountId, platformId);
+    await getDb()
+      .update(schema.users)
+      .set({ emailVerifiedAt: new Date() })
+      .where(eq(schema.users.id, userId!));
+
+    const restarted = await restartOnboarding(
+      getDb(),
+      { organizationId: orgId, userId },
+      { authOn: true, username },
+    );
+    expect(restarted.status).toBe('completed');
+    expect(restarted.completedAt).not.toBeNull();
+  });
+
+  it('skipping is a no-op once already completed', async () => {
+    const { orgId } = await setupOwner();
+    const projectId = await makeProjectWithSource(orgId);
+    const { accountId, platformId } = await makeAccount(projectId);
+    await pairExtensionDevice(orgId);
+    await makeDraft(projectId, accountId, platformId);
+    // Auth off for this identity, so the org/email steps are inapplicable
+    // and every applicable step above is satisfied.
+    const completed = await startOnboarding(
+      getDb(),
+      { organizationId: orgId, userId: null },
+      { authOn: false },
+    );
+    expect(completed.status).toBe('completed');
+    const afterSkip = await skipOnboarding(
+      getDb(),
+      { organizationId: orgId, userId: null },
+      { authOn: false },
+    );
+    expect(afterSkip.status).toBe('completed');
+    expect(afterSkip.skippedAt).toBeNull();
+  });
+});
+
+describe('self-host identity (no user row)', () => {
+  it('a null-user row is keyed on the org alone and survives a re-read', async () => {
+    const db = getDb();
+    const org = await db
+      .insert(schema.organizations)
+      .values({ slug: `onboarding-selfhost-${randomUUID()}`, name: 'Self-host' })
+      .returning();
+    createdOrgIds.push(org[0].id);
+
+    const started = await startOnboarding(
+      db,
+      { organizationId: org[0].id, userId: null },
+      { authOn: false },
+    );
+    expect(started.status).toBe('in_progress');
+
+    const rows = await db
+      .select()
+      .from(schema.onboardingState)
+      .where(eq(schema.onboardingState.organizationId, org[0].id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBeNull();
+
+    const reread = await getOnboardingSnapshot(
+      db,
+      { organizationId: org[0].id, userId: null },
+      { authOn: false },
+    );
+    expect(reread.status).toBe('in_progress');
+  });
+});

--- a/web/src/lib/components/OnboardingBanner.svelte
+++ b/web/src/lib/components/OnboardingBanner.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { ListChecks, X } from '@lucide/svelte';
+	import { goto, invalidateAll } from '$app/navigation';
+	import { TONE_BANNER_CLASS, TONE_TEXT_CLASS } from '$lib/config/status-badges';
+	import { ONBOARDING_STEP_META } from '$lib/onboarding-steps';
+	import type { OnboardingStepId } from '@pitchbox/shared/onboarding';
+
+	// The dashboard's entry point back into `/onboarding` while a flow is
+	// `in_progress` (#516) - never rendered for `skipped`/`completed`, and
+	// dismissing it here is the same server-side skip the wizard's own "Skip
+	// for now" performs, not a client-only hide: reloading, or logging in
+	// from another browser, must not bring it back on its own after that.
+	let { currentStep }: { currentStep: OnboardingStepId | null } = $props();
+
+	let busy = $state(false);
+
+	async function dismiss() {
+		busy = true;
+		try {
+			await fetch('/api/onboarding/skip', { method: 'POST' });
+			await invalidateAll();
+		} finally {
+			busy = false;
+		}
+	}
+
+	function continueSetup() {
+		goto('/onboarding');
+	}
+</script>
+
+<div role="alert" class={`mb-3 flex items-start gap-2 rounded-lg border ${TONE_BANNER_CLASS.sky}`}>
+	<ListChecks class="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+	<div class="flex-1">
+		<div class="font-medium">Finish setting up Pitchbox</div>
+		<div class="text-xs text-sky-800/85 dark:text-sky-200/80">
+			{#if currentStep}
+				Next: {ONBOARDING_STEP_META[currentStep].title}.
+			{/if}
+			<button
+				type="button"
+				onclick={continueSetup}
+				class={`underline underline-offset-2 hover:text-sky-900 dark:hover:text-sky-100`}
+			>
+				Continue setup
+			</button>
+		</div>
+	</div>
+	<button
+		type="button"
+		onclick={dismiss}
+		disabled={busy}
+		aria-label="Dismiss"
+		class={`shrink-0 rounded p-0.5 ${TONE_TEXT_CLASS.sky} hover:bg-sky-500/20 hover:text-sky-900 dark:hover:text-sky-100`}
+	>
+		<X class="size-3.5" aria-hidden="true" />
+	</button>
+</div>

--- a/web/src/lib/onboarding-steps.ts
+++ b/web/src/lib/onboarding-steps.ts
@@ -1,0 +1,68 @@
+import type { OnboardingStepId } from '@pitchbox/shared/onboarding';
+
+/**
+ * Copy and destination for each onboarding step. Deliberately no form logic
+ * here - every step deep-links to the page that actually does the thing
+ * (rename the org, add a source, connect an account, pair the extension,
+ * run a campaign) rather than duplicating that page's form on this surface.
+ */
+export const ONBOARDING_STEP_META: Record<
+  OnboardingStepId,
+  { title: string; description: string; cta: string }
+> = {
+  organization: {
+    title: 'Name your organization',
+    description:
+      'It started out named after your account. Give it the name your team or company actually uses.',
+    cta: 'Rename organization',
+  },
+  verify_email: {
+    title: 'Verify your email address',
+    description: 'Confirm the address on file before you can start a run.',
+    cta: 'Verify email',
+  },
+  project: {
+    title: 'Create a project with a source',
+    description: 'Give the agent something to write about - a folder, a repo, or a website.',
+    cta: 'Create a project',
+  },
+  account: {
+    title: 'Connect a platform account',
+    description: 'Add the Reddit, Hacker News, or Mastodon account outreach will run from.',
+    cta: 'Connect an account',
+  },
+  extension: {
+    title: 'Install the browser extension',
+    description:
+      'Pair it once and it will help you draft comments and detect replies on a real page.',
+    cta: 'Get the extension',
+  },
+  first_draft: {
+    title: 'Reach a first draft',
+    description: 'Run a campaign and let the agent produce something for you to review.',
+    cta: 'Run a campaign',
+  },
+};
+
+/** Where a step's CTA goes. `firstProjectId` sharpens `account` to a
+ * specific project's Accounts tab once one exists - before that, the
+ * project list is the honest destination. */
+export function onboardingStepHref(
+  id: OnboardingStepId,
+  ctx: { firstProjectId: number | null },
+): string {
+  switch (id) {
+    case 'organization':
+      return '/settings/organization';
+    case 'verify_email':
+      return '/settings/password';
+    case 'project':
+      return '/projects/new';
+    case 'account':
+      return ctx.firstProjectId ? `/projects/${ctx.firstProjectId}?tab=accounts` : '/projects';
+    case 'extension':
+      return '/settings/extension';
+    case 'first_draft':
+      return '/campaigns/new';
+  }
+}

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,18 +1,52 @@
+import type { RequestEvent } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import { getDb, schema } from '$lib/server/db.js';
 import { and, desc, eq, gte, inArray, isNotNull, ne, or, sql } from 'drizzle-orm';
 import { listProjects } from '@pitchbox/shared/projects';
 import { resolveOrgId } from '$lib/server/auth.js';
+import {
+  getOnboardingSnapshot,
+  startOnboarding,
+  type OnboardingStepId,
+} from '@pitchbox/shared/onboarding';
 
-export async function load(event: import('@sveltejs/kit').RequestEvent) {
+export async function load(event: RequestEvent) {
   const db = getDb();
 
   const orgId = await resolveOrgId(event);
+
+  // #516: a fresh identity's first dashboard visit is what starts the
+  // onboarding flow and, when there is genuinely something to do, redirects
+  // into it - `startOnboarding` is a no-op past `not_started`, so this fires
+  // at most once per (user, org). A pre-populated org (nothing left to walk
+  // through) reads straight through to `completed` instead and this page
+  // renders normally with no redirect at all.
+  let onboarding: { status: string; currentStep: OnboardingStepId | null } | null = null;
+  if (orgId != null) {
+    const identity = { organizationId: orgId, userId: event.locals.user?.id ?? null };
+    const ctx = {
+      authOn: process.env.PITCHBOX_AUTH === 'on',
+      username: event.locals.user?.username ?? null,
+    };
+    let snapshot = await getOnboardingSnapshot(db, identity, ctx);
+    if (snapshot.status === 'not_started') {
+      snapshot = await startOnboarding(db, identity, ctx);
+      if (snapshot.status === 'in_progress') {
+        throw redirect(302, '/onboarding');
+      }
+    }
+    if (snapshot.status === 'in_progress') {
+      onboarding = { status: snapshot.status, currentStep: snapshot.currentStep };
+    }
+  }
+
   const projects = await listProjects(db, { organizationId: orgId });
   const projectIds = projects.map((p) => p.id);
 
   // No projects in this org - nothing to show, and `inArray(x, [])` is a SQL error.
   if (projectIds.length === 0) {
     return {
+      onboarding,
       stats: {
         pending: 0,
         approved: 0,
@@ -232,6 +266,7 @@ export async function load(event: import('@sveltejs/kit').RequestEvent) {
     });
 
   return {
+    onboarding,
     stats: {
       pending: draftCountsRow?.pending ?? 0,
       approved: draftCountsRow?.approved ?? 0,

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -16,9 +16,11 @@
 	import Seo from '$lib/components/Seo.svelte';
 	import StatCard from '$lib/components/StatCard.svelte';
 	import StatusBadge from '$lib/components/StatusBadge.svelte';
+	import OnboardingBanner from '$lib/components/OnboardingBanner.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { relativeTime } from '$lib/utils/time';
 	import PageContainer from '$lib/components/PageContainer.svelte';
+	import type { OnboardingStepId } from '@pitchbox/shared/onboarding';
 
 	type Run = {
 		id: number;
@@ -46,6 +48,7 @@
 		data,
 	}: {
 		data: {
+			onboarding: { status: string; currentStep: OnboardingStepId | null } | null;
 			stats: {
 				pending: number;
 				approved: number;
@@ -90,6 +93,10 @@
 	title="Home"
 	description="Outreach overview - drafts awaiting review, recent runs, campaign status."
 />
+
+{#if data.onboarding}
+	<OnboardingBanner currentStep={data.onboarding.currentStep} />
+{/if}
 
 <!-- Primary stats -->
 <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-3">

--- a/web/src/routes/api/onboarding/restart/+server.ts
+++ b/web/src/routes/api/onboarding/restart/+server.ts
@@ -1,0 +1,25 @@
+import { json, type RequestEvent } from '@sveltejs/kit';
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId } from '$lib/server/auth.js';
+import { restartOnboarding } from '@pitchbox/shared/onboarding';
+
+/**
+ * Settings > Onboarding "Start again" (#516). Valid from every status,
+ * including the two terminal ones - this is how a demo or a support call
+ * ("run through it again with me") restarts the flow. A step whose
+ * condition is already satisfied still reads as done immediately after -
+ * restarting never re-creates anything, it only re-opens the checklist.
+ */
+export async function POST(event: RequestEvent) {
+  const db = getDb();
+  const orgId = await requireOrgId(event);
+  const authOn = process.env.PITCHBOX_AUTH === 'on';
+  const userId = event.locals.user?.id ?? null;
+
+  const snapshot = await restartOnboarding(
+    db,
+    { organizationId: orgId, userId },
+    { authOn, username: event.locals.user?.username ?? null },
+  );
+  return json({ status: snapshot.status });
+}

--- a/web/src/routes/api/onboarding/skip/+server.ts
+++ b/web/src/routes/api/onboarding/skip/+server.ts
@@ -1,0 +1,24 @@
+import { json, type RequestEvent } from '@sveltejs/kit';
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId } from '$lib/server/auth.js';
+import { skipOnboarding } from '@pitchbox/shared/onboarding';
+
+/**
+ * Dismissing the dashboard banner or the wizard's own "Skip for now" (#516).
+ * Records a real decision - `skipped`, not the absence of a row - so the
+ * flow never comes back to haunt someone who dismissed it, and stays a
+ * no-op once the flow is already `completed`.
+ */
+export async function POST(event: RequestEvent) {
+  const db = getDb();
+  const orgId = await requireOrgId(event);
+  const authOn = process.env.PITCHBOX_AUTH === 'on';
+  const userId = event.locals.user?.id ?? null;
+
+  const snapshot = await skipOnboarding(
+    db,
+    { organizationId: orgId, userId },
+    { authOn, username: event.locals.user?.username ?? null },
+  );
+  return json({ status: snapshot.status });
+}

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -1,0 +1,36 @@
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '$lib/server/db.js';
+import { requireOrgId } from '$lib/server/auth.js';
+import { startOnboarding } from '@pitchbox/shared/onboarding';
+import type { PageServerLoad } from './$types';
+
+/**
+ * Visiting this page is what starts the flow (#516): `startOnboarding` is a
+ * no-op unless the identity's row is missing or `not_started`, so a repeat
+ * visit while `in_progress` just re-reads the current snapshot, and a
+ * `skipped`/`completed` visit renders this page's own terminal-state view
+ * rather than silently resuming - only the explicit "Start again" action
+ * (POST /api/onboarding/restart) reopens those.
+ */
+export const load: PageServerLoad = async (event) => {
+  const db = getDb();
+  const orgId = await requireOrgId(event);
+  const authOn = process.env.PITCHBOX_AUTH === 'on';
+  const userId = event.locals.user?.id ?? null;
+  const username = event.locals.user?.username ?? null;
+
+  const snapshot = await startOnboarding(
+    db,
+    { organizationId: orgId, userId },
+    { authOn, username },
+  );
+
+  const [firstProject] = await db
+    .select({ id: schema.projects.id })
+    .from(schema.projects)
+    .where(eq(schema.projects.organizationId, orgId))
+    .orderBy(schema.projects.id)
+    .limit(1);
+
+  return { snapshot, firstProjectId: firstProject?.id ?? null };
+};

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+	import { CheckCircle2, Circle, ArrowRight, PartyPopper, SkipForward } from '@lucide/svelte';
+	import { goto, invalidateAll } from '$app/navigation';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import PageContainer from '$lib/components/PageContainer.svelte';
+	import Seo from '$lib/components/Seo.svelte';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { Progress } from '$lib/components/ui/progress';
+	import { TONE_TEXT_CLASS } from '$lib/config/status-badges';
+	import { ONBOARDING_STEP_META, onboardingStepHref } from '$lib/onboarding-steps';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	const applicableSteps = $derived(data.snapshot.steps.filter((s) => s.applicable));
+	const doneCount = $derived(applicableSteps.filter((s) => s.complete).length);
+	const totalCount = $derived(applicableSteps.length);
+	const progressPct = $derived(totalCount > 0 ? Math.round((100 * doneCount) / totalCount) : 100);
+
+	let busy = $state(false);
+
+	async function skip() {
+		busy = true;
+		try {
+			await fetch('/api/onboarding/skip', { method: 'POST' });
+			await goto('/');
+		} finally {
+			busy = false;
+		}
+	}
+
+	async function restart() {
+		busy = true;
+		try {
+			await fetch('/api/onboarding/restart', { method: 'POST' });
+			await invalidateAll();
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+<PageContainer size="narrow">
+	<Seo title="Set up Pitchbox" description="Name your organization, connect an account, and reach your first draft." />
+
+	{#if data.snapshot.status === 'in_progress'}
+		<PageHeader title="Set up Pitchbox" description="A few steps to get from an empty workspace to your first draft." />
+
+		<div class="mb-8 flex items-center gap-3">
+			<Progress value={progressPct} aria-label="Setup progress" class="flex-1" />
+			<span class="shrink-0 text-sm tabular-nums text-muted-foreground">{doneCount} of {totalCount} done</span>
+		</div>
+
+		<div class="flex flex-col gap-3">
+			{#each applicableSteps as step (step.id)}
+				{@const meta = ONBOARDING_STEP_META[step.id]}
+				{@const isCurrent = data.snapshot.currentStep === step.id}
+				<Card.Root class={isCurrent ? 'border-primary/50' : undefined}>
+					<Card.Content class="flex items-start gap-4 py-5">
+						{#if step.complete}
+							<CheckCircle2 class={`mt-0.5 size-5 shrink-0 ${TONE_TEXT_CLASS.emerald}`} aria-hidden="true" />
+						{:else}
+							<Circle class="mt-0.5 size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+						{/if}
+						<div class="min-w-0 flex-1">
+							<div class="font-medium">{meta.title}</div>
+							<p class="mt-1 text-sm text-muted-foreground">{meta.description}</p>
+						</div>
+						<Button
+							href={onboardingStepHref(step.id, { firstProjectId: data.firstProjectId })}
+							variant={step.complete ? 'outline' : 'default'}
+							size="sm"
+							class="shrink-0"
+						>
+							{step.complete ? 'Review' : meta.cta}
+							<ArrowRight class="size-4" aria-hidden="true" />
+						</Button>
+					</Card.Content>
+				</Card.Root>
+			{/each}
+		</div>
+
+		<div class="mt-8 flex justify-end">
+			<Button variant="ghost" size="sm" onclick={skip} disabled={busy}>
+				<SkipForward class="size-4" aria-hidden="true" />
+				Skip for now
+			</Button>
+		</div>
+	{:else if data.snapshot.status === 'completed'}
+		<Card.Root>
+			<Card.Content class="flex flex-col items-center gap-3 py-10 text-center">
+				<PartyPopper class={`size-8 ${TONE_TEXT_CLASS.emerald}`} aria-hidden="true" />
+				<div class="text-lg font-medium">You're all set</div>
+				<p class="max-w-sm text-sm text-muted-foreground">
+					Every step of setup is done. Run it again any time from Settings if you want to walk
+					through it once more.
+				</p>
+				<Button href="/" class="mt-2">Go to the dashboard</Button>
+			</Card.Content>
+		</Card.Root>
+	{:else if data.snapshot.status === 'skipped'}
+		<Card.Root>
+			<Card.Content class="flex flex-col items-center gap-3 py-10 text-center">
+				<div class="text-lg font-medium">Setup is skipped</div>
+				<p class="max-w-sm text-sm text-muted-foreground">
+					You can start it again whenever you want, from here or from Settings.
+				</p>
+				<div class="mt-2 flex gap-2">
+					<Button href="/" variant="outline">Go to the dashboard</Button>
+					<Button onclick={restart} disabled={busy}>Start setup again</Button>
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{/if}
+</PageContainer>

--- a/web/src/routes/settings/+layout.svelte
+++ b/web/src/routes/settings/+layout.svelte
@@ -4,6 +4,7 @@
   import { page } from '$app/stores';
   import {
     Activity,
+    ListChecks,
     Bot,
     Puzzle,
     Gauge,
@@ -18,14 +19,14 @@
 
   let { data, children }: { data: LayoutData; children: Snippet } = $props();
 
-  // Flat rail of ten (#254 shipped seven; LI-19/#316 added LinkedIn assist;
-  // 2026-09-07's companion decisions added Companion; #506 added Password).
-  // Status/Agent runners/Browser extension/Quota never 403 - each loader
-  // gates its own data set (member sees an "Admin access required" card
-  // instead of a thrown error) - so they're always shown, same as General
-  // used to be. Password is self-service (gated on being signed in at all,
-  // not an org role - docs/permissions.md) rather than org-scoped, so it
-  // uses `data.signedIn` instead of `data.isAdmin`/`data.authOn`.
+  // Flat rail of eleven (#254 shipped seven; LI-19/#316 added LinkedIn assist;
+  // 2026-09-07's companion decisions added Companion; #506 added Password;
+  // #516 added Onboarding). Status/Agent runners/Browser extension/Quota
+  // never 403 - each loader gates its own data set (member sees an "Admin
+  // access required" card instead of a thrown error) - so they're always
+  // shown, same as General used to be. Password and Onboarding are
+  // self-service (gated on being signed in / having an org context at all,
+  // not an org role - docs/permissions.md) rather than admin-only.
   // Organization needs an org context (auth on); Retention, Security,
   // LinkedIn assist and Companion loaders call requireRole(event, 'admin')
   // and do throw, so those stay role-filtered here too. The server loaders
@@ -33,6 +34,7 @@
   const items = $derived(
     [
       { href: '/settings/status', label: 'Status', icon: Activity, show: true },
+      { href: '/settings/onboarding', label: 'Onboarding', icon: ListChecks, show: true },
       { href: '/settings/runners', label: 'Agent runners', icon: Bot, show: true },
       { href: '/settings/extension', label: 'Browser extension', icon: Puzzle, show: true },
       { href: '/settings/quota', label: 'Quota', icon: Gauge, show: true },

--- a/web/src/routes/settings/onboarding/+page.server.ts
+++ b/web/src/routes/settings/onboarding/+page.server.ts
@@ -1,0 +1,26 @@
+import { getDb } from '$lib/server/db.js';
+import { requireOrgId } from '$lib/server/auth.js';
+import { getOnboardingSnapshot } from '@pitchbox/shared/onboarding';
+import type { PageServerLoad } from './$types';
+
+/**
+ * Settings home for the onboarding flow (#516): a read-only status card plus
+ * the one action every terminal state needs, "Start again". No loader
+ * throws on a role - restarting a walkthrough is self-service, the same as
+ * `/settings/password`, not an org-admin power.
+ */
+export const load: PageServerLoad = async (event) => {
+  const db = getDb();
+  const orgId = await requireOrgId(event);
+  const authOn = process.env.PITCHBOX_AUTH === 'on';
+  const userId = event.locals.user?.id ?? null;
+  const username = event.locals.user?.username ?? null;
+
+  const snapshot = await getOnboardingSnapshot(
+    db,
+    { organizationId: orgId, userId },
+    { authOn, username },
+  );
+
+  return { snapshot };
+};

--- a/web/src/routes/settings/onboarding/+page.svelte
+++ b/web/src/routes/settings/onboarding/+page.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import { CheckCircle2, Circle } from '@lucide/svelte';
+	import { invalidateAll } from '$app/navigation';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import PageContainer from '$lib/components/PageContainer.svelte';
+	import Seo from '$lib/components/Seo.svelte';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { TONE_CLASS, TONE_TEXT_CLASS } from '$lib/config/status-badges';
+	import { ONBOARDING_STEP_META } from '$lib/onboarding-steps';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	const applicableSteps = $derived(data.snapshot.steps.filter((s) => s.applicable));
+
+	const STATUS_LABEL: Record<string, { label: string; tone: 'muted' | 'sky' | 'emerald' | 'slate' }> = {
+		not_started: { label: 'Not started', tone: 'muted' },
+		in_progress: { label: 'In progress', tone: 'sky' },
+		completed: { label: 'Completed', tone: 'emerald' },
+		skipped: { label: 'Skipped', tone: 'slate' },
+	};
+	const status = $derived(STATUS_LABEL[data.snapshot.status] ?? STATUS_LABEL.not_started);
+
+	let busy = $state(false);
+
+	async function restart() {
+		busy = true;
+		try {
+			await fetch('/api/onboarding/restart', { method: 'POST' });
+			await invalidateAll();
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+<PageContainer size="default">
+	<Seo title="Settings - Onboarding" description="The guided first-run setup: its status, and starting it again." />
+
+	<PageHeader title="Onboarding" description="The guided setup that ran on first sign-in." />
+
+	<div class="mt-4 flex flex-col gap-4">
+		<Card.Root>
+			<Card.Header>
+				<div class="flex items-center justify-between gap-3">
+					<Card.Title>Status</Card.Title>
+					<span
+						class={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${TONE_CLASS[status.tone]}`}
+					>
+						{status.label}
+					</span>
+				</div>
+			</Card.Header>
+			<Card.Content class="flex flex-col gap-3">
+				{#each applicableSteps as step (step.id)}
+					<div class="flex items-center gap-3 text-sm">
+						{#if step.complete}
+							<CheckCircle2 class={`size-4 shrink-0 ${TONE_TEXT_CLASS.emerald}`} aria-hidden="true" />
+						{:else}
+							<Circle class="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+						{/if}
+						<span class={step.complete ? undefined : 'text-muted-foreground'}>
+							{ONBOARDING_STEP_META[step.id].title}
+						</span>
+					</div>
+				{/each}
+			</Card.Content>
+			<Card.Footer class="flex justify-end gap-2">
+				{#if data.snapshot.status === 'in_progress'}
+					<Button href="/onboarding">Continue setup</Button>
+				{:else}
+					<Button onclick={restart} disabled={busy}>Start setup again</Button>
+				{/if}
+			</Card.Footer>
+		</Card.Root>
+	</div>
+</PageContainer>


### PR DESCRIPTION
## What changed

A guided first-run sequence a new operator sees on first sign-in, with the lifecycle #516 asks for:

- `status`: `not_started` -> `in_progress` -> `skipped` | `completed`, with `skipped` -> `in_progress` a valid transition (Settings "Start again").
- Six steps in order: name the organization, verify the email address, create a project with a source, connect a platform account, install the browser extension, reach a first draft.
- A new `onboarding_state` table (`shared/src/db/migrations/0030_onboarding_state.sql`), keyed by `(user_id, organization_id)` rather than a column on `users` - an org that invites a second person must not make them repeat the first person's setup, and a person who later joins a second org must not be told it is set up when it is not. `user_id` is nullable for self-host with auth off (no login, no `users` row), guarded by a partial unique index (`onboarding_state_org_no_user_unique`) rather than an ordinary one, since Postgres treats every `NULL` as distinct.
- `shared/src/onboarding.ts` is the whole state machine: `computeOnboardingSteps` reads the real thing each step is about (`project_sources`, `accounts`, `extension_devices`, `drafts`, `organizations.name` vs the pure-function default `defaultOrgName` would still produce) rather than a stored flag, so a step never says "done" when the underlying thing is missing, and a resumed/restarted flow never re-asks for something that already exists.
- `/onboarding` is the wizard itself (progress bar + step checklist, each step deep-linking to the real page that does the thing - no duplicated forms). Visiting it is what starts the flow.
- The dashboard (`/`) redirects a fresh `not_started` identity into `/onboarding` only when there is genuinely something to do; a pre-populated org (existing self-host install, or a member joining an already-set-up org) reads straight through to `completed` with no redirect and no empty wizard. While `in_progress`, the dashboard shows a dismissible banner (`OnboardingBanner.svelte`) whose dismiss is a real `POST /api/onboarding/skip`, not `localStorage` - it must survive a reload and a login from another browser.
- `/settings/onboarding` (new rail entry) shows the current status and read-only checklist, plus "Start again" from any terminal state - this is how a demo or a support call restarts it, and restarting never re-creates anything (every step still reads its live state).
- `PITCHBOX_AUTH` off (self-host default): the organization and email-verification steps are not applicable at all (no owner concept, no email), rather than shown disabled.

## UI brief

Posted to the issue before writing any markup, per `ui-brief-first`: https://github.com/fiorelorenzo/pitchbox/issues/516#issuecomment-5601999017. No new tokens, no new hue - reuses the existing `Tone` registry (`status-badges.ts`) and the `ExtensionDeviceNudgeBanner` precedent for the dashboard banner's sky tone.

## Verified

- `pnpm -F @pitchbox/shared typecheck` and `pnpm -F web check` - both clean.
- `pnpm exec vitest run shared/tests/onboarding.test.ts` against an isolated `pitchbox_test_onboarding` DB - **19 tests, all passing**: live per-step reads (including the owner-vs-member and pre-populated-org cases), the not_started -> in_progress -> skipped -> in_progress -> completed state machine, a completed flow re-run creating nothing twice, and the self-host null-user identity surviving a re-read.
- Migration applied against a database that already held the previous 29: `migrations applied (30 in journal, all present)` on both the shared dev DB and the isolated test DB. Verified the table and its two partial unique indexes with `\d onboarding_state`. The generated `when` (a real timestamp, lower than #603's artificial `1788960000016`) was bumped to `1788960000017` and the file renamed to `0030_onboarding_state.sql`, per the migration trap in `AGENTS.md`.
- `uishot` at mobile/tablet/desktop, light/dark, `--axe`, on `/onboarding`, `/` (with the banner) and `/settings/onboarding`. Fixed one real defect this surface introduced: the progress bar had no accessible name (`aria-progressbar-name`, serious) - added `aria-label="Setup progress"`. The remaining `serious`/`moderate` axe findings (`.border-border/60` contrast, `.sr-only` region) are pre-existing global app-shell issues, reproduced identically on an untouched page (`/settings/status`) - out of scope here.
- Forced a genuine light-mode render (`mode-watcher-mode` in `localStorage`, not just the media query mode-watcher's `defaultMode="dark"` overrides) to confirm the checklist, banner and status page actually differ between themes rather than the two shots being coincidentally identical.
- Drove the real skip/restart cycle with a headless browser against the running dev server: clicked "Skip for now" -> dashboard banner gone, `/settings/onboarding` reads "Skipped" -> clicked "Start setup again" -> reads "In progress" again. A second, independent browser tab against the same server read the same server-derived "2 of 4 done" with no shared client-side state, which is the mechanism (not a full auth round trip, since this dev environment runs with `PITCHBOX_AUTH` off) that makes the cross-browser-resume acceptance criterion true: the state was never in `localStorage` to share in the first place.

## Left deliberately alone

- No re-offer logic for a future `ONBOARDING_VERSION` bump - the column is written and available, but deciding what a version bump does to an existing `completed`/`skipped` row is explicitly a future, deliberate decision per the issue text, not something to guess at now.
- The `organization` step's completion reads whether `organizations.name` still equals the pure-function default `defaultOrgName(username)` would produce - a real column comparison, not a click flag, but it means renaming an org back to that exact string would (correctly, if oddly) un-complete the step. Noted rather than engineered around, since it is the honest reading of "did the operator ever get past the name #513 derived for them."
