### PR TITLE
feat(web,shared): notify orgs at 80% and 100% of a metered limit

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -101,6 +101,7 @@
     "./billing/webhook": "./src/billing/webhook.ts",
     "./billing/grace": "./src/billing/grace.ts",
     "./usage": "./src/usage.ts",
+    "./usage-notifications": "./src/usage-notifications.ts",
     "./onboarding": "./src/onboarding.ts"
   },
   "scripts": {

--- a/shared/src/usage-notifications.ts
+++ b/shared/src/usage-notifications.ts
@@ -1,0 +1,152 @@
+// Usage-threshold notifications (#557): a hard stop that arrives without
+// warning reads as a bug. The pieces to warn with already exist -
+// `notifications` (in-app, with an unread badge), the webhook delivery
+// queue `notify()` already enqueues to when an org has a webhook configured
+// (`billing_payment_failed`, #611), and an email path since the accounts
+// work - so this is the second producer that reuses all three rather than
+// inventing a second mechanism.
+//
+// The only real difficulty is "once per threshold per period": a burst of
+// requests all computing the same usage snapshot at the boundary must not
+// send five notifications, staying over the threshold on the next request
+// must not send a second one, and the period rolling over must notify
+// again. There is no migration slot this wave (AssistPlane holds it), so
+// this follows #611's own precedent exactly instead of adding a dedicated
+// dedupe table: a `notifications` row already recorded for
+// (org, metric, threshold, period) *is* the record. That is a
+// check-then-insert, the same narrow race #611 itself accepts (two requests
+// landing in the same instant could both pass the check and double-insert) -
+// not closed here either, since closing it for real needs a partial unique
+// index and hence the migration slot nobody has this wave.
+import { and, eq, sql } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+import { schema } from './db/client.js';
+import { notify } from './notifications.js';
+import type { OrgUsageSnapshot, UsageMetric } from './usage.js';
+import type { Period } from './org-quota.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDb = PgDatabase<any, any, any>;
+
+export const USAGE_THRESHOLD_NOTIFICATION_KIND = 'usage_threshold_reached';
+
+const THRESHOLDS = [80, 100] as const;
+export type UsageThreshold = (typeof THRESHOLDS)[number];
+
+/** Every axis `OrgUsageSnapshot` can actually refuse against. `accounts` is
+ * deliberately excluded - usage.ts's own doc comment on that field: "limit
+ * is always null... no enforcement point reads a connected-account limit
+ * yet", so it can never have a threshold to cross. */
+const METERED_AXES = [
+  'runs',
+  'suggestions',
+  'projects',
+  'seats',
+  'extensionDevices',
+  'costUsd',
+] as const;
+type MeteredAxis = (typeof METERED_AXES)[number];
+
+const AXIS_LABELS: Record<MeteredAxis, string> = {
+  runs: 'agent runs',
+  suggestions: 'assist suggestions',
+  projects: 'projects',
+  seats: 'seats',
+  extensionDevices: 'paired devices',
+  costUsd: 'model spend',
+};
+
+/**
+ * At 80% and 100% of any metered axis in `usage`, emit one
+ * `usage_threshold_reached` notification per axis per threshold per
+ * `period` - idempotent by construction (see the module header) and safe to
+ * call on every request that already computes a usage snapshot for
+ * enforcement: an axis with nothing new to report does no writes at all.
+ *
+ * An unlimited axis (`limit === null`) never produces one, which is also
+ * why self-host - `getOrgUsage`'s fully-unlimited shape - never notifies:
+ * there is nothing here that treats `source === 'self-host'` specially: it
+ * doesn't need to, since every axis is already unlimited by the time this
+ * runs.
+ */
+export async function checkUsageThresholds(
+  db: AnyDb,
+  orgId: number,
+  usage: OrgUsageSnapshot,
+  period: Period,
+): Promise<void> {
+  const periodEnd = period.end.toISOString();
+
+  const crossed: { axis: MeteredAxis; threshold: UsageThreshold; metric: UsageMetric }[] = [];
+  for (const axis of METERED_AXES) {
+    const metric = usage[axis];
+    // Unlimited (`limit === null`, always true on self-host) or a
+    // zero-or-negative limit: neither has a meaningful percentage, so it
+    // can never cross a threshold.
+    if (metric.limit == null || metric.limit <= 0) continue;
+    const percent = (metric.used / metric.limit) * 100;
+    for (const threshold of THRESHOLDS) {
+      if (percent >= threshold) crossed.push({ axis, threshold, metric });
+    }
+  }
+  if (crossed.length === 0) return;
+
+  // One round trip for every dedupe key already recorded this period,
+  // rather than one SELECT per (axis, threshold) - the whole point is this
+  // stays cheap enough to call from a request that is already computing the
+  // usage snapshot for its own enforcement check.
+  const existingKeys = new Set(
+    (
+      await db
+        .select({ key: sql<string>`${schema.notifications.payload}->>'dedupeKey'` })
+        .from(schema.notifications)
+        .where(
+          and(
+            eq(schema.notifications.organizationId, orgId),
+            eq(schema.notifications.kind, USAGE_THRESHOLD_NOTIFICATION_KIND),
+            sql`${schema.notifications.payload}->>'periodEnd' = ${periodEnd}`,
+          ),
+        )
+    ).map((row) => row.key),
+  );
+
+  for (const { axis, threshold, metric } of crossed) {
+    const dedupeKey = `${axis}:${threshold}:${periodEnd}`;
+    if (existingKeys.has(dedupeKey)) continue;
+    existingKeys.add(dedupeKey); // guard against this same loop double-firing
+
+    const label = AXIS_LABELS[axis];
+    // costUsd reads as a dollar figure, every other axis as a whole count -
+    // both formatted together so the ternary isn't repeated per value.
+    const { used: usedText, limit: limitText } =
+      axis === 'costUsd'
+        ? { used: `$${metric.used.toFixed(2)}`, limit: `$${(metric.limit as number).toFixed(2)}` }
+        : {
+            used: String(Math.round(metric.used)),
+            limit: String(Math.round(metric.limit as number)),
+          };
+    const periodEndDate = periodEnd.slice(0, 10);
+
+    await notify(
+      db,
+      {
+        kind: USAGE_THRESHOLD_NOTIFICATION_KIND,
+        title: `${threshold}% of your ${label} limit`,
+        severity: threshold >= 100 ? 'warning' : 'info',
+        body:
+          `You have used ${usedText} of ${limitText} ${label} for the period ending ` +
+          `${periodEndDate}. Upgrade your plan from Settings > Billing before it starts ` +
+          `refusing requests.`,
+        payload: {
+          dedupeKey,
+          metric: axis,
+          threshold,
+          used: metric.used,
+          limit: metric.limit,
+          periodEnd,
+        },
+      },
+      orgId,
+    );
+  }
+}

--- a/shared/tests/usage-notifications.test.ts
+++ b/shared/tests/usage-notifications.test.ts
@@ -1,0 +1,253 @@
+// checkUsageThresholds (#557): "once per threshold per period" is the whole
+// difficulty, so these exercise that directly against hand-built usage
+// snapshots (metric()/makeUsage() below) rather than through real
+// getOrgUsage() plumbing - usage.test.ts already owns proving getOrgUsage
+// itself computes the right used/limit numbers from real runs, projects,
+// etc. What matters here is what checkUsageThresholds does with a snapshot
+// once it has one.
+import { randomUUID } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import {
+  checkUsageThresholds,
+  USAGE_THRESHOLD_NOTIFICATION_KIND,
+} from '../src/usage-notifications.js';
+import { saveWebhooks } from '../src/notifications.js';
+import type { Entitlements } from '../src/plans.js';
+import { getOrgUsage } from '../src/usage.js';
+import type { OrgUsageSnapshot, UsageMetric } from '../src/usage.js';
+import { calendarPeriodFor, type Period } from '../src/org-quota.js';
+
+const createdOrgIds: number[] = [];
+
+afterEach(async () => {
+  const db = getDb();
+  while (createdOrgIds.length > 0) {
+    const id = createdOrgIds.pop()!;
+    await db.delete(schema.organizations).where(eq(schema.organizations.id, id));
+  }
+  await saveWebhooks(db, {});
+});
+
+async function makeOrg(): Promise<number> {
+  const slug = `usage-notif-test-${randomUUID()}`;
+  const [org] = await getDb().insert(schema.organizations).values({ slug, name: slug }).returning();
+  createdOrgIds.push(org.id);
+  return org.id;
+}
+
+function metric(used: number, limit: number | null): UsageMetric {
+  return { used, limit, remaining: limit == null ? null : Math.max(0, limit - used) };
+}
+
+const UNLIMITED: UsageMetric = { used: 0, limit: null, remaining: null };
+
+function makeEntitlements(overrides: Partial<Entitlements> = {}): Entitlements {
+  return {
+    runsPerMonth: null,
+    suggestionsPerMonth: null,
+    projects: null,
+    seats: null,
+    extensionDevices: null,
+    maxConcurrentRuns: null,
+    monthlyRunBudgetUsd: null,
+    retentionDays: null,
+    premiumModels: true,
+    webhooks: true,
+    planId: 'free',
+    source: 'default',
+    graceEndsAt: null,
+    ...overrides,
+  };
+}
+
+function makeUsage(overrides: Partial<OrgUsageSnapshot> = {}): OrgUsageSnapshot {
+  return {
+    runs: UNLIMITED,
+    suggestions: UNLIMITED,
+    projects: UNLIMITED,
+    accounts: UNLIMITED,
+    seats: UNLIMITED,
+    extensionDevices: UNLIMITED,
+    costUsd: UNLIMITED,
+    entitlements: makeEntitlements(),
+    ...overrides,
+  };
+}
+
+const PERIOD_A: Period = {
+  start: new Date('2026-01-01T00:00:00Z'),
+  end: new Date('2026-02-01T00:00:00Z'),
+};
+const PERIOD_B: Period = {
+  start: new Date('2026-02-01T00:00:00Z'),
+  end: new Date('2026-03-01T00:00:00Z'),
+};
+
+async function thresholdNotificationsFor(orgId: number) {
+  return getDb()
+    .select()
+    .from(schema.notifications)
+    .where(
+      and(
+        eq(schema.notifications.organizationId, orgId),
+        eq(schema.notifications.kind, USAGE_THRESHOLD_NOTIFICATION_KIND),
+      ),
+    );
+}
+
+/** Three call sites below sort/compare notification rows by their
+ * payload's threshold - named and cast once here rather than inline at
+ * each `.map`/`.every`, since `payload` is untyped jsonb. */
+function thresholdOf(row: typeof schema.notifications.$inferSelect): number {
+  const payload = row.payload as { threshold: number };
+  return payload.threshold;
+}
+
+describe('checkUsageThresholds: crossing and repeating', () => {
+  it('crossing 80% notifies once, staying over it does not notify again, crossing 100% notifies once more', async () => {
+    const orgId = await makeOrg();
+
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ runs: metric(80, 100) }), PERIOD_A);
+    let rows = await thresholdNotificationsFor(orgId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].payload).toMatchObject({ metric: 'runs', threshold: 80 });
+
+    // A retry (or five requests racing the same boundary) at the same or a
+    // slightly higher usage, still under 100%, must not send a second 80%
+    // notification - exactly the burst #557 forbids.
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ runs: metric(85, 100) }), PERIOD_A);
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ runs: metric(85, 100) }), PERIOD_A);
+    rows = await thresholdNotificationsFor(orgId);
+    expect(rows).toHaveLength(1);
+
+    // 100% crosses the second threshold - a distinct notification.
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ runs: metric(100, 100) }), PERIOD_A);
+    rows = await thresholdNotificationsFor(orgId);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => thresholdOf(r)).sort((a, b) => a - b)).toEqual([80, 100]);
+
+    // Still at 100%: no third notification for the same threshold.
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ runs: metric(100, 100) }), PERIOD_A);
+    rows = await thresholdNotificationsFor(orgId);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('a new billing period notifies again for the same metric and threshold', async () => {
+    const orgId = await makeOrg();
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ runs: metric(80, 100) }), PERIOD_A);
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ runs: metric(80, 100) }), PERIOD_B);
+    const rows = await thresholdNotificationsFor(orgId);
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => thresholdOf(r) === 80)).toBe(true);
+  });
+
+  it('a single jump straight past both thresholds notifies for each of them, not just the higher one', async () => {
+    const orgId = await makeOrg();
+    // Never seen 80% before - a bulk seat grant can land at 100% in one step.
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ seats: metric(10, 10) }), PERIOD_A);
+    const rows = await thresholdNotificationsFor(orgId);
+    expect(rows.map((r) => thresholdOf(r)).sort((a, b) => a - b)).toEqual([80, 100]);
+  });
+});
+
+describe('checkUsageThresholds: nothing to cross', () => {
+  it('an unlimited axis never notifies, whatever it has used', async () => {
+    const orgId = await makeOrg();
+    await checkUsageThresholds(
+      getDb(),
+      orgId,
+      makeUsage({ costUsd: metric(1_000_000, null) }),
+      PERIOD_A,
+    );
+    expect(await thresholdNotificationsFor(orgId)).toHaveLength(0);
+  });
+
+  it('self-host - every axis already unlimited - never notifies', async () => {
+    const orgId = await makeOrg();
+    // Mirrors getOrgUsage's real self-host branch: every metric UNLIMITED,
+    // entitlements.source 'self-host'. makeUsage()'s defaults already give
+    // every axis a null limit, same as that branch.
+    const usage = makeUsage({ entitlements: makeEntitlements({ source: 'self-host' }) });
+    await checkUsageThresholds(getDb(), orgId, usage, PERIOD_A);
+    expect(await thresholdNotificationsFor(orgId)).toHaveLength(0);
+  });
+
+  it('a limit of zero never notifies - there is no percentage to compute', async () => {
+    const orgId = await makeOrg();
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ projects: metric(0, 0) }), PERIOD_A);
+    expect(await thresholdNotificationsFor(orgId)).toHaveLength(0);
+  });
+});
+
+describe('checkUsageThresholds: copy and delivery', () => {
+  it('names the axis, the used/limit numbers and the period end - never a bare "near your limit"', async () => {
+    const orgId = await makeOrg();
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ costUsd: metric(45.5, 50) }), PERIOD_A);
+    const [row] = await thresholdNotificationsFor(orgId);
+    expect(row.title).toContain('model spend');
+    expect(row.title).toContain('80%');
+    expect(row.body).toContain('$45.50');
+    expect(row.body).toContain('$50.00');
+    expect(row.body).toContain('2026-02-01'); // PERIOD_A.end, the day the window rolls
+  });
+
+  it('also enqueues a webhook delivery when the instance has one configured', async () => {
+    const orgId = await makeOrg();
+    await saveWebhooks(getDb(), { url: 'https://hooks.example.com/usage' });
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ seats: metric(4, 5) }), PERIOD_A); // 80%
+    const deliveries = await getDb()
+      .select()
+      .from(schema.webhookDeliveries)
+      .where(eq(schema.webhookDeliveries.organizationId, orgId));
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0].eventType).toBe(`notification.${USAGE_THRESHOLD_NOTIFICATION_KIND}`);
+    expect(deliveries[0].status).toBe('pending');
+  });
+
+  it('enqueues no webhook delivery when the instance has none configured', async () => {
+    const orgId = await makeOrg();
+    await checkUsageThresholds(getDb(), orgId, makeUsage({ seats: metric(4, 5) }), PERIOD_A);
+    const deliveries = await getDb()
+      .select()
+      .from(schema.webhookDeliveries)
+      .where(eq(schema.webhookDeliveries.organizationId, orgId));
+    expect(deliveries).toHaveLength(0);
+  });
+});
+
+describe('checkUsageThresholds: integration with a real getOrgUsage snapshot', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  it('notifies off the real snapshot getOrgUsage computes, not just a hand-built one - proves the wiring, not just the fixture', async () => {
+    process.env.PITCHBOX_EDITION = 'cloud';
+    const db = getDb();
+    const slug = `usage-notif-integration-${randomUUID()}`;
+    const [org] = await db
+      .insert(schema.organizations)
+      .values({ slug, name: slug, plan: 'free' })
+      .returning();
+    createdOrgIds.push(org.id);
+    // The free plan's own project ceiling is 1 (shared/src/plans.ts's
+    // PLAN_CATALOGUE.free.projects) - one real project already lands the
+    // org exactly at 100%, no usage fixture required.
+    await db.insert(schema.projects).values({ organizationId: org.id, slug: 'p', name: 'p' });
+
+    const period = calendarPeriodFor(org.createdAt, new Date());
+    const usage = await getOrgUsage(db, org.id, period);
+    await checkUsageThresholds(db, org.id, usage, period);
+
+    const rows = await thresholdNotificationsFor(org.id);
+    expect(rows.map((r) => thresholdOf(r)).sort((a, b) => a - b)).toEqual([80, 100]);
+    const metrics = rows.map((r) => {
+      const payload = r.payload as { metric: string };
+      return payload.metric;
+    });
+    expect(metrics.every((m) => m === 'projects')).toBe(true);
+  });
+});

