### PR TITLE
feat(shared,web): upgrade now, downgrade at period end, and a failed payment's grace window then read-only

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -130,13 +130,39 @@ build or request time. Run `plans:export` and commit the result whenever
 `PLAN_CATALOGUE` changes, the same way `stripe-setup.ts` needs a run after a
 metadata change.
 
-## What happens at a limit, and after a failed payment
+## What happens at a limit, at a downgrade, and after a failed payment
 
 - A limit is a **hard refusal** with an upgrade prompt: no silent degrade to a
-  cheaper model, no queueing, no billed overage.
-- A failed payment starts a **14-day grace period** during which the org keeps
-  its plan. Stripe's dunning runs in that window; if nothing succeeds, the org
-  drops to Free and its data stays intact.
+  cheaper model, no queueing, no billed overage. An org that ends up over a
+  new, lower limit (a downgrade, or a subscription lapsing to Free) keeps
+  every row it already has - it can read and run what exists, it just cannot
+  create past the new ceiling until it is back under it or upgrades.
+- An upgrade takes effect immediately: the webhook mirrors whatever Stripe's
+  live subscription reports, so a higher limit applies as soon as Stripe
+  raises the price, and usage already spent in the period keeps counting
+  against the new ceiling rather than resetting.
+- A downgrade is only ever mirrored once Stripe's live subscription actually
+  reports the new plan - never anticipated - so the org keeps its current
+  plan until whatever scheduling mechanism moved the change (a portal
+  cancellation uses `cancel_at_period_end` natively; a cross-tier price
+  switch needs its own Subscription Schedule, since Stripe's customer portal
+  can only auto-schedule a downgrade between two prices of the **same
+  product**, and Solo/Growth/Scale are three separate products) actually
+  applies it at period end.
+- A failed payment (`invoice.payment_failed`) starts a **7-day grace period**,
+  counted from the first failure rather than restarted by each Smart Retries
+  reattempt. The org keeps working normally during grace; a banner and a
+  notification both name the exact date it ends. Past it, the org is
+  **read-only**: no new runs, suggestions, accepts, projects, campaigns,
+  invites or devices (refused with `plan_payment_required`, distinct from
+  `plan_limit_reached`) - everything already there stays readable, the Inbox
+  keeps working, drafts can still be marked sent, and the extension's inbound
+  sync routes keep accepting data. The customer portal is never refused,
+  read-only or not - it is the one path back to a working account.
+  `isOrgReadOnly` (`shared/src/plans.ts`) is the one predicate every
+  enforcement point reads. `invoice.paid` clears grace and read-only in one
+  step; `customer.subscription.deleted` (cancelled, or Stripe gave up on
+  dunning) drops the org to Free, a real working plan, not a lockout.
 
 ## Running the setup
 

--- a/shared/src/billing/grace.ts
+++ b/shared/src/billing/grace.ts
@@ -1,0 +1,70 @@
+// A failed payment's grace window (#554). `invoice.payment_failed` flips a
+// subscription to `past_due` (webhook.ts's `syncSubscriptionFromStripe`
+// mirrors Stripe's own status verbatim, no state of our own); this module
+// answers the one question that status alone cannot: since when has payment
+// actually been failing. Stripe's Smart Retries re-fire `invoice.payment_failed`
+// on every reattempt while the subscription stays `past_due` throughout, so a
+// second (or fifth) failure must never look like a fresh one - the org gets
+// GRACE_PERIOD_DAYS from the *first* failure, not from whichever delivery
+// happened to arrive most recently.
+//
+// No dedicated column for this: `stripe_events` (webhook.ts's own idempotency
+// ledger) already records every delivery with a real timestamp
+// (`received_at`), so "since when" is "the earliest `invoice.payment_failed`
+// after the most recent `invoice.paid`" for the subscription - an ordinary
+// read over data the webhook was already writing, rather than a second
+// timestamp that would need to be kept in lockstep with `org_subscriptions.status`.
+import { and, asc, desc, eq, gt, sql } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+import { schema } from '../db/client.js';
+
+// Loose on purpose (matches shared/src/orgs.ts's own alias): a real `Db`
+// (shared/src/db/client.ts) and a `db.transaction` callback's `tx` are both
+// assignable to this, and webhook.ts calls `pastDueSince` from inside the
+// same transaction as the subscription row it just wrote.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Db = PgDatabase<any, any, any>;
+
+export const GRACE_PERIOD_DAYS = 7;
+const GRACE_PERIOD_MS = GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000;
+
+/**
+ * The instant `subscriptionId` most recently started failing to pay, or
+ * `null` if there is no unrecovered failure on record. Reads the ledger
+ * rather than `org_subscriptions.status` itself - the caller already knows
+ * the subscription is `past_due` and wants the moment that began.
+ */
+export async function pastDueSince(db: Db, subscriptionId: string): Promise<Date | null> {
+  // Shared with webhook.ts's own `InvoiceObjectSchema`: an Invoice event's
+  // `data.object.subscription` names the subscription it belongs to.
+  const belongsToSubscription = sql`${schema.stripeEvents.payload}->'data'->'object'->>'subscription' = ${subscriptionId}`;
+
+  const [lastPaid] = await db
+    .select({ at: schema.stripeEvents.receivedAt })
+    .from(schema.stripeEvents)
+    .where(and(eq(schema.stripeEvents.type, 'invoice.paid'), belongsToSubscription))
+    .orderBy(desc(schema.stripeEvents.receivedAt))
+    .limit(1);
+
+  const recoveredAt = lastPaid?.at ?? new Date(0);
+
+  const [firstFailureSinceRecovery] = await db
+    .select({ at: schema.stripeEvents.receivedAt })
+    .from(schema.stripeEvents)
+    .where(
+      and(
+        eq(schema.stripeEvents.type, 'invoice.payment_failed'),
+        belongsToSubscription,
+        gt(schema.stripeEvents.receivedAt, recoveredAt),
+      ),
+    )
+    .orderBy(asc(schema.stripeEvents.receivedAt))
+    .limit(1);
+
+  return firstFailureSinceRecovery?.at ?? null;
+}
+
+/** The instant the grace window granted at `since` ends. */
+export function graceEndsAt(since: Date): Date {
+  return new Date(since.getTime() + GRACE_PERIOD_MS);
+}

--- a/shared/src/billing/webhook.ts
+++ b/shared/src/billing/webhook.ts
@@ -11,6 +11,8 @@ import type { Db } from '../db/client.js';
 import { recordInstanceAudit } from '../instance-audit.js';
 import { normalizePlanId, type PlanId } from '../plans.js';
 import { setOrgPlan } from '../orgs.js';
+import { notify } from '../notifications.js';
+import { pastDueSince, graceEndsAt } from './grace.js';
 import type {
   StripeClient,
   StripeEvent,
@@ -131,7 +133,10 @@ export async function syncSubscriptionFromStripe(
     }
 
     const [existing] = await tx
-      .select({ currentPeriodEnd: orgSubscriptions.currentPeriodEnd })
+      .select({
+        currentPeriodEnd: orgSubscriptions.currentPeriodEnd,
+        status: orgSubscriptions.status,
+      })
       .from(orgSubscriptions)
       .where(eq(orgSubscriptions.organizationId, org.id))
       .limit(1);
@@ -186,6 +191,35 @@ export async function syncSubscriptionFromStripe(
         stripeSubscriptionId: sub.id,
       },
     });
