### PR TITLE
feat(web): settings/billing shows the plan, the usage and the way to change it

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -67,6 +67,11 @@ below), `settings/companion` GET + the `saveProfile`/`toggleVoiceSample` form
 actions (2026-09-07 companion decisions: the operator's persona and voice
 samples that feed every suggestion's prompt are at least as sensitive as the
 LinkedIn assist switch, so this page's loader throws the same way),
+`settings/billing` GET (#555: the plan, its usage this period and the two
+real ways to change it - org-scoped like Retention/Security, not instance-
+wide, since a plan is per-organization; additionally cloud-only, see the
+#254 note below for how the rail hides it entirely on self-host rather than
+opening onto a page with nothing to meter),
 `settings/github-sources` POST + `[id]` DELETE (adding/removing a repo the
 companion may cite; the GET is member-level, listed below, since reading it
 back is no more sensitive than reading a project),
@@ -200,7 +205,15 @@ same org-scoped `requireRole(event, 'admin')` gate). #506 added a tenth,
 gated on `locals.user` existing at all rather than an org role, since a
 password change needs nothing beyond being the account holder; 404s when
 auth is off, since there's no login concept and nothing to change a
-password for). `/settings`
+password for). #555 added an eleventh, `settings/billing` (the plan, its
+usage this period and the two real ways to change it - org-scoped, so it
+throws `requireRole(event, 'admin')` like Retention/Security, plus a second,
+edition-scoped gate: self-host has no plan concept at all
+(`shared/src/plans.ts`'s `resolveEntitlements` is unlimited there before it
+ever looks at Stripe or the plan catalogue), so the rail hides the link
+entirely rather than opening onto a page with nothing to meter - a stray
+direct hit still loads and says so rather than 404ing or rendering an empty
+plan card). `/settings`
 itself now just redirects (307) to `/settings/status`. The four routes that
 used to be General's tabs each gate their own data set in their own loader,
 the same per-data-set split #237 landed on the old combined page: `status`
@@ -216,11 +229,13 @@ empty/misleading state when it isn't. `extension`'s paired-devices list
 status); only revoking a device (DELETE) and minting a pairing code (POST
 `settings/extension-pairing`) are admin-gated. The settings rail
 (`web/src/routes/settings/+layout.svelte`) hides the `organization` link when