--- a/web/src/lib/server/runner.ts
+++ b/web/src/lib/server/runner.ts
@@ -29,6 +29,7 @@ import {
   billingPeriodFor,
 } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { checkUsageThresholds } from '@pitchbox/shared/usage-notifications';
 import type { ScenarioSlug } from '@pitchbox/shared/campaigns';
 import { getDb, schema } from './db.js';
 import { and, desc, eq } from 'drizzle-orm';
@@ -230,6 +231,17 @@ async function dispatchRun(
     if (orgId != null) {
       const period = await billingPeriodFor(db, orgId);
       const usage = await getOrgUsage(db, orgId, period);
+      // #557: 80%/100% of any metered axis, once per threshold per period -
+      // checked here since this is the single place every dispatch already
+      // computes the org's usage snapshot for enforcement. A courtesy
+      // notification never blocks the run it warns about, admitted or
+      // refused by the checks below, so a failure here is logged and
+      // swallowed rather than allowed to fail the dispatch itself.
+      try {
+        await checkUsageThresholds(db, orgId, usage, period);
+      } catch (err) {
+        console.error('[runner] checkUsageThresholds failed:', err);
+      }
       // #554: a failed payment past its grace window refuses before the
       // plan's own run-count ceiling below - an org that is both over its
       // limit and read-only gets the read-only message, since fixing the

--- a/web/src/routes/api/extension/auto-pair/+server.ts
+++ b/web/src/routes/api/extension/auto-pair/+server.ts
@@ -6,6 +6,7 @@ import { getDb, schema } from '$lib/server/db.js';
 import { mintDeviceToken } from '$lib/server/extension-auth.js';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { checkUsageThresholds } from '@pitchbox/shared/usage-notifications';
 import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 /**
@@ -83,6 +84,13 @@ export async function POST({
   // own device-count ceiling below.
   const period = await billingPeriodFor(db, organizationId);
   const usage = await getOrgUsage(db, organizationId, period);
+  // #557: a courtesy notification never blocks pairing, admitted or
+  // refused by the checks below.
+  try {
+    await checkUsageThresholds(db, organizationId, usage, period);
+  } catch (err) {
+    console.error('[extension/auto-pair] checkUsageThresholds failed:', err);
+  }
   if (isOrgReadOnly(usage.entitlements)) {
     return json({ error: 'plan_payment_required' }, { status: 402 });
   }

--- a/web/src/routes/api/extension/pair/+server.ts
+++ b/web/src/routes/api/extension/pair/+server.ts
@@ -5,6 +5,7 @@ import { getDb, schema } from '$lib/server/db.js';
 import { mintDeviceToken } from '$lib/server/extension-auth.js';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { checkUsageThresholds } from '@pitchbox/shared/usage-notifications';
 import { isOrgReadOnly } from '@pitchbox/shared/plans';
 import { RateLimiter } from '$lib/server/rate-limit.js';
 
@@ -64,6 +65,13 @@ export async function POST({ request, getClientAddress }: RequestEvent) {
   // check below already accepts.
   const period = await billingPeriodFor(db, pairing.organizationId);
   const usage = await getOrgUsage(db, pairing.organizationId, period);
+  // #557: a courtesy notification never blocks pairing, admitted or
+  // refused by the checks below.
+  try {
+    await checkUsageThresholds(db, pairing.organizationId, usage, period);
+  } catch (err) {
+    console.error('[extension/pair] checkUsageThresholds failed:', err);
+  }
   if (isOrgReadOnly(usage.entitlements)) {
     return json({ error: 'plan_payment_required' }, { status: 402 });
   }

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -27,6 +27,7 @@ import {
 import { loadRecentObservedTarget } from '@pitchbox/shared/observed-targets';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { checkUsageThresholds } from '@pitchbox/shared/usage-notifications';
 import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 // The real-time plane. What makes the in-page assistant a separate subsystem
@@ -190,6 +191,13 @@ export async function POST(event: RequestEvent) {
 
   const period = await billingPeriodFor(db, project.organizationId);
   const usage = await getOrgUsage(db, project.organizationId, period);
+  // #557: a courtesy notification never blocks a suggestion, admitted or
+  // refused by the checks below.
+  try {
+    await checkUsageThresholds(db, project.organizationId, usage, period);
+  } catch (err) {
+    console.error('[extension/suggest] checkUsageThresholds failed:', err);
+  }
   // #554: a failed payment past its grace window refuses before the plan's
   // own suggestions ceiling below, same renderable-200 shape, distinct code
   // so the panel (#556) can render "fix your payment" rather than "upgrade".

--- a/web/src/routes/api/orgs/[slug]/invites/+server.ts
+++ b/web/src/routes/api/orgs/[slug]/invites/+server.ts
@@ -7,6 +7,7 @@ import { loadMailEnv } from '@pitchbox/shared/mail/env';
 import { renderPlainTextMail } from '@pitchbox/shared/mail/template';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { checkUsageThresholds } from '@pitchbox/shared/usage-notifications';
 import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 const Body = z.object({
@@ -61,6 +62,13 @@ export async function POST(event: import('@sveltejs/kit').RequestEvent) {
   // at once (shared/src/usage.ts's getOrgUsage already counts it that way).
   const period = await billingPeriodFor(db, org.id);
   const usage = await getOrgUsage(db, org.id, period);
+  // #557: a courtesy notification never blocks the invite, admitted or
+  // refused by the checks below.
+  try {
+    await checkUsageThresholds(db, org.id, usage, period);
+  } catch (err) {
+    console.error('[invites] checkUsageThresholds failed:', err);
+  }
   // #554: a failed payment past its grace window refuses before the plan's
   // own seat limit below.
   if (isOrgReadOnly(usage.entitlements)) {

--- a/web/src/routes/api/projects/+server.ts
+++ b/web/src/routes/api/projects/+server.ts
@@ -8,6 +8,7 @@ import { resolveDefaultRunnerSlug } from '@pitchbox/shared/agents/config';
 import { isRunnerAllowed } from '@pitchbox/shared/edition';
 import { billingPeriodFor } from '@pitchbox/shared/org-quota';
 import { getOrgUsage } from '@pitchbox/shared/usage';
+import { checkUsageThresholds } from '@pitchbox/shared/usage-notifications';
 import { isOrgReadOnly } from '@pitchbox/shared/plans';
 
 const slugRegex = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
@@ -95,6 +96,13 @@ export async function POST(event) {
   // period-bound axes this same snapshot also carries.
   const period = await billingPeriodFor(db, organizationId);
   const usage = await getOrgUsage(db, organizationId, period);
+  // #557: a courtesy notification never blocks project creation, admitted
+  // or refused by the checks below.
+  try {
+    await checkUsageThresholds(db, organizationId, usage, period);
+  } catch (err) {
+    console.error('[projects] checkUsageThresholds failed:', err);
+  }
   // #554: a failed payment past its grace window refuses before the plan's
   // own project limit below.
   if (isOrgReadOnly(usage.entitlements)) {


### PR DESCRIPTION
Closes #557

## What changed

`shared/src/usage-notifications.ts` adds `checkUsageThresholds(db, orgId, usage, period)`: given the `OrgUsageSnapshot` `getOrgUsage` already computes, it emits one `usage_threshold_reached` notification per metered axis (runs, suggestions, projects, seats, extension devices, model spend) per threshold (80%, 100%) per billing period, and reuses `notify()`'s own webhook enqueue for orgs with a webhook configured - the same delivery queue #611 already uses, not a second mechanism.

Idempotency (the actual difficulty here) follows #611's own precedent exactly rather than adding a dedupe table: a `notifications` row already recorded for `(org, metric, threshold, period)` *is* the record, keyed by a `dedupeKey` in the row's jsonb payload and checked with one query per call before deciding what to insert. There is no migration slot this wave (AssistPlane holds it), so this is the same check-then-insert #611 itself accepts, including its narrow race - closing that for real needs a partial unique index and hence a migration nobody has this wave.

An unlimited axis (`limit === null`) never has a percentage to cross, which is also why self-host - `getOrgUsage`'s fully-unlimited shape - never notifies without any special-cased `source === 'self-host'` check.

Wired into every existing call site that already computes a usage snapshot for enforcement, so the feature is live end to end rather than a library nobody calls: run dispatch (`web/src/lib/server/runner.ts`, covers runs + spend), project creation, org invites (seats), both extension pairing routes (devices), and the assist suggest route (suggestions). Each call site wraps the check in try/catch - a courtesy notification never blocks the request it would have warned about.

## What I verified

- `pnpm exec vitest run shared/tests/usage-notifications.test.ts` - 10/10, covering: crossing 80% notifies once; staying over it does not notify again; crossing 100% notifies once more; a new billing period notifies again; a single jump past both thresholds notifies for each; an unlimited axis never notifies; self-host never notifies; a zero limit never notifies; the copy names the axis/numbers/period end; a webhook delivery row is enqueued when configured and skipped when not; and an integration test against a *real* `getOrgUsage` snapshot (a free-plan org with its one allowed project), not just hand-built fixtures.
- Manually commented out the dedupe guard and reran the repeat-crossing test to confirm it actually fails without it (3 rows instead of 1 for the same org/metric/threshold/period), then restored it - proof the idempotency logic is load-bearing, not incidental.
- `pnpm exec vitest run shared/tests/usage.test.ts shared/tests/notifications.test.ts shared/tests/billing-webhook.test.ts` - 28/28, no regressions in the modules this builds on.
- `pnpm -F web check` - 0 errors (whole web workspace, since I touched several route files).
- `npx tsc --noEmit -p shared/tsconfig.json`, `npx eslint`, `npx prettier --check` on every changed file.

## What I deliberately left

- The check-then-insert race window noted above (needs a migration slot).
- No UI change: the existing `/notifications` page already renders `title`/`body`/`severity` generically for any `kind`, so a new kind needs no new UI code.
- Didn't touch the extension's own real-time streaming path inside `suggest/+server.ts`'s `ReadableStream` (that's #573/#574, owned by other agents this wave) - only the pre-stream usage snapshot check, coordinated with them beforehand.
