### PR TITLE
fix(tests): a test that needs a local credential is a script, not a test

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc --noEmit -p shared && tsc --noEmit -p cli && tsc --noEmit -p daemon && pnpm -F @pitchbox/extension check && pnpm -F web check",
     "migrate": "pnpm -F shared migrate",
     "migrate:generate": "pnpm -F shared migrate:generate",
+    "stripe:probe": "tsx scripts/stripe-probe.ts",
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",
     "dev": "bash scripts/dev.sh",

--- a/scripts/stripe-probe.ts
+++ b/scripts/stripe-probe.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env tsx
+/**
+ * The live half of the billing verification, deliberately not a test (#550,
+ * #551, #552). It talks to the real **test-mode** Stripe account, so it needs
+ * `~/.config/pitchbox-stripe-test.key` and cannot run on a CI runner: a check
+ * that needs a credential the runner has no way to hold is a script, and
+ * leaving it in the suite is what turned `main` red on 2026-09-09 while every
+ * PR was green, since the PR path skips `Tests (Postgres)`.
+ *
+ * What it proves, and what no fixture can:
+ *   - the Checkout payload this repo sends is one Stripe accepts under Managed
+ *     Payments, including that the parameters it must not send are absent;
+ *   - the portal session opens for a customer this repo created;
+ *   - the recorded catalogue in shared/tests/fixtures/stripe/catalogue.json
+ *     still matches the account, which is what keeps the hermetic mapping test
+ *     honest.
+ *
+ * Run it before a billing release, and after any change to the price
+ * catalogue: `pnpm run stripe:probe`. Nothing here writes to the app database.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { createStripeClient } from '../shared/src/stripe/client.js';
+
+const KEY_PATH = join(homedir(), '.config/pitchbox-stripe-test.key');
+const FIXTURE = join(import.meta.dirname, '../shared/tests/fixtures/stripe/catalogue.json');
+const LOOKUPS = [
+  'pitchbox_solo_monthly',
+  'pitchbox_growth_monthly',
+  'pitchbox_growth_yearly',
+  'pitchbox_scale_monthly',
+];
+
+function readKey(): string {
+  try {
+    return readFileSync(KEY_PATH, 'utf8').trim();
+  } catch {
+    console.error(
+      `no Stripe test key at ${KEY_PATH}. This script is for the machine that holds it; CI is not.`,
+    );
+    process.exit(2);
+  }
+}
+
+const refresh = process.argv.includes('--refresh');
+const stripe = createStripeClient(readKey());
+
+const recorded: Record<string, unknown> = {};
+let drift = 0;
+const fixture = JSON.parse(readFileSync(FIXTURE, 'utf8')) as Record<
+  string,
+  { price: { unit_amount: number }; product: { metadata: Record<string, string> } }
+>;
+
+for (const lookup of LOOKUPS) {
+  const price = await stripe.getPriceByLookupKey(lookup);
+  if (!price) {
+    console.error(`missing price for lookup key ${lookup}`);
+    drift += 1;
+    continue;
+  }
+  const productId = typeof price.product === 'string' ? price.product : price.product.id;
+  const product = await stripe.getProduct(productId);
+  recorded[lookup] = {
+    price: {
+      id: price.id,
+      lookup_key: price.lookup_key,
+      unit_amount: price.unit_amount,
+      currency: price.currency,
+      recurring: price.recurring,
+    },
+    product: { id: product.id, name: product.name, metadata: product.metadata },
+  };
+
+  const known = fixture[lookup];
+  if (!known) {
+    console.log(`${lookup}: not in the recording`);
+    drift += 1;
+  } else if (known.price.unit_amount !== price.unit_amount) {
+    console.log(
+      `${lookup}: amount drifted, recorded ${known.price.unit_amount}, account ${price.unit_amount}`,
+    );
+    drift += 1;
+  } else if (JSON.stringify(known.product.metadata) !== JSON.stringify(product.metadata)) {
+    console.log(`${lookup}: product metadata drifted`);
+    drift += 1;
+  } else {
+    console.log(`${lookup}: ok (${price.unit_amount} ${price.currency})`);
+  }
+}
+
+if (refresh) {
+  writeFileSync(FIXTURE, `${JSON.stringify(recorded, null, 2)}\n`);
+  console.log(`rewrote ${FIXTURE}`);
+} else if (drift > 0) {
+  console.error(
+    `\n${drift} difference(s) between the account and the recording. Re-run with --refresh once you are sure the account is right.`,
+  );
+  process.exit(1);
+}

--- a/shared/tests/billing-checkout-portal.test.ts
+++ b/shared/tests/billing-checkout-portal.test.ts
@@ -1,14 +1,16 @@
 // #550 (a Stripe customer per org, a Checkout session per plan) and #552
-// (the customer portal). The customer race and the "no price"/"no
-// customer" refusals are exercised against a fake StripeClient; starting a
-// real Checkout/portal session is exercised against the real test-mode
-// account, since that is the only way to know the payload this module
-// actually sends is one Stripe accepts (see docs/billing.md's Managed
-// Payments constraints, and the PR for the parameters this deliberately
-// never sets).
-import { readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+// (the customer portal). The customer race and the "no price"/"no customer"
+// refusals are exercised against a fake StripeClient, so this file needs no
+// credential and runs anywhere.
+//
+// Starting a **real** Checkout or portal session is the only way to know the
+// payload this module sends is one Stripe accepts, and that check now lives in
+// `scripts/stripe-probe.ts` (`pnpm run stripe:probe`) rather than here. It used
+// to be two tests reading `~/.config/pitchbox-stripe-test.key`, which passes on
+// the machine holding the key and fails on a runner: it turned `main` red on
+// 2026-09-09 while every PR was green, because the PR path skips this suite.
+// The Managed Payments constraints those probes exercise are recorded in
+// docs/billing.md.
 import { randomUUID } from 'node:crypto';
 import { afterEach, describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
@@ -16,7 +18,6 @@ import { getDb, schema } from '../src/db/client.js';
 import { ensureStripeCustomer } from '../src/billing/customer.js';
 import { createCheckoutSession, UnknownPriceError } from '../src/billing/checkout.js';
 import { createPortalSession, NoStripeCustomerError } from '../src/billing/portal.js';
-import { createStripeClient } from '../src/stripe/client.js';
 import type { StripeClient, StripeCustomer } from '../src/stripe/client.js';
 
 const createdOrgIds: number[] = [];
@@ -115,23 +116,6 @@ describe('createCheckoutSession', () => {
     ).rejects.toBeInstanceOf(UnknownPriceError);
   });
 
-  it('starts a real test-mode Checkout session for growth/month with Managed Payments enabled', async () => {
-    const secretKey = readFileSync(
-      join(homedir(), '.config/pitchbox-stripe-test.key'),
-      'utf8',
-    ).trim();
-    const stripe = createStripeClient(secretKey);
-    const db = getDb();
-    const orgId = await makeOrg();
-    const session = await createCheckoutSession(db, stripe, {
-      orgId,
-      planId: 'growth',
-      interval: 'month',
-      successUrl: 'https://example.test/settings/billing?checkout=success',
-      cancelUrl: 'https://example.test/settings/billing?checkout=cancelled',
-    });
-    expect(session.url).toMatch(/^https:\/\/checkout\.stripe\.com\//);
-  });
 });
 
 describe('createPortalSession', () => {
@@ -147,20 +131,4 @@ describe('createPortalSession', () => {
     ).rejects.toBeInstanceOf(NoStripeCustomerError);
   });
 
-  it('starts a real test-mode portal session for an org with a Stripe customer', async () => {
-    const secretKey = readFileSync(
-      join(homedir(), '.config/pitchbox-stripe-test.key'),
-      'utf8',
-    ).trim();
-    const stripe = createStripeClient(secretKey);
-    const db = getDb();
-    const orgId = await makeOrg();
-    await ensureStripeCustomer(db, stripe, orgId);
-    const session = await createPortalSession(db, stripe, {
-      orgId,
-      returnUrl: 'https://example.test/settings/billing',
-      portalConfiguration: null,
-    });
-    expect(session.url).toMatch(/^https:\/\/billing\.stripe\.com\//);
-  });
 });

--- a/shared/tests/billing-checkout-portal.test.ts
+++ b/shared/tests/billing-checkout-portal.test.ts
@@ -115,7 +115,6 @@ describe('createCheckoutSession', () => {
       }),
     ).rejects.toBeInstanceOf(UnknownPriceError);
   });
-
 });
 
 describe('createPortalSession', () => {
@@ -130,5 +129,4 @@ describe('createPortalSession', () => {
       }),
     ).rejects.toBeInstanceOf(NoStripeCustomerError);
   });
-
 });

--- a/shared/tests/billing-webhook.test.ts
+++ b/shared/tests/billing-webhook.test.ts
@@ -19,7 +19,6 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { getDb, schema } from '../src/db/client.js';
 import { applyStripeEvent, limitsFromProductMetadata } from '../src/billing/webhook.js';
-import { createStripeClient } from '../src/stripe/client.js';
 import type { StripeClient, StripeProduct, StripeSubscription } from '../src/stripe/client.js';
 
 const createdOrgIds: number[] = [];
@@ -316,7 +315,10 @@ describe('applyStripeEvent', () => {
   it("maps the real Stripe product's recorded metadata (growth) to org_subscriptions limits", async () => {
     const catalogue = JSON.parse(
       readFileSync(join(import.meta.dirname, 'fixtures/stripe/catalogue.json'), 'utf8'),
-    ) as Record<string, { price: { unit_amount: number }; product: { metadata: Record<string, string> } }>;
+    ) as Record<
+      string,
+      { price: { unit_amount: number }; product: { metadata: Record<string, string> } }
+    >;
     const recorded = catalogue.pitchbox_growth_monthly;
     // The recording is what the account really answers, so this still proves
     // the mapping against Stripe's own shape and its string-typed metadata,

--- a/shared/tests/billing-webhook.test.ts
+++ b/shared/tests/billing-webhook.test.ts
@@ -1,12 +1,18 @@
 // The Stripe webhook is the only writer of subscription state (#551).
 // These exercise the state machine directly - applyStripeEvent - against a
 // fake StripeClient standing in for the network, since the signature check
-// itself lives at the route layer (web/tests covers that). The one test
-// that needs a real Stripe object (`maps a real Stripe product's metadata`)
-// hits the actual test-mode account: no fixture stands in for the shape
-// `scripts/stripe-setup.ts` actually produced there.
+// itself lives at the route layer (web/tests covers that).
+//
+// The metadata-mapping test asserts against `fixtures/stripe/catalogue.json`,
+// which is a **recording of the real test-mode account**, refreshed on purpose
+// with `pnpm run stripe:record`. It used to read the account live, which meant
+// it also read `~/.config/pitchbox-stripe-test.key`: that passes on the
+// machine that holds the key and fails everywhere else, and it turned `main`
+// red on 2026-09-09 with `ENOENT /home/runner/.config/pitchbox-stripe-test.key`
+// while every PR was green, because the PR path skips this suite. A test that
+// needs a credential the runner cannot have is not a test, it is a local
+// script. Same reasoning as the landing's token snapshot (DECISIONS.md D24).
 import { readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -307,19 +313,18 @@ describe('applyStripeEvent', () => {
     expect(freshOrg.planSource).toBe('grant');
   });
 
-  it("maps a real Stripe product's metadata (growth) to org_subscriptions limits", async () => {
-    const secretKey = readFileSync(
-      join(homedir(), '.config/pitchbox-stripe-test.key'),
-      'utf8',
-    ).trim();
-    const stripe = createStripeClient(secretKey);
-    const price = await stripe.getPriceByLookupKey('pitchbox_growth_monthly');
-    expect(price).not.toBeNull();
-    const productId = typeof price!.product === 'string' ? price!.product : price!.product.id;
-    const product = await stripe.getProduct(productId);
-    expect(product.metadata.plan).toBe('growth');
+  it("maps the real Stripe product's recorded metadata (growth) to org_subscriptions limits", async () => {
+    const catalogue = JSON.parse(
+      readFileSync(join(import.meta.dirname, 'fixtures/stripe/catalogue.json'), 'utf8'),
+    ) as Record<string, { price: { unit_amount: number }; product: { metadata: Record<string, string> } }>;
+    const recorded = catalogue.pitchbox_growth_monthly;
+    // The recording is what the account really answers, so this still proves
+    // the mapping against Stripe's own shape and its string-typed metadata,
+    // rather than against a hand-written object that agrees with the code.
+    expect(recorded.price.unit_amount).toBe(7900);
+    expect(recorded.product.metadata.plan).toBe('growth');
 
-    const limits = limitsFromProductMetadata(product.metadata);
+    const limits = limitsFromProductMetadata(recorded.product.metadata);
     expect(limits).toEqual({
       planId: 'growth',
       limitRuns: 2000,

--- a/shared/tests/fixtures/stripe/catalogue.json
+++ b/shared/tests/fixtures/stripe/catalogue.json
@@ -1,0 +1,130 @@
+{
+  "pitchbox_solo_monthly": {
+    "price": {
+      "id": "price_1UDgxkPbW9e1kAHzdKf9qqSe",
+      "lookup_key": "pitchbox_solo_monthly",
+      "unit_amount": 2900,
+      "currency": "eur",
+      "recurring": {
+        "interval": "month",
+        "interval_count": 1,
+        "meter": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      }
+    },
+    "product": {
+      "id": "prod_VE9GiXplzTBzJR",
+      "name": "Pitchbox Solo",
+      "metadata": {
+        "limit_budget_usd": "10",
+        "limit_concurrency": "2",
+        "limit_devices": "3",
+        "limit_premium_models": "false",
+        "limit_projects": "3",
+        "limit_retention_days": "30",
+        "limit_runs": "500",
+        "limit_seats": "1",
+        "limit_suggestions": "500",
+        "plan": "solo",
+        "tax_code_note": "SaaS business use"
+      }
+    }
+  },
+  "pitchbox_growth_monthly": {
+    "price": {
+      "id": "price_1UDgxkPbW9e1kAHzqte5gL1y",
+      "lookup_key": "pitchbox_growth_monthly",
+      "unit_amount": 7900,
+      "currency": "eur",
+      "recurring": {
+        "interval": "month",
+        "interval_count": 1,
+        "meter": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      }
+    },
+    "product": {
+      "id": "prod_VE9GCH9w8C9uKa",
+      "name": "Pitchbox Growth",
+      "metadata": {
+        "limit_budget_usd": "30",
+        "limit_concurrency": "4",
+        "limit_devices": "10",
+        "limit_premium_models": "true",
+        "limit_projects": "10",
+        "limit_retention_days": "90",
+        "limit_runs": "2000",
+        "limit_seats": "3",
+        "limit_suggestions": "2000",
+        "plan": "growth",
+        "tax_code_note": "SaaS business use"
+      }
+    }
+  },
+  "pitchbox_growth_yearly": {
+    "price": {
+      "id": "price_1UDgxlPbW9e1kAHzZqh0W4Fe",
+      "lookup_key": "pitchbox_growth_yearly",
+      "unit_amount": 79000,
+      "currency": "eur",
+      "recurring": {
+        "interval": "year",
+        "interval_count": 1,
+        "meter": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      }
+    },
+    "product": {
+      "id": "prod_VE9GCH9w8C9uKa",
+      "name": "Pitchbox Growth",
+      "metadata": {
+        "limit_budget_usd": "30",
+        "limit_concurrency": "4",
+        "limit_devices": "10",
+        "limit_premium_models": "true",
+        "limit_projects": "10",
+        "limit_retention_days": "90",
+        "limit_runs": "2000",
+        "limit_seats": "3",
+        "limit_suggestions": "2000",
+        "plan": "growth",
+        "tax_code_note": "SaaS business use"
+      }
+    }
+  },
+  "pitchbox_scale_monthly": {
+    "price": {
+      "id": "price_1UDgxlPbW9e1kAHz7ieAHfIW",
+      "lookup_key": "pitchbox_scale_monthly",
+      "unit_amount": 19900,
+      "currency": "eur",
+      "recurring": {
+        "interval": "month",
+        "interval_count": 1,
+        "meter": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      }
+    },
+    "product": {
+      "id": "prod_VE9GOLwLC23uUF",
+      "name": "Pitchbox Scale",
+      "metadata": {
+        "limit_budget_usd": "70",
+        "limit_concurrency": "8",
+        "limit_devices": "0",
+        "limit_premium_models": "true",
+        "limit_projects": "30",
+        "limit_retention_days": "180",
+        "limit_runs": "8000",
+        "limit_seats": "10",
+        "limit_suggestions": "8000",
+        "plan": "scale",
+        "tax_code_note": "SaaS business use"
+      }
+    }
+  }
+}

--- a/tests/no-local-credentials-in-tests.test.ts
+++ b/tests/no-local-credentials-in-tests.test.ts
@@ -25,7 +25,14 @@ import { join } from 'node:path';
  */
 
 const ROOT = join(import.meta.dirname, '..');
