### PR TITLE
chore: release 0.13.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.12.3",
+  "version": "0.13.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Everything since v0.12.3, which is most of the monetization work plus the assistant's own plane.

Plans, billing and limits: the plan catalogue and `resolveEntitlements` (#592), the premium-model gate (#547), Stripe billing server-side with customer, Checkout, webhook and portal (#603), a spend window that is the billing period (#600), notifications at 80% and 100% of a metered limit (#618), `/settings/billing` (#620), and a 14-day grace window after a failed payment that matches what the terms promise (#611, #612).

The assistant: the panel narrates the loop, continues a retune and knows the plan (#622), one suggestion's cost is measured and bounded (#621), and the assist plane now has its own ledger with the project optional (#521, #523).

Also: an onboarding you can skip and resume (#609), the optional GitHub App so the companion can read private repos (#390), and the trunk's full suite made green again (#616, #617).