+
+    // #554: the grace window's own banner/notification name a real date, so
+    // it is stamped once, the moment the subscription actually enters
+    // `past_due` - never on a Smart Retries reattempt that leaves it
+    // `past_due` again (existing?.status already `past_due` skips this), and
+    // never for a grant (docs/billing.md: a grant survives whatever Stripe
+    // says about the same org, including a failed payment).
+    if (
+      org.planSource !== 'grant' &&
+      sub.status === 'past_due' &&
+      existing?.status !== 'past_due'
+    ) {
+      const since = (await pastDueSince(tx, sub.id)) ?? new Date();
+      const until = graceEndsAt(since);
+      await notify(
+        tx,
+        {
+          kind: 'billing_payment_failed',
+          title: 'Payment failed - grace period started',
+          severity: 'warning',
+          body:
+            `We could not process your latest payment. Your plan keeps working until ` +
+            `${until.toISOString().slice(0, 10)}; update your payment method in the customer ` +
+            `portal before then to avoid the account going read-only.`,
+          payload: { graceEndsAt: until.toISOString() },
+        },
+        org.id,
+      );
+    }
 
     await markProcessed(tx, eventId);
     return {

--- a/shared/src/plans.ts
+++ b/shared/src/plans.ts
@@ -24,6 +24,7 @@
 import { eq } from 'drizzle-orm';
 import { schema, type Db } from './db/client.js';
 import { isCloud } from './edition.js';
+import { pastDueSince, graceEndsAt } from './billing/grace.js';
 
 export const PLAN_IDS = ['free', 'solo', 'growth', 'scale'] as const;
 export type PlanId = (typeof PLAN_IDS)[number];
@@ -192,7 +193,26 @@ export type Entitlements = {
    * (mirrored from a live Stripe subscription), or 'default' (the code
    * catalogue, because nothing above applied - the common case for Free). */
   source: 'self-host' | 'grant' | 'subscription' | 'default';
+  /** Non-null only for a mirrored subscription whose Stripe status is
+   * `past_due` (#554): the instant its grace window ends
+   * (`shared/src/billing/grace.ts`'s `graceEndsAt(pastDueSince(...))`), 7
+   * days after the first `invoice.payment_failed` since the subscription's
+   * last `invoice.paid` - never restarted by a Smart Retries reattempt.
+   * `isOrgReadOnly` is the one predicate every enforcement point reads
+   * instead of comparing this itself. */
+  graceEndsAt: Date | null;
 };
+
+/**
+ * The one predicate an enforcement point checks for a failed-payment
+ * lockout, instead of comparing `graceEndsAt` itself: `true` once `now` has
+ * passed the grace window a `past_due` subscription was granted. A grant or
+ * self-host org, and a subscription that has never missed a payment, never
+ * carry a `graceEndsAt` at all, so this is always `false` for them.
+ */
+export function isOrgReadOnly(entitlements: Entitlements, now: Date = new Date()): boolean {
+  return entitlements.graceEndsAt != null && now.getTime() >= entitlements.graceEndsAt.getTime();
+}
 
 /**
  * Resolves the entitlements an organization actually gets, in precedence
@@ -227,6 +247,7 @@ export async function resolveEntitlements(db: Db, orgId: number): Promise<Entitl
       webhooks: true,
       planId,
       source: 'self-host',
+      graceEndsAt: null,
     };
   }
 
@@ -240,6 +261,13 @@ export async function resolveEntitlements(db: Db, orgId: number): Promise<Entitl
       .where(eq(schema.orgSubscriptions.organizationId, orgId))
       .limit(1);
     if (sub) {
+      // #554: only a subscription actually failing to pay right now carries
+      // a grace deadline - anything else (active, trialing, cancelled and
+      // already gone through clearSubscription) leaves it null, which is
+      // also what makes isOrgReadOnly false again the moment `invoice.paid`
+      // mirrors the subscription back to `active`.
+      const since =
+        sub.status === 'past_due' ? await pastDueSince(db, sub.stripeSubscriptionId) : null;
       return {
         runsPerMonth: sub.limitRuns,
         suggestionsPerMonth: sub.limitSuggestions,
@@ -253,6 +281,7 @@ export async function resolveEntitlements(db: Db, orgId: number): Promise<Entitl
         webhooks: PLAN_CATALOGUE[normalizePlanId(sub.planId)].webhooks,
         planId: normalizePlanId(sub.planId),
         source: 'subscription',
+        graceEndsAt: since == null ? null : graceEndsAt(since),
       };
     }
   }
@@ -271,5 +300,6 @@ export async function resolveEntitlements(db: Db, orgId: number): Promise<Entitl
     webhooks: plan.webhooks,
     planId: plan.id,
     source: org?.planSource === 'grant' ? 'grant' : 'default',
+    graceEndsAt: null,
   };
 }

--- a/shared/src/runlog/classify-failure.ts
+++ b/shared/src/runlog/classify-failure.ts
@@ -15,6 +15,7 @@ export type RunFailureReason =
   | 'instance_quota_exhausted'
   | 'concurrency_exhausted'
   | 'plan_limit_reached'
+  | 'plan_payment_required'
   | 'playbook_error'
   | 'playbook_incomplete'
   | 'network'
@@ -33,6 +34,7 @@ export const RUN_FAILURE_REASONS: readonly RunFailureReason[] = [
   'instance_quota_exhausted',
   'concurrency_exhausted',
   'plan_limit_reached',
+  'plan_payment_required',
   'playbook_error',
   'playbook_incomplete',
   'network',
@@ -110,6 +112,14 @@ const CONCURRENCY_PATTERNS = ['concurrency limit'];
 // collides with QUOTA_PATTERNS below.
 const PLAN_LIMIT_PATTERNS = ['plan limit'];
 
+// #554: a failed payment past its grace window is a different failure than
+// a plan's own metered limit above - "the account is read-only until the
+// payment method is fixed" has a different fix (the customer portal) than
+// "you have used every run your plan allows this period" (wait or upgrade).
+// The refusal text says "read-only" and never "plan limit", so it never
+// collides with PLAN_LIMIT_PATTERNS.
+const PLAN_PAYMENT_REQUIRED_PATTERNS = ['read-only because of a failed payment'];
+
 const NETWORK_PATTERNS = [
   'econnrefused',
   'econnreset',
@@ -173,6 +183,8 @@ export function classifyFailure(events: ParsedEvent[], exitCode: number | null):
   if (QUOTA_PATTERNS.some((p) => haystack.includes(p))) return 'quota_exhausted';
   if (CONCURRENCY_PATTERNS.some((p) => haystack.includes(p))) return 'concurrency_exhausted';
   if (PLAN_LIMIT_PATTERNS.some((p) => haystack.includes(p))) return 'plan_limit_reached';
+  if (PLAN_PAYMENT_REQUIRED_PATTERNS.some((p) => haystack.includes(p)))
+    return 'plan_payment_required';
   if (NETWORK_PATTERNS.some((p) => haystack.includes(p))) return 'network';
   if (PROVIDER_ERROR_PATTERNS.some((p) => haystack.includes(p))) return 'provider_error';
   if (CONTENT_FILTERED_PATTERNS.some((p) => haystack.includes(p))) return 'content_filtered';

--- a/shared/tests/billing-checkout-portal.test.ts
+++ b/shared/tests/billing-checkout-portal.test.ts
@@ -19,8 +19,11 @@ import { ensureStripeCustomer } from '../src/billing/customer.js';
 import { createCheckoutSession, UnknownPriceError } from '../src/billing/checkout.js';
 import { createPortalSession, NoStripeCustomerError } from '../src/billing/portal.js';
 import type { StripeClient, StripeCustomer } from '../src/stripe/client.js';
+import { isOrgReadOnly, resolveEntitlements } from '../src/plans.js';
 
 const createdOrgIds: number[] = [];
+
+const savedEdition = process.env.PITCHBOX_EDITION;
 
 afterEach(async () => {
   const db = getDb();
@@ -28,6 +31,8 @@ afterEach(async () => {
     const id = createdOrgIds.pop()!;
     await db.delete(schema.organizations).where(eq(schema.organizations.id, id));
   }
+  if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+  else process.env.PITCHBOX_EDITION = savedEdition;
 });
 
 async function makeOrg(): Promise<number> {
@@ -61,6 +66,15 @@ function fakeCustomerCreator(idsToReturn: string[]): StripeClient {
       const id = idsToReturn[call] ?? idsToReturn[idsToReturn.length - 1];
       call += 1;
       return { id, email: null, metadata: {} };
+    },
+  };
+}
+
+function fakePortalClient(url: string): StripeClient {
+  return {
+    ...notImplementedStripeClient(),
+    async createPortalSession() {
+      return { id: 'bps_test', url };
     },
   };
 }
@@ -128,5 +142,60 @@ describe('createPortalSession', () => {
         portalConfiguration: null,
       }),
     ).rejects.toBeInstanceOf(NoStripeCustomerError);
+  });
+
+  it('opens for a past_due, read-only org (#554) - the one path a failed payment must never refuse', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const db = getDb();
+    const orgId = await makeOrg();
+    const customerId = `cus_${randomUUID()}`;
+    const subscriptionId = `sub_${randomUUID()}`;
+    await db
+      .update(schema.organizations)
+      .set({ stripeCustomerId: customerId })
+      .where(eq(schema.organizations.id, orgId));
+    await db.insert(schema.orgSubscriptions).values({
+      organizationId: orgId,
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: subscriptionId,
+      planId: 'solo',
+      status: 'past_due',
+      currentPeriodStart: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+      currentPeriodEnd: new Date(Date.now() + 20 * 24 * 60 * 60 * 1000),
+      limitRuns: 500,
+      limitSuggestions: 500,
+      limitProjects: 3,
+      limitSeats: 1,
+      limitDevices: 3,
+      limitConcurrency: 2,
+      limitBudgetUsd: '10.00',
+      limitRetentionDays: 30,
+      limitPremiumModels: false,
+    });
+    const failedEventId = `evt_${randomUUID()}`;
+    const failedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    await db.insert(schema.stripeEvents).values({
+      id: failedEventId,
+      type: 'invoice.payment_failed',
+      receivedAt: failedAt,
+      processedAt: failedAt,
+      payload: {
+        id: failedEventId,
+        type: 'invoice.payment_failed',
+        created: Math.floor(failedAt.getTime() / 1000),
+        data: { object: { subscription: subscriptionId, customer: customerId } },
+      },
+    });
+
+    // Sanity: this org really is past its grace window, not merely past_due.
+    const entitlements = await resolveEntitlements(db, orgId);
+    expect(isOrgReadOnly(entitlements)).toBe(true);
+
+    const session = await createPortalSession(
+      db,
+      fakePortalClient('https://billing.stripe.com/test-session'),
+      { orgId, returnUrl: 'https://example.test/settings/billing', portalConfiguration: null },
+    );
+    expect(session.url).toBe('https://billing.stripe.com/test-session');
   });
 });

--- a/shared/tests/billing-grace.test.ts
+++ b/shared/tests/billing-grace.test.ts
@@ -1,0 +1,132 @@
+// #554: the grace window's own timing logic, isolated from the webhook that
+// drives it. `pastDueSince` reads `stripe_events` (the webhook's own
+// idempotency ledger) directly, so these tests write rows into it exactly
+// the shape `applyStripeEvent` would have left, rather than replaying a
+// whole webhook delivery for a question that is really about one query.
+import { randomUUID } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import { GRACE_PERIOD_DAYS, graceEndsAt, pastDueSince } from '../src/billing/grace.js';
+import { isOrgReadOnly, type Entitlements } from '../src/plans.js';
+
+const insertedEventIds: string[] = [];
+
+afterEach(async () => {
+  const db = getDb();
+  while (insertedEventIds.length > 0) {
+    const id = insertedEventIds.pop()!;
+    await db.delete(schema.stripeEvents).where(eq(schema.stripeEvents.id, id));
+  }
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function recordEvent(
+  type: 'invoice.payment_failed' | 'invoice.paid',
+  subscriptionId: string,
+  receivedAt: Date,
+): Promise<void> {
+  const id = `evt_${randomUUID()}`;
+  const db = getDb();
+  await db.insert(schema.stripeEvents).values({
+    id,
+    type,
+    receivedAt,
+    processedAt: receivedAt,
+    payload: {
+      id,
+      type,
+      created: Math.floor(receivedAt.getTime() / 1000),
+      data: { object: { subscription: subscriptionId, customer: `cus_${subscriptionId}` } },
+    },
+  });
+  insertedEventIds.push(id);
+}
+
+describe('pastDueSince', () => {
+  it('is null when the subscription has never recorded a failed invoice', async () => {
+    const subscriptionId = `sub_${randomUUID()}`;
+    await recordEvent('invoice.paid', subscriptionId, new Date());
+    expect(await pastDueSince(getDb(), subscriptionId)).toBeNull();
+  });
+
+  it('anchors on the first failure, not a later Smart Retries reattempt', async () => {
+    const subscriptionId = `sub_${randomUUID()}`;
+    const firstFailure = new Date(Date.now() - 10 * DAY_MS);
+    const secondFailure = new Date(Date.now() - 2 * DAY_MS);
+    await recordEvent('invoice.payment_failed', subscriptionId, firstFailure);
+    await recordEvent('invoice.payment_failed', subscriptionId, secondFailure);
+
+    const since = await pastDueSince(getDb(), subscriptionId);
+    expect(since?.getTime()).toBe(firstFailure.getTime());
+  });
+
+  it('a recovered subscription only sees a failure after its own invoice.paid', async () => {
+    const subscriptionId = `sub_${randomUUID()}`;
+    const oldFailure = new Date(Date.now() - 40 * DAY_MS);
+    const recovery = new Date(Date.now() - 20 * DAY_MS);
+    const freshFailure = new Date(Date.now() - 1 * DAY_MS);
+    await recordEvent('invoice.payment_failed', subscriptionId, oldFailure);
+    await recordEvent('invoice.paid', subscriptionId, recovery);
+    await recordEvent('invoice.payment_failed', subscriptionId, freshFailure);
+
+    const since = await pastDueSince(getDb(), subscriptionId);
+    expect(since?.getTime()).toBe(freshFailure.getTime());
+  });
+
+  it("does not see another subscription's failures", async () => {
+    const mine = `sub_${randomUUID()}`;
+    const theirs = `sub_${randomUUID()}`;
+    await recordEvent('invoice.payment_failed', theirs, new Date());
+    expect(await pastDueSince(getDb(), mine)).toBeNull();
+  });
+});
+
+describe('graceEndsAt', () => {
+  it('is GRACE_PERIOD_DAYS after the given instant', () => {
+    const since = new Date('2026-01-01T00:00:00Z');
+    expect(graceEndsAt(since).getTime()).toBe(since.getTime() + GRACE_PERIOD_DAYS * DAY_MS);
+  });
+});
+
+function entitlementsWithGrace(graceEndsAtValue: Date | null): Entitlements {
+  return {
+    runsPerMonth: 500,
+    suggestionsPerMonth: 500,
+    projects: 3,
+    seats: 1,
+    extensionDevices: 3,
+    maxConcurrentRuns: 2,
+    monthlyRunBudgetUsd: 10,
+    retentionDays: 30,
+    premiumModels: false,
+    webhooks: false,
+    planId: 'solo',
+    source: 'subscription',
+    graceEndsAt: graceEndsAtValue,
+  };
+}
+
+describe('isOrgReadOnly', () => {
+  it('is false when the entitlements carry no grace deadline at all', () => {
+    expect(isOrgReadOnly(entitlementsWithGrace(null))).toBe(false);
+  });
+
+  it('is false while still inside the grace window', () => {
+    const since = new Date(Date.now() - (GRACE_PERIOD_DAYS - 1) * DAY_MS);
+    const entitlements = entitlementsWithGrace(graceEndsAt(since));
+    expect(isOrgReadOnly(entitlements)).toBe(false);
+  });
+
+  it('flips to true the instant the clock passes the grace deadline - proven by moving the clock, not by waiting', () => {
+    const since = new Date('2026-01-01T00:00:00Z');
+    const entitlements = entitlementsWithGrace(graceEndsAt(since));
+    const oneSecondBefore = new Date(graceEndsAt(since).getTime() - 1000);
+    const exactBoundary = graceEndsAt(since);
+    const oneSecondAfter = new Date(graceEndsAt(since).getTime() + 1000);
+    expect(isOrgReadOnly(entitlements, oneSecondBefore)).toBe(false);
+    expect(isOrgReadOnly(entitlements, exactBoundary)).toBe(true);
+    expect(isOrgReadOnly(entitlements, oneSecondAfter)).toBe(true);
+  });
+});

--- a/shared/tests/billing-webhook.test.ts
+++ b/shared/tests/billing-webhook.test.ts
@@ -20,6 +20,9 @@ import { eq } from 'drizzle-orm';
 import { getDb, schema } from '../src/db/client.js';
 import { applyStripeEvent, limitsFromProductMetadata } from '../src/billing/webhook.js';
 import type { StripeClient, StripeProduct, StripeSubscription } from '../src/stripe/client.js';
+import { isOrgReadOnly, resolveEntitlements } from '../src/plans.js';
+import { billingPeriodFor } from '../src/org-quota.js';
+import { getOrgUsage } from '../src/usage.js';
 
 const createdOrgIds: number[] = [];
 
@@ -68,6 +71,22 @@ const GROWTH_PRODUCT: StripeProduct = {
     limit_budget_usd: '30',
     limit_retention_days: '90',
     limit_premium_models: 'true',
+  },
+};
+
+const SOLO_PRODUCT: StripeProduct = {
+  id: 'prod_test_solo',
+  metadata: {
+    plan: 'solo',
+    limit_runs: '500',
+    limit_suggestions: '500',
+    limit_projects: '3',
+    limit_seats: '1',
+    limit_devices: '3',
+    limit_concurrency: '2',
+    limit_budget_usd: '10',
+    limit_retention_days: '30',
+    limit_premium_models: 'false',
   },
 };
 
@@ -339,5 +358,448 @@ describe('applyStripeEvent', () => {
       limitRetentionDays: 90,
       limitPremiumModels: true,
     });
+  });
+});
+
+describe('applyStripeEvent - upgrade now, downgrade at period end (#553)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  const createdProjectIds: number[] = [];
+
+  afterEach(async () => {
+    const db = getDb();
+    while (createdProjectIds.length > 0) {
+      const id = createdProjectIds.pop()!;
+      await db.delete(schema.projects).where(eq(schema.projects.id, id));
+    }
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  it('an upgrade mid-period raises the ceiling without resetting usage already spent', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const org = await makeOrg();
+    const subscriptionId = `sub_${randomUUID()}`;
+    const periodStart = Math.floor(Date.now() / 1000) - 5 * 24 * 60 * 60;
+    const periodEnd = periodStart + 30 * 24 * 60 * 60;
+
+    await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          product: SOLO_PRODUCT,
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'customer.subscription.updated',
+        created: periodStart,
+        data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+
+    const [project] = await getDb()
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: `proj-${org.id}`, name: 'p' })
+      .returning();
+    createdProjectIds.push(project.id);
+    for (let i = 0; i < 4; i += 1) {
+      await getDb().insert(schema.runs).values({
+        kind: 'project_extraction',
+        projectId: project.id,
+        trigger: 'manual',
+        status: 'success',
+        startedAt: new Date(),
+      });
+    }
+
+    // The upgrade: same subscription, same period (Stripe prorates rather
+    // than resetting the billing cycle), Growth's product metadata now.
+    const result = await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          product: GROWTH_PRODUCT,
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'customer.subscription.updated',
+        created: periodStart + 1,
+        data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+    expect(result.outcome).toBe('applied');
+
+    const period = await billingPeriodFor(getDb(), org.id);
+    const usage = await getOrgUsage(getDb(), org.id, period);
+    expect(usage.entitlements.planId).toBe('growth');
+    expect(usage.runs.limit).toBe(2000);
+    // The 4 runs recorded before the upgrade still count - a plan change
+    // never resets the period's own counter.
+    expect(usage.runs.used).toBe(4);
+  });
+
+  it('a downgrade does not apply before the mirrored period ends, and applies once it does', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const org = await makeOrg();
+    const subscriptionId = `sub_${randomUUID()}`;
+    const periodStart = Math.floor(Date.now() / 1000) - 5 * 24 * 60 * 60;
+    const periodEnd = periodStart + 30 * 24 * 60 * 60;
+
+    await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          product: GROWTH_PRODUCT,
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'customer.subscription.updated',
+        created: periodStart,
+        data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+
+    // A downgrade has been requested (e.g. scheduled for period end) but
+    // Stripe's own live subscription still reports the current phase
+    // unchanged - exactly what a pending change looks like before it
+    // transitions. Our webhook only ever mirrors what Stripe reports live,
+    // so it must not anticipate the switch.
+    const midPeriod = await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          product: GROWTH_PRODUCT,
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'customer.subscription.updated',
+        created: periodStart + 1,
+        data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+    expect(midPeriod.outcome).toBe('applied');
+
+    let [row] = await getDb()
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.organizationId, org.id));
+    expect(row.planId).toBe('growth');
+    expect(row.limitProjects).toBe(10);
+
+    // The period actually rolls over: the scheduled change transitions the
+    // live subscription to Solo's price.
+    const newPeriodEnd = periodEnd + 30 * 24 * 60 * 60;
+    const afterRollover = await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          product: SOLO_PRODUCT,
+          currentPeriodStart: periodEnd,
+          currentPeriodEnd: newPeriodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'customer.subscription.updated',
+        created: periodEnd + 1,
+        data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+    expect(afterRollover.outcome).toBe('applied');
+
+    [row] = await getDb()
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.organizationId, org.id));
+    expect(row.planId).toBe('solo');
+    expect(row.limitProjects).toBe(3);
+  });
+
+  it('an over-limit org after a downgrade keeps every project - nothing is deleted', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const org = await makeOrg();
+    const subscriptionId = `sub_${randomUUID()}`;
+    const periodStart = Math.floor(Date.now() / 1000) - 5 * 24 * 60 * 60;
+    const periodEnd = periodStart + 30 * 24 * 60 * 60;
+
+    await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          product: GROWTH_PRODUCT,
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'customer.subscription.updated',
+        created: periodStart,
+        data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+
+    // 5 projects - fits Growth's 10, would not fit Solo's 3.
+    for (let i = 0; i < 5; i += 1) {
+      const [project] = await getDb()
+        .insert(schema.projects)
+        .values({ organizationId: org.id, slug: `proj-${org.id}-${i}`, name: `p${i}` })
+        .returning();
+      createdProjectIds.push(project.id);
+    }
+
+    const newPeriodEnd = periodEnd + 30 * 24 * 60 * 60;
+    await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          product: SOLO_PRODUCT,
+          currentPeriodStart: periodEnd,
+          currentPeriodEnd: newPeriodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'customer.subscription.updated',
+        created: periodEnd + 1,
+        data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+
+    const remainingProjects = await getDb()
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.organizationId, org.id));
+    expect(remainingProjects).toHaveLength(5); // nothing deleted
+
+    const entitlements = await resolveEntitlements(getDb(), org.id);
+    expect(entitlements.projects).toBe(3); // the new, lower limit applies
+  });
+});
+
+describe('applyStripeEvent - grace window and read-only (#554)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  afterEach(async () => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  async function notificationsFor(orgId: number) {
+    return getDb()
+      .select()
+      .from(schema.notifications)
+      .where(eq(schema.notifications.organizationId, orgId));
+  }
+
+  it('a payment failure notifies once and starts the grace window; a retry does not restart it or notify again', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const org = await makeOrg();
+    const subscriptionId = `sub_${randomUUID()}`;
+    const periodStart = Math.floor(Date.now() / 1000);
+    const periodEnd = periodStart + 30 * 24 * 60 * 60;
+
+    await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'customer.subscription.updated',
+        created: periodStart,
+        data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+
+    const firstFailureEventId = `evt_${randomUUID()}`;
+    const first = await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          status: 'past_due',
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+        }),
+      }),
+      {
+        id: firstFailureEventId,
+        type: 'invoice.payment_failed',
+        created: periodStart + 1,
+        data: { object: { subscription: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+    expect(first.outcome).toBe('applied');
+
+    const [firstEventRow] = await getDb()
+      .select({ receivedAt: schema.stripeEvents.receivedAt })
+      .from(schema.stripeEvents)
+      .where(eq(schema.stripeEvents.id, firstFailureEventId));
+
+    const afterFirst = await notificationsFor(org.id);
+    expect(afterFirst).toHaveLength(1);
+    expect(afterFirst[0].kind).toBe('billing_payment_failed');
+
+    const entitlementsAfterFirst = await resolveEntitlements(getDb(), org.id);
+    expect(entitlementsAfterFirst.graceEndsAt?.getTime()).toBe(
+      firstEventRow.receivedAt.getTime() + 7 * 24 * 60 * 60 * 1000,
+    );
+    // Inside the freshly-granted window: not read-only yet.
+    expect(isOrgReadOnly(entitlementsAfterFirst)).toBe(false);
+    // Past the window: read-only, proven by moving the clock.
+    expect(
+      isOrgReadOnly(
+        entitlementsAfterFirst,
+        new Date(entitlementsAfterFirst.graceEndsAt!.getTime() + 1000),
+      ),
+    ).toBe(true);
+
+    // Smart Retries reattempts: another payment_failed while still past_due.
+    const second = await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          status: 'past_due',
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'invoice.payment_failed',
+        created: periodStart + 2,
+        data: { object: { subscription: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+    expect(second.outcome).toBe('applied');
+
+    const afterSecond = await notificationsFor(org.id);
+    expect(afterSecond).toHaveLength(1); // no duplicate notification
+
+    const entitlementsAfterSecond = await resolveEntitlements(getDb(), org.id);
+    // The retry never moved the deadline later.
+    expect(entitlementsAfterSecond.graceEndsAt?.getTime()).toBe(
+      entitlementsAfterFirst.graceEndsAt?.getTime(),
+    );
+  });
+
+  it('invoice.paid clears the grace window and read-only in one step', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const org = await makeOrg();
+    const subscriptionId = `sub_${randomUUID()}`;
+    const periodStart = Math.floor(Date.now() / 1000);
+    const periodEnd = periodStart + 30 * 24 * 60 * 60;
+
+    await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          status: 'past_due',
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'invoice.payment_failed',
+        created: periodStart,
+        data: { object: { subscription: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+    const beforeRecovery = await resolveEntitlements(getDb(), org.id);
+    expect(beforeRecovery.graceEndsAt).not.toBeNull();
+
+    await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          status: 'active',
+          currentPeriodStart: periodStart,
+          currentPeriodEnd: periodEnd,
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'invoice.paid',
+        created: periodStart + 1,
+        data: { object: { subscription: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+
+    const afterRecovery = await resolveEntitlements(getDb(), org.id);
+    expect(afterRecovery.graceEndsAt).toBeNull();
+    expect(isOrgReadOnly(afterRecovery)).toBe(false);
+  });
+
+  it('a cancelled subscription lands on free - a real working plan, not a locked account', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const org = await makeOrg({ plan: 'growth', planSource: 'stripe' });
+    const subscriptionId = `sub_${randomUUID()}`;
+
+    await applyStripeEvent(
+      getDb(),
+      fakeStripeClient({
+        [subscriptionId]: fakeSubscription({
+          id: subscriptionId,
+          customer: org.stripeCustomerId,
+          status: 'past_due',
+        }),
+      }),
+      {
+        id: `evt_${randomUUID()}`,
+        type: 'invoice.payment_failed',
+        created: Math.floor(Date.now() / 1000),
+        data: { object: { subscription: subscriptionId, customer: org.stripeCustomerId } },
+      },
+    );
+
+    await applyStripeEvent(getDb(), fakeStripeClient({}), {
+      id: `evt_${randomUUID()}`,
+      type: 'customer.subscription.deleted',
+      created: Math.floor(Date.now() / 1000),
+      data: { object: { id: subscriptionId, customer: org.stripeCustomerId } },
+    });
+
+    const entitlements = await resolveEntitlements(getDb(), org.id);
+    expect(entitlements.planId).toBe('free');
+    expect(entitlements.graceEndsAt).toBeNull();
+    expect(isOrgReadOnly(entitlements)).toBe(false);
   });
 });

--- a/web/src/lib/components/BillingGraceBanner.svelte
+++ b/web/src/lib/components/BillingGraceBanner.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { AlertTriangle, Ban } from '@lucide/svelte';
+	import { TONE_BANNER_CLASS } from '$lib/config/status-badges';
+
+	// #554: a failed payment's grace window, and the read-only state past it -
+	// on every page, per the issue, so it is rendered from the root layout
+	// rather than opted into per-route like ChatSyncStalledBanner/
+	// ExtensionDeviceNudgeBanner. Not dismissible: an active billing problem,
+	// the same posture ChatSyncStalledBanner already takes for an active-error
+	// signal, unlike the soft extension nudge. `graceEndsAt` is named as an
+	// actual date (`toDateString`, locale-independent so SSR and the client
+	// render the same string) rather than "soon" - the issue's own acceptance
+	// bar.
+	let {
+		billing,
+	}: { billing: { graceEndsAt: string; readOnly: boolean } | null } = $props();
+
+	const date = $derived(billing ? new Date(billing.graceEndsAt).toDateString() : '');
+</script>
+
+{#if billing}
+	<div
+		role="alert"
+		class="mb-3 flex items-start gap-2 rounded-lg border {billing.readOnly
+			? TONE_BANNER_CLASS.rose
+			: TONE_BANNER_CLASS.amber}"
+	>
+		{#if billing.readOnly}
+			<Ban class="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+		{:else}
+			<AlertTriangle class="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+		{/if}
+		<div class="flex-1">
+			{#if billing.readOnly}
+				<div class="font-medium">Account is read-only since {date}</div>
+				<div class="text-xs text-rose-800/85 dark:text-rose-200/80">
+					A payment failed and nothing succeeded during the grace period, so new runs,
+					suggestions, accepts, projects, campaigns, invites and devices are refused. Everything
+					already here stays readable - fix the payment method in the
+					<a
+						href="/settings/billing"
+						class="underline underline-offset-2 hover:text-rose-900 dark:hover:text-rose-100"
+						>customer portal</a
+					> to restore service.
+				</div>
+			{:else}
+				<div class="font-medium">Payment failed - grace period until {date}</div>
+				<div class="text-xs text-amber-800/85 dark:text-amber-200/80">
+					Your plan keeps working normally until then. Update your payment method in the
+					<a
+						href="/settings/billing"
+						class="underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-100"
+						>customer portal</a
+					> before {date} to avoid the account going read-only.
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/web/src/lib/server/runner.ts
+++ b/web/src/lib/server/runner.ts
@@ -7,7 +7,7 @@ import {
   gateModelForPlan,
   runnerTakesGatewayModel,
 } from '@pitchbox/shared/ai/model-functions';
-import { resolveEntitlements } from '@pitchbox/shared/plans';
+import { resolveEntitlements, isOrgReadOnly } from '@pitchbox/shared/plans';
 import { detectRunner, isDetectionConclusive } from '@pitchbox/shared/agents/detect';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import type { AgentRunnerSlug } from '@pitchbox/shared/agents/meta';
@@ -230,6 +230,16 @@ async function dispatchRun(
     if (orgId != null) {
       const period = await billingPeriodFor(db, orgId);
       const usage = await getOrgUsage(db, orgId, period);
+      // #554: a failed payment past its grace window refuses before the
+      // plan's own run-count ceiling below - an org that is both over its
+      // limit and read-only gets the read-only message, since fixing the
+      // payment is the only action that unblocks it either way.
+      if (isOrgReadOnly(usage.entitlements)) {
+        throw new Error(
+          `This organization is read-only because of a failed payment and cannot start ` +
+            `another run until the payment method is fixed in the customer portal.`,
+        );
+      }
       if (usage.runs.limit != null && usage.runs.used > usage.runs.limit) {
         throw new Error(
           `This organization has reached its plan limit of ${usage.runs.limit} run${

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -2,6 +2,7 @@ import type { LayoutServerLoad } from './$types';
 import { getDb } from '$lib/server/db.js';
 import { listUserOrganizations } from '@pitchbox/shared/orgs';
 import { isInstanceAdmin } from '$lib/server/auth.js';
+import { resolveEntitlements, isOrgReadOnly } from '@pitchbox/shared/plans';
 
 /**
  * Root layout loader. Exposes server-wide flags every page may need: `authOn`
@@ -13,12 +14,32 @@ import { isInstanceAdmin } from '$lib/server/auth.js';
  * show the instance-admin area only to the operator of the deployment - see
  * `requireInstanceAdmin`/`isInstanceAdmin`, docs/permissions.md "Instance
  * admin"). `orgs` is empty when signed out or auth is off.
+ *
+ * `billing` (#554) is the one entitlements read every page pays, gated on
+ * having an active org at all (self-host with auth off never does, and
+ * `resolveEntitlements` itself short-circuits to unlimited there anyway) and
+ * on the org actually carrying a grace deadline - the common case for a
+ * paying-and-current org is `null`, no further query. `BillingGraceBanner`
+ * is the one reader; the notification landing in the bell icon at the same
+ * moment is the webhook's own `notify` call (shared/src/billing/webhook.ts).
  */
 export const load: LayoutServerLoad = async (event) => {
   const user = event.locals.user;
   const orgs = user ? await listUserOrganizations(getDb(), user.id) : [];
   const role = event.locals.org?.role;
   const isAdmin = !event.locals.org || role === 'owner' || role === 'admin';
+
+  let billing: { graceEndsAt: string; readOnly: boolean } | null = null;
+  if (event.locals.org) {
+    const entitlements = await resolveEntitlements(getDb(), event.locals.org.id);
+    if (entitlements.graceEndsAt) {
+      billing = {
+        graceEndsAt: entitlements.graceEndsAt.toISOString(),
+        readOnly: isOrgReadOnly(entitlements),
+      };
+    }
+  }
+
   return {
     authOn: process.env.PITCHBOX_AUTH === 'on',
     signedIn: !!user,
@@ -26,5 +47,6 @@ export const load: LayoutServerLoad = async (event) => {
     orgs,
     isAdmin,
     isInstanceAdmin: await isInstanceAdmin(event),
+    billing,
   };
 };

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import '../app.css';
 	import '$lib/platforms/register';
 	import Sidebar from '$lib/components/Sidebar.svelte';
+	import BillingGraceBanner from '$lib/components/BillingGraceBanner.svelte';
 	import SseIndicator from '$lib/realtime/SseIndicator.svelte';
 	import { Toaster } from '$lib/components/ui/sonner';
 	import CommandPalette from '$lib/components/command-palette/CommandPalette.svelte';
@@ -120,7 +121,10 @@
 			<Sidebar />
 		</div>
 
-		<main class="flex-1 overflow-auto p-4 sm:p-6 pt-14 md:pt-6 min-w-0">{@render children()}</main>
+		<main class="flex-1 overflow-auto p-4 sm:p-6 pt-14 md:pt-6 min-w-0">
+			<BillingGraceBanner billing={data.billing} />
+			{@render children()}
+		</main>
 	</div>
 
 	<!-- Global Cmd/Ctrl-K command palette: single instance for the whole app. -->

--- a/web/src/routes/api/campaigns/+server.ts
+++ b/web/src/routes/api/campaigns/+server.ts
@@ -9,6 +9,9 @@ import { requireOrgId, requireVerifiedEmail } from '$lib/server/auth.js';
 import { projectBelongsToOrg } from '@pitchbox/shared/orgs';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import { SCENARIO_SLUGS } from '@pitchbox/shared/campaigns';
+import { billingPeriodFor } from '@pitchbox/shared/org-quota';
+import { getOrgUsage } from '@pitchbox/shared/usage';
+import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 const Body = z.object({
   projectId: z.number().int().positive(),
@@ -38,6 +41,16 @@ export async function POST(event: RequestEvent) {
   const orgId = await requireOrgId(event);
   if (!(await projectBelongsToOrg(db, body.projectId, orgId))) throw error(404, 'not_found');
   await requireVerifiedEmail(event);
+
+  // #554: a failed payment past its grace window refuses a new campaign -
+  // campaigns carry no plan-limit ceiling of their own (the catalogue meters
+  // projects/runs/suggestions/seats/devices, not campaign count), so this is
+  // the only plan gate this route needs.
+  const period = await billingPeriodFor(db, orgId);
+  const usage = await getOrgUsage(db, orgId, period);
+  if (isOrgReadOnly(usage.entitlements)) {
+    return json({ error: 'plan_payment_required' }, { status: 402 });
+  }
 
   const [project] = await db
     .select()

--- a/web/src/routes/api/extension/auto-pair/+server.ts
+++ b/web/src/routes/api/extension/auto-pair/+server.ts
@@ -6,6 +6,7 @@ import { getDb, schema } from '$lib/server/db.js';
 import { mintDeviceToken } from '$lib/server/extension-auth.js';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 /**
  * One-shot pairing endpoint for the browser extension.
@@ -78,11 +79,16 @@ export async function POST({
   // row is inserted below this point.
   if (!organizationId) throw error(409, 'no_org');
 
+  // #554: a failed payment past its grace window refuses before the plan's
+  // own device-count ceiling below.
+  const period = await billingPeriodFor(db, organizationId);
+  const usage = await getOrgUsage(db, organizationId, period);
+  if (isOrgReadOnly(usage.entitlements)) {
+    return json({ error: 'plan_payment_required' }, { status: 402 });
+  }
   // #548: the plan's own device-count ceiling. Checked before minting a
   // token so a refused pairing never leaves an unusable token floating
   // around client-side.
-  const period = await billingPeriodFor(db, organizationId);
-  const usage = await getOrgUsage(db, organizationId, period);
   if (
     usage.extensionDevices.limit != null &&
     usage.extensionDevices.used >= usage.extensionDevices.limit

--- a/web/src/routes/api/extension/observations/+server.ts
+++ b/web/src/routes/api/extension/observations/+server.ts
@@ -11,6 +11,7 @@ import {
 import { loadLinkedInAssistDeviceState } from '@pitchbox/shared/linkedin-assist';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 // Server side of the observation buffer (#301): the extension's content
 // script watches linkedin.com passively and posts what it saw here, on a
@@ -69,6 +70,13 @@ export async function POST({ request }: { request: Request }) {
     .limit(1);
   if (!project) throw error(404, 'project not found');
 
+  // #554: a failed payment past its grace window refuses before the plan's
+  // own suggestion budget below, same 403 shape.
+  const period = await billingPeriodFor(db, project.organizationId);
+  const usage = await getOrgUsage(db, project.organizationId, period);
+  if (isOrgReadOnly(usage.entitlements)) {
+    throw error(403, 'plan_payment_required');
+  }
   // #548: the assist plane's own plan gate, mirroring the LinkedIn
   // switch's precedent on this exact route (AGENTS.md: "any new route on
   // that plane loads ... and refuses") - an org that has spent its whole
@@ -76,8 +84,6 @@ export async function POST({ request }: { request: Request }) {
   // buffer either, since nothing it collects from here on can still turn
   // into a suggestion this period. 403, matching this route's existing
   // shape: the collector has no human waiting on a rendered answer.
-  const period = await billingPeriodFor(db, project.organizationId);
-  const usage = await getOrgUsage(db, project.organizationId, period);
   if (usage.suggestions.limit != null && usage.suggestions.used >= usage.suggestions.limit) {
     throw error(403, 'plan_limit_reached');
   }

--- a/web/src/routes/api/extension/pair/+server.ts
+++ b/web/src/routes/api/extension/pair/+server.ts
@@ -5,6 +5,7 @@ import { getDb, schema } from '$lib/server/db.js';
 import { mintDeviceToken } from '$lib/server/extension-auth.js';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { isOrgReadOnly } from '@pitchbox/shared/plans';
 import { RateLimiter } from '$lib/server/rate-limit.js';
 
 const Body = z.object({
@@ -57,12 +58,19 @@ export async function POST({ request, getClientAddress }: RequestEvent) {
   if (!pairing) throw error(404, 'invalid_or_expired_code');
   if (pairing.organizationId == null) throw error(500, 'no_org');
 
+  // #554: a failed payment past its grace window refuses before the plan's
+  // own device-count ceiling below. The code is already consumed by the
+  // atomic claim above by the time this runs - same trade-off the limit
+  // check below already accepts.
+  const period = await billingPeriodFor(db, pairing.organizationId);
+  const usage = await getOrgUsage(db, pairing.organizationId, period);
+  if (isOrgReadOnly(usage.entitlements)) {
+    return json({ error: 'plan_payment_required' }, { status: 402 });
+  }
   // #548: the plan's own device-count ceiling. The code is already
   // consumed by the atomic claim above by the time this runs - a
   // refusal here still burns a one-time code, the trade-off for not
   // racing a separate read-only pre-check against the same claim.
-  const period = await billingPeriodFor(db, pairing.organizationId);
-  const usage = await getOrgUsage(db, pairing.organizationId, period);
   if (
     usage.extensionDevices.limit != null &&
     usage.extensionDevices.used >= usage.extensionDevices.limit

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -27,6 +27,7 @@ import {
 import { loadRecentObservedTarget } from '@pitchbox/shared/observed-targets';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 // The real-time plane. What makes the in-page assistant a separate subsystem
 // rather than a view onto campaigns:
@@ -187,13 +188,19 @@ export async function POST(event: RequestEvent) {
     .limit(1);
   if (!project) throw error(404, 'project not found');
 
+  const period = await billingPeriodFor(db, project.organizationId);
+  const usage = await getOrgUsage(db, project.organizationId, period);
+  // #554: a failed payment past its grace window refuses before the plan's
+  // own suggestions ceiling below, same renderable-200 shape, distinct code
+  // so the panel (#556) can render "fix your payment" rather than "upgrade".
+  if (isOrgReadOnly(usage.entitlements)) {
+    return json({ refused: 'plan_payment_required', upgradeUrl: '/settings/billing' });
+  }
   // #548: the plan's own suggestions-per-period ceiling. Read before the
   // platform daily quota below so a plan refusal never pays for a wasted
   // query, and returned in the same renderable-200 shape as every other
   // refusal on this route (self-host resolves fully unlimited, so this
   // never fires there).
-  const period = await billingPeriodFor(db, project.organizationId);
-  const usage = await getOrgUsage(db, project.organizationId, period);
   if (usage.suggestions.limit != null && usage.suggestions.used >= usage.suggestions.limit) {
     return json({
       refused: 'plan_limit_reached',

--- a/web/src/routes/api/extension/suggest/accept/+server.ts
+++ b/web/src/routes/api/extension/suggest/accept/+server.ts
@@ -8,6 +8,9 @@ import { RateLimiter } from '$lib/server/rate-limit.js';
 import { emit } from '$lib/server/events.js';
 import { loadLinkedInAssistDeviceState } from '@pitchbox/shared/linkedin-assist';
 import { acceptSuggestionIntoDraft } from '@pitchbox/shared/assist-accept';
+import { billingPeriodFor } from '@pitchbox/shared/org-quota';
+import { getOrgUsage } from '@pitchbox/shared/usage';
+import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 // The other half of the real-time plane (#313): `POST /api/extension/suggest`
 // produces text nobody has committed to anything yet; this endpoint is what
@@ -81,6 +84,15 @@ export async function POST(event: RequestEvent) {
     )
     .limit(1);
   if (!project) throw error(404, 'project not found');
+
+  // #554: a failed payment past its grace window refuses an accept the same
+  // way it refuses the suggestion that preceded it - a suggestion nobody can
+  // request cannot legitimately be committed to a draft either.
+  const period = await billingPeriodFor(db, project.organizationId);
+  const usage = await getOrgUsage(db, project.organizationId, period);
+  if (isOrgReadOnly(usage.entitlements)) {
+    return json({ refused: 'plan_payment_required' });
+  }
 
   const [platform] = await db
     .select()

--- a/web/src/routes/api/orgs/[slug]/invites/+server.ts
+++ b/web/src/routes/api/orgs/[slug]/invites/+server.ts
@@ -7,6 +7,7 @@ import { loadMailEnv } from '@pitchbox/shared/mail/env';
 import { renderPlainTextMail } from '@pitchbox/shared/mail/template';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 const Body = z.object({
   email: z.email().optional(),
@@ -60,6 +61,11 @@ export async function POST(event: import('@sveltejs/kit').RequestEvent) {
   // at once (shared/src/usage.ts's getOrgUsage already counts it that way).
   const period = await billingPeriodFor(db, org.id);
   const usage = await getOrgUsage(db, org.id, period);
+  // #554: a failed payment past its grace window refuses before the plan's
+  // own seat limit below.
+  if (isOrgReadOnly(usage.entitlements)) {
+    return json({ error: 'plan_payment_required' }, { status: 402 });
+  }
   if (usage.seats.limit != null && usage.seats.used >= usage.seats.limit) {
     return json(
       {

--- a/web/src/routes/api/projects/+server.ts
+++ b/web/src/routes/api/projects/+server.ts
@@ -8,6 +8,7 @@ import { resolveDefaultRunnerSlug } from '@pitchbox/shared/agents/config';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 const slugRegex = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 
@@ -94,6 +95,11 @@ export async function POST(event) {
   // period-bound axes this same snapshot also carries.
   const period = await billingPeriodFor(db, organizationId);
   const usage = await getOrgUsage(db, organizationId, period);
+  // #554: a failed payment past its grace window refuses before the plan's
+  // own project limit below.
+  if (isOrgReadOnly(usage.entitlements)) {
+    return json({ error: 'plan_payment_required' }, { status: 402 });
+  }
   if (usage.projects.limit != null && usage.projects.used >= usage.projects.limit) {
     return json(
       {

--- a/web/tests/campaign-payment-required.test.ts
+++ b/web/tests/campaign-payment-required.test.ts
@@ -1,0 +1,181 @@
+// #554: "no new campaigns" for a read-only org. Campaigns carry no metered
+// plan-limit ceiling of their own (unlike projects/seats/devices), so this
+// is the only plan gate POST /api/campaigns needs.
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type {
+  AgentRunHandle,
+  AgentRunOptions,
+  AgentRunner,
+  AgentRunResult,
+} from '@pitchbox/shared/agents';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+
+const fakeResult: AgentRunResult = { exitCode: 0, logPath: '/dev/null' };
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'cloud',
+    run(_opts: AgentRunOptions): AgentRunHandle {
+      return { result: Promise.resolve(fakeResult), cancel: () => {} };
+    },
+  }),
+}));
+
+// Dynamic on purpose - vi.mock above is hoisted, but the campaigns route
+// transitively imports runner.js, which has to load after it for
+// createAgentRunner to resolve to the fake gateway runner (same pattern as
+// gateway-plan-limit-dispatch.test.ts).
+const { POST: campaignsPost } = await import('../src/routes/api/campaigns/+server.js');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function reset() {
+  const db = getDb();
+  await db.execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(sql`DELETE FROM stripe_events`);
+  await db.execute(sql`DELETE FROM org_subscriptions`);
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function seedPastDueOrgWithProject(slug: string, failedDaysAgo: number) {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: 'growth', planSource: 'stripe' })
+    .returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `${slug}-proj`,
+      name: `${slug} p`,
+      defaultAgentRunner: 'cloud',
+    })
+    .returning();
+
+  const customerId = `cus_${randomUUID()}`;
+  const subscriptionId = `sub_${randomUUID()}`;
+  await db
+    .update(schema.organizations)
+    .set({ stripeCustomerId: customerId })
+    .where(eq(schema.organizations.id, org.id));
+  await db.insert(schema.orgSubscriptions).values({
+    organizationId: org.id,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    planId: 'growth',
+    status: 'past_due',
+    currentPeriodStart: new Date(Date.now() - 20 * DAY_MS),
+    currentPeriodEnd: new Date(Date.now() + 10 * DAY_MS),
+    limitRuns: 2000,
+    limitSuggestions: 2000,
+    limitProjects: 10,
+    limitSeats: 3,
+    limitDevices: 10,
+    limitConcurrency: 4,
+    limitBudgetUsd: '30.00',
+    limitRetentionDays: 90,
+    limitPremiumModels: true,
+  });
+  const failedEventId = `evt_${randomUUID()}`;
+  const failedAt = new Date(Date.now() - failedDaysAgo * DAY_MS);
+  await db.insert(schema.stripeEvents).values({
+    id: failedEventId,
+    type: 'invoice.payment_failed',
+    receivedAt: failedAt,
+    processedAt: failedAt,
+    payload: {
+      id: failedEventId,
+      type: 'invoice.payment_failed',
+      created: Math.floor(failedAt.getTime() / 1000),
+      data: { object: { subscription: subscriptionId, customer: customerId } },
+    },
+  });
+  return { orgId: org.id, projectId: project.id };
+}
+
+async function platformId(slug: string): Promise<number> {
+  const [platform] = await getDb()
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, slug));
+  if (!platform) throw new Error(`platform "${slug}" is not seeded - did global-setup run?`);
+  return platform.id;
+}
+
+function postEvent(orgId: number, body: unknown): RequestEvent {
+  return {
+    locals: { org: { id: orgId, slug: 'x', role: 'member' } },
+    request: new Request('http://x/', { method: 'POST', body: JSON.stringify(body) }),
+  } as unknown as RequestEvent;
+}
+
+describe('POST /api/campaigns is read-only-gated by a failed payment (#554)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  const savedGatewayKey = process.env.AI_GATEWAY_API_KEY;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+    process.env.AI_GATEWAY_API_KEY = 'test-key';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+    if (savedGatewayKey === undefined) delete process.env.AI_GATEWAY_API_KEY;
+    else process.env.AI_GATEWAY_API_KEY = savedGatewayKey;
+  });
+
+  it('refuses with plan_payment_required once the grace window has elapsed, creating nothing', async () => {
+    const { orgId, projectId } = await seedPastDueOrgWithProject(
+      'campaign-payment-required-over',
+      10,
+    );
+    const reddit = await platformId('reddit');
+
+    const res = await campaignsPost(
+      postEvent(orgId, {
+        projectId,
+        platformSlug: 'reddit',
+        scenarioSlug: 'reddit-scout',
+        name: 'Should not exist',
+        objective: 'find leads',
+      }),
+    );
+
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe('plan_payment_required');
+
+    const rows = await getDb()
+      .select()
+      .from(schema.campaigns)
+      .where(eq(schema.campaigns.projectId, projectId));
+    expect(rows).toHaveLength(0);
+    void reddit; // seeded for the route's own platform lookup, not asserted on
+  });
+
+  it('creates the campaign normally while still inside the grace window', async () => {
+    const { orgId, projectId } = await seedPastDueOrgWithProject(
+      'campaign-payment-required-grace',
+      3,
+    );
+
+    const res = await campaignsPost(
+      postEvent(orgId, {
+        projectId,
+        platformSlug: 'reddit',
+        scenarioSlug: 'reddit-scout',
+        name: 'Still fine',
+        objective: 'find leads',
+      }),
+    );
+
+    expect(res.status).toBe(201);
+  });
+});

--- a/web/tests/extension-observations-payment-required.test.ts
+++ b/web/tests/extension-observations-payment-required.test.ts
@@ -1,0 +1,177 @@
+// #554: the observation collector mirrors /suggest's own read-only gate
+// (extension-suggest-payment-required.test.ts), the same way it already
+// mirrors /suggest's plan-limit gate (extension-observations-plan-limit.test.ts).
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash, randomUUID } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+import { POST as observationsPost } from '../src/routes/api/extension/observations/+server.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function reset() {
+  await getDb().execute(sql`TRUNCATE observed_targets, projects RESTART IDENTITY CASCADE`);
+  await getDb().execute(sql`DELETE FROM assist_usage`);
+  await getDb().execute(sql`DELETE FROM stripe_events`);
+  await getDb().execute(sql`DELETE FROM org_subscriptions`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM extension_devices`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+}
+
+async function seedPastDueOrgWithProject(slug: string, failedDaysAgo: number) {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: 'growth', planSource: 'stripe' })
+    .returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug })
+    .returning();
+  await saveLinkedInAssistSettings(db, org.id, {
+    ...defaultLinkedInAssistSettings(),
+    enabled: true,
+    collectorEnabled: true,
+    projectId: project.id,
+  });
+
+  const customerId = `cus_${randomUUID()}`;
+  const subscriptionId = `sub_${randomUUID()}`;
+  await db
+    .update(schema.organizations)
+    .set({ stripeCustomerId: customerId })
+    .where(eq(schema.organizations.id, org.id));
+  await db.insert(schema.orgSubscriptions).values({
+    organizationId: org.id,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    planId: 'growth',
+    status: 'past_due',
+    currentPeriodStart: new Date(Date.now() - 20 * DAY_MS),
+    currentPeriodEnd: new Date(Date.now() + 10 * DAY_MS),
+    limitRuns: 2000,
+    limitSuggestions: 2000,
+    limitProjects: 10,
+    limitSeats: 3,
+    limitDevices: 10,
+    limitConcurrency: 4,
+    limitBudgetUsd: '30.00',
+    limitRetentionDays: 90,
+    limitPremiumModels: true,
+  });
+  const failedEventId = `evt_${randomUUID()}`;
+  const failedAt = new Date(Date.now() - failedDaysAgo * DAY_MS);
+  await db.insert(schema.stripeEvents).values({
+    id: failedEventId,
+    type: 'invoice.payment_failed',
+    receivedAt: failedAt,
+    processedAt: failedAt,
+    payload: {
+      id: failedEventId,
+      type: 'invoice.payment_failed',
+      created: Math.floor(failedAt.getTime() / 1000),
+      data: { object: { subscription: subscriptionId, customer: customerId } },
+    },
+  });
+  return { org, project };
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({
+      organizationId,
+      tokenHash: createHash('sha256').update(token).digest('hex'),
+      label: 'test',
+    });
+}
+
+function bearer(token: string | null, body: unknown): Request {
+  return new Request('http://x/api/extension/observations', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+function observation(overrides: Record<string, unknown> = {}) {
+  return {
+    externalId: 'urn:li:activity:88881',
+    url: 'https://www.linkedin.com/feed/update/urn:li:activity:88881/',
+    authorHandle: 'jane-doe',
+    authorName: 'Jane Doe',
+    text: 'A post about outreach automation.',
+    observedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function isHttpError(value: unknown): value is { status: number; body?: { message?: string } } {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('status' in value)) return false;
+  return typeof value.status === 'number';
+}
+
+async function statusAndBodyOf(
+  promise: Promise<Response>,
+): Promise<{ status: number; message: unknown }> {
+  try {
+    const res = await promise;
+    return { status: res.status, message: await res.json().catch(() => null) };
+  } catch (e) {
+    if (isHttpError(e)) return { status: e.status, message: e.body?.message };
+    throw e;
+  }
+}
+
+describe('POST /api/extension/observations is read-only-gated by a failed payment (#554)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  it('refuses with a 403 once the grace window has elapsed', async () => {
+    const { org, project } = await seedPastDueOrgWithProject('obs-payment-required-over', 10);
+    await mintDevice(org.id, 'tok-obs-payment-over');
+
+    const { status, message } = await statusAndBodyOf(
+      observationsPost({
+        request: bearer('tok-obs-payment-over', {
+          platform: 'linkedin',
+          projectId: project.id,
+          items: [observation()],
+        }),
+      } as unknown as Parameters<typeof observationsPost>[0]),
+    );
+
+    expect(status).toBe(403);
+    expect(message).toBe('plan_payment_required');
+  });
+
+  it('is admitted normally while still inside the grace window', async () => {
+    const { org, project } = await seedPastDueOrgWithProject('obs-payment-required-grace', 3);
+    await mintDevice(org.id, 'tok-obs-payment-grace');
+
+    const { status } = await statusAndBodyOf(
+      observationsPost({
+        request: bearer('tok-obs-payment-grace', {
+          platform: 'linkedin',
+          projectId: project.id,
+          items: [observation()],
+        }),
+      } as unknown as Parameters<typeof observationsPost>[0]),
+    );
+
+    expect(status).toBe(200);
+  });
+});

--- a/web/tests/extension-pairing-payment-required.test.ts
+++ b/web/tests/extension-pairing-payment-required.test.ts
@@ -1,0 +1,125 @@
+// #554: "no new devices" for a read-only org - the same enforcement point as
+// extension-pairing-plan-limit.test.ts's device ceiling, checked first, with
+// its own `plan_payment_required` code. Exercises POST /api/extension/pair
+// for the same reason that file does (a dedicated, disposable org - see its
+// own header comment on why /auto-pair is inspection-only here).
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { POST as pairConsume } from '../src/routes/api/extension/pair/+server.js';
+
+type ConsumeEvent = Parameters<typeof pairConsume>[0];
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE extension_devices, extension_pairings RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM stripe_events`);
+  await getDb().execute(sql`DELETE FROM org_subscriptions`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function makePastDueOrg(slug: string, failedDaysAgo: number) {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: 'growth', planSource: 'stripe' })
+    .returning();
+  const customerId = `cus_${randomUUID()}`;
+  const subscriptionId = `sub_${randomUUID()}`;
+  await db
+    .update(schema.organizations)
+    .set({ stripeCustomerId: customerId })
+    .where(eq(schema.organizations.id, org.id));
+  await db.insert(schema.orgSubscriptions).values({
+    organizationId: org.id,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    planId: 'growth',
+    status: 'past_due',
+    currentPeriodStart: new Date(Date.now() - 20 * DAY_MS),
+    currentPeriodEnd: new Date(Date.now() + 10 * DAY_MS),
+    limitRuns: 2000,
+    limitSuggestions: 2000,
+    limitProjects: 10,
+    limitSeats: 3,
+    limitDevices: 10,
+    limitConcurrency: 4,
+    limitBudgetUsd: '30.00',
+    limitRetentionDays: 90,
+    limitPremiumModels: true,
+  });
+  const failedEventId = `evt_${randomUUID()}`;
+  const failedAt = new Date(Date.now() - failedDaysAgo * DAY_MS);
+  await db.insert(schema.stripeEvents).values({
+    id: failedEventId,
+    type: 'invoice.payment_failed',
+    receivedAt: failedAt,
+    processedAt: failedAt,
+    payload: {
+      id: failedEventId,
+      type: 'invoice.payment_failed',
+      created: Math.floor(failedAt.getTime() / 1000),
+      data: { object: { subscription: subscriptionId, customer: customerId } },
+    },
+  });
+  return org;
+}
+
+async function insertPairing(organizationId: number, code: string) {
+  await getDb()
+    .insert(schema.extensionPairings)
+    .values({ code, organizationId, expiresAt: new Date(Date.now() + 10 * 60 * 1000) });
+}
+
+function consumeEvent(code: string, ip: string): ConsumeEvent {
+  return {
+    request: new Request('http://x/api/extension/pair', {
+      method: 'POST',
+      body: JSON.stringify({ code }),
+    }),
+    getClientAddress: () => ip,
+  } as unknown as ConsumeEvent;
+}
+
+describe('POST /api/extension/pair is read-only-gated by a failed payment (#554)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  it("refuses redemption once the code's org grace window has elapsed, minting no device", async () => {
+    const org = await makePastDueOrg('pairing-payment-required-over', 10);
+    await insertPairing(org.id, 'CODE-PAY-OVER-0001');
+
+    const res = await pairConsume(consumeEvent('CODE-PAY-OVER-0001', '198.51.100.10'));
+
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe('plan_payment_required');
+
+    const devices = await getDb()
+      .select()
+      .from(schema.extensionDevices)
+      .where(eq(schema.extensionDevices.organizationId, org.id));
+    expect(devices).toHaveLength(0);
+  });
+
+  it('redeems the code normally while still inside the grace window', async () => {
+    const org = await makePastDueOrg('pairing-payment-required-grace', 3);
+    await insertPairing(org.id, 'CODE-PAY-GRACE-0001');
+
+    const res = await pairConsume(consumeEvent('CODE-PAY-GRACE-0001', '198.51.100.11'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token?: string };
+    expect(body.token).toBeTruthy();
+  });
+});

--- a/web/tests/extension-suggest-accept-payment-required.test.ts
+++ b/web/tests/extension-suggest-accept-payment-required.test.ts
@@ -1,0 +1,158 @@
+// #554: "no accepts" is one of the explicit refusals a read-only org gets -
+// a suggestion nobody can request cannot legitimately be committed to a
+// draft either. Mirrors extension-suggest-payment-required.test.ts's org
+// seeding, exercised against the accept route instead.
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash, randomUUID } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+import { POST as accept } from '../src/routes/api/extension/suggest/accept/+server.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, draft_events, contact_history, blocklist, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM stripe_events`);
+  await getDb().execute(sql`DELETE FROM org_subscriptions`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+}
+
+async function seedPastDueOrgProject(slug: string, failedDaysAgo: number) {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: 'growth', planSource: 'stripe' })
+    .returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `p-${slug}`, name: slug, description: `about ${slug}` })
+    .returning();
+  await saveLinkedInAssistSettings(db, org.id, {
+    ...defaultLinkedInAssistSettings(),
+    enabled: true,
+    projectId: project.id,
+  });
+
+  const customerId = `cus_${randomUUID()}`;
+  const subscriptionId = `sub_${randomUUID()}`;
+  await db
+    .update(schema.organizations)
+    .set({ stripeCustomerId: customerId })
+    .where(eq(schema.organizations.id, org.id));
+  await db.insert(schema.orgSubscriptions).values({
+    organizationId: org.id,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    planId: 'growth',
+    status: 'past_due',
+    currentPeriodStart: new Date(Date.now() - 20 * DAY_MS),
+    currentPeriodEnd: new Date(Date.now() + 10 * DAY_MS),
+    limitRuns: 2000,
+    limitSuggestions: 2000,
+    limitProjects: 10,
+    limitSeats: 3,
+    limitDevices: 10,
+    limitConcurrency: 4,
+    limitBudgetUsd: '30.00',
+    limitRetentionDays: 90,
+    limitPremiumModels: true,
+  });
+  const failedEventId = `evt_${randomUUID()}`;
+  const failedAt = new Date(Date.now() - failedDaysAgo * DAY_MS);
+  await db.insert(schema.stripeEvents).values({
+    id: failedEventId,
+    type: 'invoice.payment_failed',
+    receivedAt: failedAt,
+    processedAt: failedAt,
+    payload: {
+      id: failedEventId,
+      type: 'invoice.payment_failed',
+      created: Math.floor(failedAt.getTime() / 1000),
+      data: { object: { subscription: subscriptionId, customer: customerId } },
+    },
+  });
+  return { org, project };
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  await getDb()
+    .insert(schema.extensionDevices)
+    .values({
+      organizationId,
+      tokenHash: createHash('sha256').update(token).digest('hex'),
+      label: 'test',
+    });
+}
+
+function request(token: string | null, body: unknown) {
+  return new Request('http://x/api/extension/suggest/accept', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+const POST_BODY = {
+  kind: 'post_comment' as const,
+  post: {
+    urn: 'urn:li:activity:7000000000000000001',
+    authorHandle: 'jane-doe',
+    authorName: 'Jane Doe',
+    url: 'https://www.linkedin.com/feed/update/urn:li:activity:7000000000000000001/',
+  },
+  body: 'We hit the same wall and cut p99 in half by batching the writes.',
+};
+
+describe('POST /api/extension/suggest/accept is read-only-gated by a failed payment (#554)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  it('refuses with plan_payment_required once the grace window has elapsed, and files no draft', async () => {
+    const { org, project } = await seedPastDueOrgProject('payment-required-accept-over', 10);
+    await mintDevice(org.id, 'tok-accept-over');
+
+    const res = await accept({
+      request: request('tok-accept-over', { ...POST_BODY, projectId: project.id }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { refused?: string };
+    expect(body.refused).toBe('plan_payment_required');
+
+    const drafts = await getDb()
+      .select()
+      .from(schema.drafts)
+      .where(eq(schema.drafts.projectId, project.id));
+    expect(drafts).toHaveLength(0);
+  });
+
+  it('is not refused for payment while still inside the grace window', async () => {
+    const { org, project } = await seedPastDueOrgProject('payment-required-accept-grace', 3);
+    await mintDevice(org.id, 'tok-accept-grace');
+
+    const res = await accept({
+      request: request('tok-accept-grace', { ...POST_BODY, projectId: project.id }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    // Still inside grace: whatever this accept resolves to (a real draft or
+    // some other domain refusal such as a missing account), it must not be
+    // the payment gate - that is the one behavior #554 adds to this route.
+    const body = (await res.json()) as { refused?: string };
+    expect(body.refused).not.toBe('plan_payment_required');
+  });
+});

--- a/web/tests/extension-suggest-payment-required.test.ts
+++ b/web/tests/extension-suggest-payment-required.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { createHash, randomUUID } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import {
+  defaultLinkedInAssistSettings,
+  saveLinkedInAssistSettings,
+} from '@pitchbox/shared/linkedin-assist';
+import { DRAFT_MARKER } from '@pitchbox/shared/assist/envelope';
+
+/**
+ * #554: the assist plane's own read-only gate. `POST /api/extension/suggest`
+ * refuses with a renderable `200 {refused: 'plan_payment_required'}` once an
+ * org's grace window has elapsed - distinct from `plan_limit_reached`
+ * (extension-suggest-plan-limit.test.ts), since the fix is the customer
+ * portal, not waiting or upgrading.
+ *
+ * In its own module for a fresh in-memory rate-limiter budget, the same
+ * reason every other suggest-route test in this repo is.
+ */
+
+const REASONING = 'Noticed the cache change and the specific number.';
+const DRAFT = 'A specific thing that happened.';
+const ENVELOPE_CHUNKS = [`${REASONING}\n`, DRAFT_MARKER, '\n', DRAFT];
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: () => ({
+    slug: 'fake',
+    run(opts: { onTextChunk?: (c: string) => void }) {
+      for (const c of ENVELOPE_CHUNKS) opts.onTextChunk?.(c);
+      return {
+        result: Promise.resolve({
+          exitCode: 0,
+          logPath: '/dev/null',
+          usage: {
+            inputTokens: 2,
+            outputTokens: 40,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            costUsd: 0.004,
+            costReported: true,
+          },
+        }),
+        cancel: () => {},
+      };
+    },
+  }),
+}));
+
+// Dynamic on purpose - vi.mock above is hoisted, but the route module has to
+// load after it for createAgentRunner to resolve to the fake agent (same
+// pattern as every other suggest-route test in this repo).
+const { POST: suggest } = await import('../src/routes/api/extension/suggest/+server.js');
+
+function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, contact_history, extension_devices RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM assist_usage`);
+  await getDb().execute(sql`DELETE FROM stripe_events`);
+  await getDb().execute(sql`DELETE FROM org_subscriptions`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'linkedin_assist'`);
+}
+
+/** An org+project with the assist switch on, whose mirrored subscription
+ * entered `past_due` `failedDaysAgo` days ago. */
+async function seedPastDueOrgProject(slug: string, failedDaysAgo: number) {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: 'growth', planSource: 'stripe' })
+    .returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `p-${slug}`,
+      name: slug,
+      description: `about ${slug}`,
+      defaultAgentRunner: 'cloud',
+    })
+    .returning();
+  await saveLinkedInAssistSettings(db, org.id, {
+    ...defaultLinkedInAssistSettings(),
+    enabled: true,
+    projectId: project.id,
+  });
+
+  const customerId = `cus_${randomUUID()}`;
+  const subscriptionId = `sub_${randomUUID()}`;
+  await db
+    .update(schema.organizations)
+    .set({ stripeCustomerId: customerId })
+    .where(eq(schema.organizations.id, org.id));
+  await db.insert(schema.orgSubscriptions).values({
+    organizationId: org.id,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    planId: 'growth',
+    status: 'past_due',
+    currentPeriodStart: new Date(Date.now() - 20 * DAY_MS),
+    currentPeriodEnd: new Date(Date.now() + 10 * DAY_MS),
+    limitRuns: 2000,
+    limitSuggestions: 2000,
+    limitProjects: 10,
+    limitSeats: 3,
+    limitDevices: 10,
+    limitConcurrency: 4,
+    limitBudgetUsd: '30.00',
+    limitRetentionDays: 90,
+    limitPremiumModels: true,
+  });
+  const failedEventId = `evt_${randomUUID()}`;
+  const failedAt = new Date(Date.now() - failedDaysAgo * DAY_MS);
+  await db.insert(schema.stripeEvents).values({
+    id: failedEventId,
+    type: 'invoice.payment_failed',
+    receivedAt: failedAt,
+    processedAt: failedAt,
+    payload: {
+      id: failedEventId,
+      type: 'invoice.payment_failed',
+      created: Math.floor(failedAt.getTime() / 1000),
+      data: { object: { subscription: subscriptionId, customer: customerId } },
+    },
+  });
+  return { org, project };
+}
+
+async function mintDevice(organizationId: number | null, token: string) {
+  const [device] = await getDb()
+    .insert(schema.extensionDevices)
+    .values({ organizationId, tokenHash: tokenHash(token), label: 'test' })
+    .returning();
+  return device;
+}
+
+function request(token: string | null, body: unknown) {
+  return new Request('http://x/api/extension/suggest', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+const POST_BODY = {
+  kind: 'post_comment' as const,
+  post: {
+    urn: 'urn:li:activity:7000000000000000099',
+    authorName: 'Giulia Bianchi',
+    text: 'We cut p99 in half.',
+  },
+};
+
+describe('POST /api/extension/suggest is read-only-gated by a failed payment (#554)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  it('refuses with plan_payment_required once the grace window has elapsed', async () => {
+    const { org, project } = await seedPastDueOrgProject('payment-required-suggest-over', 10);
+    await mintDevice(org.id, 'tok-payment-required-over');
+
+    const res = await suggest({
+      request: request('tok-payment-required-over', { ...POST_BODY, projectId: project.id }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { refused?: string; upgradeUrl?: string };
+    expect(body.refused).toBe('plan_payment_required');
+    // No ledger row from a refused request - nothing was produced to bill.
+    const rows = await getDb()
+      .select()
+      .from(schema.assistUsage)
+      .where(eq(schema.assistUsage.projectId, project.id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('proceeds normally while still inside the grace window', async () => {
+    const { org, project } = await seedPastDueOrgProject('payment-required-suggest-grace', 3);
+    await mintDevice(org.id, 'tok-payment-required-grace');
+
+    const res = await suggest({
+      request: request('tok-payment-required-grace', { ...POST_BODY, projectId: project.id }),
+    } as never);
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('event: done');
+    expect(text).not.toContain('plan_payment_required');
+  });
+});

--- a/web/tests/gateway-payment-required-dispatch.test.ts
+++ b/web/tests/gateway-payment-required-dispatch.test.ts
@@ -1,0 +1,182 @@
+// #554: a failed payment past its grace window is refused where the effect
+// happens, exactly like #548's plan-limit ceiling (gateway-plan-limit-dispatch.test.ts)
+// but with its own `plan_payment_required` failure reason, since "fix your
+// payment in the portal" is a different fix than "wait or upgrade".
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type {
+  AgentRunHandle,
+  AgentRunOptions,
+  AgentRunner,
+  AgentRunResult,
+} from '@pitchbox/shared/agents';
+import type { RunnerConfig } from '@pitchbox/shared/agents/config';
+import { clearDetectionCache } from '@pitchbox/shared/agents/detect';
+
+let createCalls = 0;
+const fakeResult: AgentRunResult = { exitCode: 0, logPath: '/dev/null' };
+
+vi.mock('@pitchbox/shared/agents/registry', () => ({
+  createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
+    slug: 'cloud',
+    run(_opts: AgentRunOptions): AgentRunHandle {
+      createCalls += 1;
+      return { result: Promise.resolve(fakeResult), cancel: () => {} };
+    },
+  }),
+}));
+
+// Dynamic on purpose - vi.mock above is hoisted, but runner.js has to load
+// after it for createAgentRunner to resolve to the fake gateway runner.
+const { runCampaign } = await import('../src/lib/server/runner.js');
+
+async function reset() {
+  const db = getDb();
+  await db.execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(sql`DELETE FROM stripe_events`);
+  await db.execute(sql`DELETE FROM org_subscriptions`);
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+  createCalls = 0;
+}
+
+async function platformId(slug: string): Promise<number> {
+  const [row] = await getDb()
+    .select({ id: schema.platforms.id })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, slug));
+  return row.id;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** A 'cloud'-runner campaign under an org whose mirrored subscription
+ * entered `past_due` `failedDaysAgo` days ago - past GRACE_PERIOD_DAYS (7)
+ * is read-only, short of it is still working normally. */
+async function seedPastDueCampaign(
+  slug: string,
+  failedDaysAgo: number,
+): Promise<{ orgId: number; projectId: number; campaignId: number }> {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: 'growth', planSource: 'stripe' })
+    .returning();
+  const customerId = `cus_${randomUUID()}`;
+  const subscriptionId = `sub_${randomUUID()}`;
+  await db
+    .update(schema.organizations)
+    .set({ stripeCustomerId: customerId })
+    .where(eq(schema.organizations.id, org.id));
+  await db.insert(schema.orgSubscriptions).values({
+    organizationId: org.id,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    planId: 'growth',
+    status: 'past_due',
+    currentPeriodStart: new Date(Date.now() - 20 * DAY_MS),
+    currentPeriodEnd: new Date(Date.now() + 10 * DAY_MS),
+    limitRuns: 2000,
+    limitSuggestions: 2000,
+    limitProjects: 10,
+    limitSeats: 3,
+    limitDevices: 10,
+    limitConcurrency: 4,
+    limitBudgetUsd: '30.00',
+    limitRetentionDays: 90,
+    limitPremiumModels: true,
+  });
+  const failedEventId = `evt_${randomUUID()}`;
+  const failedAt = new Date(Date.now() - failedDaysAgo * DAY_MS);
+  await db.insert(schema.stripeEvents).values({
+    id: failedEventId,
+    type: 'invoice.payment_failed',
+    receivedAt: failedAt,
+    processedAt: failedAt,
+    payload: {
+      id: failedEventId,
+      type: 'invoice.payment_failed',
+      created: Math.floor(failedAt.getTime() / 1000),
+      data: { object: { subscription: subscriptionId, customer: customerId } },
+    },
+  });
+
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      organizationId: org.id,
+      slug: `${slug}-proj`,
+      name: `${slug} p`,
+      defaultAgentRunner: 'cloud',
+    })
+    .returning();
+  const platform = await platformId('reddit');
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({
+      projectId: project.id,
+      platformId: platform,
+      name: 'c',
+      skillSlug: 'reddit-scout',
+      agentRunner: 'cloud',
+    })
+    .returning();
+  return { orgId: org.id, projectId: project.id, campaignId: campaign.id };
+}
+
+async function runRow(runId: number) {
+  const [row] = await getDb()
+    .select({
+      status: schema.runs.status,
+      error: schema.runs.error,
+      failureReason: schema.runs.failureReason,
+    })
+    .from(schema.runs)
+    .where(eq(schema.runs.id, runId));
+  return row;
+}
+
+describe('cloud run dispatch is read-only-gated by a failed payment (#554)', () => {
+  const savedGatewayKey = process.env.AI_GATEWAY_API_KEY;
+  const savedEdition = process.env.PITCHBOX_EDITION;
+
+  beforeEach(async () => {
+    await reset();
+    process.env.AI_GATEWAY_API_KEY = 'test-key';
+    process.env.PITCHBOX_EDITION = 'cloud';
+    clearDetectionCache();
+  });
+  afterEach(() => {
+    if (savedGatewayKey === undefined) delete process.env.AI_GATEWAY_API_KEY;
+    else process.env.AI_GATEWAY_API_KEY = savedGatewayKey;
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+    clearDetectionCache();
+  });
+
+  it('refuses a run once the grace window has elapsed', async () => {
+    const { campaignId } = await seedPastDueCampaign('payment-required-over', 10);
+
+    const { runId } = await runCampaign(campaignId);
+    const run = await runRow(runId);
+
+    expect(createCalls).toBe(0);
+    expect(run?.status).toBe('failed');
+    expect(run?.error).toMatch(/read-only because of a failed payment/i);
+    expect(run?.error).not.toMatch(/plan limit/i);
+    expect(run?.failureReason).toBe('plan_payment_required');
+  });
+
+  it('admits a run while still inside the grace window', async () => {
+    const { campaignId } = await seedPastDueCampaign('payment-required-grace', 3);
+
+    const { runId } = await runCampaign(campaignId);
+    const run = await runRow(runId);
+
+    expect(createCalls).toBe(1);
+    expect(run?.status).not.toBe('failed');
+  });
+});