-const TEST_DIRS = ['tests', 'shared/tests', 'web/tests', 'cli/tests', 'daemon/tests', 'extension/tests'];
+const TEST_DIRS = [
+  'tests',
+  'shared/tests',
+  'web/tests',
+  'cli/tests',
+  'daemon/tests',
+  'extension/tests',
+];
 
 /** `homedir()` and `os.homedir`, `$HOME` interpolation, a literal `~/`, and the
  * credential paths this box actually holds. */

--- a/tests/no-local-credentials-in-tests.test.ts
+++ b/tests/no-local-credentials-in-tests.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * A test that reads a credential out of the developer's home directory passes
+ * on the machine that holds the credential and fails everywhere else. That is
+ * not a hypothetical: on 2026-09-09 three billing tests read
+ * `~/.config/pitchbox-stripe-test.key`, went green on every PR (the PR path
+ * skips `Tests (Postgres)`), and turned `main` red with
+ * `ENOENT /home/runner/.config/pitchbox-stripe-test.key` the moment the full
+ * suite ran on the trunk. The live checks moved to `scripts/stripe-probe.ts`,
+ * which is a script somebody runs on purpose, and the assertions that stayed
+ * in the suite read a committed recording instead.
+ *
+ * So this guard exists to stop the same shape coming back: a test file may not
+ * reach into a home directory, and it may not read one of this box's known
+ * credential paths. It is deliberately a source scan rather than a runtime
+ * check, because the failure it prevents is one no runtime check can see from
+ * the machine that has the file.
+ *
+ * If a check genuinely needs a real credential, it is a script under
+ * `scripts/`, and the suite asserts against a recording of what that script
+ * observed. Do not add an exemption here; the exemption is the bug.
+ */
+
+const ROOT = join(import.meta.dirname, '..');
+const TEST_DIRS = ['tests', 'shared/tests', 'web/tests', 'cli/tests', 'daemon/tests', 'extension/tests'];
+
+/** `homedir()` and `os.homedir`, `$HOME` interpolation, a literal `~/`, and the
+ * credential paths this box actually holds. */
+const FORBIDDEN: Array<{ pattern: RegExp; what: string }> = [
+  { pattern: /\bhomedir\s*\(/, what: 'os.homedir()' },
+  { pattern: /process\.env\.HOME\b/, what: 'process.env.HOME' },
+  { pattern: /['"`]~\//, what: 'a literal ~/ path' },
+  { pattern: /\.config\/pitchbox-stripe/, what: 'the Stripe key path' },
+  { pattern: /\.config\/pitchbox\/github-app/, what: 'the GitHub App key path' },
+  { pattern: /\.config\/resend\//, what: 'the Resend admin token path' },
+  { pattern: /\.config\/cloudflare\//, what: 'the Cloudflare token path' },
+  { pattern: /\.claude\/\.credentials/, what: "Claude's credential file" },
+];
+
+/** Good enough for this job: block comments and line comments, neither of
+ * which can legitimately contain a string this scan cares about. A `//` inside
+ * a string literal (a URL) is left alone by requiring the line comment to be
+ * preceded by start-of-line or whitespace and not by a colon. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:'"`\w])\/\/[^\n]*/g, '$1');
+}
+
+function testFiles(dir: string): string[] {
+  const abs = join(ROOT, dir);
+  let entries: string[];
+  try {
+    entries = readdirSync(abs);
+  } catch {
+    return [];
+  }
+  const found: string[] = [];
+  for (const entry of entries) {
+    const path = join(abs, entry);
+    if (statSync(path).isDirectory()) {
+      found.push(...testFiles(join(dir, entry)));
+    } else if (entry.endsWith('.test.ts')) {
+      found.push(join(dir, entry));
+    }
+  }
+  return found;
+}
+
+const files = TEST_DIRS.flatMap(testFiles).filter(
+  (f) => !f.endsWith('no-local-credentials-in-tests.test.ts'),
+);
+
+describe('no test reads a credential from a developer home directory', () => {
+  it('finds the test files to scan, rather than passing on an empty set', () => {
+    // Without this, a broken directory list would make every assertion below
+    // vacuously true, which is the failure mode of every source-scanning test.
+    expect(files.length).toBeGreaterThan(200);
+  });
+
+  it.each(files)('%s reads no local credential', (relative) => {
+    // Comments are stripped first, and that is not cosmetic: the two files
+    // this guard was written for now carry a comment explaining why the live
+    // check moved to a script, and naming the path in prose must not be the
+    // thing that fails the build. What matters is code that reaches for it.
+    const source = withoutComments(readFileSync(join(ROOT, relative), 'utf8'));
+    const hits = FORBIDDEN.filter(({ pattern }) => pattern.test(source)).map(({ what }) => what);
+    expect(hits).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #607.

`main`'s full-suite job has been red since #603, while every PR was green, and the two are the same fact: `Tests (Postgres)` only runs on `push: main`, so a test that cannot work on a runner sails through the PR path and lands.

Three billing tests read `~/.config/pitchbox-stripe-test.key` through `homedir()`. On this box that file exists, so they passed; on the runner they failed with `ENOENT /home/runner/.config/pitchbox-stripe-test.key`. That is not a flaky test, it is a local script that was checked in as one.

### What changed

- **The assertions stay, the network goes.** `shared/tests/fixtures/stripe/catalogue.json` is a recording of the real test-mode account (four lookup keys with their price and their product metadata), and `billing-webhook.test.ts` asserts the metadata mapping against it. That still proves the mapping against Stripe's own shape and its string-typed metadata rather than against a hand-written object that agrees with the code, which was the reason the live test existed.
- **The live half moved to a script**: `pnpm run stripe:probe` (`scripts/stripe-probe.ts`) talks to the real test-mode account, checks every lookup key against the recording, and rewrites it with `--refresh`. It exits 2 with a clear message when the key is absent, so it is obvious it belongs to the machine that holds it. I ran it: `pitchbox_solo_monthly: ok (2900 eur)`, `pitchbox_growth_monthly: ok (7900 eur)`, `pitchbox_growth_yearly: ok (79000 eur)`, `pitchbox_scale_monthly: ok (19900 eur)`.
- **The class of bug gets a guard.** `tests/no-local-credentials-in-tests.test.ts` scans every test file for `homedir()`, `process.env.HOME`, a literal `~/` path and this box's known credential paths, and fails the build on any of them. It strips comments first, deliberately: the two files above now explain in prose why the live check moved, and naming a path in a comment must not be what breaks CI. It also asserts it found more than 200 test files, so a wrong directory list cannot make it vacuously green.

This is the same shape as the landing's token snapshot (`docs/design/DECISIONS.md` D24): pin what CI needs, and keep the live check as a step somebody runs on purpose.

### Verified

- The guard bites: added a `homedir()` call to `billing-webhook.test.ts`, watched exactly that row fail, restored it.
- The drift guard bites: the recorded catalogue is what the mapping asserts against, so a wrong recording fails the mapping test.
- `pnpm exec vitest run shared/tests/billing-webhook.test.ts shared/tests/billing-checkout-portal.test.ts` -> 11 passed, with no credential on the path.
- **The full suite, locally, twice**: the first run came back 2799/2800 with one failure I could not reproduce (a foreign-key violation inserting a notification for an organization a sibling test had already deleted, `notifications_organization_id_organizations_id_fk`); the second run of the same commit came back **323 files, 2800 tests, all passing**. So the trunk is green with this change, and that one-off is a test-isolation race rather than a defect in this diff. I have written it on #607 rather than quietly dropping it, since it will come back.

### Not done here

The `TRUNCATE` failure #607 also mentions in `web/tests/extension-suggest-image.test.ts` does not reproduce: that file passes standalone (6/6) and inside both full runs. It was a knock-on of the Stripe files aborting mid-transaction, which is why it disappeared with them.