### PR TITLE
feat(extension,web): the panel narrates the loop, continues a retune, and knows the plan

### DIFF
--- a/extension/src/content/linkedin-comment-assist-panel.svelte
+++ b/extension/src/content/linkedin-comment-assist-panel.svelte
@@ -21,7 +21,8 @@
    * model's (D18).
    */
   import PanelFrame from './panel-frame.svelte';
-  import { t } from '../lib/i18n/index.js';
+  import { t, locale } from '../lib/i18n/index.js';
+  import { describeStatus } from './shared/assist-status.js';
   import type { CommentAssistPanelProps } from './linkedin-comment-assist.js';
   import type { RetuneDirection } from '../lib/api.js';
 
@@ -92,7 +93,7 @@
         </div>
       {:else if assistState.phase === 'streaming'}
         <p class="assist-status" aria-live="polite">
-          {$t(assistState.status === 'reading' ? 'assist.status.reading' : 'assist.status.writing')}
+          {describeStatus(assistState.status, $t, $locale)}
         </p>
         <!-- While the stream is open the reasoning is the whole point of
              showing anything: it arrives before the draft does and it is
@@ -119,6 +120,9 @@
           value={assistState.draft}
           oninput={onTextareaInput}
         ></textarea>
+        {#if assistState.phase === 'ready' && assistState.budgetExhausted}
+          <p class="assist-hint" role="status">{$t('assist.status.budget_exhausted')}</p>
+        {/if}
         <div class="assist-row">
           <button type="button" class="assist-button" onclick={onAccept}>
             {$t('assist.action.accept')}
@@ -226,6 +230,13 @@
         {/if}
       {:else if assistState.phase === 'refused'}
         <p class="assist-refusal" role="alert">{$t(assistState.messageKey, assistState.messageParams)}</p>
+        {#if assistState.link}
+          <p class="assist-hint">
+            <a class="assist-link" href={assistState.link} target="_blank" rel="noopener noreferrer">
+              {$t('assist.action.open_billing')}
+            </a>
+          </p>
+        {/if}
         <div class="assist-row">
           <button type="button" class="assist-button assist-button--ghost" onclick={onRequest}>
             {$t('assist.action.retry')}

--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -369,13 +369,13 @@ function resolveAnchor(composer: HTMLElement): Element {
   return composer.closest('form') ?? composer;
 }
 
-function logRefusal(reason: string): void {
+function logRefusal(reason: string, detail?: Record<string, unknown>): void {
   logFromContent({
     level: 'warn',
     source: 'linkedin-action',
     message: 'activity.linkedin-action.suggestion-refused',
     messageParams: { reason },
-    meta: { reason, script: 'linkedin-comment-assist' },
+    meta: { reason, script: 'linkedin-comment-assist', ...detail },
   });
 }
 
@@ -514,7 +514,7 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
   if (autoRequest) void requestSuggestion();
 
   async function setRefused(reason: string, detail?: Record<string, unknown>): Promise<void> {
-    logRefusal(reason);
+    logRefusal(reason, detail);
     const { key, params } = refusalMessage(reason);
     let link: string | undefined;
     if (billingLinkFor(reason)) {

--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -5,7 +5,9 @@ import './shared/trusted-types-shim.js';
 import { claimDocument } from './shared/claim-document.js';
 import {
   api,
+  pickPairing,
   type AcceptRefusalReason,
+  type AssistStatusPhase,
   type RetuneDirection,
   type SuggestEvent,
   type SuggestUsage,
@@ -270,6 +272,11 @@ const KNOWN_REFUSALS: Record<AssistRefusal, true> = {
   selector_health_degraded: true,
   generation_failed: true,
   extension_reloaded: true,
+  // #556: the plan's own ceiling and a failed payment past its grace
+  // window - distinct from `quota_exhausted` so the panel can say which
+  // one stopped it and point at billing rather than a generic upgrade.
+  plan_limit_reached: true,
+  plan_payment_required: true,
 };
 
 /**
@@ -310,6 +317,12 @@ export function refusalMessage(reason: string): {
   return { key: 'assist.refusal.unknown', params: { reason } };
 }
 
+/** Whether `reason` is one #556 gives its own link to billing settings, in
+ * a new tab, alongside its message. */
+function billingLinkFor(reason: string): boolean {
+  return reason === 'plan_limit_reached' || reason === 'plan_payment_required';
+}
+
 /**
  * State machine (#382): `reasoning` and `draft` travel apart through every
  * phase that carries both, so nothing here can ever hand the model's
@@ -321,13 +334,20 @@ export function refusalMessage(reason: string): {
  */
 export type CommentAssistState =
   | { phase: 'resting' }
-  | { phase: 'streaming'; status: 'reading' | 'writing'; reasoning: string; draft: string }
-  | { phase: 'ready'; reasoning: string; draft: string }
+  | { phase: 'streaming'; status: AssistStatusPhase; reasoning: string; draft: string }
+  | { phase: 'ready'; reasoning: string; draft: string; budgetExhausted?: boolean }
   | { phase: 'edited'; reasoning: string; draft: string }
   | { phase: 'accepting'; reasoning: string; draft: string }
   | { phase: 'inserted' }
   | { phase: 'no_draft'; reasoning: string; skipped: boolean }
-  | { phase: 'refused'; messageKey: string; messageParams?: Record<string, string> };
+  | {
+      phase: 'refused';
+      messageKey: string;
+      messageParams?: Record<string, string>;
+      /** #556: opens `/settings/billing` on the paired backend, in a new
+       * tab - present only for the two plan refusals. */
+      link?: string;
+    };
 
 export type CommentAssistPanelProps = {
   subject?: string;
@@ -445,6 +465,11 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
   let personalProjectId: number | null = null;
   let lastUsage: SuggestUsage | undefined;
   let lastMs: number | undefined;
+  // #576: the live session id from the last `done` event, if any - handed
+  // straight back on the next retune so the loop continues instead of
+  // starting over. Cleared implicitly by a fresh `resting`/`streaming` cycle
+  // never reading it before a `done` sets it again.
+  let lastSessionId: string | undefined;
 
   // What the panel shows the instant it appears, and whether anything is
   // asked for at all (#439): a result already generated for this card, then
@@ -488,23 +513,28 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
 
   if (autoRequest) void requestSuggestion();
 
-  function setRefused(reason: string): void {
+  async function setRefused(reason: string, detail?: Record<string, unknown>): Promise<void> {
     logRefusal(reason);
     const { key, params } = refusalMessage(reason);
+    let link: string | undefined;
+    if (billingLinkFor(reason)) {
+      const pairing = await pickPairing();
+      if (pairing) link = `${pairing.backendUrl}/settings/billing`;
+    }
     if (handle.alive) {
-      handle.update({ state: { phase: 'refused', messageKey: key, messageParams: params } });
+      handle.update({ state: { phase: 'refused', messageKey: key, messageParams: params, link } });
     }
   }
 
   async function requestSuggestion(retune?: RetuneDirection): Promise<void> {
     if (!capturedPost) {
-      setRefused('selector_health_degraded');
+      void setRefused('selector_health_degraded');
       return;
     }
     // Checked before the request, not inferred from its failure: a dead
     // context fails the same way an unreachable backend does (#438).
     if (!extensionContextAlive()) {
-      setRefused('extension_reloaded');
+      void setRefused('extension_reloaded');
       return;
     }
     handle.update({ state: { phase: 'streaming', status: 'reading', reasoning: '', draft: '' } });
@@ -512,20 +542,20 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
     const assistRes = await api.linkedinAssist();
     if (!handle.alive) return;
     if (!assistRes.ok) {
-      setRefused('backend_unreachable');
+      void setRefused('backend_unreachable');
       return;
     }
     const { assist } = assistRes.data;
     if (assist.killSwitch) {
-      setRefused('kill_switch');
+      void setRefused('kill_switch');
       return;
     }
     if (!assist.enabled) {
-      setRefused('assist_disabled');
+      void setRefused('assist_disabled');
       return;
     }
     if (assist.projectId === null) {
-      setRefused('project_not_bound');
+      void setRefused('project_not_bound');
       return;
     }
     boundProjectId = assist.projectId;
@@ -557,6 +587,7 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
           image,
         },
         retune,
+        sessionId: lastSessionId,
       },
       (event: SuggestEvent) => {
         if (!handle.alive) return;
@@ -574,6 +605,7 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
           case 'done':
             lastUsage = event.usage;
             lastMs = event.ms;
+            lastSessionId = event.sessionId;
             currentReasoning = event.reasoning;
             if (event.draft === null) {
               logNoDraft(event.skipped);
@@ -586,27 +618,28 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
                 phase: 'ready',
                 reasoning: event.reasoning,
                 draft: event.draft,
+                budgetExhausted: event.budgetExhausted,
               };
               lastResultFor.set(anchor, ready);
               handle.update({ state: ready });
             }
             break;
           case 'failed':
-            setRefused('generation_failed');
+            void setRefused('generation_failed');
             break;
           case 'refused':
-            setRefused(event.reason);
+            void setRefused(event.reason, event.detail);
             break;
         }
       },
     );
     if (!handle.alive) return;
-    if (!res.ok) setRefused('backend_unreachable');
+    if (!res.ok) void setRefused('backend_unreachable');
   }
 
   async function acceptAndInsert(): Promise<void> {
     if (personalProjectId === null || !capturedPost) {
-      setRefused('selector_health_degraded');
+      void setRefused('selector_health_degraded');
       return;
     }
     handle.update({
@@ -627,11 +660,11 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
     });
     if (!handle.alive) return;
     if (!res.ok) {
-      setRefused('backend_unreachable');
+      void setRefused('backend_unreachable');
       return;
     }
     if (!res.data.accepted) {
-      setRefused(res.data.refused);
+      void setRefused(res.data.refused);
       return;
     }
 

--- a/extension/src/content/linkedin-post-assist-panel.svelte
+++ b/extension/src/content/linkedin-post-assist-panel.svelte
@@ -16,7 +16,8 @@
    * differently is drift, so this file changes whenever that one does.
    */
   import PanelFrame from './panel-frame.svelte';
-  import { t } from '../lib/i18n/index.js';
+  import { t, locale } from '../lib/i18n/index.js';
+  import { describeStatus } from './shared/assist-status.js';
   import type { PostAssistPanelProps } from './linkedin-post-assist.js';
   import type { RetuneDirection } from '../lib/api.js';
 
@@ -73,7 +74,7 @@
         </div>
       {:else if assistState.phase === 'streaming'}
         <p class="assist-status" aria-live="polite">
-          {$t(assistState.status === 'reading' ? 'assist.status.reading' : 'assist.status.writing')}
+          {describeStatus(assistState.status, $t, $locale)}
         </p>
         {#if assistState.reasoning}
           <p class="assist-hint">{assistState.reasoning}</p>
@@ -95,6 +96,9 @@
           value={assistState.draft}
           oninput={onTextareaInput}
         ></textarea>
+        {#if assistState.phase === 'ready' && assistState.budgetExhausted}
+          <p class="assist-hint" role="status">{$t('assist.status.budget_exhausted')}</p>
+        {/if}
         <div class="assist-row">
           <button type="button" class="assist-button" onclick={onAccept}>
             {$t('assist.action.accept')}
@@ -188,6 +192,13 @@
         {/if}
       {:else if assistState.phase === 'refused'}
         <p class="assist-refusal" role="alert">{$t(assistState.messageKey, assistState.messageParams)}</p>
+        {#if assistState.link}
+          <p class="assist-hint">
+            <a class="assist-link" href={assistState.link} target="_blank" rel="noopener noreferrer">
+              {$t('assist.action.open_billing')}
+            </a>
+          </p>
+        {/if}
         <div class="assist-row">
           <button type="button" class="assist-button assist-button--ghost" onclick={onRequest}>
             {$t('assist.action.retry')}

--- a/extension/src/content/linkedin-post-assist.ts
+++ b/extension/src/content/linkedin-post-assist.ts
@@ -347,7 +347,7 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
       source: 'linkedin-action',
       message: 'activity.linkedin-action.suggestion-refused',
       messageParams: { reason },
-      meta: { reason, script: 'linkedin-post-assist' },
+      meta: { reason, script: 'linkedin-post-assist', ...detail },
     });
     const { key, params } = refusalMessage(reason);
     let link: string | undefined;

--- a/extension/src/content/linkedin-post-assist.ts
+++ b/extension/src/content/linkedin-post-assist.ts
@@ -5,7 +5,9 @@ import './shared/trusted-types-shim.js';
 import { claimDocument } from './shared/claim-document.js';
 import {
   api,
+  pickPairing,
   type AcceptRefusalReason,
+  type AssistStatusPhase,
   type RetuneDirection,
   type SuggestEvent,
   type SuggestUsage,
@@ -128,7 +130,15 @@ const KNOWN_REFUSALS: Record<PostAssistRefusal, true> = {
   blocked: true,
   backend_unreachable: true,
   generation_failed: true,
+  plan_limit_reached: true,
+  plan_payment_required: true,
 };
+
+/** Whether `reason` is one #556 gives its own link to billing settings, in
+ * a new tab, alongside its message. Mirrors the comment assist's own. */
+function billingLinkFor(reason: string): boolean {
+  return reason === 'plan_limit_reached' || reason === 'plan_payment_required';
+}
 
 /**
  * Maps a refusal reason to its own i18n key. `quota_exhausted` gets a key
@@ -157,13 +167,18 @@ export function refusalMessage(reason: string): {
  */
 export type PostAssistState =
   | { phase: 'resting' }
-  | { phase: 'streaming'; status: 'reading' | 'writing'; reasoning: string; draft: string }
-  | { phase: 'ready'; reasoning: string; draft: string }
+  | { phase: 'streaming'; status: AssistStatusPhase; reasoning: string; draft: string }
+  | { phase: 'ready'; reasoning: string; draft: string; budgetExhausted?: boolean }
   | { phase: 'edited'; reasoning: string; draft: string }
   | { phase: 'accepting'; reasoning: string; draft: string }
   | { phase: 'inserted' }
   | { phase: 'no_draft'; reasoning: string; skipped: boolean }
-  | { phase: 'refused'; messageKey: string; messageParams?: Record<string, string> };
+  | {
+      phase: 'refused';
+      messageKey: string;
+      messageParams?: Record<string, string>;
+      link?: string;
+    };
 
 export type PostAssistPanelProps = {
   state: PostAssistState;
@@ -302,6 +317,8 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
   let personalProjectId: number | null = null;
   let lastUsage: SuggestUsage | undefined;
   let lastMs: number | undefined;
+  // #576: the live session id from the last `done` event, if any.
+  let lastSessionId: string | undefined;
 
   const props: PostAssistPanelProps = {
     state: { phase: 'resting' },
@@ -324,7 +341,7 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
     onDismiss: () => handle.destroy(),
   });
 
-  function setRefused(reason: string): void {
+  async function setRefused(reason: string, detail?: Record<string, unknown>): Promise<void> {
     logFromContent({
       level: 'warn',
       source: 'linkedin-action',
@@ -333,8 +350,13 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
       meta: { reason, script: 'linkedin-post-assist' },
     });
     const { key, params } = refusalMessage(reason);
+    let link: string | undefined;
+    if (billingLinkFor(reason)) {
+      const pairing = await pickPairing();
+      if (pairing) link = `${pairing.backendUrl}/settings/billing`;
+    }
     if (handle.alive) {
-      handle.update({ state: { phase: 'refused', messageKey: key, messageParams: params } });
+      handle.update({ state: { phase: 'refused', messageKey: key, messageParams: params, link } });
     }
   }
 
@@ -344,20 +366,20 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
     const assistRes = await api.linkedinAssist();
     if (!handle.alive) return;
     if (!assistRes.ok) {
-      setRefused('backend_unreachable');
+      void setRefused('backend_unreachable');
       return;
     }
     const { assist } = assistRes.data;
     if (assist.killSwitch) {
-      setRefused('kill_switch');
+      void setRefused('kill_switch');
       return;
     }
     if (!assist.enabled) {
-      setRefused('assist_disabled');
+      void setRefused('assist_disabled');
       return;
     }
     if (assist.projectId === null) {
-      setRefused('project_not_bound');
+      void setRefused('project_not_bound');
       return;
     }
     boundProjectId = assist.projectId;
@@ -369,7 +391,13 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
     // observation buffer for `kind: 'post'` (see the module doc comment).
     // `post` here is informational context only.
     const res = await api.suggest(
-      { projectId: boundProjectId, kind: POST_KIND, post: { url: location.href }, retune },
+      {
+        projectId: boundProjectId,
+        kind: POST_KIND,
+        post: { url: location.href },
+        retune,
+        sessionId: lastSessionId,
+      },
       (event: SuggestEvent) => {
         if (!handle.alive) return;
         switch (event.kind) {
@@ -386,6 +414,7 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
           case 'done':
             lastUsage = event.usage;
             lastMs = event.ms;
+            lastSessionId = event.sessionId;
             currentReasoning = event.reasoning;
             if (event.draft === null) {
               logNoDraft(event.skipped);
@@ -395,26 +424,31 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
             } else {
               currentDraft = event.draft;
               handle.update({
-                state: { phase: 'ready', reasoning: event.reasoning, draft: event.draft },
+                state: {
+                  phase: 'ready',
+                  reasoning: event.reasoning,
+                  draft: event.draft,
+                  budgetExhausted: event.budgetExhausted,
+                },
               });
             }
             break;
           case 'failed':
-            setRefused('generation_failed');
+            void setRefused('generation_failed');
             break;
           case 'refused':
-            setRefused(event.reason);
+            void setRefused(event.reason, event.detail);
             break;
         }
       },
     );
     if (!handle.alive) return;
-    if (!res.ok) setRefused('backend_unreachable');
+    if (!res.ok) void setRefused('backend_unreachable');
   }
 
   async function acceptAndInsert(): Promise<void> {
     if (personalProjectId === null) {
-      setRefused('backend_unreachable');
+      void setRefused('backend_unreachable');
       return;
     }
     handle.update({
@@ -434,14 +468,13 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
     });
     if (!handle.alive) return;
     if (!res.ok) {
-      setRefused('backend_unreachable');
+      void setRefused('backend_unreachable');
       return;
     }
     if (!res.data.accepted) {
-      setRefused(res.data.refused);
+      void setRefused(res.data.refused);
       return;
     }
-
     insertComposerText(editor, currentDraft);
     watchPostForSend(modal, res.data.draftId);
     logFromContent({

--- a/extension/src/content/panel.css
+++ b/extension/src/content/panel.css
@@ -422,6 +422,21 @@
   color: var(--destructive);
 }
 
+/* #556: the plan-refusal link, opening /settings/billing in a new tab
+ * alongside `.assist-refusal` above. `--link` exists precisely because
+ * `--primary` resolves to near-white in this dark palette (D3) - the
+ * dashboard's own Markdown links use the same token for the same reason. */
+.assist-link {
+  color: var(--link);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.assist-link:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+}
+
 /* A state's own headline, in the product's voice: "No suggestion for this
  * post", "Inserted". One step above the hint under it, and the reason
  * `.assist-status` is no longer carrying copy it was never sized for

--- a/extension/src/content/shared/assist-status.ts
+++ b/extension/src/content/shared/assist-status.ts
@@ -1,0 +1,57 @@
+/**
+ * Turns the SSE `status` event's `phase` (#573) into the one line the panel
+ * shows next to the skeleton (D12, D27 in docs/design/DECISIONS.md). Shared
+ * between `linkedin-comment-assist-panel.svelte` and
+ * `linkedin-post-assist-panel.svelte`, which must never each invent their
+ * own wording for the same phase.
+ *
+ * `phase` arrives as one of three fixed values (`reading`, `writing`,
+ * `slow`) or, while a tool step is running, a comma-joined set of the tool
+ * names the loop is actually running that step
+ * (`web/src/routes/api/extension/suggest/+server.ts`'s own `onToolStep`
+ * wiring, `toolNames.join(',')`). Each recognised tool name maps to its own
+ * lowercase clause in the operator's own words - D27's quoted examples
+ * ("reading the thread", "looking at the image", "checking your prior
+ * takes") are exactly the single-tool case below - and several running at
+ * once (`docs/design/in-page-agent.md`'s parallelism section) are joined
+ * the way a human would list them, via `Intl.ListFormat`, rather than
+ * rendered as separate lines: the panel is never quiet for longer than a
+ * step, but it also never scrolls through five lines for one. A tool name
+ * this build does not recognise still renders, as a generic "still working
+ * on it" clause, rather than a raw identifier or nothing.
+ */
+
+const STEP_KEYS: Record<string, string> = {
+  read_thread: 'assist.status.step.read_thread',
+  look_at_image: 'assist.status.step.look_at_image',
+  author_history: 'assist.status.step.author_history',
+  operator_voice: 'assist.status.step.operator_voice',
+  project_knowledge: 'assist.status.step.project_knowledge',
+  my_prior_takes: 'assist.status.step.my_prior_takes',
+  check_style: 'assist.status.step.check_style',
+};
+
+/**
+ * `t`/`locale` are passed in rather than imported from `lib/i18n/index.js`
+ * directly so this stays reactive to the caller's own `$t`/`$locale` store
+ * subscriptions instead of reading a snapshot - both panels already hold
+ * both live.
+ */
+export function describeStatus(
+  phase: string,
+  t: (key: string, params?: Record<string, string | number>) => string,
+  locale: string,
+): string {
+  if (phase === 'reading' || phase === '') return t('assist.status.reading');
+  if (phase === 'writing') return t('assist.status.writing');
+  if (phase === 'slow') return t('assist.status.slow');
+
+  const names = phase.split(',').filter(Boolean);
+  if (names.length === 0) return t('assist.status.reading');
+
+  const phrases = names.map((name) => t(STEP_KEYS[name] ?? 'assist.status.step.unknown'));
+  const joined = new Intl.ListFormat(locale, { style: 'long', type: 'conjunction' }).format(
+    phrases,
+  );
+  return `${joined.charAt(0).toUpperCase()}${joined.slice(1)}…`;
+}

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -26,6 +26,21 @@ export type LinkedInAssistState = {
   dailyPostCap: number;
 };
 
+/** The exact shape served alongside `assist` by the same endpoint (#556):
+ * the plan's own name, the suggestion allowance for this period and how
+ * much of it is left (both null when unlimited - self-host, or a plan with
+ * no ceiling), and whether the org is read-only from a failed payment. For
+ * display only - the panel never predicts a refusal from this, it only
+ * explains one the server already returned. */
+export type LinkedInAssistPlanState = {
+  id: string;
+  name: string;
+  suggestionsUsed: number;
+  suggestionsLimit: number | null;
+  suggestionsRemaining: number | null;
+  readOnly: boolean;
+};
+
 // #436, spike #435's "Plane 3": types mirror the server's own zod schemas
 // (web/src/routes/api/extension/project-source-match/+server.ts) rather
 // than importing them, matching every other api.ts shape on this file.
@@ -139,6 +154,30 @@ export type SuggestUsage = {
  */
 export type RetuneDirection = 'drier' | 'warmer' | 'shorter';
 
+/**
+ * Every `status` phase the loop can honestly report (#573,
+ * docs/design/in-page-agent.md): `reading` before the loop has decided
+ * anything and `writing` once real draft text starts are unchanged; a live
+ * tool step reports as that tool's own name (or several, comma-joined, when
+ * a step ran more than one in parallel), and `slow` marks the "taking longer
+ * than usual" threshold. `(string & {})` keeps autocomplete on the known
+ * values while still accepting a comma-joined combination or a future name
+ * this build does not recognise yet - `shared/content/assist-status.ts`
+ * degrades an unknown one to its raw text rather than dropping it.
+ */
+export type AssistStatusPhase =
+  | 'reading'
+  | 'writing'
+  | 'slow'
+  | 'read_thread'
+  | 'look_at_image'
+  | 'author_history'
+  | 'operator_voice'
+  | 'project_knowledge'
+  | 'my_prior_takes'
+  | 'check_style'
+  | (string & {});
+
 /** Every `refused` value POST /api/extension/suggest can answer with, ahead of the stream.
  * `no_recent_activity` only ever answers a `kind: 'post'` request: the observation
  * buffer this project's account has filled has nothing recent enough to draft from. */
@@ -147,7 +186,12 @@ export type SuggestRefusalReason =
   | 'kill_switch'
   | 'project_not_bound'
   | 'quota_exhausted'
-  | 'no_recent_activity';
+  | 'no_recent_activity'
+  // #556: the plan's own ceiling and a failed payment past its grace window -
+  // distinct from `quota_exhausted` (the platform's own daily cap) and from
+  // each other, so the panel can say which one stopped it and what to do.
+  | 'plan_limit_reached'
+  | 'plan_payment_required';
 
 /** Every `refused` value POST /api/extension/suggest/accept can answer with: the same
  * assist gate as /suggest, plus shared/src/assist-accept.ts's own refusals for a
@@ -171,7 +215,7 @@ export type AcceptRefusalReason =
  * happens.
  */
 export type SuggestEvent =
-  | { kind: 'status'; phase: 'reading' | 'writing' }
+  | { kind: 'status'; phase: AssistStatusPhase }
   | { kind: 'chunk'; text: string; section: 'reasoning' | 'draft' }
   | {
       kind: 'done';
@@ -180,6 +224,13 @@ export type SuggestEvent =
       skipped: boolean;
       usage?: SuggestUsage;
       ms: number;
+      // #576: hand this back on the next retune/hint so the loop continues
+      // instead of starting over. Absent when there was nothing to persist.
+      sessionId?: string;
+      // #573: a genuine early stop with a draft already in hand - the panel
+      // says it answered with what it had rather than treating this as an
+      // ordinary, deliberate finish.
+      budgetExhausted?: boolean;
     }
   | { kind: 'failed'; message: string }
   | { kind: 'refused'; reason: SuggestRefusalReason; detail: Record<string, unknown> };
@@ -300,8 +351,8 @@ export function parseSuggestSseFrame(frame: string): SuggestEvent | null {
   }
   switch (eventKind) {
     case 'status':
-      return data.phase === 'reading' || data.phase === 'writing'
-        ? { kind: 'status', phase: data.phase }
+      return typeof data.phase === 'string'
+        ? { kind: 'status', phase: data.phase as AssistStatusPhase }
         : null;
     case 'chunk':
       return typeof data.text === 'string' &&
@@ -317,6 +368,9 @@ export function parseSuggestSseFrame(frame: string): SuggestEvent | null {
             skipped: data.skipped,
             usage: data.usage as SuggestUsage | undefined,
             ms: typeof data.ms === 'number' ? data.ms : 0,
+            sessionId: typeof data.sessionId === 'string' ? data.sessionId : undefined,
+            budgetExhausted:
+              typeof data.budgetExhausted === 'boolean' ? data.budgetExhausted : undefined,
           }
         : null;
     case 'failed':
@@ -551,7 +605,7 @@ export const api = {
    */
   linkedinAssist: async (
     backendUrl?: string,
-  ): Promise<ApiResult<{ assist: LinkedInAssistState }>> => {
+  ): Promise<ApiResult<{ assist: LinkedInAssistState; plan: LinkedInAssistPlanState }>> => {
     const p = await pickPairing(backendUrl);
     if (!p) return { ok: false, status: 0, error: 'not configured' };
     return getJson(p, '/api/extension/linkedin-assist');
@@ -642,6 +696,10 @@ export const api = {
       /** #409: a per-call regeneration direction, forwarded verbatim - never
        * stored, never a substitute for a tone setting. */
       retune?: RetuneDirection;
+      /** #576: a live session id from a prior `done` event - continues that
+       * turn's gathered context instead of a full rebuild. Omit for a first
+       * suggestion; there is nothing yet to continue. */
+      sessionId?: string;
       platform?: string;
     },
     onEvent: (event: SuggestEvent) => void,

--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -293,6 +293,19 @@ export const en = {
 
   'dashboard.connection.no-active-tab': 'No active tab',
 
+  // #556: the plan readout PairingList.svelte shows per paired backend,
+  // display only - the server refuses regardless of what this says
+  // (docs/design/DECISIONS.md D28). `plan-remaining-low` is the same fact
+  // as `plan-remaining`, worded to stand out once suggestionsRemaining
+  // drops to the 80%-used warning threshold #557 already established
+  // elsewhere in this product.
+  'dashboard.connection.plan-remaining':
+    '{plan} plan: {remaining} of {limit} suggestions left this period',
+  'dashboard.connection.plan-remaining-low':
+    '{plan} plan: only {remaining} of {limit} suggestions left this period',
+  'dashboard.connection.plan-unlimited': '{plan} plan: unlimited suggestions',
+  'dashboard.connection.plan-read-only': '{plan} plan: read-only until the payment issue is fixed',
+
   // In-page panel chrome. The wordmark is the product name, so it is not
   // translated; everything else on this surface is.
   'panel.title': 'Pitchbox',
@@ -305,6 +318,24 @@ export const en = {
   'assist.comment.resting.cta': 'Suggest a comment',
   'assist.status.reading': 'Reading the post…',
   'assist.status.writing': 'Writing…',
+  // #573: the loop's own step narration - see
+  // content/shared/assist-status.ts's own doc comment for how a tool name
+  // becomes one of these clauses and how several running at once combine.
+  // Lowercase and without a leading capital: `describeStatus` capitalises
+  // whichever one (or combination) actually renders.
+  'assist.status.step.read_thread': 'reading the thread',
+  'assist.status.step.look_at_image': 'looking at the image',
+  'assist.status.step.author_history': 'checking what you have said to them before',
+  'assist.status.step.operator_voice': 'finding how you have written about this',
+  'assist.status.step.project_knowledge': 'checking what it knows about this project',
+  'assist.status.step.my_prior_takes': 'checking your prior takes',
+  'assist.status.step.check_style': 'checking the style',
+  'assist.status.step.unknown': 'still working on it',
+  // Past the 35s soft budget (docs/design/in-page-agent.md section 2, D27).
+  'assist.status.slow': 'This is taking longer than usual.',
+  // A genuine early stop at the 90s hard ceiling with a draft already in
+  // hand - said plainly rather than surfaced as an error (D27).
+  'assist.status.budget_exhausted': 'Answered with what it had time to gather.',
   'assist.comment.ready.label': 'Suggested comment (editable)',
   'assist.action.accept': 'Insert',
   'assist.action.retry': 'Try again',
@@ -353,6 +384,13 @@ export const en = {
   'assist.refusal.selector_health_degraded':
     "LinkedIn's layout changed and Pitchbox could not read this post reliably.",
   'assist.refusal.generation_failed': 'Something went wrong while writing the suggestion.',
+  // #556: the plan's own ceiling and a failed payment past its grace
+  // window - distinct from `quota_exhausted` (the platform's own daily
+  // cap) so the panel can say which one stopped it, each with a link that
+  // opens `/settings/billing` in a new tab (D28).
+  'assist.refusal.plan_limit_reached': "Your plan's suggestion limit for this period is used up.",
+  'assist.refusal.plan_payment_required': 'Fix your payment to keep using the assistant.',
+  'assist.action.open_billing': 'Open billing settings',
   // The content script's own extension context dies on a reload/update of
   // the extension itself while this tab stayed open - every message.send
   // to the background worker then fails the same way `backend_unreachable`

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -283,6 +283,15 @@ export const it = {
 
   'dashboard.connection.no-active-tab': 'Nessuna scheda attiva',
 
+  // #556: vedi il commento in dict-en.ts.
+  'dashboard.connection.plan-remaining':
+    'Piano {plan}: {remaining} di {limit} suggerimenti rimasti in questo periodo',
+  'dashboard.connection.plan-remaining-low':
+    'Piano {plan}: solo {remaining} di {limit} suggerimenti rimasti in questo periodo',
+  'dashboard.connection.plan-unlimited': 'Piano {plan}: suggerimenti illimitati',
+  'dashboard.connection.plan-read-only':
+    'Piano {plan}: sola lettura finché il problema di pagamento non è risolto',
+
   // In-page panel chrome. The wordmark is the product name, so it is not
   // translated; everything else on this surface is.
   'panel.title': 'Pitchbox',
@@ -293,6 +302,19 @@ export const it = {
   'assist.comment.resting.cta': 'Suggerisci un commento',
   'assist.status.reading': 'Lettura del post in corso…',
   'assist.status.writing': 'Scrittura in corso…',
+  // #573: vedi il commento in content/shared/assist-status.ts e in
+  // dict-en.ts. Minuscolo e senza iniziale maiuscola: `describeStatus`
+  // maiuscola quale che sia la frase (o combinazione) resa.
+  'assist.status.step.read_thread': 'lettura del thread',
+  'assist.status.step.look_at_image': "osservazione dell'immagine",
+  'assist.status.step.author_history': 'verifica di cosa hai già scritto a questa persona',
+  'assist.status.step.operator_voice': 'ricerca di come scrivi di solito su questo tema',
+  'assist.status.step.project_knowledge': 'verifica di cosa sa su questo progetto',
+  'assist.status.step.my_prior_takes': 'verifica dei tuoi commenti precedenti',
+  'assist.status.step.check_style': 'verifica dello stile',
+  'assist.status.step.unknown': 'ancora al lavoro',
+  'assist.status.slow': 'Questo sta richiedendo più tempo del solito.',
+  'assist.status.budget_exhausted': 'Risposto con quello che è riuscito a raccogliere in tempo.',
   'assist.comment.ready.label': 'Commento suggerito (modificabile)',
   'assist.action.accept': 'Inserisci',
   'assist.action.retry': 'Riprova',
@@ -327,6 +349,12 @@ export const it = {
     'Il layout di LinkedIn è cambiato e Pitchbox non è riuscito a leggere questo post in modo affidabile.',
   'assist.refusal.generation_failed':
     'Qualcosa è andato storto durante la scrittura del suggerimento.',
+  // #556: vedi il commento in dict-en.ts.
+  'assist.refusal.plan_limit_reached':
+    'Il limite di suggerimenti del tuo piano per questo periodo è esaurito.',
+  'assist.refusal.plan_payment_required':
+    "Risolvi il pagamento per continuare a usare l'assistente.",
+  'assist.action.open_billing': 'Apri le impostazioni di fatturazione',
   // See the comment on `assist.refusal.extension_reloaded` in dict-en.ts.
   'assist.refusal.extension_reloaded':
     'Pitchbox è stato ricaricato o aggiornato - ricarica questa pagina per riconnetterti.',

--- a/extension/src/sidepanel/components/PairingList.svelte
+++ b/extension/src/sidepanel/components/PairingList.svelte
@@ -13,7 +13,8 @@
   import { Input } from '$ui/input';
   import * as AlertDialog from '$ui/alert-dialog';
   import { t } from '$ext/i18n';
-  import { api } from '$ext/api';
+  import { api, type LinkedInAssistPlanState } from '$ext/api';
+  import PlanReadout from './PlanReadout.svelte';
   import {
     patchPairing,
     removePairing,
@@ -75,6 +76,23 @@
   type ConnectionTestResult = { ok: true; version: string } | { ok: false; error: string };
   let testPending = $state<Record<string, boolean>>({});
   let testResults = $state<Record<string, ConnectionTestResult>>({});
+
+  // #556: the plan and remaining-suggestion allowance per paired backend,
+  // display only - the server refuses regardless of what this says (D28
+  // in docs/design/DECISIONS.md). Fetched here rather than through home's
+  // own `getSettings()`/`chrome.storage` read: this is live backend state,
+  // not a stored pairing field, so it follows `testConnection`'s own
+  // per-row network-call posture instead of the storage-ownership rule.
+  let plans = $state<Record<string, LinkedInAssistPlanState>>({});
+
+  $effect(() => {
+    for (const p of pairings) void loadPlan(p.backendUrl);
+  });
+
+  async function loadPlan(backendUrl: string): Promise<void> {
+    const res = await api.linkedinAssist(backendUrl);
+    if (res.ok) plans = { ...plans, [backendUrl]: res.data.plan };
+  }
 
   // Every mutation below routes through home, which re-reads storage and
   // hands a fresh `pairings` back down.
@@ -353,6 +371,9 @@
                 ·
                 {$t('dashboard.connection.sync-ago', { ago: fmtAgo(p.lastDmSyncAt) })}
               </div>
+              {#if plans[p.backendUrl]}
+                <PlanReadout plan={plans[p.backendUrl]} />
+              {/if}
               {#if testResult}
                 <div
                   class="pl-4 text-xs {testResult.ok

--- a/extension/src/sidepanel/components/PlanReadout.svelte
+++ b/extension/src/sidepanel/components/PlanReadout.svelte
@@ -1,0 +1,48 @@
+<!-- The plan and remaining-suggestion allowance for one paired backend (#556),
+     shown next to that pairing's own connection state. Display only: the
+     server refuses a suggestion regardless of what this says
+     (docs/design/DECISIONS.md D28), so a stale fetch here can only ever
+     under- or over-state the allowance, never let one through.
+
+     Its own component, not inline in PairingList.svelte's row markup: that
+     component already carries the pairing/permission/dialog machinery, and
+     keeping this presentational sliver separate is what lets it be mounted
+     and tested on its own. `PairingList` owns the fetch (one owner reads
+     the network, matching how it already owns `chrome.storage`); this only
+     renders what it is handed. -->
+<script lang="ts">
+  import { t } from '$ext/i18n';
+  import type { LinkedInAssistPlanState } from '$ext/api';
+
+  let { plan }: { plan: LinkedInAssistPlanState } = $props();
+
+  // Reuses #557's own 80%-used notification threshold, so this readout's
+  // warning and the org's own email/webhook notice agree on what "near"
+  // means rather than inventing a second number.
+  const WARNING_USED_RATIO = 0.8;
+
+  function line(p: LinkedInAssistPlanState): { key: string; tone: string } {
+    if (p.readOnly) {
+      return { key: 'dashboard.connection.plan-read-only', tone: 'text-destructive' };
+    }
+    if (p.suggestionsLimit == null || p.suggestionsRemaining == null) {
+      return { key: 'dashboard.connection.plan-unlimited', tone: 'text-muted-foreground' };
+    }
+    const usedRatio = p.suggestionsLimit > 0 ? 1 - p.suggestionsRemaining / p.suggestionsLimit : 1;
+    if (usedRatio >= WARNING_USED_RATIO) {
+      return {
+        key: 'dashboard.connection.plan-remaining-low',
+        tone: 'text-amber-600 dark:text-amber-400',
+      };
+    }
+    return { key: 'dashboard.connection.plan-remaining', tone: 'text-muted-foreground' };
+  }
+</script>
+
+<div class="truncate pl-4 text-xs {line(plan).tone}">
+  {$t(line(plan).key, {
+    plan: plan.name,
+    remaining: plan.suggestionsRemaining ?? 0,
+    limit: plan.suggestionsLimit ?? 0,
+  })}
+</div>

--- a/extension/tests/content/linkedin-comment-assist.test.ts
+++ b/extension/tests/content/linkedin-comment-assist.test.ts
@@ -24,6 +24,10 @@ const suggest = vi.fn();
 const acceptSuggestion = vi.fn();
 const armed = vi.fn(async () => ({ ok: true as const, data: {} }));
 const sent = vi.fn(async () => ({ ok: true as const, data: {} }));
+// #556: only reached from `setRefused`'s `billingLinkFor` branch (the two
+// plan refusals) - every other test in this file never calls it, so a
+// resolved default here changes nothing for them.
+const pickPairing = vi.fn(async () => ({ backendUrl: 'https://app.pitchbox.app' }));
 
 vi.mock('../../src/lib/api.js', () => ({
   api: {
@@ -33,6 +37,7 @@ vi.mock('../../src/lib/api.js', () => ({
     armed: () => armed(),
     sent: () => sent(),
   },
+  pickPairing: () => pickPairing(),
 }));
 
 const logged: Array<Record<string, unknown>> = [];
@@ -749,6 +754,11 @@ describe('every refusal says which one it is', () => {
       'quota_exhausted',
       'backend_unreachable',
       'selector_health_degraded',
+      // #556: the plan's own ceiling and a failed payment - distinct from
+      // each other and from `quota_exhausted`, so the panel can say which
+      // one stopped it.
+      'plan_limit_reached',
+      'plan_payment_required',
     ].map((reason) => refusalMessage(reason).key);
 
     expect(new Set(keys).size).toBe(keys.length);
@@ -780,6 +790,158 @@ describe('every refusal says which one it is', () => {
     await settle();
 
     expect(panelText()).not.toBe(killed);
+  });
+});
+
+describe('a plan refusal explains itself and links to billing (#556)', () => {
+  it('renders its own message for a spent suggestion limit, with a billing link', async () => {
+    const composer = renderPost();
+    suggest.mockImplementation(
+      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+        onEvent({ kind: 'refused', reason: 'plan_limit_reached', detail: {} });
+        return { ok: true as const, data: { ok: true } };
+      },
+    );
+
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(panelText()).toMatch(/suggestion limit/i);
+    const link = shadow().querySelector<HTMLAnchorElement>('.assist-link');
+    expect(link?.getAttribute('href')).toBe('https://app.pitchbox.app/settings/billing');
+    expect(link?.getAttribute('target')).toBe('_blank');
+  });
+
+  it('renders a distinct message for a failed payment, also with a billing link', async () => {
+    const composer = renderPost();
+    suggest.mockImplementation(
+      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+        onEvent({ kind: 'refused', reason: 'plan_payment_required', detail: {} });
+        return { ok: true as const, data: { ok: true } };
+      },
+    );
+
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(panelText()).toMatch(/payment/i);
+    expect(panelText()).not.toMatch(/suggestion limit/i);
+    const link = shadow().querySelector<HTMLAnchorElement>('.assist-link');
+    expect(link?.getAttribute('href')).toBe('https://app.pitchbox.app/settings/billing');
+  });
+
+  it('never links out for a refusal #556 did not name', async () => {
+    const composer = renderPost();
+    suggest.mockImplementation(
+      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+        onEvent({ kind: 'refused', reason: 'quota_exhausted', detail: {} });
+        return { ok: true as const, data: { ok: true } };
+      },
+    );
+
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(shadow().querySelector('.assist-link')).toBeNull();
+  });
+});
+
+describe('the loop narrates its own steps (#573)', () => {
+  it('names the tool it is running, collapses a parallel step into one line, and hands off to writing', async () => {
+    const composer = renderPost();
+    // Driven from out here, one `settle()` per event, rather than paced by
+    // internal awaits inside the mock: the panel's own re-render only ever
+    // needs one round trip to settle, and stacking several nested delays
+    // inside a single `suggest()` call raced against the outer `settle()`
+    // and left later events observed before they had actually rendered.
+    let deliver: ((event: Record<string, unknown>) => void) | undefined;
+    // extension/tsconfig.json targets a lib without `Promise.withResolvers`
+    // (cli/src/lib/password.ts hit the same wall) - the executor form is
+    // the one that typechecks here.
+    let finish!: (value: { ok: true; data: { ok: true } }) => void;
+    const suggestPromise = new Promise<{ ok: true; data: { ok: true } }>((resolve) => {
+      finish = resolve;
+    });
+    suggest.mockImplementation((_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+      deliver = onEvent;
+      return suggestPromise;
+    });
+
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    deliver!({ kind: 'status', phase: 'read_thread' });
+    await settle();
+    expect(panelText()).toContain('Reading the thread…');
+
+    // A parallel step collapses into one line naming the set, not two lines.
+    deliver!({ kind: 'status', phase: 'read_thread,look_at_image' });
+    await settle();
+    expect(panelText()).toContain('Reading the thread and looking at the image…');
+
+    deliver!({ kind: 'status', phase: 'my_prior_takes' });
+    await settle();
+    expect(panelText()).toContain('Checking your prior takes…');
+
+    deliver!({ kind: 'status', phase: 'slow' });
+    await settle();
+    expect(panelText()).toContain('This is taking longer than usual.');
+
+    deliver!({ kind: 'status', phase: 'writing' });
+    await settle();
+    expect(panelText()).toContain('Writing…');
+
+    deliver!({ kind: 'chunk', text: 'A reply.', section: 'draft' });
+    deliver!({ kind: 'done', reasoning: '', draft: 'A reply.', skipped: false, ms: 900 });
+    finish({ ok: true, data: { ok: true } });
+    await settle();
+    expect(shadow().querySelector('textarea')?.value).toBe('A reply.');
+  });
+
+  it('never shows a raw tool name for a step this build does not recognise', async () => {
+    const composer = renderPost();
+    suggest.mockImplementation(
+      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+        onEvent({ kind: 'status', phase: 'some_future_tool' });
+        onEvent({ kind: 'chunk', text: 'A reply.', section: 'draft' });
+        onEvent({ kind: 'done', reasoning: '', draft: 'A reply.', skipped: false, ms: 900 });
+        return { ok: true as const, data: { ok: true } };
+      },
+    );
+
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(panelText()).not.toContain('some_future_tool');
+  });
+
+  it('says it answered with what it had once the hard budget cuts a draft short', async () => {
+    const composer = renderPost();
+    suggest.mockImplementation(
+      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+        onEvent({ kind: 'chunk', text: 'A reply.', section: 'draft' });
+        onEvent({
+          kind: 'done',
+          reasoning: '',
+          draft: 'A reply.',
+          skipped: false,
+          ms: 90_000,
+          budgetExhausted: true,
+        });
+        return { ok: true as const, data: { ok: true } };
+      },
+    );
+
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(panelText()).toContain('Answered with what it had time to gather.');
   });
 });
 

--- a/extension/tests/content/linkedin-post-assist.test.ts
+++ b/extension/tests/content/linkedin-post-assist.test.ts
@@ -25,6 +25,10 @@ const armed = vi.fn(async (_draftId: number, _backendUrl?: string) => ({
   ok: true as const,
   data: {},
 }));
+// #556: only reached from `setRefused`'s `billingLinkFor` branch (the two
+// plan refusals) - every other test in this file never calls it, so a
+// resolved default here changes nothing for them.
+const pickPairing = vi.fn(async () => ({ backendUrl: 'https://app.pitchbox.app' }));
 
 vi.mock('../../src/lib/api.js', () => ({
   api: {
@@ -33,6 +37,7 @@ vi.mock('../../src/lib/api.js', () => ({
     acceptSuggestion: (body: unknown) => acceptSuggestion(body),
     armed: (draftId: number, backendUrl?: string) => armed(draftId, backendUrl),
   },
+  pickPairing: () => pickPairing(),
 }));
 
 const logged: Array<Record<string, unknown>> = [];
@@ -449,6 +454,10 @@ describe('every refusal says which one it is', () => {
       'blocked',
       'backend_unreachable',
       'generation_failed',
+      // #556: the plan's own ceiling and a failed payment - distinct from
+      // each other, so the panel can say which one stopped it.
+      'plan_limit_reached',
+      'plan_payment_required',
     ].map((reason) => refusalMessage(reason).key);
 
     expect(new Set(keys).size).toBe(keys.length);
@@ -492,6 +501,122 @@ describe('refusal rendering: post-specific, not the comment assist copy', () => 
     await settle();
 
     expect(panelText()).toMatch(/nothing recent/i);
+  });
+});
+
+describe('a plan refusal explains itself and links to billing (#556)', () => {
+  it('renders its own message for a spent suggestion limit, with a billing link', async () => {
+    const { editor, modal } = renderModal();
+    suggest.mockImplementation(
+      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+        onEvent({ kind: 'refused', reason: 'plan_limit_reached', detail: {} });
+        return { ok: true as const, data: { ok: true } };
+      },
+    );
+
+    wirePostAssist(editor, modal);
+    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    expect(panelText()).toMatch(/suggestion limit/i);
+    const link = shadow().querySelector<HTMLAnchorElement>('.assist-link');
+    expect(link?.getAttribute('href')).toBe('https://app.pitchbox.app/settings/billing');
+    expect(link?.getAttribute('target')).toBe('_blank');
+  });
+
+  it('renders a distinct message for a failed payment, also with a billing link', async () => {
+    const { editor, modal } = renderModal();
+    suggest.mockImplementation(
+      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+        onEvent({ kind: 'refused', reason: 'plan_payment_required', detail: {} });
+        return { ok: true as const, data: { ok: true } };
+      },
+    );
+
+    wirePostAssist(editor, modal);
+    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    expect(panelText()).toMatch(/payment/i);
+    expect(panelText()).not.toMatch(/suggestion limit/i);
+    const link = shadow().querySelector<HTMLAnchorElement>('.assist-link');
+    expect(link?.getAttribute('href')).toBe('https://app.pitchbox.app/settings/billing');
+  });
+});
+
+describe('the loop narrates its own steps (#573)', () => {
+  it('names the tool it is running, collapses a parallel step into one line, and hands off to writing', async () => {
+    const { editor, modal } = renderModal();
+    // Driven from out here, one `settle()` per event - see the comment
+    // assist's own test of this, which this mirrors exactly, for why.
+    let deliver: ((event: Record<string, unknown>) => void) | undefined;
+    // extension/tsconfig.json targets a lib without `Promise.withResolvers`
+    // (cli/src/lib/password.ts hit the same wall) - the executor form is
+    // the one that typechecks here.
+    let finish!: (value: { ok: true; data: { ok: true } }) => void;
+    const suggestPromise = new Promise<{ ok: true; data: { ok: true } }>((resolve) => {
+      finish = resolve;
+    });
+    suggest.mockImplementation((_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+      deliver = onEvent;
+      return suggestPromise;
+    });
+
+    wirePostAssist(editor, modal);
+    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    deliver!({ kind: 'status', phase: 'operator_voice' });
+    await settle();
+    expect(panelText()).toContain('Finding how you have written about this…');
+
+    deliver!({ kind: 'status', phase: 'project_knowledge,check_style' });
+    await settle();
+    expect(panelText()).toContain(
+      'Checking what it knows about this project and checking the style…',
+    );
+
+    deliver!({ kind: 'status', phase: 'writing' });
+    await settle();
+    expect(panelText()).toContain('Writing…');
+
+    deliver!({ kind: 'chunk', text: 'A short update.', section: 'draft' });
+    deliver!({ kind: 'done', reasoning: '', draft: 'A short update.', skipped: false, ms: 900 });
+    finish({ ok: true, data: { ok: true } });
+    await settle();
+    expect(shadow().querySelector('textarea')?.value).toBe('A short update.');
+  });
+
+  it('says it answered with what it had once the hard budget cuts a draft short', async () => {
+    const { editor, modal } = renderModal();
+    suggest.mockImplementation(
+      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
+        onEvent({ kind: 'chunk', text: 'A short update.', section: 'draft' });
+        onEvent({
+          kind: 'done',
+          reasoning: '',
+          draft: 'A short update.',
+          skipped: false,
+          ms: 90_000,
+          budgetExhausted: true,
+        });
+        return { ok: true as const, data: { ok: true } };
+      },
+    );
+
+    wirePostAssist(editor, modal);
+    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    expect(panelText()).toContain('Answered with what it had time to gather.');
   });
 });
 

--- a/extension/tests/sidepanel/plan-readout.test.ts
+++ b/extension/tests/sidepanel/plan-readout.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import PlanReadout from '../../src/sidepanel/components/PlanReadout.svelte';
+import type { LinkedInAssistPlanState } from '../../src/lib/api.js';
+
+/**
+ * The plan and remaining-suggestion readout PairingList.svelte shows per
+ * paired backend (#556), against the real compiled component - same
+ * posture as `home-state-line.test.ts`: a missing dictionary entry or a
+ * template branch that never renders both look like a working panel until
+ * something reads the actual text. Its own component (not PairingList
+ * itself) precisely so it can be mounted without that component's
+ * pairing/permission/AlertDialog machinery, which needs a real profile to
+ * exercise meaningfully anyway (#400's own acceptance).
+ */
+
+let host: HTMLElement;
+let component: Record<string, unknown> | null = null;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  host = document.createElement('div');
+  document.body.append(host);
+});
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = null;
+  document.body.innerHTML = '';
+});
+
+function plan(over: Partial<LinkedInAssistPlanState> = {}): LinkedInAssistPlanState {
+  return {
+    id: 'growth',
+    name: 'Growth',
+    suggestionsUsed: 10,
+    suggestionsLimit: 50,
+    suggestionsRemaining: 40,
+    readOnly: false,
+    ...over,
+  };
+}
+
+function render(planState: LinkedInAssistPlanState): string {
+  component = mount(PlanReadout, {
+    target: host,
+    props: { plan: planState },
+  }) as Record<string, unknown>;
+  return (host.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+describe('the plan readout (#556)', () => {
+  it('reads as fine with plenty of the allowance left', () => {
+    const text = render(
+      plan({ suggestionsUsed: 10, suggestionsLimit: 50, suggestionsRemaining: 40 }),
+    );
+
+    expect(text).toBe('Growth plan: 40 of 50 suggestions left this period');
+  });
+
+  it('reads as near the limit once the 80%-used warning threshold is crossed', () => {
+    const text = render(
+      plan({ suggestionsUsed: 46, suggestionsLimit: 50, suggestionsRemaining: 4 }),
+    );
+
+    expect(text).toBe('Growth plan: only 4 of 50 suggestions left this period');
+  });
+
+  it('reads as read-only once a failed payment has gone past its grace window', () => {
+    const text = render(
+      plan({ readOnly: true, suggestionsUsed: 50, suggestionsLimit: 50, suggestionsRemaining: 0 }),
+    );
+
+    expect(text).toBe('Growth plan: read-only until the payment issue is fixed');
+  });
+
+  it('names the plan as unlimited rather than a fraction when self-host resolves no ceiling', () => {
+    const text = render(plan({ suggestionsLimit: null, suggestionsRemaining: null }));
+
+    expect(text).toBe('Growth plan: unlimited suggestions');
+  });
+
+  it('read-only wins over a low-remaining count - one message, not two contradicting ones', () => {
+    const text = render(
+      plan({ readOnly: true, suggestionsUsed: 46, suggestionsLimit: 50, suggestionsRemaining: 4 }),
+    );
+
+    expect(text).toBe('Growth plan: read-only until the payment issue is fixed');
+    expect(text).not.toMatch(/only 4/);
+  });
+});

--- a/shared/package.json
+++ b/shared/package.json
@@ -41,6 +41,7 @@
     "./assist/voice-defaults": "./src/assist/voice-defaults.ts",
     "./assist/example-selection": "./src/assist/example-selection.ts",
     "./assist/loop": "./src/assist/loop.ts",
+    "./assist/session": "./src/assist/session.ts",
     "./operator-profile": "./src/operator-profile.ts",
     "./operator-voice-profile": "./src/operator-voice-profile.ts",
     "./github-sources": "./src/github-sources.ts",

--- a/shared/src/agents/base.ts
+++ b/shared/src/agents/base.ts
@@ -34,6 +34,20 @@ export interface AgentRunOptions {
    */
   tools?: Record<string, unknown>;
   /**
+   * A prior turn's own conversation, fed back in ahead of `prompt` instead of
+   * rebuilding the whole context from scratch (#576) - the in-page
+   * assistant's own continuation path. Only the `cloud` runner (`SdkRunner`)
+   * reads this: it prepends these as `messages` before the new user turn
+   * built from `prompt`, so a model that already called `read_thread` or
+   * `look_at_image` sees their results already in context rather than
+   * needing to call them again. Left untyped here (an opaque conversation,
+   * not a runner-agnostic shape) because only the SDK path's own AI SDK
+   * message format can consume it - `AcpRunner` ignores it exactly as it
+   * ignores `tools`/`toolLoopBudget`, since it has no equivalent notion of a
+   * continued turn.
+   */
+  priorMessages?: unknown[];
+  /**
    * Step/time/token/cost budget for a native tool-calling loop (#566),
    * enforced only by the `cloud` runner (`SdkRunner`) - `AcpRunner` ignores
    * it exactly as it ignores `budgetRemainingUsd`, since its own coding-agent
@@ -92,6 +106,17 @@ export interface AgentRunOptions {
    * this instead.
    */
   onTextChunk?: (text: string) => void;
+  /**
+   * Called with the tool name(s) the model decided to run in the current
+   * step, as soon as they are known and before any of them execute (#573).
+   * Several tools requested in the same step arrive as one call carrying
+   * every name gathered so far in that step, so a caller narrating this into
+   * a status line naturally ends up with the full set the moment they are
+   * all known rather than one line per tool. Only the `cloud` runner
+   * (`SdkRunner`) fires this - `AcpRunner` has no native tool-calling loop of
+   * its own to observe.
+   */
+  onToolStep?: (toolNames: string[]) => void;
 }
 
 export interface AgentRunResult {
@@ -108,6 +133,13 @@ export interface AgentRunResult {
     costUsd: number | null;
     costReported: boolean;
   };
+  /**
+   * This turn's own assistant/tool messages, in the shape `priorMessages`
+   * above expects back - present only when the `cloud` runner ran with a
+   * tool set attached (#576). Undefined for every other runner and for a
+   * tool-less suggestion: there is nothing to continue from.
+   */
+  responseMessages?: unknown[];
 }
 
 export interface AgentRunHandle {

--- a/shared/src/agents/sdk/runner.ts
+++ b/shared/src/agents/sdk/runner.ts
@@ -8,7 +8,13 @@
 import { mkdirSync, writeFileSync, appendFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { streamText, stepCountIs, type ToolSet, type PrepareStepFunction } from 'ai';
+import {
+  streamText,
+  stepCountIs,
+  type ToolSet,
+  type PrepareStepFunction,
+  type ModelMessage,
+} from 'ai';
 import {
   createGateway,
   type GatewayProvider,
@@ -228,6 +234,16 @@ export class SdkRunner implements AgentRunner {
         throw new Error('SdkRunner.run needs either a prompt or a playbookPath');
       }
 
+      // #576: a retune/hint continuation supplies the prior turn's own
+      // conversation (assistant text, tool calls, tool results) so the model
+      // sees what it already gathered instead of re-deriving it. Untyped at
+      // the `AgentRunOptions` boundary (base.ts) since that module stays
+      // runner-agnostic; cast to this call's own message shape here, the one
+      // place that actually reads it.
+      const messages: ModelMessage[] = opts.priorMessages
+        ? [...(opts.priorMessages as ModelMessage[]), { role: 'user', content: userText }]
+        : [{ role: 'user', content: userText }];
+
       const gateway = this.createGatewayFn({ apiKey });
       const model = gateway(modelId);
 
@@ -388,12 +404,23 @@ export class SdkRunner implements AgentRunner {
         let stepUsage: SdkLanguageModelUsage | undefined;
         let finishUsage: SdkLanguageModelUsage | undefined;
         let finishReason: string | undefined;
+        // #573: the tool name(s) the current step is running, reset at each
+        // `start-step` and reported via `onToolStep` the moment a tool call
+        // is known - before it executes, so a caller narrating this into a
+        // status line is never behind the work it describes.
+        let stepToolNames: string[] = [];
+        // #576: this turn's own assistant/tool messages, captured once the
+        // stream settles, for a caller to persist and feed back in as the
+        // next call's `priorMessages`. Left undefined when no tool set was
+        // attached (nothing worth continuing from) or the stream never
+        // settled (a hard abort raced it).
+        let capturedResponseMessages: unknown[] | undefined;
 
         try {
           const streamResult = this.streamTextFn({
             model,
             system,
-            messages: [{ role: 'user', content: userText }],
+            messages,
             tools,
             stopWhen: stepCountIs(this.stepCeiling),
             prepareStep,
@@ -418,7 +445,12 @@ export class SdkRunner implements AgentRunner {
               }
               flushPendingText();
 
-              if (part.type === 'finish-step') {
+              if (part.type === 'start-step') {
+                stepToolNames = [];
+              } else if (part.type === 'tool-call') {
+                if (!stepToolNames.includes(part.toolName)) stepToolNames.push(part.toolName);
+                opts.onToolStep?.(stepToolNames.slice());
+              } else if (part.type === 'finish-step') {
                 stepCount += 1;
                 stepUsage = addSdkUsage(stepUsage, part.usage);
                 // Stop the run the moment its own accumulated cost would
@@ -462,6 +494,15 @@ export class SdkRunner implements AgentRunner {
               log(
                 `[loop-error] ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
               );
+            }
+          }
+          if (tools) {
+            try {
+              capturedResponseMessages = (await streamResult.responseMessages) as unknown[];
+            } catch {
+              // Best-effort: an aborted or errored stream may never settle
+              // this - the caller loses continuation for this one turn,
+              // never the answer itself.
             }
           }
         } finally {
@@ -543,7 +584,13 @@ export class SdkRunner implements AgentRunner {
           `# sdk run finished ${new Date().toISOString()} stopReason=${stopReasonKind} exitCode=${exitCode}`,
         );
 
-        return { exitCode, logPath, tokensUsed, usage: usageResult };
+        return {
+          exitCode,
+          logPath,
+          tokensUsed,
+          usage: usageResult,
+          responseMessages: capturedResponseMessages,
+        };
       } finally {
         clearTimeout(timeoutTimer);
         await toolSet?.close().catch(() => {});

--- a/shared/src/assist/session.ts
+++ b/shared/src/assist/session.ts
@@ -1,0 +1,99 @@
+// shared/src/assist/session.ts (#576)
+//
+// A retune or a hint-on-a-regenerate continues the loop instead of starting
+// over: the operator's typed steer and the retune direction are cheap and
+// coherent as a continuation, but only if the model's own gathered tool
+// calls and results travel with it (see `suggest-prompt.ts`'s
+// `buildRetunePrompt` and `docs/design/in-page-agent.md`). This module is
+// where that "gathered" state actually lives between one suggestion and the
+// next: a suggestion has no `runs` row and no database home
+// (docs/design/in-page-agent.md - "the assist plane's isolation from the
+// campaign plane"), so a session is in-memory, per process, and bounded by a
+// short lifetime rather than persisted anywhere.
+//
+// A session id is not a capability by itself: `getAssistSession` also checks
+// the org, the project the suggestion is filed under and the suggestion kind
+// against the caller's own request, so a foreign or stale id (or a stolen
+// device token replaying somebody else's id) never gets to lean on a
+// different tenant's gathered context - it falls back to a full re-gather,
+// exactly as an expired session does.
+
+import type { ModelMessage } from 'ai';
+import type { SuggestionKind } from './suggest-prompt.js';
+
+/**
+ * How long a session's gathered context is kept. A human rereads a draft and
+ * clicks a retune button within seconds, not minutes - this is generous for
+ * that and still short enough that "the page has moved on" (#576's own
+ * framing) forces a fresh, honest re-gather rather than answering from a
+ * post the human may not even be looking at anymore.
+ */
+export const ASSIST_SESSION_TTL_MS = 10 * 60 * 1000;
+
+interface AssistSessionEntry {
+  messages: ModelMessage[];
+  orgId: number | null;
+  projectId: number;
+  kind: SuggestionKind;
+  createdAt: number;
+}
+
+interface AssistSessionScope {
+  orgId: number | null;
+  projectId: number;
+  kind: SuggestionKind;
+}
+
+const sessions = new Map<string, AssistSessionEntry>();
+
+function purgeExpired(now: number): void {
+  for (const [id, entry] of sessions) {
+    if (now - entry.createdAt > ASSIST_SESSION_TTL_MS) sessions.delete(id);
+  }
+}
+
+/**
+ * Records a turn's own conversation as a continuable session and returns its
+ * id. Called after every completed suggestion (fresh or itself a
+ * continuation) that ran with a tool set attached, so the *next* retune or
+ * hint can continue from it - this is the only writer.
+ */
+export function createAssistSession(scope: AssistSessionScope, messages: ModelMessage[]): string {
+  const now = Date.now();
+  purgeExpired(now);
+  const id = crypto.randomUUID();
+  sessions.set(id, { ...scope, messages, createdAt: now });
+  return id;
+}
+
+/**
+ * Reads back a session for continuation, or `null` when it never existed,
+ * expired, or was scoped to a different org/project/kind than this request -
+ * every one of those is treated the same way by the caller: fall back to a
+ * full re-gather rather than answer from stale or foreign context.
+ */
+export function getAssistSession(id: string, scope: AssistSessionScope): ModelMessage[] | null {
+  const now = Date.now();
+  purgeExpired(now);
+  const entry = sessions.get(id);
+  if (!entry) return null;
+  if (entry.orgId !== scope.orgId || entry.projectId !== scope.projectId || entry.kind !== scope.kind) {
+    return null;
+  }
+  return entry.messages;
+}
+
+/** Frees a session immediately once a newer one supersedes it, rather than
+ * waiting on its TTL - keeps the map bounded by live panels, not by how long
+ * TTL happens to be. Safe to call with an id that is already gone. */
+export function deleteAssistSession(id: string): void {
+  sessions.delete(id);
+}
+
+/** Test-only: the map above is process-lifetime by design (mirrors the
+ * model-catalogue cache in `agents/sdk/runner.ts`), so a suite that creates
+ * several sessions across test files needs a way to start clean. Not used by
+ * any production code path. */
+export function __resetAssistSessionsForTests(): void {
+  sessions.clear();
+}

--- a/shared/src/assist/session.ts
+++ b/shared/src/assist/session.ts
@@ -77,7 +77,11 @@ export function getAssistSession(id: string, scope: AssistSessionScope): ModelMe
   purgeExpired(now);
   const entry = sessions.get(id);
   if (!entry) return null;
-  if (entry.orgId !== scope.orgId || entry.projectId !== scope.projectId || entry.kind !== scope.kind) {
+  if (
+    entry.orgId !== scope.orgId ||
+    entry.projectId !== scope.projectId ||
+    entry.kind !== scope.kind
+  ) {
     return null;
   }
   return entry.messages;

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -530,3 +530,42 @@ export function buildSuggestionPrompt(args: {
 
   return parts.join('\n\n');
 }
+
+/**
+ * The continuation turn a retune or a hint-on-a-regenerate sends when the
+ * loop's prior context is still live (#576, `shared/src/assist/session.ts`).
+ * Deliberately not `buildSuggestionPrompt` run again: everything that
+ * function assembles - the operator, the voice, the post, the examples - is
+ * already in the conversation this continues, sitting behind whatever
+ * `read_thread`/`look_at_image`/`author_history`/`operator_voice`/
+ * `project_knowledge`/`my_prior_takes` calls the model already made. Rebuilding
+ * it here would double the very cost a continuation exists to avoid. Only
+ * the steer, the house style (never optional) and the envelope instruction
+ * (the split still has to hold) travel again.
+ */
+export function buildRetunePrompt(args: { retune?: RetuneDirection; hint?: string }): string {
+  const parts: string[] = [
+    "You already gathered everything above for this post - the thread, the image if there was one, the author's history, your voice and your prior takes. Do not call any of those tools again unless something is genuinely missing; rewrite from what you already have.",
+  ];
+
+  if (args.retune) {
+    parts.push(
+      `The operator asked you to retune this one draft, which outranks the tone above but not the house style: ${RETUNE_INSTRUCTION[args.retune]}`,
+    );
+  }
+  if (args.hint?.trim()) {
+    parts.push(
+      `The operator added this steer, which outranks your own angle but not the house style:\n${clamp(args.hint, 500)}`,
+    );
+  }
+  if (!args.retune && !args.hint?.trim()) {
+    parts.push(
+      'The operator asked for another take on the same draft. Keep everything you already know and write it again, varying your phrasing.',
+    );
+  }
+
+  parts.push(`${HOUSE_STYLE_HEADING}${HOUSE_STYLE_SECTION}`);
+  parts.push(envelopeInstruction());
+
+  return parts.join('\n\n');
+}

--- a/shared/tests/assist-session.test.ts
+++ b/shared/tests/assist-session.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+  ASSIST_SESSION_TTL_MS,
+  createAssistSession,
+  getAssistSession,
+  deleteAssistSession,
+  __resetAssistSessionsForTests,
+} from '../src/assist/session.js';
+import type { ModelMessage } from 'ai';
+
+/**
+ * The store #576 leans on to make a retune cheap: the prior turn's own
+ * conversation, kept just long enough for a human to reread a draft and
+ * click a retune button, and never handed back to a caller it wasn't
+ * created for.
+ */
+
+const SCOPE = { orgId: 1, projectId: 10, kind: 'post_comment' as const };
+const MESSAGES: ModelMessage[] = [{ role: 'assistant', content: 'gathered context' }];
+
+afterEach(() => {
+  __resetAssistSessionsForTests();
+  vi.useRealTimers();
+});
+
+describe('createAssistSession / getAssistSession', () => {
+  it('reads back exactly what was written, for the scope it was created with', () => {
+    const id = createAssistSession(SCOPE, MESSAGES);
+    expect(getAssistSession(id, SCOPE)).toEqual(MESSAGES);
+  });
+
+  it('returns null for an id that was never created', () => {
+    expect(getAssistSession('not-a-real-session', SCOPE)).toBeNull();
+  });
+
+  it('refuses a mismatched org, project or kind rather than leaking cross-tenant context', () => {
+    const id = createAssistSession(SCOPE, MESSAGES);
+    expect(getAssistSession(id, { ...SCOPE, orgId: 2 })).toBeNull();
+    expect(getAssistSession(id, { ...SCOPE, projectId: 11 })).toBeNull();
+    expect(getAssistSession(id, { ...SCOPE, kind: 'post' })).toBeNull();
+    // The real scope still works - the mismatched reads above didn't consume it.
+    expect(getAssistSession(id, SCOPE)).toEqual(MESSAGES);
+  });
+
+  it('re-gathers past the session lifetime instead of answering from a stale post', () => {
+    vi.useFakeTimers();
+    const id = createAssistSession(SCOPE, MESSAGES);
+    vi.advanceTimersByTime(ASSIST_SESSION_TTL_MS + 1);
+    expect(getAssistSession(id, SCOPE)).toBeNull();
+  });
+
+  it('stays live one millisecond before the lifetime bound', () => {
+    vi.useFakeTimers();
+    const id = createAssistSession(SCOPE, MESSAGES);
+    vi.advanceTimersByTime(ASSIST_SESSION_TTL_MS - 1);
+    expect(getAssistSession(id, SCOPE)).toEqual(MESSAGES);
+  });
+});
+
+describe('deleteAssistSession', () => {
+  it('frees a session immediately rather than waiting on its TTL', () => {
+    const id = createAssistSession(SCOPE, MESSAGES);
+    deleteAssistSession(id);
+    expect(getAssistSession(id, SCOPE)).toBeNull();
+  });
+});

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -257,7 +257,6 @@ export function runSuggestion(args: {
    * no result yet - the panel's "this is taking longer than usual" state. */
   onSlow?: () => void;
 }): SuggestionHandle {
-
   // `cancel()` can arrive before the runner exists: resolving its config and
   // making a temp directory are both awaits, and a human who closes the panel
   // immediately lands in that window. A cancel that only forwards to a handle

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, rm } from 'node:fs/promises';
+import type { ModelMessage } from 'ai';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getDb } from './db.js';
@@ -14,6 +15,7 @@ import {
 import { resolveEntitlements } from '@pitchbox/shared/plans';
 import {
   buildSuggestionPrompt,
+  buildRetunePrompt,
   type CurrentProject,
   type ObservedPost,
   type RetuneDirection,
@@ -36,6 +38,11 @@ import {
 } from '@pitchbox/shared/style-check';
 import { ASSIST_TOOLS } from '@pitchbox/shared/assist/tools';
 import { buildAssistToolSet } from '@pitchbox/shared/assist/loop';
+import {
+  createAssistSession,
+  deleteAssistSession,
+  getAssistSession,
+} from '@pitchbox/shared/assist/session';
 import {
   ASSIST_HARD_TIMEOUT_MS,
   ASSIST_MAX_STEPS,
@@ -94,6 +101,18 @@ export interface SuggestionResult {
     cacheCreationTokens: number;
     costUsd: number | null;
   };
+  /** Set only when this call continued a live session (#576) - the id the
+   * caller hands back on the *next* retune or hint so it continues from
+   * here instead of starting over. Absent when no tool set was attached
+   * (nothing to continue from) or the run never produced a usable
+   * conversation to persist (a hard abort raced it). */
+  sessionId?: string;
+  /** True when the hard ceiling (or an equivalent early stop - a mid-stream
+   * provider error, a cost ceiling) cut the loop short and this is only
+   * whatever had already streamed, not a deliberately finished answer
+   * (docs/design/in-page-agent.md, "a partial suggestion beats an error").
+   * Absent/false on an ordinary completion. */
+  budgetExhausted?: boolean;
 }
 
 export interface SuggestionHandle {
@@ -225,21 +244,19 @@ export function runSuggestion(args: {
    * halves (#382). The caller decides what to do with each half - the SSE
    * route turns non-empty pieces into `chunk` events with a `section`. */
   onChunk?: (chunk: EnvelopeChunk) => void;
+  /** #576: a live session id from a prior `done` event - when present and
+   * still live, this call continues that turn's own gathered context
+   * instead of rebuilding the whole prompt (`buildRetunePrompt` rather than
+   * `buildSuggestionPrompt`). Absent, expired, or scoped to a different
+   * org/project/kind falls back to today's full rebuild. */
+  continueSessionId?: string;
+  /** #573: fires with the tool name(s) the loop is running, as soon as they
+   * are known. Undefined for the ACP path, which has no equivalent hook. */
+  onToolStep?: (toolNames: string[]) => void;
+  /** #573: fires once, past `ASSIST_SOFT_BUDGET_MS` of wall-clock time with
+   * no result yet - the panel's "this is taking longer than usual" state. */
+  onSlow?: () => void;
 }): SuggestionHandle {
-  const prompt = buildSuggestionPrompt({
-    kind: args.kind,
-    post: args.post,
-    currentProject: args.currentProject,
-    persona: args.persona,
-    voiceProfile: args.voiceProfile,
-    projects: args.projects,
-    repos: args.repos,
-    examples: args.examples,
-    hint: args.hint,
-    retune: args.retune,
-    tone: args.tone,
-    toneNotes: args.toneNotes,
-  });
 
   // `cancel()` can arrive before the runner exists: resolving its config and
   // making a temp directory are both awaits, and a human who closes the panel
@@ -344,6 +361,42 @@ export function runSuggestion(args: {
           })
         : undefined;
 
+    // #576: reading a session also consumes it - a retune uses its prior
+    // context at most once, so a second concurrent request against the same
+    // id falls back to a full rebuild rather than racing this one for it.
+    // Scoped to this org/project/kind: a foreign or mismatched id is treated
+    // exactly like an expired one, never trusted.
+    const continuedSession =
+      args.continueSessionId && toolSet
+        ? getAssistSession(args.continueSessionId, {
+            orgId: toolOrgId,
+            projectId: args.projectId,
+            kind: args.kind,
+          })
+        : null;
+    if (continuedSession && args.continueSessionId) deleteAssistSession(args.continueSessionId);
+    const priorMessages = continuedSession ?? undefined;
+    // #576: a live continuation replaces the whole rebuilt prompt with the
+    // small steer-only turn - everything else (the operator, the voice, the
+    // post, the examples) is already in `priorMessages`, behind whatever
+    // tool calls the model already made for it.
+    const prompt = continuedSession
+      ? buildRetunePrompt({ retune: args.retune, hint: args.hint })
+      : buildSuggestionPrompt({
+          kind: args.kind,
+          post: args.post,
+          currentProject: args.currentProject,
+          persona: args.persona,
+          voiceProfile: args.voiceProfile,
+          projects: args.projects,
+          repos: args.repos,
+          examples: args.examples,
+          hint: args.hint,
+          retune: args.retune,
+          tone: args.tone,
+          toneNotes: args.toneNotes,
+        });
+
     // `rawText` is the whole response, unsplit - used only to tell an actual
     // zero-text turn (a real failure) apart from a well-formed response whose
     // envelope happens to carry no draft (#382: that is a success, not an
@@ -351,6 +404,7 @@ export function runSuggestion(args: {
     let rawText = '';
     const splitter = new EnvelopeSplitter();
 
+    let slowTimer: ReturnType<typeof setTimeout> | undefined;
     try {
       const handle = runner.run({
         prompt,
@@ -372,6 +426,14 @@ export function runSuggestion(args: {
               costCeilingUsd: ASSIST_COST_CEILING_USD,
             }
           : undefined,
+        // #576: the prior turn's own gathered conversation, or undefined on
+        // a fresh suggestion - `prompt` above already carries the full
+        // context in that case, so this changes nothing.
+        priorMessages,
+        // #573: narrates which tool(s) the loop is actually running, the
+        // moment they are known - undefined for the ACP path, which has no
+        // equivalent hook to call back on.
+        onToolStep: args.onToolStep,
         onTextChunk: (chunk) => {
           rawText += chunk;
           // `args.onChunk?.(splitter.push(chunk))` looks equivalent but is
@@ -391,7 +453,14 @@ export function runSuggestion(args: {
       // A cancel that landed between the last gate and this assignment still
       // has to reach the process it just missed.
       if (cancelled) handle.cancel();
+      // #573: "taking longer than usual" is honest wall-clock elapsed time
+      // against the same threshold the loop itself answers-now at
+      // (ASSIST_SOFT_BUDGET_MS) - a passive UI signal, not a second
+      // enforcement point, so it needs no runner hook of its own and applies
+      // to the ACP path exactly as it does to the SDK one.
+      slowTimer = setTimeout(() => args.onSlow?.(), ASSIST_SOFT_BUDGET_MS);
       const run = await handle.result;
+      clearTimeout(slowTimer);
 
       if (cancelled) throw new Cancelled();
       if (!rawText.trim()) {
@@ -431,6 +500,24 @@ export function runSuggestion(args: {
         styleFindings = enforcement.findings;
       }
 
+      // #576: this turn's own conversation - whatever it continued, plus
+      // the turn it just ran - becomes the next retune's session, so a
+      // second retune never re-pays for the same read_thread/look_at_image
+      // call either. Only when a tool set was actually attached (nothing
+      // gathered to continue from otherwise) and the run actually produced
+      // something to persist.
+      let sessionId: string | undefined;
+      if (toolSet && run.responseMessages && run.responseMessages.length > 0) {
+        sessionId = createAssistSession(
+          { orgId: toolOrgId, projectId: args.projectId, kind: args.kind },
+          [
+            ...(priorMessages ?? []),
+            { role: 'user', content: prompt },
+            ...(run.responseMessages as ModelMessage[]),
+          ],
+        );
+      }
+
       return {
         reasoning: envelope.reasoning,
         draft,
@@ -447,8 +534,14 @@ export function runSuggestion(args: {
               costUsd: run.usage.costUsd,
             }
           : undefined,
+        sessionId,
+        // #573: a genuine early stop with text already in hand - never a
+        // clean end_turn - so the panel says it answered with what it had
+        // instead of treating this as an ordinary finish.
+        budgetExhausted: run.exitCode !== 0,
       };
     } finally {
+      clearTimeout(slowTimer);
       await rm(cwd, { recursive: true, force: true }).catch(() => {});
     }
   })();

--- a/web/src/routes/api/extension/linkedin-assist/+server.ts
+++ b/web/src/routes/api/extension/linkedin-assist/+server.ts
@@ -3,6 +3,9 @@ import { getDb } from '$lib/server/db.js';
 import { requireExtensionAuth, resolveDeviceOrgId } from '$lib/server/extension-auth.js';
 import { RateLimiter } from '$lib/server/rate-limit.js';
 import { loadLinkedInAssistDeviceState } from '@pitchbox/shared/linkedin-assist';
+import { billingPeriodFor } from '@pitchbox/shared/org-quota';
+import { getOrgUsage } from '@pitchbox/shared/usage';
+import { isOrgReadOnly, PLAN_CATALOGUE } from '@pitchbox/shared/plans';
 
 // The read path #302's collector and #314's panel poll to learn whether they
 // should be running at all and which project a suggestion writes as (LI-19,
@@ -13,12 +16,17 @@ import { loadLinkedInAssistDeviceState } from '@pitchbox/shared/linkedin-assist'
 // switch" (docs/linkedin-integration-design.md).
 //
 // Response shape (see PR body for the frozen contract):
-//   { assist: LinkedInAssistDeviceState }
+//   { assist: LinkedInAssistDeviceState, plan: LinkedInAssistPlanState }
 // LinkedInAssistDeviceState (shared/src/linkedin-assist.ts) carries booleans,
 // the bound project id, the org's `personal` project id (2026-09-07 - where
 // an accepted suggestion files when it is not about a product) and the two
 // daily caps - nothing org-scoped beyond what the device already handles in
-// observations/suggest bodies.
+// observations/suggest bodies. `plan` is #556: the panel and the side panel
+// need the plan's name, the suggestion allowance and how much of it is left,
+// and whether the org is read-only, purely for display - extending this
+// endpoint rather than adding a second poll. Anything cached from it is a
+// hint: `/suggest` refuses on its own read of the same numbers regardless of
+// what a stale poll here still shows.
 
 // Polled on an interval by a background script, not user-driven, so this is
 // tighter than /suggest's perDevice(20, 60_000) while still generous for any
@@ -34,5 +42,15 @@ export async function GET({ request }: { request: Request }) {
   if (orgId == null) throw error(404, 'not_found');
 
   const assist = await loadLinkedInAssistDeviceState(db, orgId);
-  return json({ assist });
+  const period = await billingPeriodFor(db, orgId);
+  const usage = await getOrgUsage(db, orgId, period);
+  const plan = {
+    id: usage.entitlements.planId,
+    name: PLAN_CATALOGUE[usage.entitlements.planId].name,
+    suggestionsUsed: usage.suggestions.used,
+    suggestionsLimit: usage.suggestions.limit,
+    suggestionsRemaining: usage.suggestions.remaining,
+    readOnly: isOrgReadOnly(usage.entitlements),
+  };
+  return json({ assist, plan });
 }

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -115,6 +115,12 @@ const BodySchema = z
     // comment on `assistSettings` below for why this is the one field on
     // this plane the request may legitimately carry.
     retune: z.enum(RETUNE_DIRECTIONS).optional(),
+    // #576: a live session id from a prior `done` event, so a retune or a
+    // hint-on-a-regenerate continues that turn's gathered context instead
+    // of starting over. Never trusted blind - `runSuggestion` re-checks it
+    // against this request's own org/project/kind and falls back to a full
+    // rebuild on anything that doesn't match or has expired.
+    sessionId: z.string().max(200).optional(),
     platform: z.string().min(1).max(40).default('linkedin'),
   })
   .superRefine((val, ctx) => {
@@ -400,6 +406,18 @@ export async function POST(event: RequestEvent) {
         projectId: project.id,
         orgId: auth.organizationId ?? undefined,
         runnerSlug: project.defaultAgentRunner,
+        continueSessionId: body.sessionId,
+        // #573: the tool name(s) the loop is running, comma-joined - the
+        // panel translates each into the operator's own words and collapses
+        // several into one line. Sent only before the draft starts: once
+        // `writing` has fired the step narration is over regardless of what
+        // the model does with a tool afterward (`check_style` included).
+        onToolStep: (toolNames) => {
+          if (!wroteDraft) send('status', { phase: toolNames.join(',') });
+        },
+        onSlow: () => {
+          if (!wroteDraft) send('status', { phase: 'slow' });
+        },
         onChunk: (chunk) => {
           if (chunk.reasoning) send('chunk', { text: chunk.reasoning, section: 'reasoning' });
           if (chunk.draft) {
@@ -451,6 +469,14 @@ export async function POST(event: RequestEvent) {
               skipped: res.skipped,
               usage: res.usage,
               ms: res.ms,
+              // #576: the panel hands this back on the next retune/hint so
+              // the loop continues instead of starting over. Absent when no
+              // tool set was attached or the run never settled into one.
+              sessionId: res.sessionId,
+              // #573: a genuine early stop with a draft already in hand -
+              // the panel says it answered with what it had rather than
+              // treating this as an ordinary, deliberate finish.
+              budgetExhausted: res.budgetExhausted,
             });
             controller.close();
           } catch (err) {

--- a/web/tests/extension-suggest.test.ts
+++ b/web/tests/extension-suggest.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@pitchbox/shared/linkedin-assist';
 import { ingestObservedTargets } from '@pitchbox/shared/observed-targets';
 import { DRAFT_MARKER, SKIP_MARKER } from '@pitchbox/shared/assist/envelope';
+import { ASSIST_SESSION_TTL_MS } from '@pitchbox/shared/assist/session';
 
 /**
  * The real-time suggestion endpoint (#312). What these tests defend is the
@@ -37,6 +38,18 @@ const ENVELOPE_CHUNKS = [
   'happened.',
 ];
 let responseChunks: string[] = ENVELOPE_CHUNKS;
+
+/** #573: tool-step sets a test wants the fake runner to announce, in order,
+ * before it emits any text - mirrors `SdkRunner`'s own `onToolStep`
+ * contract (one call per step, carrying that step's full tool-name set). */
+let toolStepsToEmit: string[][] = [];
+/** #576: the conversation a test wants the fake runner to hand back as this
+ * turn's own `responseMessages`, so `runSuggestion` has something to
+ * persist into a continuable session. Undefined mirrors a tool-less turn. */
+let responseMessagesToReturn: unknown[] | undefined;
+/** #573: overrides the fake run's `exitCode` - non-zero with non-empty text
+ * is what `runSuggestion` reads as "the budget cut this short". */
+let exitCodeToReturn = 0;
 
 let lastOptions: AgentRunOptions | null = null;
 /** The runner config the route actually handed to the registry, so a test can
@@ -69,10 +82,11 @@ vi.mock('@pitchbox/shared/agents/registry', () => ({
           },
         };
       }
+      for (const toolNames of toolStepsToEmit) opts.onToolStep?.(toolNames);
       for (const c of responseChunks) opts.onTextChunk?.(c);
       return {
         result: Promise.resolve({
-          exitCode: 0,
+          exitCode: exitCodeToReturn,
           logPath: '/dev/null',
           usage: {
             // Modelled on the real measurement in #313's comment: the prompt
@@ -86,6 +100,7 @@ vi.mock('@pitchbox/shared/agents/registry', () => ({
             costUsd: 0.004,
             costReported: true,
           },
+          responseMessages: responseMessagesToReturn,
         }),
         cancel: () => {
           cancelCalls += 1;
@@ -115,6 +130,9 @@ async function reset() {
   cancelCalls = 0;
   hangForever = false;
   responseChunks = ENVELOPE_CHUNKS;
+  toolStepsToEmit = [];
+  responseMessagesToReturn = undefined;
+  exitCodeToReturn = 0;
 }
 
 /**
@@ -203,6 +221,9 @@ describe('POST /api/extension/suggest', () => {
   it('streams the suggestion in chunks and closes with a terminal event', async () => {
     const { org, project } = await seedOrgProject('org-a');
     await mintDevice(org.id, 'tok');
+    // #576: a tool set was attached and produced something to persist -
+    // the route's `done` payload should carry the session id back.
+    responseMessagesToReturn = [{ role: 'assistant', content: 'gathered context' }];
 
     const res = await suggest({
       request: request('tok', { ...POST_BODY, projectId: project.id }),
@@ -222,6 +243,8 @@ describe('POST /api/extension/suggest', () => {
       draft: string | null;
       skipped: boolean;
       usage?: { outputTokens: number; cacheReadTokens: number; cacheCreationTokens: number };
+      sessionId?: string;
+      budgetExhausted?: boolean;
     };
     expect(done.reasoning).toBe(REASONING);
     expect(done.draft).toBe(DRAFT);
@@ -232,6 +255,10 @@ describe('POST /api/extension/suggest', () => {
     // path's `runs` row to not read as broken accounting.
     expect(done.usage?.cacheReadTokens).toBe(780);
     expect(done.usage?.cacheCreationTokens).toBe(0);
+    // #576: forwarded straight from `runSuggestion`'s own result.
+    expect(typeof done.sessionId).toBe('string');
+    // #573: an ordinary, clean finish is never flagged as cut short.
+    expect(done.budgetExhausted).toBe(false);
   });
 
   // #382: the fail-safe this endpoint exists for. Every `chunk` event carries
@@ -241,6 +268,9 @@ describe('POST /api/extension/suggest', () => {
   it('tags each chunk with its section and flips to writing only when the draft begins', async () => {
     const { org, project } = await seedOrgProject('org-section');
     await mintDevice(org.id, 'tok-section');
+    // #573: a tool step the route must translate into its own status event,
+    // before the draft ever starts.
+    toolStepsToEmit = [['read_thread', 'look_at_image']];
 
     const res = await suggest({
       request: request('tok-section', { ...POST_BODY, projectId: project.id }),
@@ -278,13 +308,14 @@ describe('POST /api/extension/suggest', () => {
     const firstDraftIdx = chunkEvents.map((e) => e.data.section).indexOf('draft');
     expect(lastReasoningIdx).toBeLessThan(firstDraftIdx);
 
-    // "writing" appears exactly once, and only after the draft chunks start
-    // arriving - "reading" is the only status during the reasoning stretch.
+    // "writing" appears exactly once, after the tool step's own comma-joined
+    // phase and only once the draft chunks start arriving - "reading" is the
+    // very first status, before the loop has decided anything.
     const statusEvents = events.filter((e) => e.kind === 'status') as Array<{
       data: { phase: string };
     }>;
     const statusPhases = statusEvents.map((e) => e.data.phase);
-    expect(statusPhases).toEqual(['reading', 'writing']);
+    expect(statusPhases).toEqual(['reading', 'read_thread,look_at_image', 'writing']);
   });
 
   // The fail-safe itself: a model that never emits the marker (ignored the
@@ -606,6 +637,187 @@ describe('POST /api/extension/suggest', () => {
       expect(lastOptions?.prompt).not.toContain('whatever the panel scraped');
       expect(lastOptions?.prompt).toContain('Recent Author');
     });
+  });
+});
+
+// #573/#576: `runSuggestion` itself is the one place both the tool-step
+// narration hook and the session-continuation branching actually decide
+// anything - the route only forwards what it returns. Calling it directly
+// here (like the #410 test below already does) is deliberate: the
+// per-device rate limiter is in-memory, keyed by a device id every test in
+// this file shares (TRUNCATE ... RESTART IDENTITY), and its whole 20-call
+// budget is already spent by the route-level describes above (see the note
+// at the end of the tone describe) - these tests would blow it for no
+// reason, since none of them need auth, quota or the SSE framing at all.
+describe('runSuggestion narrates its own steps and budget (#573)', () => {
+  beforeEach(reset);
+
+  it('reports a genuine early stop as budgetExhausted, an ordinary finish as clean', async () => {
+    const { project } = await seedOrgProject('org-budget');
+
+    exitCodeToReturn = 1;
+    const cutShort = await runSuggestion({
+      kind: 'post_comment',
+      post: POST_BODY.post,
+      currentProject: { name: project.name, description: project.description },
+      persona: null,
+      voiceProfile: null,
+      projects: [],
+      repos: [],
+      projectId: project.id,
+      orgId: project.organizationId,
+      runnerSlug: project.defaultAgentRunner,
+    }).result;
+    expect(cutShort.draft).toBe(DRAFT);
+    expect(cutShort.budgetExhausted).toBe(true);
+
+    exitCodeToReturn = 0;
+    const clean = await runSuggestion({
+      kind: 'post_comment',
+      post: POST_BODY.post,
+      currentProject: { name: project.name, description: project.description },
+      persona: null,
+      voiceProfile: null,
+      projects: [],
+      repos: [],
+      projectId: project.id,
+      orgId: project.organizationId,
+      runnerSlug: project.defaultAgentRunner,
+    }).result;
+    expect(clean.budgetExhausted).toBe(false);
+  });
+
+  it('forwards the loop\'s own tool steps to onToolStep as they are known', async () => {
+    const { project } = await seedOrgProject('org-narrate');
+    toolStepsToEmit = [['read_thread'], ['read_thread', 'look_at_image']];
+    const seen: string[][] = [];
+
+    await runSuggestion({
+      kind: 'post_comment',
+      post: POST_BODY.post,
+      currentProject: { name: project.name, description: project.description },
+      persona: null,
+      voiceProfile: null,
+      projects: [],
+      repos: [],
+      projectId: project.id,
+      orgId: project.organizationId,
+      runnerSlug: project.defaultAgentRunner,
+      onToolStep: (toolNames) => seen.push(toolNames),
+    }).result;
+
+    expect(seen).toEqual([['read_thread'], ['read_thread', 'look_at_image']]);
+  });
+});
+
+// #576: a retune keeps the loop's own gathered context instead of paying to
+// re-read the thread and re-run the vision call for the same information a
+// second time. Same rate-limit reasoning as the describe above - every case
+// here is `runSuggestion`'s own branching, called directly.
+describe('runSuggestion session continuation (#576)', () => {
+  beforeEach(reset);
+
+  function baseArgs(project: { id: number; name: string; description: string | null; organizationId: number; defaultAgentRunner: string }) {
+    return {
+      kind: 'post_comment' as const,
+      post: POST_BODY.post,
+      currentProject: { name: project.name, description: project.description },
+      persona: null,
+      voiceProfile: null,
+      projects: [],
+      repos: [],
+      projectId: project.id,
+      orgId: project.organizationId,
+      runnerSlug: project.defaultAgentRunner,
+    };
+  }
+
+  it('hands back a session id, and a retune against it continues instead of rebuilding', async () => {
+    const { project } = await seedOrgProject('org-session');
+    responseMessagesToReturn = [{ role: 'assistant', content: 'gathered: thread + image' }];
+
+    const first = await runSuggestion(baseArgs(project)).result;
+    expect(typeof first.sessionId).toBe('string');
+    // The baseline a continuation is measured against: a fresh suggestion's
+    // prompt carries the whole rebuilt context.
+    const fullPromptLength = lastOptions?.prompt?.length ?? 0;
+    expect(lastOptions?.prompt).toContain('Your task:');
+    expect(lastOptions?.priorMessages).toBeUndefined();
+
+    await runSuggestion({
+      ...baseArgs(project),
+      retune: 'drier',
+      continueSessionId: first.sessionId,
+    }).result;
+
+    // A continuation sends the prior turn's own conversation back in - the
+    // original user turn plus whatever the model gathered - and a short
+    // steer-only turn on top, never the full rebuilt prompt again. That is
+    // most of the latency and cost #576 exists to stop paying twice.
+    expect(lastOptions?.priorMessages).toHaveLength(2);
+    expect(lastOptions?.priorMessages?.[0]).toMatchObject({ role: 'user' });
+    expect(lastOptions?.priorMessages?.[1]).toEqual({
+      role: 'assistant',
+      content: 'gathered: thread + image',
+    });
+    expect(lastOptions?.prompt).not.toContain('Your task:');
+    expect(lastOptions?.prompt).toContain('already gathered');
+    expect(lastOptions?.prompt?.length ?? 0).toBeLessThan(fullPromptLength);
+  });
+
+  it('acts on a hint against the prior draft without rebuilding the context', async () => {
+    const { project } = await seedOrgProject('org-session-hint');
+    responseMessagesToReturn = [{ role: 'assistant', content: 'gathered once' }];
+
+    const first = await runSuggestion(baseArgs(project)).result;
+    await runSuggestion({
+      ...baseArgs(project),
+      hint: 'mention the launch date',
+      continueSessionId: first.sessionId,
+    }).result;
+
+    expect(lastOptions?.priorMessages).toBeDefined();
+    expect(lastOptions?.prompt).toContain('mention the launch date');
+  });
+
+  it('falls back to a full rebuild for a session id scoped to a different org', async () => {
+    const { project: projectA } = await seedOrgProject('org-session-a');
+    responseMessagesToReturn = [{ role: 'assistant', content: 'org a context' }];
+    const first = await runSuggestion(baseArgs(projectA)).result;
+
+    const { project: projectB } = await seedOrgProject('org-session-b');
+    await runSuggestion({
+      ...baseArgs(projectB),
+      retune: 'drier',
+      continueSessionId: first.sessionId,
+    }).result;
+
+    // A foreign session id is treated exactly like a missing one: the full
+    // context is rebuilt rather than leaking org A's gathered thread/image
+    // into org B's answer.
+    expect(lastOptions?.priorMessages).toBeUndefined();
+    expect(lastOptions?.prompt).toContain('Your task:');
+  });
+
+  it('re-gathers past the session lifetime instead of answering from a stale post', async () => {
+    const { project } = await seedOrgProject('org-session-ttl');
+    responseMessagesToReturn = [{ role: 'assistant', content: 'about to expire' }];
+    const first = await runSuggestion(baseArgs(project)).result;
+
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(ASSIST_SESSION_TTL_MS + 1);
+    try {
+      await runSuggestion({
+        ...baseArgs(project),
+        retune: 'drier',
+        continueSessionId: first.sessionId,
+      }).result;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(lastOptions?.priorMessages).toBeUndefined();
+    expect(lastOptions?.prompt).toContain('Your task:');
   });
 });
 

--- a/web/tests/extension-suggest.test.ts
+++ b/web/tests/extension-suggest.test.ts
@@ -687,7 +687,7 @@ describe('runSuggestion narrates its own steps and budget (#573)', () => {
     expect(clean.budgetExhausted).toBe(false);
   });
 
-  it('forwards the loop\'s own tool steps to onToolStep as they are known', async () => {
+  it("forwards the loop's own tool steps to onToolStep as they are known", async () => {
     const { project } = await seedOrgProject('org-narrate');
     toolStepsToEmit = [['read_thread'], ['read_thread', 'look_at_image']];
     const seen: string[][] = [];
@@ -717,7 +717,13 @@ describe('runSuggestion narrates its own steps and budget (#573)', () => {
 describe('runSuggestion session continuation (#576)', () => {
   beforeEach(reset);
 
-  function baseArgs(project: { id: number; name: string; description: string | null; organizationId: number; defaultAgentRunner: string }) {
+  function baseArgs(project: {
+    id: number;
+    name: string;
+    description: string | null;
+    organizationId: number;
+    defaultAgentRunner: string;
+  }) {
     return {
       kind: 'post_comment' as const,
       post: POST_BODY.post,

--- a/web/tests/linkedin-assist-settings.test.ts
+++ b/web/tests/linkedin-assist-settings.test.ts
@@ -274,6 +274,58 @@ describe('GET /api/extension/linkedin-assist (device read path)', () => {
     expect(body.assist.projectId).toBeNull();
     expect(body.assist.enabled).toBe(false);
   });
+
+  // #556: the panel and the side panel need the plan's name, allowance and
+  // remaining count, and whether the org is read-only, purely for display -
+  // extended onto this endpoint rather than a second poll.
+  it('resolves the self-host default: unlimited, still named by the code catalogue', async () => {
+    const { orgId, projectId } = await seedOrg('la-plan-selfhost');
+    await saveLinkedInAssistSettings(getDb(), orgId, {
+      ...defaultLinkedInAssistSettings(),
+      enabled: true,
+      projectId,
+    });
+    const token = 'device-token-plan-selfhost';
+    await mintDevice(orgId, token);
+
+    const body = await (await deviceGet({ request: deviceRequest(token) })).json();
+    expect(body.plan).toEqual({
+      id: 'free',
+      name: 'Free',
+      suggestionsUsed: 0,
+      suggestionsLimit: null,
+      suggestionsRemaining: null,
+      readOnly: false,
+    });
+  });
+
+  it('resolves the cloud edition Free tier numbers for an org with no subscription or grant', async () => {
+    const savedEdition = process.env.PITCHBOX_EDITION;
+    process.env.PITCHBOX_EDITION = 'cloud';
+    try {
+      const { orgId, projectId } = await seedOrg('la-plan-cloud');
+      await saveLinkedInAssistSettings(getDb(), orgId, {
+        ...defaultLinkedInAssistSettings(),
+        enabled: true,
+        projectId,
+      });
+      const token = 'device-token-plan-cloud';
+      await mintDevice(orgId, token);
+
+      const body = await (await deviceGet({ request: deviceRequest(token) })).json();
+      expect(body.plan).toEqual({
+        id: 'free',
+        name: 'Free',
+        suggestionsUsed: 0,
+        suggestionsLimit: 50,
+        suggestionsRemaining: 50,
+        readOnly: false,
+      });
+    } finally {
+      if (savedEdition === undefined) delete process.env.PITCHBOX_EDITION;
+      else process.env.PITCHBOX_EDITION = savedEdition;
+    }
+  });
 });
 
 // The role gate is exactly the kind of bug ISO-1 (#132) hid: a hand-injected


### PR DESCRIPTION
Lands the panel side of #573, #576 and #556. The server side (SdkRunner narration, session continuation, plan info on the device-state route) was built and verified by a prior agent and is included here unmodified except for a rebase onto `origin/main` (a conflict in `shared/src/agents/base.ts` against #574's own budget-doc edit, resolved by keeping both the `priorMessages` field and the updated `costCeilingUsd` doc comment; `shared/src/agents/sdk/runner.ts` auto-merged cleanly, and I re-read the whole streaming loop afterward to confirm the `tool-call` (#573) and `tool-result` (#574) arms sit as separate, non-conflicting branches).

What this PR adds, on top of that:

- `extension/src/content/shared/assist-status.ts`: turns the SSE `status.phase` (`reading`/`writing`/`slow`, or a comma-joined tool-name set) into the operator's own words, joining a parallel step into one line with `Intl.ListFormat` rather than one line per tool.
- Both assist panels (`linkedin-comment-assist-panel.svelte`, `linkedin-post-assist-panel.svelte`) narrate every phase through that helper instead of the old binary reading/writing ternary, show a note when `budgetExhausted` cut a draft short, and render `plan_limit_reached`/`plan_payment_required` as their own message with a `/settings/billing` link in a new tab (`.assist-link` in `panel.css`, using the existing `--link` token).
- New EN+IT i18n keys for the per-tool narration, the slow/budget-exhausted lines, the two plan refusals, and the billing-link label.
- `extension/src/sidepanel/components/PlanReadout.svelte`: the side panel's plan/remaining-suggestions readout, its own component (not inlined into `PairingList.svelte`) so it can be mounted in a test without that component's pairing/permission/`AlertDialog` machinery. `PairingList` owns the per-backend `api.linkedinAssist()` fetch and hands the plan down as a prop.
- Component tests mounting the real panels: narration renders in order and a parallel step collapses into one line, an unrecognised tool name never leaks raw, `budgetExhausted` renders, every refusal (including the two new plan reasons) maps to its own message, the two plan refusals render a billing link, and the side panel's plan readout renders its three states (fine, near the limit, read-only).

Verification:
- `pnpm -F web check`, `pnpm -F @pitchbox/extension check`, `pnpm -F @pitchbox/shared typecheck`: 0 errors.
- `pnpm run test:linkedin-compliance`: 15/15, no rule relaxed.
- Full touched-suite run (`extension-suggest`, `linkedin-assist-settings`, `assist-session`, both content-script suites, sidepanel): 118 pre-existing + 86 in the content-script suites (incl. the new ones) + 5 new `plan-readout` tests, all green.
- `pnpm run build:extension`: both panel scripts land in `extension/dist/src/content/` with no top-level `import`/`export`; `tests/extension-packaged-build.test.ts` (7/7) passes.
- Real Chrome: loaded the built `extension/dist` unpacked in a real (headless) Chrome 149 profile over raw CDP - the service worker starts clean with no manifest/runtime error, confirming the packaged build itself is sound. I could not complete the rest of the AGENTS.md recipe (driving a live LinkedIn post, forcing a refusal server-side, screenshotting the panel at ~400px) in this sandbox: there is no LinkedIn session available to it, and AGENTS.md's own documented Private Network Access finding means even with one, the in-page panel's `fetch` to a local dev backend fails from a real `https://www.linkedin.com` document regardless - that verification needs either `preview.pitchbox.app` after this deploys, or a human's own logged-in Chrome profile (`omp-chrome`/relay). Flagging this honestly rather than claiming a screenshot I did not take.

No `docs/design/DECISIONS.md` edit: D27 and D28 already describe exactly this behavior (narration wording, the two budget states, and reusing the `kill_switch`/`assist_disabled` refusal shape for the two plan reasons), and nothing here deviates from either row.

Closes #573
Closes #576
Closes #556
