### PR TITLE
fix(shared,docs): the grace window is 14 days, which is what the terms promise

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -149,7 +149,7 @@ metadata change.
   can only auto-schedule a downgrade between two prices of the **same
   product**, and Solo/Growth/Scale are three separate products) actually
   applies it at period end.
-- A failed payment (`invoice.payment_failed`) starts a **7-day grace period**,
+- A failed payment (`invoice.payment_failed`) starts a **14-day grace period**,
   counted from the first failure rather than restarted by each Smart Retries
   reattempt. The org keeps working normally during grace; a banner and a
   notification both name the exact date it ends. Past it, the org is

--- a/shared/src/billing/grace.ts
+++ b/shared/src/billing/grace.ts
@@ -25,7 +25,17 @@ import { schema } from '../db/client.js';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Db = PgDatabase<any, any, any>;
 
-export const GRACE_PERIOD_DAYS = 7;
+// 14, and this number is not ours to pick freely: the published terms already
+// promise it. `https://pitchbox.app/terms` (and its Italian twin) say "If a
+// payment fails you keep your plan for 14 days while Stripe retries; after
+// that the organization falls back to Free, with its data intact", and
+// `docs/billing.md` says the same. #554's body said 7, which is where this
+// started, but a live page a customer can read outranks an issue body: a
+// window shorter than the promise is a term we would be breaking, and one
+// longer is a promise we can keep quietly. Change this only together with the
+// terms in `pitchbox-landing`'s `src/lib/legal.ts`, in both languages, and
+// with `docs/billing.md`.
+export const GRACE_PERIOD_DAYS = 14;
 const GRACE_PERIOD_MS = GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000;
 
 /**


### PR DESCRIPTION
The grace window shipped at 7 days in #611 and the published terms say 14. This makes the code match the promise.

`https://pitchbox.app/terms` and `https://pitchbox.app/it/terms` both say, in the text a customer reads before paying: "If a payment fails you keep your plan for 14 days while Stripe retries; after that the organization falls back to Free, with its data intact". `docs/billing.md`'s own "What happens at a limit" section said 14 too, in the paragraph written when the Stripe design landed (#588).

#554's body said 7, which is where the constant came from, and the agent that implemented it flagged the discrepancy rather than papering over it, which was the right call. Resolving it the other way: a live page a customer can read outranks an issue body. A window shorter than the promise is a term we would be breaking; a longer one is a promise we can keep quietly.

So `GRACE_PERIOD_DAYS` is 14, the doc's own bullet that still said 7 is corrected, and the constant carries a comment naming the three places that have to move together if this ever changes: `shared/src/billing/grace.ts`, `docs/billing.md`, and `pitchbox-landing`'s `src/lib/legal.ts` in both languages.

Verified: `pnpm exec vitest run shared/tests/billing-grace.test.ts shared/tests/plans.test.ts` -> 11 passed. Every test in that file is written against `GRACE_PERIOD_DAYS` rather than a hardcoded 7, which is why the change needed no test edits, and is also what makes them still meaningful at 14: the boundary test computes `GRACE_PERIOD_DAYS - 1` days ago and asserts the org is not yet read-only.

Nothing else moves: the banner and the notification both name the real date rather than a duration, so they were already correct.