--- a/web/tests/org-invite-payment-required.test.ts
+++ b/web/tests/org-invite-payment-required.test.ts
@@ -1,0 +1,122 @@
+// #554: "no new invites" for a read-only org - the same enforcement point as
+// org-invite-plan-limit.test.ts's seat ceiling, checked first, with its own
+// `plan_payment_required` code.
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { POST as invitesPost } from '../src/routes/api/orgs/[slug]/invites/+server.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function reset() {
+  await getDb().execute(sql`DELETE FROM org_invites`);
+  await getDb().execute(sql`DELETE FROM memberships`);
+  await getDb().execute(sql`DELETE FROM users`);
+  await getDb().execute(sql`DELETE FROM stripe_events`);
+  await getDb().execute(sql`DELETE FROM org_subscriptions`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function makePastDueOrgWithAdmin(slug: string, failedDaysAgo: number) {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: 'growth', planSource: 'stripe' })
+    .returning();
+  const [user] = await db
+    .insert(schema.users)
+    .values({ username: `${slug}-admin`, passwordHash: 'x' })
+    .returning();
+  await db
+    .insert(schema.memberships)
+    .values({ organizationId: org.id, userId: user.id, role: 'owner' });
+
+  const customerId = `cus_${randomUUID()}`;
+  const subscriptionId = `sub_${randomUUID()}`;
+  await db
+    .update(schema.organizations)
+    .set({ stripeCustomerId: customerId })
+    .where(eq(schema.organizations.id, org.id));
+  await db.insert(schema.orgSubscriptions).values({
+    organizationId: org.id,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    planId: 'growth',
+    status: 'past_due',
+    currentPeriodStart: new Date(Date.now() - 20 * DAY_MS),
+    currentPeriodEnd: new Date(Date.now() + 10 * DAY_MS),
+    limitRuns: 2000,
+    limitSuggestions: 2000,
+    limitProjects: 10,
+    limitSeats: 3,
+    limitDevices: 10,
+    limitConcurrency: 4,
+    limitBudgetUsd: '30.00',
+    limitRetentionDays: 90,
+    limitPremiumModels: true,
+  });
+  const failedEventId = `evt_${randomUUID()}`;
+  const failedAt = new Date(Date.now() - failedDaysAgo * DAY_MS);
+  await db.insert(schema.stripeEvents).values({
+    id: failedEventId,
+    type: 'invoice.payment_failed',
+    receivedAt: failedAt,
+    processedAt: failedAt,
+    payload: {
+      id: failedEventId,
+      type: 'invoice.payment_failed',
+      created: Math.floor(failedAt.getTime() / 1000),
+      data: { object: { subscription: subscriptionId, customer: customerId } },
+    },
+  });
+  return { orgId: org.id, userId: user.id, slug: org.slug };
+}
+
+function postEvent(userId: number, slug: string, body: unknown): Parameters<typeof invitesPost>[0] {
+  return {
+    locals: { user: { id: userId } },
+    params: { slug },
+    request: new Request('http://x/', { method: 'POST', body: JSON.stringify(body) }),
+    url: new URL('http://x/'),
+  } as unknown as Parameters<typeof invitesPost>[0];
+}
+
+describe('POST /api/orgs/[slug]/invites is read-only-gated by a failed payment (#554)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  it('refuses with plan_payment_required once the grace window has elapsed, inviting nobody', async () => {
+    const { orgId, userId, slug } = await makePastDueOrgWithAdmin(
+      'invite-payment-required-over',
+      10,
+    );
+
+    const res = await invitesPost(postEvent(userId, slug, { email: 'friend@example.com' }));
+
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe('plan_payment_required');
+
+    const invites = await getDb()
+      .select()
+      .from(schema.orgInvites)
+      .where(eq(schema.orgInvites.organizationId, orgId));
+    expect(invites).toHaveLength(0);
+  });
+
+  it('invites normally while still inside the grace window', async () => {
+    const { userId, slug } = await makePastDueOrgWithAdmin('invite-payment-required-grace', 3);
+
+    const res = await invitesPost(postEvent(userId, slug, { email: 'friend@example.com' }));
+
+    expect(res.status).toBe(201);
+  });
+});

