### PR TITLE
chore: release 0.13.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.13.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Patch release so the Stripe configuration fix from #625 reaches prod: `deploy-prod.yml` only fires on a `v*` tag, and the fix is in the compose files the deploy rsyncs.

Only change since v0.13.0 is #625: both compose files now pass `PITCHBOX_BILLING`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` and `STRIPE_PORTAL_CONFIGURATION` into the web containers, with a test that fails when one is missing from either file.

Live Stripe state is already in place (`acct_1UDgw4PbW9e1kAHz`, charges and payouts enabled, six live prices, both webhook endpoints, portal configuration), and prod's `.env` holds the live key and the prod signing secret. Verified before this release by creating a live Checkout session for `pitchbox_solo_monthly` and rendering it: Pitchbox Solo, €29.00, VAT computed on top, Managed Payments (`automatic_tax.liability.type = stripe`). The session was expired and the probe customer deleted.