### PR TITLE
fix(deploy): keep deploy restore points out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,13 @@ cloud
 private
 .claude
 .DS_Store
+# scripts/deploy.sh writes its pre-migrate restore point into backups/<utc>/
+# next to this file, i.e. inside the build context, and Dockerfile.app ends
+# with `COPY . .`. A restore point is deployment state, never image content:
+# it belongs to the host and must not travel into a layer. The `.env` entries
+# above do not cover it, since a leading-dot pattern only matches the context
+# root. Found on 2026-09-10, when a restore point with different ownership
+# failed a build outright at `error from sender: ... permission denied`.
+backups
+**/*.sql.gz
+**/encryption_key.env


### PR DESCRIPTION
`scripts/deploy.sh` writes its pre-migrate restore point into `backups/<utc>/` inside the deploy directory, which is also the docker build context, and `Dockerfile.app` ends with `COPY . .`. So every image built on a deploy host carried that host's own restore points into a layer. A restore point is deployment state, not image content. The `.env` entries already in `.dockerignore` do not cover it: a leading-dot pattern only matches the context root.

How I found it: the v0.13.1 prod deploy failed at `error from sender: open /opt/apps/pitchbox/backups/<utc>: permission denied`, because a restore point had been left with different ownership by a hand-run deploy. That ownership was the symptom, and fixing it alone would have left the real defect in place. Verified against the image prod was running: it listed four restore points under `/app/backups`.

Also excludes `**/*.sql.gz` and `**/encryption_key.env` as a second line of defence, so a restore point written somewhere else does not walk back in.