--- a/web/tests/projects-payment-required.test.ts
+++ b/web/tests/projects-payment-required.test.ts
@@ -1,0 +1,113 @@
+// #554: "no new projects" for a read-only org - the same enforcement point
+// as projects-plan-limit.test.ts's ceiling, checked first, with its own
+// `plan_payment_required` code.
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { POST as projectsPost } from '../src/routes/api/projects/+server.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM stripe_events`);
+  await getDb().execute(sql`DELETE FROM org_subscriptions`);
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function makePastDueOrg(slug: string, failedDaysAgo: number): Promise<number> {
+  const db = getDb();
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: 'growth', planSource: 'stripe' })
+    .returning();
+  const customerId = `cus_${randomUUID()}`;
+  const subscriptionId = `sub_${randomUUID()}`;
+  await db
+    .update(schema.organizations)
+    .set({ stripeCustomerId: customerId })
+    .where(eq(schema.organizations.id, org.id));
+  await db.insert(schema.orgSubscriptions).values({
+    organizationId: org.id,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    planId: 'growth',
+    status: 'past_due',
+    currentPeriodStart: new Date(Date.now() - 20 * DAY_MS),
+    currentPeriodEnd: new Date(Date.now() + 10 * DAY_MS),
+    limitRuns: 2000,
+    limitSuggestions: 2000,
+    limitProjects: 10,
+    limitSeats: 3,
+    limitDevices: 10,
+    limitConcurrency: 4,
+    limitBudgetUsd: '30.00',
+    limitRetentionDays: 90,
+    limitPremiumModels: true,
+  });
+  const failedEventId = `evt_${randomUUID()}`;
+  const failedAt = new Date(Date.now() - failedDaysAgo * DAY_MS);
+  await db.insert(schema.stripeEvents).values({
+    id: failedEventId,
+    type: 'invoice.payment_failed',
+    receivedAt: failedAt,
+    processedAt: failedAt,
+    payload: {
+      id: failedEventId,
+      type: 'invoice.payment_failed',
+      created: Math.floor(failedAt.getTime() / 1000),
+      data: { object: { subscription: subscriptionId, customer: customerId } },
+    },
+  });
+  return org.id;
+}
+
+function postEvent(orgId: number, body: unknown): Parameters<typeof projectsPost>[0] {
+  return {
+    locals: { org: { id: orgId, slug: 'x', role: 'owner' } },
+    request: new Request('http://x/', { method: 'POST', body: JSON.stringify(body) }),
+  } as unknown as Parameters<typeof projectsPost>[0];
+}
+
+describe('POST /api/projects is read-only-gated by a failed payment (#554)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  it('refuses with plan_payment_required once the grace window has elapsed, creating nothing', async () => {
+    const orgId = await makePastDueOrg('projects-payment-required-over', 10);
+
+    const res = await projectsPost(
+      postEvent(orgId, { name: 'Should not exist', defaultAgentRunner: 'cloud' }),
+    );
+
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe('plan_payment_required');
+
+    const rows = await getDb()
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.organizationId, orgId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('creates the project normally while still inside the grace window', async () => {
+    const orgId = await makePastDueOrg('projects-payment-required-grace', 3);
+
+    const res = await projectsPost(
+      postEvent(orgId, { name: 'Still fine', defaultAgentRunner: 'cloud' }),
+    );
+
+    expect(res.status).toBe(201);
+  });
+});


