### PR TITLE
fix(tests): express the grace window as the constant, not as a literal

### DIFF
--- a/shared/tests/billing-checkout-portal.test.ts
+++ b/shared/tests/billing-checkout-portal.test.ts
@@ -18,6 +18,7 @@ import { getDb, schema } from '../src/db/client.js';
 import { ensureStripeCustomer } from '../src/billing/customer.js';
 import { createCheckoutSession, UnknownPriceError } from '../src/billing/checkout.js';
 import { createPortalSession, NoStripeCustomerError } from '../src/billing/portal.js';
+import { GRACE_PERIOD_DAYS } from '../src/billing/grace.js';
 import type { StripeClient, StripeCustomer } from '../src/stripe/client.js';
 import { isOrgReadOnly, resolveEntitlements } from '../src/plans.js';
 
@@ -173,7 +174,12 @@ describe('createPortalSession', () => {
       limitPremiumModels: false,
     });
     const failedEventId = `evt_${randomUUID()}`;
-    const failedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    // Past the grace window by a day, expressed against the constant rather
+    // than as a literal: this test asserted 10 days ago while the window was
+    // 7, so it silently stopped testing "read-only" when the window became
+    // the 14 days the published terms promise (#612) and started asserting
+    // the opposite of its own name.
+    const failedAt = new Date(Date.now() - (GRACE_PERIOD_DAYS + 1) * 24 * 60 * 60 * 1000);
     await db.insert(schema.stripeEvents).values({
       id: failedEventId,
       type: 'invoice.payment_failed',

--- a/shared/tests/billing-webhook.test.ts
+++ b/shared/tests/billing-webhook.test.ts
@@ -19,6 +19,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { getDb, schema } from '../src/db/client.js';
 import { applyStripeEvent, limitsFromProductMetadata } from '../src/billing/webhook.js';
+import { GRACE_PERIOD_DAYS } from '../src/billing/grace.js';
 import type { StripeClient, StripeProduct, StripeSubscription } from '../src/stripe/client.js';
 import { isOrgReadOnly, resolveEntitlements } from '../src/plans.js';
 import { billingPeriodFor } from '../src/org-quota.js';
@@ -673,7 +674,7 @@ describe('applyStripeEvent - grace window and read-only (#554)', () => {
 
     const entitlementsAfterFirst = await resolveEntitlements(getDb(), org.id);
     expect(entitlementsAfterFirst.graceEndsAt?.getTime()).toBe(
-      firstEventRow.receivedAt.getTime() + 7 * 24 * 60 * 60 * 1000,
+      firstEventRow.receivedAt.getTime() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000,
     );
     // Inside the freshly-granted window: not read-only yet.
     expect(isOrgReadOnly(entitlementsAfterFirst)).toBe(false);


### PR DESCRIPTION
Follow-up to #612, and a mistake of mine worth writing down rather than quietly fixing.

Changing `GRACE_PERIOD_DAYS` from 7 to 14 broke two tests, and CI on `main` caught it because the PR path skips `Tests (Postgres)`. I only ran `billing-grace.test.ts` and `plans.test.ts` before merging #612, and the two files that actually encode the window as arithmetic are elsewhere:

- `shared/tests/billing-checkout-portal.test.ts`'s "opens for a past_due, read-only org" seeded a failure **10 days ago**, which was past a 7-day window and is inside a 14-day one. Its own sanity assertion (`isOrgReadOnly` is true) then failed, which means the test had stopped testing the thing its name claims.
- `shared/tests/billing-webhook.test.ts` asserted `graceEndsAt` equals the first failure plus `7 * 24 * 60 * 60 * 1000`.

Both now express the window as `GRACE_PERIOD_DAYS` rather than as a literal, so the next change to that constant moves them with it: the fixture is "the grace window plus a day ago", and the assertion is "the first failure plus the window". That is the shape `billing-grace.test.ts` already had, which is exactly why it kept passing at 14 and why it was the wrong file to trust alone.

Verified: `pnpm exec vitest run shared/tests/billing-webhook.test.ts shared/tests/billing-checkout-portal.test.ts shared/tests/billing-grace.test.ts shared/tests/plans.test.ts` -> 4 files, 29 tests, all passing against a freshly migrated database. eslint and prettier clean on both files.

I also grepped the rest of `shared/` and `web/` for a hardcoded seven-day span in case the window leaked anywhere else: every remaining hit is a different seven days (the invite TTL, the weekly quota window, the dashboard's 7-day run health), none of them billing.