-auth is off (no org context to show), and hides the `retention`/`security`/
-`linkedin-assist`/`companion` links from a non-admin since those routes'
-loaders call `requireRole(event, 'admin')` and would 403; `status`/`runners`/
-`extension`/`quota`/`password` are always shown to a signed-in caller because
-none of their loaders throw a role error (`password` still 404s with no
+auth is off (no org context to show), hides the `retention`/`security`/
+`linkedin-assist`/`companion`/`billing` links from a non-admin since those
+routes' loaders call `requireRole(event, 'admin')` and would 403, and
+additionally hides `billing` from self-host regardless of role
+(`data.isCloud`, root `+layout.server.ts`); `status`/`runners`/`extension`/
+`quota`/`password` are always shown to a signed-in caller because none of
+their loaders throw a role error (`password` still 404s with no
 `locals.user`, i.e. auth off); they only narrow the payload or, for
 `password`, gate on being signed in at all.
 

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -3,6 +3,7 @@ import { getDb } from '$lib/server/db.js';
 import { listUserOrganizations } from '@pitchbox/shared/orgs';
 import { isInstanceAdmin } from '$lib/server/auth.js';
 import { resolveEntitlements, isOrgReadOnly } from '@pitchbox/shared/plans';
+import { currentEdition } from '@pitchbox/shared/edition';
 
 /**
  * Root layout loader. Exposes server-wide flags every page may need: `authOn`
@@ -47,6 +48,11 @@ export const load: LayoutServerLoad = async (event) => {
     orgs,
     isAdmin,
     isInstanceAdmin: await isInstanceAdmin(event),
+    // #555: the settings rail's Billing entry - self-host has no plan
+    // concept at all (shared/src/plans.ts's resolveEntitlements is
+    // unlimited before it ever looks at Stripe or the catalogue there), so
+    // the link is edition-gated the same way `organization` is auth-gated.
+    isCloud: currentEdition() === 'cloud',
     billing,
   };
 };

--- a/web/src/routes/settings/+layout.svelte
+++ b/web/src/routes/settings/+layout.svelte
@@ -10,6 +10,7 @@
     Gauge,
     KeyRound,
     Building2,
+    CreditCard,
     Archive,
     ShieldCheck,
     Sparkles,
@@ -19,18 +20,23 @@
 
   let { data, children }: { data: LayoutData; children: Snippet } = $props();
 
-  // Flat rail of eleven (#254 shipped seven; LI-19/#316 added LinkedIn assist;
+  // Flat rail of twelve (#254 shipped seven; LI-19/#316 added LinkedIn assist;
   // 2026-09-07's companion decisions added Companion; #506 added Password;
-  // #516 added Onboarding). Status/Agent runners/Browser extension/Quota
-  // never 403 - each loader gates its own data set (member sees an "Admin
-  // access required" card instead of a thrown error) - so they're always
-  // shown, same as General used to be. Password and Onboarding are
-  // self-service (gated on being signed in / having an org context at all,
-  // not an org role - docs/permissions.md) rather than admin-only.
-  // Organization needs an org context (auth on); Retention, Security,
-  // LinkedIn assist and Companion loaders call requireRole(event, 'admin')
-  // and do throw, so those stay role-filtered here too. The server loaders
-  // enforce the real rule; this only hides links that would otherwise 403.
+  // #516 added Onboarding; #555 added Billing). Status/Agent runners/Browser
+  // extension/Quota never 403 - each loader gates its own data set (member
+  // sees an "Admin access required" card instead of a thrown error) - so
+  // they're always shown, same as General used to be. Password and
+  // Onboarding are self-service (gated on being signed in / having an org
+  // context at all, not an org role - docs/permissions.md) rather than
+  // admin-only. Organization needs an org context (auth on); Retention,
+  // Security, LinkedIn assist, Companion and Billing loaders call
+  // requireRole(event, 'admin') and do throw, so those stay role-filtered
+  // here too. Billing additionally needs `data.isCloud`: self-host has no
+  // plan concept at all (shared/src/plans.ts's resolveEntitlements is
+  // unlimited there before it ever looks at a plan), so the link does not
+  // exist rather than opening onto a page with nothing to show. The server
+  // loaders enforce the real rule; this only hides links that would
+  // otherwise 403 or land on a dead page.
   const items = $derived(
     [
       { href: '/settings/status', label: 'Status', icon: Activity, show: true },
@@ -52,6 +58,12 @@
         show: data.isAdmin,
       },
       { href: '/settings/organization', label: 'Organization', icon: Building2, show: data.authOn },
+      {
+        href: '/settings/billing',
+        label: 'Billing',
+        icon: CreditCard,
+        show: data.isAdmin && data.isCloud,
+      },
       { href: '/settings/retention', label: 'Retention', icon: Archive, show: data.isAdmin },
       { href: '/settings/security', label: 'Security', icon: ShieldCheck, show: data.isAdmin },
     ].filter((i) => i.show),

--- a/web/src/routes/settings/billing/+page.server.ts
+++ b/web/src/routes/settings/billing/+page.server.ts
@@ -1,0 +1,153 @@
+// The billing page (#555): the plan, what of it is used, and the two real
+// ways to change it. Every metered number comes from `getOrgUsage`
+// (`@pitchbox/shared/usage`), which itself calls `resolveEntitlements` -
+// this loader never declares a limit, it only reads the org's own
+// `organizations`/`org_subscriptions` rows for the display-only fields
+// neither of those expose: the Stripe customer id (to decide whether the
+// portal link is safe to show at all - matches `/api/billing/portal`'s own
+// `NoStripeCustomerError` gate rather than guessing from `entitlements.source`),
+// and the raw subscription period/cancel flag/status Stripe mirrors onto
+// `org_subscriptions` (#551), which nothing meters and nothing else surfaces.
+import type { PageServerLoad } from './$types';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '../../../lib/server/db.js';
+import { requireOrgId, requireRole } from '../../../lib/server/auth.js';
+import { currentEdition } from '@pitchbox/shared/edition';
+import { getOrgUsage, type UsageMetric } from '@pitchbox/shared/usage';
+import { PLAN_CATALOGUE, PLAN_IDS, isOrgReadOnly, type Entitlements } from '@pitchbox/shared/plans';
+import { billingPeriodFor } from '@pitchbox/shared/org-quota';
+
+export type BillingUsage = {
+  runs: UsageMetric;
+  suggestions: UsageMetric;
+  projects: UsageMetric;
+  accounts: UsageMetric;
+  seats: UsageMetric;
+  extensionDevices: UsageMetric;
+  costUsd: UsageMetric;
+};
+
+export type PickablePlan = {
+  id: string;
+  name: string;
+  monthlyPriceCents: number;
+  annualPriceCents: number;
+};
+
+export type BillingPageData =
+  | { selfHost: true }
+  | {
+      selfHost: false;
+      planId: string;
+      planName: string;
+      source: Entitlements['source'];
+      priceCents: number | null;
+      interval: 'month' | 'year' | null;
+      currentPeriodEnd: string | null;
+      cancelAtPeriodEnd: boolean;
+      status: string | null;
+      readOnly: boolean;
+      graceEndsAt: string | null;
+      hasStripeCustomer: boolean;
+      usage: BillingUsage;
+      /** The paid tiers a free (no Stripe customer, no grant) org can pick
+       * from - plain data rather than a client-side import of
+       * `@pitchbox/shared/plans`, which pulls in `db/client.js` and has no
+       * business in a browser bundle (`do not import @pitchbox/shared/db
+       * from client code`, AGENTS.md). */
+      pickablePlans: PickablePlan[];
+    };
+
+// Nothing persists the interval a subscription was actually bought at -
+// `org_subscriptions` mirrors only what enforcement reads (#551), and no
+// enforcement point ever needs to tell month from year. Reading it back
+// from the period Stripe already gave us (a month is never longer than 31
+// days, a year is never shorter than 365) avoids adding a column whose only
+// reader would be this page.
+function intervalFromPeriod(start: Date, end: Date): 'month' | 'year' {
+  const days = (end.getTime() - start.getTime()) / 86_400_000;
+  return days > 60 ? 'year' : 'month';
+}
+
+export const load: PageServerLoad = async (event) => {
+  // Billing is admin+, like retention/security/linkedin-assist/companion -
+  // its loader throws rather than narrowing the payload like quota/runners
+  // do, so a member's direct hit 403s instead of rendering a stripped-down
+  // page (docs/permissions.md). The API (`/api/billing/checkout`,
+  // `/api/billing/portal`) enforces the same gate independently either way.
+  requireRole(event, 'admin');
+  const orgId = await requireOrgId(event);
+
+  // Self-host has no plan concept at all: `resolveEntitlements` returns the
+  // unlimited shape with `source: 'self-host'` before it ever looks at
+  // Stripe or the plan catalogue, because there is nothing to meter and
+  // nothing to sell. The settings rail hides this link entirely for
+  // self-host (matching how `organization` is hidden when auth is off) -
+  // a billing page with no numbers and two dead buttons is worse than no
+  // page, and the self-host operator already has full access with nothing
+  // to decide here. This branch only covers a stray direct hit on the URL:
+  // it says plainly that self-host is unlimited rather than inventing an
+  // empty plan card full of dashes.
+  if (currentEdition() !== 'cloud') {
+    return { selfHost: true } satisfies BillingPageData;
+  }
+
+  const db = getDb();
+  const [org] = await db
+    .select({ stripeCustomerId: schema.organizations.stripeCustomerId })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.id, orgId))
+    .limit(1);
+  const [sub] = await db
+    .select({
+      status: schema.orgSubscriptions.status,
+      currentPeriodStart: schema.orgSubscriptions.currentPeriodStart,
+      currentPeriodEnd: schema.orgSubscriptions.currentPeriodEnd,
+      cancelAtPeriodEnd: schema.orgSubscriptions.cancelAtPeriodEnd,
+    })
+    .from(schema.orgSubscriptions)
+    .where(eq(schema.orgSubscriptions.organizationId, orgId))
+    .limit(1);
+
+  const period = await billingPeriodFor(db, orgId);
+  const usage = await getOrgUsage(db, orgId, period);
+  const entitlements = usage.entitlements;
+  const plan = PLAN_CATALOGUE[entitlements.planId];
+  const interval = sub ? intervalFromPeriod(sub.currentPeriodStart, sub.currentPeriodEnd) : null;
+
+  return {
+    selfHost: false,
+    planId: entitlements.planId,
+    planName: plan.name,
+    source: entitlements.source,
+    priceCents: interval === 'year' ? plan.annualPriceCents : plan.monthlyPriceCents,
+    interval,
+    currentPeriodEnd: sub ? sub.currentPeriodEnd.toISOString() : null,
+    cancelAtPeriodEnd: sub?.cancelAtPeriodEnd ?? false,
+    status: sub?.status ?? null,
+    readOnly: isOrgReadOnly(entitlements),
+    graceEndsAt: entitlements.graceEndsAt ? entitlements.graceEndsAt.toISOString() : null,
+    // The real gate `/api/billing/portal` itself enforces (NoStripeCustomerError)
+    // - a grant never has a customer id, so this is also what keeps the
+    // portal link off a granted org without special-casing `source === 'grant'`.
+    hasStripeCustomer: org?.stripeCustomerId != null,
+    pickablePlans: PLAN_IDS.filter((id) => id !== 'free').map((id) => {
+      const p = PLAN_CATALOGUE[id];
+      return {
+        id: p.id,
+        name: p.name,
+        monthlyPriceCents: p.monthlyPriceCents ?? 0,
+        annualPriceCents: p.annualPriceCents ?? 0,
+      };
+    }),
+    usage: {
+      runs: usage.runs,
+      suggestions: usage.suggestions,
+      projects: usage.projects,
+      accounts: usage.accounts,
+      seats: usage.seats,
+      extensionDevices: usage.extensionDevices,
+      costUsd: usage.costUsd,
+    },
+  } satisfies BillingPageData;
+};