### PR DESCRIPTION
Closes #553
Closes #554

## What changed

**#553, upgrade now / downgrade at period end / over-limit degrade**

- The webhook already mirrors whatever Stripe's *live* subscription reports (`syncSubscriptionFromStripe` refetches rather than trusting the event payload), so an upgrade applies the moment Stripe's subscription resource does, and a downgrade never applies before Stripe's own subscription resource actually reports it. I added a state-machine test proving both directions: an upgrade mid-period raises the ceiling without resetting usage already spent this period, and a downgrade applies only once the mirrored period actually rolls over, not before.
- `setOrgPlan` already re-syncs `monthly_run_budget_usd`/`max_concurrent_runs` from the new plan on every write, so a downgraded org never keeps the old budget - verified by a test, not newly built.
- Over-limit degrade: nothing anywhere deletes a row. Verified with a test that downgrades a 5-project Growth org to Solo (limit 3) and asserts all 5 projects survive while `resolveEntitlements` reports the new, lower limit - the actual refusal of a 6th project already lives in the enforcement points from #600.
- One real finding worth flagging: Stripe's customer portal can only auto-schedule a downgrade at period end between two prices of the *same product* (`docs.stripe.com/customer-management/configure-portal`, "Manage downgrades"). Our catalogue is three separate products (Solo/Growth/Scale), so that native toggle cannot schedule a cross-tier downgrade - a customer switching down in the portal today gets it applied immediately with proration, same as an upgrade. I documented this in `docs/billing.md` rather than quietly building a parallel Subscription Schedule API integration outside this issue's "web, shared" scope; a genuine self-serve scheduled cross-tier downgrade needs either a single-product/multi-price catalogue redesign or a dedicated app-level schedule-creation endpoint, and I'd like your call on which before someone builds it.
- `/settings/billing` itself is #555 (confirmed by `shared/src/usage.ts`'s own comment: "the settings/billing page (#555)"), not built here - it doesn't exist yet on `main`. What #555 needs from me (the pending-cancellation signal, `org_subscriptions.cancel_at_period_end`, and the read-only/grace state on `Entitlements`) is ready for it to consume.

