### PR TITLE
fix(deploy,tests): pass the Stripe configuration into the containers

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -33,7 +33,6 @@ GITHUB_APP_PRIVATE_KEY_B64=
 # than a client that only fails once it tries to call Stripe.
 # PITCHBOX_BILLING=on
 # STRIPE_SECRET_KEY=
-# STRIPE_PUBLISHABLE_KEY=
 # Signing secret of *this deployment's own* webhook endpoint - production and
 # preview each have their own, never share one.
 # STRIPE_WEBHOOK_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -68,7 +68,6 @@ WEB_PORT=5180
 # Stripe - same convention as MAIL_PROVIDER above.
 # PITCHBOX_BILLING=on
 # STRIPE_SECRET_KEY=
-# STRIPE_PUBLISHABLE_KEY=
 # Signing secret of *this deployment's own* webhook endpoint - production
 # and preview each have their own, never share one (docs/billing.md).
 # STRIPE_WEBHOOK_SECRET=

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -63,6 +63,17 @@ services:
       GITHUB_APP_ID: ${GITHUB_APP_ID:-}
       GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
       GITHUB_APP_PRIVATE_KEY_B64: ${GITHUB_APP_PRIVATE_KEY_B64:-}
+      # Hosted billing (#549, #551). Same enumeration rule as the two blocks
+      # above: the billing routes and the Stripe webhook read these from the
+      # process environment, so a key that lives only in `.env` leaves the
+      # deployment answering 404 `billing_disabled` while looking configured.
+      # Measured on prod 2026-09-10, with a live key in `.env` and nothing in
+      # this file. The daemon is deliberately not given them - nothing under
+      # `daemon/` touches Stripe.
+      PITCHBOX_BILLING: ${PITCHBOX_BILLING:-}
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
+      STRIPE_PORTAL_CONFIGURATION: ${STRIPE_PORTAL_CONFIGURATION:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.bluegreen.yml
+++ b/docker-compose.bluegreen.yml
@@ -59,6 +59,14 @@ x-web-common: &web-common
     GITHUB_APP_ID: ${GITHUB_APP_ID:-}
     GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
     GITHUB_APP_PRIVATE_KEY_B64: ${GITHUB_APP_PRIVATE_KEY_B64:-}
+    # Hosted billing (#549, #551), in this overlay for the same reason: this
+    # anchor replaces the base service's whole environment, so the four
+    # variables added to docker-compose.app.yml would reach nothing that
+    # production actually runs.
+    PITCHBOX_BILLING: ${PITCHBOX_BILLING:-}
+    STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
+    STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
+    STRIPE_PORTAL_CONFIGURATION: ${STRIPE_PORTAL_CONFIGURATION:-}
   healthcheck:
     test:
       [

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -208,7 +208,6 @@ change to the price catalogue. It never writes to the app database.
 | ----------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `PITCHBOX_BILLING`            | web (server only) | `on` to enable the billing routes; unset means self-host posture, same 404 `/api/auth/*` takes when `PITCHBOX_AUTH` is off |
 | `STRIPE_SECRET_KEY`           | web (server only) | `sk_live_…` in production, `sk_test_…` in preview and locally                                                              |
-| `STRIPE_PUBLISHABLE_KEY`      | web               | `pk_live_…` / `pk_test_…`, safe to expose                                                                                  |
 | `STRIPE_WEBHOOK_SECRET`       | web (server only) | signing secret of **that deployment's own** endpoint                                                                       |
 | `STRIPE_PORTAL_CONFIGURATION` | web (server only) | optional; pins the portal configuration instead of the default                                                             |
 | `PITCHBOX_APP_ORIGIN`         | setup script      | defaults to `https://app.pitchbox.app`                                                                                     |
@@ -217,6 +216,19 @@ change to the price catalogue. It never writes to the app database.
 Production and preview have **separate webhook endpoints with separate signing
 secrets** on purpose: a preview deployment holding the production secret could
 write production billing state. Never copy one into the other.
+
+A Docker deployment needs each of those four in **both** compose files, not
+only in `.env`: `docker-compose.app.yml` enumerates the container's
+environment instead of passing `.env` through, and `docker-compose.bluegreen.yml`
+replaces that whole block through its `x-web-common` anchor, so a variable
+present in one place still reaches nothing. Prod held a live key in `.env` and
+in neither file on 2026-09-10, which answers every billing route 404
+`billing_disabled` while looking configured. `tests/docker-mail-env.test.ts`
+now fails when a variable `loadStripeEnv` reads is missing from either file.
+
+Nothing reads a publishable key: Checkout is hosted and the app only ever
+redirects to a session URL, so there is no `STRIPE_PUBLISHABLE_KEY` here and
+setting one configures nothing.
 
 ## Webhooks
 

--- a/tests/docker-mail-env.test.ts
+++ b/tests/docker-mail-env.test.ts
@@ -41,6 +41,16 @@ function githubAppEnvVarsReadByTheLoader(): string[] {
   return envVarsReadBy('shared/src/github-app.ts');
 }
 
+/** Hosted billing's own configuration (#549, #551), which fails in the same
+ * silent shape as mail: `loadStripeEnv` collapses to `{ enabled: false }` and
+ * every billing route answers 404 `billing_disabled`, so a deployment holding
+ * a real live key looks configured and sells nothing. Measured on prod
+ * 2026-09-10: the four variables were in `/opt/apps/pitchbox/.env` and in
+ * neither compose file. */
+function stripeEnvVarsReadByTheLoader(): string[] {
+  return envVarsReadBy('shared/src/stripe/env.ts');
+}
+
 /** The `web:` service's own block, cut at the next service at the same indent. */
 function webServiceBlock(): string {
   const src = readFileSync(join(root, 'docker-compose.app.yml'), 'utf8');
@@ -107,6 +117,35 @@ describe('the deployed app receives the mail configuration it reads', () => {
   );
 
   it.each(mailEnvVarsReadByTheLoader())(
+    'passes %s into the blue-green web containers, which are what production runs',
+    (name) => {
+      expect(blueGreenCommonBlock()).toMatch(
+        new RegExp(`^\\s+${name}: \\$\\{${name}(:-[^}]*)?\\}$`, 'm'),
+      );
+    },
+  );
+});
+
+describe('the deployed app receives the billing configuration it reads', () => {
+  it('finds the variables to check, rather than passing on an empty set', () => {
+    expect(stripeEnvVarsReadByTheLoader()).toEqual([
+      'PITCHBOX_BILLING',
+      'STRIPE_PORTAL_CONFIGURATION',
+      'STRIPE_SECRET_KEY',
+      'STRIPE_WEBHOOK_SECRET',
+    ]);
+  });
+
+  it.each(stripeEnvVarsReadByTheLoader())(
+    'passes %s into the base web service, interpolated from the deployment environment',
+    (name) => {
+      expect(webServiceBlock()).toMatch(
+        new RegExp(`^\\s+${name}: \\$\\{${name}(:-[^}]*)?\\}$`, 'm'),
+      );
+    },
+  );
+
+  it.each(stripeEnvVarsReadByTheLoader())(
     'passes %s into the blue-green web containers, which are what production runs',
     (name) => {
       expect(blueGreenCommonBlock()).toMatch(


### PR DESCRIPTION
Prod has held a live Stripe key in `/opt/apps/pitchbox/.env` since today, and every billing route still answered 404 `billing_disabled`. The reason is the one the mail block in these files already records: `docker-compose.app.yml` enumerates the container environment instead of passing `.env` through, and `docker-compose.bluegreen.yml` replaces that whole block through its `x-web-common` anchor. None of the four variables `loadStripeEnv` reads were in either file, so the key reached nothing.

What changed:

- both compose files now pass `PITCHBOX_BILLING`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` and `STRIPE_PORTAL_CONFIGURATION`. The daemon deliberately gets none of them, since nothing under `daemon/` touches Stripe.
- `tests/docker-mail-env.test.ts` derives those names from `shared/src/stripe/env.ts` and asserts each one is present in both files, exactly as it already does for mail and the GitHub App. I proved it bites by deleting `STRIPE_WEBHOOK_SECRET` from the overlay: 1 failed, 32 passed.
- `STRIPE_PUBLISHABLE_KEY` is gone from both `.env` examples and from the docs table. Nothing reads it: Checkout is hosted and the app only redirects to a session URL, so setting one configured nothing.
- `docs/billing.md` records the two-file requirement and today's failure.

Verified locally: the rendered `docker compose config` carries all four in `web-blue` and `web-green`, the test file passes (33 tests), prettier and eslint clean on the touched files.