--- a/web/src/routes/settings/billing/+page.svelte
+++ b/web/src/routes/settings/billing/+page.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Progress } from '$lib/components/ui/progress';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import Seo from '$lib/components/Seo.svelte';
+	import PageContainer from '$lib/components/PageContainer.svelte';
+	import { toast } from 'svelte-sonner';
+	import { AlertTriangle, Ban, ExternalLink } from '@lucide/svelte';
+	import { TONE_BANNER_CLASS } from '$lib/config/status-badges';
+	import type { PageData } from './$types';
+	import type { UsageMetric } from '@pitchbox/shared/usage';
+
+	let { data }: { data: PageData } = $props();
+
+	function money(dollars: number): string {
+		return dollars.toLocaleString(undefined, { style: 'currency', currency: 'USD' });
+	}
+
+	function moneyCents(cents: number): string {
+		return money(cents / 100);
+	}
+
+	// Locale-independent so SSR and the client render the same string,
+	// matching BillingGraceBanner's own convention for the same date.
+	function formatDate(iso: string): string {
+		return new Date(iso).toDateString();
+	}
+
+	// A Stripe session response body, narrowed without an inline cast: after
+	// the `in` check TypeScript already knows `body.url` is `unknown`, so the
+	// final `typeof` check is what actually proves it is a string.
+	function sessionUrl(body: unknown): string | null {
+		if (body && typeof body === 'object' && 'url' in body && typeof body.url === 'string') {
+			return body.url;
+		}
+		return null;
+	}
+
+	const isGrant = $derived(!data.selfHost && data.source === 'grant');
+	const isFree = $derived(!data.selfHost && data.source === 'default' && data.planId === 'free');
+	const isSubscription = $derived(!data.selfHost && data.source === 'subscription');
+
+	let checkoutBusy = $state<string | null>(null);
+	async function startCheckout(planId: string, interval: 'month' | 'year') {
+		if (checkoutBusy) return;
+		checkoutBusy = `${planId}:${interval}`;
+		try {
+			const res = await fetch('/api/billing/checkout', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ plan: planId, interval }),
+			});
+			if (!res.ok) {
+				toast.error('Could not start checkout');
+				return;
+			}
+			const url = sessionUrl(await res.json());
+			if (!url) {
+				toast.error('Could not start checkout');
+				return;
+			}
+			window.location.href = url;
+		} catch {
+			toast.error('Could not start checkout');
+		} finally {
+			checkoutBusy = null;
+		}
+	}
+
+	let portalBusy = $state(false);
+	async function openPortal() {
+		if (portalBusy) return;
+		portalBusy = true;
+		try {
+			const res = await fetch('/api/billing/portal', { method: 'POST' });
+			if (!res.ok) {
+				toast.error('Could not open the customer portal');
+				return;
+			}
+			const url = sessionUrl(await res.json());
+			if (!url) {
+				toast.error('Could not open the customer portal');
+				return;
+			}
+			window.location.href = url;
+		} catch {
+			toast.error('Could not open the customer portal');
+		} finally {
+			portalBusy = false;
+		}
+	}
+</script>
+
+{#snippet usageRow(label: string, metric: UsageMetric)}
+	<div class="grid gap-1.5">
+		<div class="flex items-baseline justify-between text-sm">
+			<span class="font-medium">{label}</span>
+			{#if metric.limit == null}
+				<span class="text-muted-foreground">Unlimited</span>
+			{:else}
+				<span class="tabular-nums text-muted-foreground">{metric.used} / {metric.limit}</span>
+			{/if}
+		</div>
+		{#if metric.limit != null}
+			<Progress
+				value={metric.limit > 0 ? Math.min(100, (metric.used / metric.limit) * 100) : 100}
+				aria-label={label}
+			/>
+		{/if}
+	</div>
+{/snippet}
+
+<PageContainer size="default">
+	<Seo
+		title="Settings - Billing"
+		description="Your plan, what of it is used this period, and how to change it."
+	/>
+
+	<PageHeader
+		title="Billing"
+		description="The plan, what of it is used this period, and the two real ways to change it."
+	/>
+
+	{#if data.selfHost}
+		<Card.Root class="mt-4">
+			<Card.Header>
+				<Card.Title>Self-hosted</Card.Title>
+				<Card.Description>
+					This deployment runs outside the cloud edition, so every limit is unlimited and there is
+					nothing to bill. There is no plan to pick or portal to open here.
+				</Card.Description>
+			</Card.Header>
+		</Card.Root>
+	{:else}
+		{#if data.graceEndsAt}
+			<div
+				role="alert"
+				class="mt-4 flex items-start gap-2 rounded-lg border {data.readOnly
+					? TONE_BANNER_CLASS.rose
+					: TONE_BANNER_CLASS.amber}"
+			>
+				{#if data.readOnly}
+					<Ban class="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+				{:else}
+					<AlertTriangle class="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+				{/if}
+				<div class="flex-1">
+					{#if data.readOnly}
+						<div class="font-medium">Account is read-only since {formatDate(data.graceEndsAt)}</div>
+						<div class="text-xs opacity-85">
+							A payment failed and nothing succeeded during the grace period. New runs,
+							suggestions, accepts, projects, campaigns, invites and devices are refused until the
+							payment method is fixed in the portal below.
+						</div>
+					{:else}
+						<div class="font-medium">Payment failed - grace period until {formatDate(data.graceEndsAt)}</div>
+						<div class="text-xs opacity-85">
+							The plan keeps working normally until then. Update the payment method in the portal
+							below before {formatDate(data.graceEndsAt)} to avoid going read-only.
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/if}
+
+		<Card.Root class="mt-4">
+			<Card.Header>
+				<div class="flex items-center gap-2">
+					<Card.Title>{data.planName}</Card.Title>
+					{#if data.status}
+						<Badge variant={data.status === 'active' ? 'secondary' : 'outline'}>{data.status}</Badge>
+					{/if}
+					{#if isGrant}
+						<Badge variant="outline">Granted</Badge>
+					{/if}
+				</div>
+				<Card.Description>
+					{#if isGrant}
+						This plan was granted by an instance admin. It is not billed through Stripe, and does
+						not change from this page.
+					{:else if isFree}
+						No subscription. Free covers a single project on the house.
+					{:else if data.priceCents != null && data.interval}
+						{moneyCents(data.priceCents)} / {data.interval} · {data.cancelAtPeriodEnd
+							? `cancels on ${formatDate(data.currentPeriodEnd ?? '')}`
+							: `renews on ${formatDate(data.currentPeriodEnd ?? '')}`}
+					{/if}
+				</Card.Description>
+			</Card.Header>
+			<Card.Content>
+				{#if isFree}
+					<div class="grid gap-3 sm:grid-cols-3">
+						{#each data.pickablePlans as plan (plan.id)}
+							<div class="rounded-lg border p-3">
+								<div class="font-medium">{plan.name}</div>
+								<div class="mt-1 text-sm text-muted-foreground">
+									{moneyCents(plan.monthlyPriceCents)} / month or {moneyCents(plan.annualPriceCents)} / year
+								</div>
+								<div class="mt-3 flex gap-2">
+									<Button
+										size="sm"
+										variant="outline"
+										loading={checkoutBusy === `${plan.id}:month`}
+										onclick={() => startCheckout(plan.id, 'month')}
+									>
+										Monthly
+									</Button>
+									<Button
+										size="sm"
+										loading={checkoutBusy === `${plan.id}:year`}
+										onclick={() => startCheckout(plan.id, 'year')}
+									>
+										Yearly
+									</Button>
+								</div>
+							</div>
+						{/each}
+					</div>
+				{:else if isSubscription && data.hasStripeCustomer}
+					<Button loading={portalBusy} onclick={openPortal}>
+						Open customer portal
+						<ExternalLink class="size-3.5" />
+					</Button>
+					<p class="mt-2 text-xs text-muted-foreground">
+						Change plan, update the payment method, or see invoices in the portal. Nothing here
+						writes a plan directly - the portal and its webhook are the only path.
+					</p>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root class="mt-4">
+			<Card.Header>
+				<Card.Title>Usage this period</Card.Title>
+				<Card.Description>
+					What the plan meters, measured against its limits. A metric the plan leaves unmetered
+					says unlimited rather than a full bar.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content class="grid gap-4">
+				{@render usageRow('Runs', data.usage.runs)}
+				{@render usageRow('Suggestions', data.usage.suggestions)}
+				{@render usageRow('Projects', data.usage.projects)}
+				{@render usageRow('Connected accounts', data.usage.accounts)}
+				{@render usageRow('Seats', data.usage.seats)}
+				{@render usageRow('Paired devices', data.usage.extensionDevices)}
+
+				<div class="grid gap-1.5 border-t pt-4">
+					<div class="flex items-baseline justify-between text-sm">
+						<span class="font-medium">Model spend this period</span>
+						{#if data.usage.costUsd.limit == null}
+							<span class="tabular-nums text-muted-foreground">{money(data.usage.costUsd.used)}</span>
+						{:else}
+							<span class="tabular-nums text-muted-foreground">
+								{money(data.usage.costUsd.used)} / {money(data.usage.costUsd.limit)}
+							</span>
+						{/if}
+					</div>
+					<p class="text-xs text-muted-foreground">
+						What the deployment actually spent running this org's models. Not an invoice line -
+						the portal has those.
+					</p>
+					{#if data.usage.costUsd.limit != null}
+						<Progress
+							value={data.usage.costUsd.limit > 0
+								? Math.min(100, (data.usage.costUsd.used / data.usage.costUsd.limit) * 100)
+								: 100}
+							aria-label="Model spend this period"
+						/>
+					{/if}
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{/if}
+</PageContainer>

--- a/web/tests/settings-billing.test.ts
+++ b/web/tests/settings-billing.test.ts
@@ -1,0 +1,258 @@
+// #555: the settings/billing loader gates on admin+ role like retention/
+// security, and on `currentEdition() === 'cloud'` for anything past the
+// self-host early return - self-host has no plan concept at all
+// (shared/src/plans.ts's resolveEntitlements). Every number asserted here
+// comes straight off `getOrgUsage`/`resolveEntitlements`; this file never
+// re-derives a limit, it only checks the loader handed the page what those
+// two functions actually returned for each state.
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import type { RequestEvent } from '@sveltejs/kit';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { GRACE_PERIOD_DAYS } from '@pitchbox/shared/billing/grace';
+import { load } from '../src/routes/settings/billing/+page.server.js';
+import type { BillingPageData } from '../src/routes/settings/billing/+page.server.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const billingLoad = load as (event: RequestEvent) => Promise<BillingPageData>;
+
+function loaderEvent(orgId: number, role: 'member' | 'admin' | 'owner'): RequestEvent {
+  return {
+    locals: { org: { id: orgId, slug: 'x', role } },
+  } as unknown as RequestEvent;
+}
+
+async function statusOf(fn: () => Promise<unknown>): Promise<number> {
+  try {
+    await fn();
+    return 200;
+  } catch (e) {
+    if (e && typeof e === 'object' && 'status' in e && typeof e.status === 'number') {
+      return e.status;
+    }
+    return 500;
+  }
+}
+
+async function reset() {
+  const db = getDb();
+  await db.execute(sql`DELETE FROM stripe_events`);
+  await db.execute(sql`DELETE FROM org_subscriptions`);
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function makeFreeOrg(slug: string): Promise<number> {
+  const [org] = await getDb().insert(schema.organizations).values({ slug, name: slug }).returning();
+  return org.id;
+}
+
+async function makeGrantOrg(slug: string, planId: string): Promise<number> {
+  const [org] = await getDb()
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: planId, planSource: 'grant' })
+    .returning();
+  return org.id;
+}
+
+async function makeSubscriptionOrg(
+  slug: string,
+  opts: {
+    status: string;
+    currentPeriodStart: Date;
+    currentPeriodEnd: Date;
+    cancelAtPeriodEnd?: boolean;
+    planId?: string;
+  },
+): Promise<{ orgId: number; subscriptionId: string; customerId: string }> {
+  const db = getDb();
+  const planId = opts.planId ?? 'growth';
+  const [org] = await db
+    .insert(schema.organizations)
+    .values({ slug, name: slug, plan: planId, planSource: 'stripe' })
+    .returning();
+  const customerId = `cus_${randomUUID()}`;
+  const subscriptionId = `sub_${randomUUID()}`;
+  await db
+    .update(schema.organizations)
+    .set({ stripeCustomerId: customerId })
+    .where(eq(schema.organizations.id, org.id));
+  await db.insert(schema.orgSubscriptions).values({
+    organizationId: org.id,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscriptionId,
+    planId,
+    status: opts.status,
+    currentPeriodStart: opts.currentPeriodStart,
+    currentPeriodEnd: opts.currentPeriodEnd,
+    cancelAtPeriodEnd: opts.cancelAtPeriodEnd ?? false,
+    limitRuns: 2000,
+    limitSuggestions: 2000,
+    limitProjects: 10,
+    limitSeats: 3,
+    limitDevices: 10,
+    limitConcurrency: 4,
+    limitBudgetUsd: '30.00',
+    limitRetentionDays: 90,
+    limitPremiumModels: true,
+  });
+  return { orgId: org.id, subscriptionId, customerId };
+}
+
+async function markPastDue(subscriptionId: string, customerId: string, daysAgo: number) {
+  const failedEventId = `evt_${randomUUID()}`;
+  const failedAt = new Date(Date.now() - daysAgo * DAY_MS);
+  await getDb()
+    .insert(schema.stripeEvents)
+    .values({
+      id: failedEventId,
+      type: 'invoice.payment_failed',
+      receivedAt: failedAt,
+      processedAt: failedAt,
+      payload: {
+        id: failedEventId,
+        type: 'invoice.payment_failed',
+        created: Math.floor(failedAt.getTime() / 1000),
+        data: { object: { subscription: subscriptionId, customer: customerId } },
+      },
+    });
+}
+
+describe('settings/billing loader (#555)', () => {
+  const savedEdition = process.env.PITCHBOX_EDITION;
+
+  beforeEach(async () => {
+    await reset();
+    process.env.PITCHBOX_EDITION = 'cloud';
+  });
+
+  afterEach(() => {
+    if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+    else process.env.PITCHBOX_EDITION = savedEdition;
+  });
+
+  it('a member is forbidden (403)', async () => {
+    const orgId = await makeFreeOrg('billing-role-member');
+    expect(await statusOf(() => billingLoad(loaderEvent(orgId, 'member')))).toBe(403);
+  });
+
+  it('an admin can load the page', async () => {
+    const orgId = await makeFreeOrg('billing-role-admin');
+    expect(await statusOf(() => billingLoad(loaderEvent(orgId, 'admin')))).toBe(200);
+  });
+
+  it('self-host: unlimited, no plan card', async () => {
+    delete process.env.PITCHBOX_EDITION;
+    const orgId = await makeFreeOrg('billing-self-host');
+    const data = await billingLoad(loaderEvent(orgId, 'admin'));
+    expect(data).toEqual({ selfHost: true });
+  });
+
+  it('free org: no subscription, offers plans to pick', async () => {
+    const orgId = await makeFreeOrg('billing-free');
+    const data = await billingLoad(loaderEvent(orgId, 'admin'));
+    if (data.selfHost) throw new Error('expected cloud data');
+    expect(data.planId).toBe('free');
+    expect(data.source).toBe('default');
+    expect(data.hasStripeCustomer).toBe(false);
+    expect(data.cancelAtPeriodEnd).toBe(false);
+    expect(data.graceEndsAt).toBeNull();
+    expect(data.pickablePlans.map((p) => p.id)).toEqual(['solo', 'growth', 'scale']);
+    expect(data.usage.runs.limit).toBe(20); // Free's runsPerMonth
+  });
+
+  it('active paying plan: portal offered, no grace banner', async () => {
+    const now = new Date();
+    const { orgId } = await makeSubscriptionOrg('billing-active', {
+      status: 'active',
+      currentPeriodStart: now,
+      currentPeriodEnd: new Date(now.getTime() + 30 * DAY_MS),
+    });
+    const data = await billingLoad(loaderEvent(orgId, 'admin'));
+    if (data.selfHost) throw new Error('expected cloud data');
+    expect(data.source).toBe('subscription');
+    expect(data.planId).toBe('growth');
+    expect(data.hasStripeCustomer).toBe(true);
+    expect(data.status).toBe('active');
+    expect(data.interval).toBe('month');
+    expect(data.cancelAtPeriodEnd).toBe(false);
+    expect(data.readOnly).toBe(false);
+    expect(data.graceEndsAt).toBeNull();
+    expect(data.usage.runs.limit).toBe(2000); // the subscription's own mirrored limit
+  });
+
+  it('a yearly period resolves interval "year"', async () => {
+    const now = new Date();
+    const { orgId } = await makeSubscriptionOrg('billing-yearly', {
+      status: 'active',
+      currentPeriodStart: now,
+      currentPeriodEnd: new Date(now.getTime() + 365 * DAY_MS),
+    });
+    const data = await billingLoad(loaderEvent(orgId, 'admin'));
+    if (data.selfHost) throw new Error('expected cloud data');
+    expect(data.interval).toBe('year');
+  });
+
+  it('past_due inside the grace window: banner named with the real date, still not read-only', async () => {
+    const now = new Date();
+    const { orgId, subscriptionId, customerId } = await makeSubscriptionOrg('billing-grace', {
+      status: 'past_due',
+      currentPeriodStart: new Date(now.getTime() - 20 * DAY_MS),
+      currentPeriodEnd: new Date(now.getTime() + 10 * DAY_MS),
+    });
+    await markPastDue(subscriptionId, customerId, GRACE_PERIOD_DAYS - 2);
+    const data = await billingLoad(loaderEvent(orgId, 'admin'));
+    if (data.selfHost) throw new Error('expected cloud data');
+    expect(data.status).toBe('past_due');
+    expect(data.readOnly).toBe(false);
+    expect(data.graceEndsAt).not.toBeNull();
+    expect(new Date(data.graceEndsAt as string).getTime()).toBeGreaterThan(now.getTime());
+    // Still a live customer, so the portal is still the right action.
+    expect(data.hasStripeCustomer).toBe(true);
+  });
+
+  it('past the grace window: read-only, louder', async () => {
+    const now = new Date();
+    const { orgId, subscriptionId, customerId } = await makeSubscriptionOrg('billing-readonly', {
+      status: 'past_due',
+      currentPeriodStart: new Date(now.getTime() - 20 * DAY_MS),
+      currentPeriodEnd: new Date(now.getTime() + 10 * DAY_MS),
+    });
+    await markPastDue(subscriptionId, customerId, GRACE_PERIOD_DAYS + 2);
+    const data = await billingLoad(loaderEvent(orgId, 'admin'));
+    if (data.selfHost) throw new Error('expected cloud data');
+    expect(data.status).toBe('past_due');
+    expect(data.readOnly).toBe(true);
+    expect(data.graceEndsAt).not.toBeNull();
+    expect(new Date(data.graceEndsAt as string).getTime()).toBeLessThan(now.getTime());
+  });
+
+  it('cancel_at_period_end set: named with the real date, portal still offered', async () => {
+    const now = new Date();
+    const periodEnd = new Date(now.getTime() + 12 * DAY_MS);
+    const { orgId } = await makeSubscriptionOrg('billing-cancelling', {
+      status: 'active',
+      currentPeriodStart: now,
+      currentPeriodEnd: periodEnd,
+      cancelAtPeriodEnd: true,
+    });
+    const data = await billingLoad(loaderEvent(orgId, 'admin'));
+    if (data.selfHost) throw new Error('expected cloud data');
+    expect(data.cancelAtPeriodEnd).toBe(true);
+    expect(data.currentPeriodEnd).toBe(periodEnd.toISOString());
+    expect(data.hasStripeCustomer).toBe(true);
+    expect(data.readOnly).toBe(false);
+  });
+
+  it('an instance-admin grant: no Stripe customer, so no portal link', async () => {
+    const orgId = await makeGrantOrg('billing-grant', 'growth');
+    const data = await billingLoad(loaderEvent(orgId, 'admin'));
+    if (data.selfHost) throw new Error('expected cloud data');
+    expect(data.source).toBe('grant');
+    expect(data.planId).toBe('growth');
+    expect(data.hasStripeCustomer).toBe(false);
+    expect(data.status).toBeNull();
+    expect(data.usage.runs.limit).toBe(2000); // catalogue's growth number, not a subscription row
+  });
+});


### PR DESCRIPTION
Closes #555.

## What changed

Adds `/settings/billing`, an eleventh settings route between Organization and
Retention. Its loader reads only `resolveEntitlements` and `getOrgUsage`
(`@pitchbox/shared/plans` / `@pitchbox/shared/usage`) for every number, plus
the org's own `organizations`/`org_subscriptions` rows for the display-only
fields neither of those expose: the Stripe customer id (to decide whether the
portal link is safe to show, matching `/api/billing/portal`'s own
`NoStripeCustomerError` gate rather than guessing from `entitlements.source`),
and the raw period bounds/cancel flag/status Stripe mirrors onto
`org_subscriptions`. Nothing in this page declares a plan limit.

The page shows the plan, its price and interval (derived from the mirrored
period's length, since nothing persists which interval a subscription was
actually bought at), the period it renews or cancels on, a usage bar per
metered axis (runs, suggestions, projects, seats, paired devices; connected
accounts and model spend shown but not gated the same way), and one action per
state:

- **Free** (no subscription): a plan picker (Solo/Growth/Scale x Monthly/
  Yearly) that posts to the existing `/api/billing/checkout`.
- **Active subscription**: "Open customer portal" (`/api/billing/portal`).
- **`past_due` inside the grace window**: an amber banner named with the real
  date from `entitlements.graceEndsAt` (never restates the 14-day constant),
  portal button still offered.
- **Read-only past the grace window**: the same banner, rose and louder.
- **`cancel_at_period_end` set**: the plan card says "cancels on `<date>`"
  instead of "renews on", portal still offered (that's where reactivation
  lives).
- **Instance-admin grant** (`source: 'grant'`): a "Granted" badge and a note
  that it isn't billed through Stripe - no portal link, since `hasStripeCustomer`
  is false and there's no Stripe subscription behind it, and no checkout picker
  either (starting one would charge real money for a plan the grant already
  overrides).

**Self-host decision** (`currentEdition() !== 'cloud'`): the rail hides the
`Billing` link entirely rather than rendering an empty plan card with dashes,
the same convention `organization` already uses for "not applicable in this
context" (root `+layout.server.ts` gets a new `isCloud` flag alongside
`isAdmin`). A stray direct hit on the URL still loads and says self-host is
unlimited, rather than 404ing or showing a misleading empty state.

**Role gate**: `requireRole(event, 'admin')` in the loader, same posture as
Retention/Security/LinkedIn assist/Companion (throws, doesn't narrow like
Quota/Runners) - added to `docs/permissions.md`'s route table and its
`#254` narrative section in this PR, per the issue.

Every value in the markup is an existing Tailwind/shadcn token (`Card`,
`Badge`, `Progress`, `Button`, `TONE_BANNER_CLASS` reused verbatim from
`BillingGraceBanner` for the two banner tones) - no raw hex, px or shadow.

## Verified

- `pnpm exec vitest run web/tests/settings-billing.test.ts` - 10 cases green:
  role gate (member 403, admin 200), self-host early return, free (plan
  picker + Free's real `runsPerMonth` limit), an active subscription (portal
  offered, correct interval for both a ~30-day and a ~365-day period), `past_due`
  inside the grace window (not read-only, real `graceEndsAt`), past the grace
  window (read-only), `cancel_at_period_end` (real date, portal still offered),
  and an instance-admin grant (no Stripe customer, so no portal, catalogue's
  own limit rather than a subscription row).
- `pnpm -F web check` - 0 errors, 0 warnings.
- `npx eslint`/`npx prettier --check` on every changed non-Svelte file - clean.
- Real render: `pnpm run dev:web` on my own worktree port (5219), seeding each
  of the six states directly in Postgres (never faking the loader) against the
  `default` org, then `uishot` in light and dark at desktop (1440x900), tablet
  (768x1024) and mobile (390x844), `--axe` on every state at desktop.
  - Free state's first render surfaced a real defect: every usage `Progress`
    bar had no accessible name (`aria-progressbar-name`, serious). Fixed by
    adding `aria-label` to each bar; re-shot clean.
  - The two axe findings that remained on every state (`color-contrast` on the
    sidebar's version footer, `region` on the command palette's `sr-only` live
    text) are pre-existing on every page in the app - traced both to elements
    outside this page's markup (`SystemStatusCard.svelte`'s footer,
    `CommandPalette.svelte`'s announcer) via `tab.evaluate` - and left alone as
    out of scope for this issue.
  - No horizontal overflow at 390px for either the three-plan picker grid or
    the longest banner text (read-only's three-sentence copy wraps cleanly).

## Left alone

- The extension panel's own billing surface (#556) and the in-app limit
  notifications (#557) - explicit non-goals, owned by this wave's other
  agents.
- `shared/src/billing/*` - server side, already shipped.
- The marketing pricing page (#558, not built yet) - this page's plan picker
  is a self-contained fallback for a free org that needs to upgrade, not a
  copy of that page.

## Linear

I'd set this issue's Linear counterpart to `Done` once merged - I don't have
write access to Linear from this worktree, so reporting the state for `Main`
to apply.
