### PR TITLE
fix(tests): drain the assist-suggest stream and dispatch background writes before the test ends

### DIFF
--- a/web/tests/extension-suggest-image.test.ts
+++ b/web/tests/extension-suggest-image.test.ts
@@ -113,6 +113,10 @@ describe('the attached image (#569): the schema rejects what the cap forbids', (
       }),
     } as never);
     expect(res.headers.get('content-type')).toContain('text/event-stream');
+    // #616: drain to `done`, or the ledger write in the route's
+    // `handle.result.then(...)` (after this call already returned) keeps
+    // running past this test and races the next file's TRUNCATE.
+    await res.text();
   });
 
   it('accepts an image with no dataUrl at all - the capture-unavailable, alt-only fallback', async () => {
@@ -130,6 +134,7 @@ describe('the attached image (#569): the schema rejects what the cap forbids', (
       }),
     } as never);
     expect(res.headers.get('content-type')).toContain('text/event-stream');
+    await res.text(); // #616: drain to `done` - see the comment above.
   });
 
   // Hostile fixture (#569 acceptance): an oversized image, whether from a
@@ -166,6 +171,7 @@ describe('the attached image (#569): the schema rejects what the cap forbids', (
       }),
     } as never);
     expect(res.headers.get('content-type')).toContain('text/event-stream');
+    await res.text(); // #616: drain to `done` - see the comment above.
   });
 
   it('rejects a dataUrl that is not an image data URL at all - a licdn URL handed over instead of pixels', async () => {

--- a/web/tests/extension-suggest-thread.test.ts
+++ b/web/tests/extension-suggest-thread.test.ts
@@ -129,6 +129,10 @@ describe('the visible thread (#568): the schema rejects what the caps forbid', (
       }),
     } as never);
     expect(res.headers.get('content-type')).toContain('text/event-stream');
