### PR TITLE
fix(tests): the payment-required fixtures follow the grace constant too

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -99,6 +99,7 @@
     "./billing/checkout": "./src/billing/checkout.ts",
     "./billing/portal": "./src/billing/portal.ts",
     "./billing/webhook": "./src/billing/webhook.ts",
+    "./billing/grace": "./src/billing/grace.ts",
     "./usage": "./src/usage.ts",
     "./onboarding": "./src/onboarding.ts"
   },

--- a/web/tests/campaign-payment-required.test.ts
+++ b/web/tests/campaign-payment-required.test.ts
@@ -6,6 +6,7 @@ import { sql, eq } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import type { RequestEvent } from '@sveltejs/kit';
 import { getDb, schema } from '@pitchbox/shared/db';
+import { GRACE_PERIOD_DAYS } from '@pitchbox/shared/billing/grace';
 import type {
   AgentRunHandle,
   AgentRunOptions,
@@ -134,7 +135,7 @@ describe('POST /api/campaigns is read-only-gated by a failed payment (#554)', ()
   it('refuses with plan_payment_required once the grace window has elapsed, creating nothing', async () => {
     const { orgId, projectId } = await seedPastDueOrgWithProject(
       'campaign-payment-required-over',
-      10,
+      GRACE_PERIOD_DAYS + 1,
     );
     const reddit = await platformId('reddit');
 

--- a/web/tests/extension-observations-payment-required.test.ts
+++ b/web/tests/extension-observations-payment-required.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { createHash, randomUUID } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
+import { GRACE_PERIOD_DAYS } from '@pitchbox/shared/billing/grace';
 import {
   defaultLinkedInAssistSettings,
   saveLinkedInAssistSettings,
@@ -141,7 +142,10 @@ describe('POST /api/extension/observations is read-only-gated by a failed paymen
   });
 
   it('refuses with a 403 once the grace window has elapsed', async () => {
-    const { org, project } = await seedPastDueOrgWithProject('obs-payment-required-over', 10);
+    const { org, project } = await seedPastDueOrgWithProject(
+      'obs-payment-required-over',
+      GRACE_PERIOD_DAYS + 1,
+    );
     await mintDevice(org.id, 'tok-obs-payment-over');
 
     const { status, message } = await statusAndBodyOf(

--- a/web/tests/extension-pairing-payment-required.test.ts
+++ b/web/tests/extension-pairing-payment-required.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
+import { GRACE_PERIOD_DAYS } from '@pitchbox/shared/billing/grace';
 import { POST as pairConsume } from '../src/routes/api/extension/pair/+server.js';
 
 type ConsumeEvent = Parameters<typeof pairConsume>[0];
@@ -96,7 +97,7 @@ describe('POST /api/extension/pair is read-only-gated by a failed payment (#554)
   });
 
   it("refuses redemption once the code's org grace window has elapsed, minting no device", async () => {
-    const org = await makePastDueOrg('pairing-payment-required-over', 10);
+    const org = await makePastDueOrg('pairing-payment-required-over', GRACE_PERIOD_DAYS + 1);
     await insertPairing(org.id, 'CODE-PAY-OVER-0001');
 
     const res = await pairConsume(consumeEvent('CODE-PAY-OVER-0001', '198.51.100.10'));

--- a/web/tests/extension-suggest-accept-payment-required.test.ts
+++ b/web/tests/extension-suggest-accept-payment-required.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { createHash, randomUUID } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
+import { GRACE_PERIOD_DAYS } from '@pitchbox/shared/billing/grace';
 import {
   defaultLinkedInAssistSettings,
   saveLinkedInAssistSettings,
@@ -122,7 +123,10 @@ describe('POST /api/extension/suggest/accept is read-only-gated by a failed paym
   });
 
   it('refuses with plan_payment_required once the grace window has elapsed, and files no draft', async () => {
-    const { org, project } = await seedPastDueOrgProject('payment-required-accept-over', 10);
+    const { org, project } = await seedPastDueOrgProject(
+      'payment-required-accept-over',
+      GRACE_PERIOD_DAYS + 1,
+    );
     await mintDevice(org.id, 'tok-accept-over');
 
     const res = await accept({

--- a/web/tests/extension-suggest-payment-required.test.ts
+++ b/web/tests/extension-suggest-payment-required.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { createHash, randomUUID } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
+import { GRACE_PERIOD_DAYS } from '@pitchbox/shared/billing/grace';
 import {
   defaultLinkedInAssistSettings,
   saveLinkedInAssistSettings,
@@ -171,7 +172,10 @@ describe('POST /api/extension/suggest is read-only-gated by a failed payment (#5
   });
 
   it('refuses with plan_payment_required once the grace window has elapsed', async () => {
-    const { org, project } = await seedPastDueOrgProject('payment-required-suggest-over', 10);
+    const { org, project } = await seedPastDueOrgProject(
+      'payment-required-suggest-over',
+      GRACE_PERIOD_DAYS + 1,
+    );
     await mintDevice(org.id, 'tok-payment-required-over');
 
     const res = await suggest({

--- a/web/tests/gateway-payment-required-dispatch.test.ts
+++ b/web/tests/gateway-payment-required-dispatch.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
+import { GRACE_PERIOD_DAYS } from '@pitchbox/shared/billing/grace';
 import type {
   AgentRunHandle,
   AgentRunOptions,
@@ -54,7 +55,7 @@ async function platformId(slug: string): Promise<number> {
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** A 'cloud'-runner campaign under an org whose mirrored subscription
- * entered `past_due` `failedDaysAgo` days ago - past GRACE_PERIOD_DAYS (7)
+ * entered `past_due` `failedDaysAgo` days ago - past GRACE_PERIOD_DAYS
  * is read-only, short of it is still working normally. */
 async function seedPastDueCampaign(
   slug: string,
@@ -158,7 +159,10 @@ describe('cloud run dispatch is read-only-gated by a failed payment (#554)', () 
   });
 
   it('refuses a run once the grace window has elapsed', async () => {
-    const { campaignId } = await seedPastDueCampaign('payment-required-over', 10);
+    const { campaignId } = await seedPastDueCampaign(
+      'payment-required-over',
+      GRACE_PERIOD_DAYS + 1,
+    );
 
     const { runId } = await runCampaign(campaignId);
     const run = await runRow(runId);

--- a/web/tests/org-invite-payment-required.test.ts
+++ b/web/tests/org-invite-payment-required.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
+import { GRACE_PERIOD_DAYS } from '@pitchbox/shared/billing/grace';
 import { POST as invitesPost } from '../src/routes/api/orgs/[slug]/invites/+server.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -96,7 +97,7 @@ describe('POST /api/orgs/[slug]/invites is read-only-gated by a failed payment (
   it('refuses with plan_payment_required once the grace window has elapsed, inviting nobody', async () => {
     const { orgId, userId, slug } = await makePastDueOrgWithAdmin(
       'invite-payment-required-over',
-      10,
+      GRACE_PERIOD_DAYS + 1,
     );
 
     const res = await invitesPost(postEvent(userId, slug, { email: 'friend@example.com' }));

--- a/web/tests/projects-payment-required.test.ts
+++ b/web/tests/projects-payment-required.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { getDb, schema } from '@pitchbox/shared/db';
+import { GRACE_PERIOD_DAYS } from '@pitchbox/shared/billing/grace';
 import { POST as projectsPost } from '../src/routes/api/projects/+server.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -84,7 +85,7 @@ describe('POST /api/projects is read-only-gated by a failed payment (#554)', () 
   });
 
   it('refuses with plan_payment_required once the grace window has elapsed, creating nothing', async () => {
-    const orgId = await makePastDueOrg('projects-payment-required-over', 10);
+    const orgId = await makePastDueOrg('projects-payment-required-over', GRACE_PERIOD_DAYS + 1);
 
     const res = await projectsPost(
       postEvent(orgId, { name: 'Should not exist', defaultAgentRunner: 'cloud' }),


### PR DESCRIPTION
The rest of #612's fallout, and the same mistake twice is worth stating plainly: I changed the grace window from 7 to 14 days and did not run the suites that encode it as arithmetic. #614 fixed the two `shared` ones. The trunk's full-suite run then found eight more in `web/tests`, all seeding "the grace window has elapsed" as **10 days ago**, which is past a 7-day window and comfortably inside a 14-day one, so every one of them asserted the opposite of its own name.

Fixed the same way: the fixture is now `GRACE_PERIOD_DAYS + 1` days ago, imported from the constant, in `campaign`, `org-invite`, `projects`, `extension-observations`, `extension-pairing`, `extension-suggest`, `extension-suggest-accept` and `gateway-payment-required-dispatch`. The inside-the-window cases stay at 3 days, which is inside any plausible window and still tests what it claims. Two doc comments that said "past GRACE_PERIOD_DAYS (7)" lost the stale number rather than gaining a new one.

`shared/package.json` gains `"./billing/grace"` in its exports map, since a `web` test importing the constant needs it and deep imports are banned (AGENTS.md).

### Why this happened twice, since that is the useful part

`Tests (Postgres)` runs on `push: main` and not on a PR, which is a deliberate trade (it is the 5-minute job) and is fine as long as the local covering subset is chosen honestly. Mine was not: I ran the file named after the constant, which was the one file already written against it, and therefore the only one that could not fail. The lesson is not "run the full suite" but "when you change a shared constant, grep for the value, not for the name": the eight files were invisible to `grep GRACE_PERIOD_DAYS` and obvious to `grep '10 \* DAY_MS'`.

### Verified

`pnpm exec vitest run` on all eight files -> 8 files, 16 tests, passing against a freshly migrated database. `pnpm -F web check` -> 0 errors, 0 warnings. eslint and prettier clean. I also re-grepped `web/` and `shared/` for a bare day-count near a `past_due` fixture and found none left.