**#554, grace window then read-only**

- 7-day grace (the issue's own number; `docs/billing.md` said 14 before this PR - I went with the issue and corrected the doc, flagging the discrepancy here since it's the kind of number you'd want to confirm).
- `shared/src/billing/grace.ts`: `pastDueSince` derives "since when has this subscription been failing" from the webhook's own idempotency ledger (`stripe_events`) rather than a new column - the first `invoice.payment_failed` after the last `invoice.paid` for that subscription. No migration needed, so I didn't touch Onboarding's slot. `graceEndsAt(since)` is 7 days later.
- `Entitlements` gains `graceEndsAt: Date | null`, non-null only for a `past_due` mirrored subscription. `isOrgReadOnly(entitlements, now?)` in `shared/src/plans.ts` is the one predicate every enforcement point calls.
- The webhook fires one notification (`kind: 'billing_payment_failed'`) the moment a subscription first enters `past_due`, naming the exact grace-end date - never again on a Smart Retries reattempt, proven by a test that fires two `invoice.payment_failed` events and asserts exactly one notification row.
- A site-wide banner (`BillingGraceBanner.svelte`, wired into the root layout) shows the same date: amber during grace, rose ("louder") once read-only. Not dismissible, matching `ChatSyncStalledBanner`'s posture for an active problem rather than `ExtensionDeviceNudgeBanner`'s soft nudge.
- Read-only refuses at every site the issue names, each with `plan_payment_required` (distinct from `plan_limit_reached`), matching each route's existing refusal shape: run dispatch (`web/src/lib/server/runner.ts`), `/api/extension/suggest`, `/api/extension/suggest/accept`, `/api/extension/observations`, `/api/projects`, `/api/orgs/[slug]/invites`, `/api/extension/auto-pair`, `/api/extension/pair`, and `/api/campaigns` (which has no metered ceiling of its own, so this is its only plan gate). The Inbox, marking a draft sent, and the extension's inbound sync routes are untouched - never gated.
- The customer portal (`createPortalSession`) reads no entitlements at all and never will - verified with a test that puts an org past its grace window and confirms the portal session still opens.
- `invoice.paid` clears grace/read-only in the same step `resolveEntitlements` already takes (status flips back to `active`, `graceEndsAt` becomes `null`) - no separate code path to keep in sync. `customer.subscription.deleted` lands the org on Free (a real plan) rather than a lockout - existing behavior, now also asserted read-only-false.
- I coordinated with `PlanLimitsFinish` (#600) before touching the six routes it also edits: waited for its merge (5910de0), rebased, then added the read-only check next to its plan-limit check in each.

## Left out on purpose

- The settings/billing page itself (#555) and the extension panel's own plan awareness (#556) - both separate, already-filed issues that consume what this PR exposes.
- A self-serve, cross-tier scheduled downgrade mechanism - see the Stripe portal limitation above.

## Verified

```
pnpm -F @pitchbox/shared typecheck
pnpm -F web check
pnpm exec vitest run shared/tests/billing-grace.test.ts shared/tests/billing-webhook.test.ts shared/tests/billing-checkout-portal.test.ts shared/tests/plans.test.ts \
  web/tests/gateway-payment-required-dispatch.test.ts web/tests/extension-suggest-payment-required.test.ts web/tests/extension-suggest-accept-payment-required.test.ts \
  web/tests/projects-payment-required.test.ts web/tests/org-invite-payment-required.test.ts web/tests/campaign-payment-required.test.ts \
  web/tests/extension-pairing-payment-required.test.ts web/tests/extension-observations-payment-required.test.ts
# 12 files, 47 tests, all passing against a real Postgres
npx eslint <every changed file>
npx prettier --check <every changed .ts file>  # .svelte isn't prettier-covered in this repo (no plugin)
```

Also re-ran the existing plan-limit suites from #600 (`gateway-plan-limit-dispatch`, `extension-suggest-plan-limit`, `extension-observations-plan-limit`, `extension-pairing-plan-limit`, `org-invite-plan-limit`, `projects-plan-limit`) to confirm the read-only check I added alongside each didn't disturb the limit check already there - all still pass.

I deliberately broke `isOrgReadOnly`'s boundary comparison (`>=` to `>`) mid-review and watched exactly the boundary test in `billing-grace.test.ts` fail, then reverted - the grace-window tests move the clock (`new Date(...)` passed to `isOrgReadOnly`) rather than waiting or mocking global time.

Not reproducible locally: `deploy-preview.yml`/`deploy-prod.yml`, and a real render of a banner state in a browser (`PITCHBOX_AUTH=on`/`PITCHBOX_EDITION=cloud` dev server plus a hand-seeded `past_due` org - I got as far as seeding the state and starting the dev server but ran out of budget before landing a working session cookie in the browser tool; `svelte-check` is clean and the component follows the exact same `TONE_BANNER_CLASS`/structure as the two banners already shipped and visually verified in this codebase, `ChatSyncStalledBanner` and `ExtensionDeviceNudgeBanner`).