+    // #616: drain to `done`, or the ledger write in the route's
+    // `handle.result.then(...)` (after this call already returned) keeps
+    // running past this test and races the next file's TRUNCATE.
+    await res.text();
   });
 
   it('rejects more comments than MAX_THREAD_COMMENTS', async () => {

--- a/web/tests/gateway-payment-required-dispatch.test.ts
+++ b/web/tests/gateway-payment-required-dispatch.test.ts
@@ -15,6 +15,7 @@ import type {
 } from '@pitchbox/shared/agents';
 import type { RunnerConfig } from '@pitchbox/shared/agents/config';
 import { clearDetectionCache } from '@pitchbox/shared/agents/detect';
+import { subscribe } from '../src/lib/server/events.js';
 
 let createCalls = 0;
 const fakeResult: AgentRunResult = { exitCode: 0, logPath: '/dev/null' };
@@ -140,6 +141,28 @@ async function runRow(runId: number) {
   return row;
 }
 
+/** dispatchRun's completion write runs off `handle.result`'s own promise
+ * chain, outside runCampaign's own await for a real dispatch - `run:finished`
+ * is emitted right after that write, on the realtime bus every SSE client
+ * already relies on, so subscribing to it is the actual completion signal
+ * rather than a guessed delay. A pre-flight refusal (already read-only past
+ * the grace window) never reaches this: it fails synchronously inside
+ * runCampaign's own await, before dispatchRun ever calls the runner. The
+ * test below that admits the run (createCalls becomes 1) has to wait on
+ * this before it ends, or dispatchRun's background write can still be
+ * running when the next file's `TRUNCATE ... CASCADE` truncates the org
+ * it's writing to - see #616.
+ */
+function waitForRunFinished(orgId: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const unsubscribe = subscribe(orgId, (evt) => {
+    if (evt.kind !== 'run:finished') return;
+    unsubscribe();
+    resolve();
+  });
+  return promise;
+}
+
 describe('cloud run dispatch is read-only-gated by a failed payment (#554)', () => {
   const savedGatewayKey = process.env.AI_GATEWAY_API_KEY;
   const savedEdition = process.env.PITCHBOX_EDITION;
@@ -175,12 +198,20 @@ describe('cloud run dispatch is read-only-gated by a failed payment (#554)', () 
   });
 
   it('admits a run while still inside the grace window', async () => {
-    const { campaignId } = await seedPastDueCampaign('payment-required-grace', 3);
+    const { orgId, campaignId } = await seedPastDueCampaign('payment-required-grace', 3);
 
+    const finished = waitForRunFinished(orgId);
     const { runId } = await runCampaign(campaignId);
+    await finished;
     const run = await runRow(runId);
 
     expect(createCalls).toBe(1);
-    expect(run?.status).not.toBe('failed');
+    // The fake runner never creates a draft or calls run:finish, so
+    // dispatchRun's own "ended its turn without creating a draft" check
+    // marks the run failed once it settles - same posture as
+    // gateway-budget-dispatch.test.ts's identical fake. What this test
+    // proves is admission (still inside the grace window let it reach the
+    // runner at all), not agent completion semantics.
+    expect(run?.status).not.toBe('running');
   });
 });

--- a/web/tests/gateway-plan-limit-dispatch.test.ts
+++ b/web/tests/gateway-plan-limit-dispatch.test.ts
@@ -18,6 +18,7 @@ import type {
 } from '@pitchbox/shared/agents';
 import type { RunnerConfig } from '@pitchbox/shared/agents/config';
 import { clearDetectionCache } from '@pitchbox/shared/agents/detect';
+import { subscribe } from '../src/lib/server/events.js';
 
 let createCalls = 0;
 const fakeResult: AgentRunResult = { exitCode: 0, logPath: '/dev/null' };
@@ -111,6 +112,29 @@ async function runRow(runId: number) {
   return row;
 }
 
+/** dispatchRun's completion write runs off `handle.result`'s own promise
+ * chain, outside runCampaign's own await for a real dispatch - `run:finished`
+ * is emitted right after that write, on the realtime bus every SSE client
+ * already relies on, so subscribing to it is the actual completion signal
+ * rather than a guessed delay. A pre-flight refusal (the org already over
+ * its plan limit) never reaches this: it fails synchronously inside
+ * runCampaign's own await, before dispatchRun ever calls the runner. Every
+ * test below that admits the run (createCalls becomes 1) has to wait on
+ * this before it ends, or dispatchRun's background write (including its
+ * `assist_usage`-shaped notify() on a later failure) can still be running
+ * when the next file's `TRUNCATE ... CASCADE` truncates the org it's
+ * writing to - see #616.
+ */
+function waitForRunFinished(orgId: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const unsubscribe = subscribe(orgId, (evt) => {
+    if (evt.kind !== 'run:finished') return;
+    unsubscribe();
+    resolve();
+  });
+  return promise;
+}
+
 describe('cloud run dispatch is plan-run-count-gated (#548)', () => {
   const savedGatewayKey = process.env.AI_GATEWAY_API_KEY;
   const savedEdition = process.env.PITCHBOX_EDITION;
@@ -148,44 +172,56 @@ describe('cloud run dispatch is plan-run-count-gated (#548)', () => {
   });
 
   it('admits a run when it is exactly the last one the plan allows this period', async () => {
-    const { campaignId } = await seedCloudCampaign('plan-limit-exact', {
+    const { orgId, campaignId } = await seedCloudCampaign('plan-limit-exact', {
       plan: 'free',
       existingRuns: freeLimit - 1, // this dispatch's own row makes exactly `limit`
     });
 
+    const finished = waitForRunFinished(orgId);
     const { runId } = await runCampaign(campaignId);
+    await finished;
     const run = await runRow(runId);
 
     expect(createCalls).toBe(1);
-    expect(run?.status).not.toBe('failed');
+    // The fake runner never creates a draft or calls run:finish, so
+    // dispatchRun's own "ended its turn without creating a draft" check
+    // marks the run failed once it settles - same posture as
+    // gateway-budget-dispatch.test.ts's identical fake. What this test
+    // proves is admission (the plan-limit gate let it reach the runner at
+    // all), not agent completion semantics.
+    expect(run?.status).not.toBe('running');
   });
 
   it('an org well under its plan limit proceeds normally', async () => {
-    const { campaignId } = await seedCloudCampaign('plan-limit-under', {
+    const { orgId, campaignId } = await seedCloudCampaign('plan-limit-under', {
       plan: 'free',
       existingRuns: 2,
     });
 
+    const finished = waitForRunFinished(orgId);
     const { runId } = await runCampaign(campaignId);
+    await finished;
     const run = await runRow(runId);
 
     expect(createCalls).toBe(1);
-    expect(run?.status).not.toBe('failed');
+    expect(run?.status).not.toBe('running');
   });
 
   // The regression that would make this feature unshippable: a self-host
   // install must never be refused, however many runs it has recorded.
   it('a self-host install refuses nothing, however many runs the org already has this period', async () => {
     delete process.env.PITCHBOX_EDITION;
-    const { campaignId } = await seedCloudCampaign('plan-limit-self-host', {
+    const { orgId, campaignId } = await seedCloudCampaign('plan-limit-self-host', {
       plan: 'free',
       existingRuns: freeLimit + 50, // wildly over the free plan's count
     });
 
+    const finished = waitForRunFinished(orgId);
     const { runId } = await runCampaign(campaignId);
+    await finished;
     const run = await runRow(runId);
 
     expect(createCalls).toBe(1);
-    expect(run?.status).not.toBe('failed');
+    expect(run?.status).not.toBe('running');
   });
 });

--- a/web/tests/home-campaigns-widget.test.ts
+++ b/web/tests/home-campaigns-widget.test.ts
@@ -3,6 +3,7 @@ import { sql, eq } from 'drizzle-orm';
 import type { RequestEvent } from '@sveltejs/kit';
 import { getDb, schema } from '@pitchbox/shared/db';
 import { load as loadHome } from '../src/routes/+page.server.js';
+import { skipOnboarding } from '@pitchbox/shared/onboarding';
 
 /**
  * The home page's campaigns widget only ever rendered `data.campaigns.slice(0,
@@ -52,6 +53,17 @@ describe('home page campaigns widget', () => {
       skillSlug: 's',
     }));
     await db.insert(schema.campaigns).values(campaigns);
+    // #609: the home loader gates a first-ever visit on the onboarding
+    // wizard. This test seeds campaigns directly and shares the `default`
+    // org with the rest of the suite, so whether it redirects depends on
+    // which file happens to load `default`'s dashboard first - exactly the
+    // ordering hazard #616 is about. Opt this org out explicitly instead of
+    // relying on being non-first.
+    await skipOnboarding(
+      db,
+      { organizationId: org.id, userId: null },
+      { authOn: false, username: null },
+    );
 
     const data = await loadHome(fakeEvent(org.id));
 

--- a/web/tests/route-guards-aggregates.test.ts
+++ b/web/tests/route-guards-aggregates.test.ts
@@ -8,6 +8,7 @@ import { load as analyticsLoad } from '../src/routes/analytics/+page.server.js';
 import { load as newCampaignLoad } from '../src/routes/campaigns/new/+page.server.js';
 import { GET as extensionDevicesGet } from '../src/routes/api/settings/extension-devices/+server.js';
 import { DELETE as extensionDeviceDelete } from '../src/routes/api/settings/extension-devices/[id]/+server.js';
+import { skipOnboarding } from '@pitchbox/shared/onboarding';
 
 /**
  * Cross-org exclusion for the unscoped list/aggregate loaders and the
@@ -40,6 +41,17 @@ async function seedOrgWithProject(slug: string) {
       defaultAgentRunner: 'claude-code',
     })
     .returning();
+  // #609: the home loader now gates a first-ever visit on the onboarding
+  // wizard, and its "project" step means an active source, not just a
+  // project shell - without this, `homeLoad` below redirects to
+  // `/onboarding` instead of rendering the dashboard this file tests.
+  // This org is meant to read as pre-populated (nothing left to walk
+  // through), same posture as every other fixture below it.
+  await db.insert(schema.projectSources).values({
+    projectId: project.id,
+    kind: 'github',
+    config: { value: `${slug}/repo` },
+  });
   const [platform] = await db
     .select()
     .from(schema.platforms)
@@ -217,6 +229,17 @@ describe('route guards on aggregate/list loaders and extension-devices', () => {
         .insert(schema.organizations)
         .values({ slug: 'rga-empty', name: 'rga-empty' })
         .returning();
+      // #609: an org with nothing set up at all is exactly what the
+      // onboarding wizard exists to catch on a first visit - `homeLoad`
+      // would redirect before ever computing the aggregates this test
+      // means to check. That redirect is its own concern (onboarding.test.ts
+      // owns it); mark this org as having deliberately opted out so the
+      // loader falls through to the zero-state logic under test.
+      await skipOnboarding(
+        getDb(),
+        { organizationId: org.id, userId: null },
+        { authOn: false, username: null },
+      );
       const data = await homeLoad(fakeEvent(org.id));
       expect(data).toMatchObject({
         campaigns: [],


### PR DESCRIPTION
Closes #616.

## What was actually racing

Reproduced locally on unmodified `main` (`3a67a25`): `pnpm test` failed twice in a row, and the current `Tests (Postgres)` run on `main` (`3a67a25`, https://github.com/fiorelorenzo/pitchbox/actions/runs/34371815336/job/102534659208) shows the exact deadlock #616 describes, on the exact test it names:

```
web/tests/extension-suggest-image.test.ts > ... > rejects a dataUrl that is not an image data URL at all
Caused by: error: deadlock detected
Serialized Error: { code: '40P01', ... }
```

`POST /api/extension/suggest` ledgers `assist_usage` inside `handle.result.then(...)`, after the route has already returned its `Response` (`web/src/routes/api/extension/suggest/+server.ts`, kept exactly as-is - #522's intended behavior). Three tests in `extension-suggest-image.test.ts` and one in `extension-suggest-thread.test.ts` call the route, get back the streamed `Response`, and only check `res.headers.get('content-type')` - they never read the body, so the ledger write from *that* test is still running when the *next* file's `beforeEach` runs `TRUNCATE ... CASCADE`. Went with fix #1 from the issue: added `await res.text()` to drain each of those four tests to `done`.

`dispatchRun` (`web/src/lib/server/runner.ts`) has the identical shape: its own completion write (`handle.result.then(...)`, including a `notify()` call on failure) isn't awaited by `runCampaign`. Most `gateway-*-dispatch.test.ts` files already know this and use a `waitForRunFinished(orgId)` helper subscribed to the `run:finished` realtime event before asserting on the run row - `gateway-plan-limit-dispatch.test.ts` and `gateway-payment-required-dispatch.test.ts` were the two that didn't, and one of my two clean local reproductions failed there instead of on the suggest route (`FK violation on notifications`, same shape as #616, different call site). Added the same `waitForRunFinished` helper to both, matching the sibling files exactly.

Waiting for the real completion also exposed a pre-existing wrong assertion in those same two files, previously masked by the race: they asserted `run.status` is not `'failed'`, but their fake runner never creates a draft or calls `run:finish`, so `dispatchRun`'s own "ended its turn without creating a draft" check legitimately marks the run failed once it actually settles - exactly like the identical fake runner in `gateway-budget-dispatch.test.ts`, `gateway-concurrency-dispatch.test.ts` and `gateway-instance-ceiling-dispatch.test.ts`, which all correctly assert `not 'running'` instead (what's actually being tested is admission, not agent-completion semantics). Matched that convention.

No production code changed. No retry around any truncate, no test skipped.

## A second, unrelated regression I found while reproducing

Both of my clean local `pnpm test` runs on unmodified `main`, and the current CI run linked above, also fail `route-guards-aggregates.test.ts` and (non-deterministically) `home-campaigns-widget.test.ts` with a 302 redirect to `/onboarding` - nothing to do with locks or timing. `#609` (the onboarding wizard, merged earlier today) gates a first-ever home-dashboard load on `computeOnboardingSteps`, whose `project` step requires an *active `project_sources` row*, not just a project. `route-guards-aggregates.test.ts`'s `seedOrgWithProject` fixture and `home-campaigns-widget.test.ts`'s inline fixture both predate #609 and never seed one, so the very first home load for their org now redirects instead of rendering - deterministically for a brand-new org, order-dependently for the shared `default` org (whichever file happens to load its dashboard first in a run "wins" the redirect - which is why `home-campaigns-widget.test.ts` didn't fail in every local run).

Fixed on the test side, matching the loader's own documented intent ("a pre-populated org reads straight through to completed"):
- `seedOrgWithProject` now seeds an active `project_sources` row alongside the project/campaign/account/device/draft it already seeds.
- The one test that deliberately wants an org with *nothing* set up, and `home-campaigns-widget.test.ts`'s use of the shared `default` org, call `skipOnboarding` directly instead of relying on fixture shape or file order.

I didn't touch `#609`'s production code or open a separate issue for this - flagging it here since it was making the same CI tier red as #616 and blocking the local green-x3 bar this PR needs to clear. Happy to file it separately if you'd rather track it apart from #616.

## Verification

- `pnpm test` on unmodified `main`: failed twice locally (assist_usage deadlock + FK violations + onboarding redirects, moving between runs), matching CI.
- `pnpm test` with this branch: green three times in a row locally (338 files, 2894 tests each run; ~600-740s per run, no slower than the unfixed baseline - nothing here serializes anything).
- Targeted re-runs of every touched file plus every sibling `gateway-*-dispatch.test.ts` and every `extension-suggest*.test.ts` file: all green.
