### PR TITLE
fix(deploy): defer a cross-tier downgrade in the customer portal

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -142,13 +142,24 @@ metadata change.
   raises the price, and usage already spent in the period keeps counting
   against the new ceiling rather than resetting.
 - A downgrade is only ever mirrored once Stripe's live subscription actually
-  reports the new plan - never anticipated - so the org keeps its current
-  plan until whatever scheduling mechanism moved the change (a portal
-  cancellation uses `cancel_at_period_end` natively; a cross-tier price
-  switch needs its own Subscription Schedule, since Stripe's customer portal
-  can only auto-schedule a downgrade between two prices of the **same
-  product**, and Solo/Growth/Scale are three separate products) actually
-  applies it at period end.
+  reports the new plan - never anticipated. The customer portal defers it for
+  us: its configuration carries
+  `subscription_update[schedule_at_period_end][conditions]` =
+  `decreasing_item_amount` + `shortening_interval`, so a cheaper plan, or a
+  move from yearly to monthly, leaves the subscription on its current price and
+  creates a **Subscription Schedule** whose second phase starts at
+  `current_period_end` (`end_behavior: release`, so the schedule releases
+  itself once that phase begins and the subscription simply continues on the
+  new price). The org therefore keeps what it paid for until period end, and
+  the plan swap arrives here as an ordinary `customer.subscription.updated`.
+  This works **across products**, so Solo/Growth/Scale staying three separate
+  products costs nothing and this app owns no scheduling code: measured against
+  the real test account on 2026-09-10, driving the portal from Growth monthly
+  down to Solo monthly, which answered "Your subscription will be updated at
+  the end of your current billing period on October 10, 2026" and produced a
+  two-phase schedule (Growth until the 10th, Solo after). An **upgrade** is
+  unaffected and stays immediate with proration, since neither condition
+  matches it.
 - A failed payment (`invoice.payment_failed`) starts a **14-day grace period**,
   counted from the first failure rather than restarted by each Smart Retries
   reattempt. The org keeps working normally during grace; a banner and a
@@ -193,14 +204,28 @@ does. It talks to the real **test-mode** account (`~/.config/pitchbox-stripe-
 test.key`), so it cannot run on a CI runner and is deliberately a script, not
 a test in the suite: `shared/tests/billing-checkout-portal.test.ts` used to
 hold this check and turned `main` red on a runner that had no key while every
-PR stayed green, which is what moved it here. It proves three things no
+PR stayed green, which is what moved it here. It proves four things no
 fixture can: the Checkout payload this repo builds is one Stripe accepts
 under Managed Payments (including that the parameters Stripe rejects are
-absent), a portal session opens for a customer this repo created, and the
+absent), a portal session opens for a customer this repo created, the
 prices/metadata recorded in `shared/tests/fixtures/stripe/catalogue.json`
 still match the live account (`--refresh` rewrites that fixture after a
-deliberate catalogue change). Run it before a billing release and after any
-change to the price catalogue. It never writes to the app database.
+deliberate catalogue change), and the portal configuration still carries the
+two `schedule_at_period_end` conditions - a configuration that lost them
+applies a downgrade immediately, which is invisible from this repo and costs a
+customer money.
+
+It has one blind spot, deliberately not papered over.
+`subscription_update[products]`, the list that decides which prices a customer
+can switch between, is accepted on write and **not returned** on read: the
+object comes back with `enabled`, `default_allowed_updates`,
+`proration_behavior`, `schedule_at_period_end`, `billing_cycle_anchor` and
+`trial_update_behavior`, and nothing else. Reading it back therefore proves
+nothing about the price list, so the probe does not claim to check it; that
+half is verified by opening a portal session for a subscribed customer in test
+mode and looking at the page. Run the probe before a billing release and after
+any change to the price catalogue or the portal. It never writes to the app
+database.
 
 ## Environment
 
@@ -269,8 +294,16 @@ Two places, and both are real: Stripe gives every Managed Payments customer
 [link.com](https://link.com) for order history, cancellation, payment method and
 billing address, and the app offers the same through the **Stripe customer
 portal** (configuration created by the setup script, plan switching over the six
-prices, cancellation at period end with a reason, invoice history), returning to
+prices with a monthly/yearly toggle, a downgrade deferred to period end,
+cancellation at period end with a reason, invoice history), returning to
 `/settings/billing`.
+
+What the app does **not** show yet is a plan change the portal has scheduled: a
+customer who downgrades sees "Your service will be updated on <date>" in the
+portal, while `/settings/billing` keeps reporting the current plan with no hint
+that it changes at period end, because `org_subscriptions` mirrors the live
+subscription and the pending phase lives on a Subscription Schedule this app
+never reads.
 
 ## Tax
 

--- a/scripts/stripe-probe.ts
+++ b/scripts/stripe-probe.ts
@@ -11,6 +11,9 @@
  *   - the Checkout payload this repo sends is one Stripe accepts under Managed
  *     Payments, including that the parameters it must not send are absent;
  *   - the portal session opens for a customer this repo created;
+ *   - the portal configuration still defers a downgrade to period end, which
+ *     is a property of an object in Stripe and cannot be asserted from here
+ *     any other way (#613);
  *   - the recorded catalogue in shared/tests/fixtures/stripe/catalogue.json
  *     still matches the account, which is what keeps the hermetic mapping test
  *     honest.
@@ -25,11 +28,16 @@ import { createStripeClient } from '../shared/src/stripe/client.js';
 
 const KEY_PATH = join(homedir(), '.config/pitchbox-stripe-test.key');
 const FIXTURE = join(import.meta.dirname, '../shared/tests/fixtures/stripe/catalogue.json');
+// All six prices, not a sample: every one of them is a price a customer can be
+// sold, so a drifted amount or a missing lookup key on any of them is a real
+// defect, and the two yearly ones were exactly the pair nothing looked at.
 const LOOKUPS = [
   'pitchbox_solo_monthly',
+  'pitchbox_solo_yearly',
   'pitchbox_growth_monthly',
   'pitchbox_growth_yearly',
   'pitchbox_scale_monthly',
+  'pitchbox_scale_yearly',
 ];
 
 function readKey(): string {
@@ -87,6 +95,64 @@ for (const lookup of LOOKUPS) {
     drift += 1;
   } else {
     console.log(`${lookup}: ok (${price.unit_amount} ${price.currency})`);
+  }
+}
+
+// The portal configuration is what defers a downgrade to period end (#613), and
+// nothing in the app can assert it: the app only ever passes a configuration id
+// to `billing_portal/sessions`, and the behaviour lives in the object that id
+// names. A configuration whose `schedule_at_period_end` conditions went missing
+// applies a cheaper price immediately, taking value from a customer who did
+// nothing wrong, and it looks identical from this repo. So read it back here.
+//
+// Only the conditions can be checked this way. `subscription_update.products`,
+// which is what decides that all six prices are switchable, is accepted on
+// write and then **not returned** on read (measured 2026-09-10: the object
+// comes back with `enabled`, `default_allowed_updates`, `proration_behavior`,
+// `schedule_at_period_end`, `billing_cycle_anchor` and
+// `trial_update_behavior`, and nothing else). Reading it back proves nothing
+// about the price list, so this does not pretend to: that half is verified by
+// opening a portal session for a subscribed customer and looking at the page.
+const REQUIRED_CONDITIONS = ['decreasing_item_amount', 'shortening_interval'];
+
+type PortalConfiguration = {
+  id: string;
+  is_default: boolean;
+  metadata: Record<string, string>;
+  features: {
+    subscription_update: {
+      enabled: boolean;
+      schedule_at_period_end?: { conditions: { type: string }[] };
+    };
+  };
+};
+
+const portalResponse = await fetch(
+  'https://api.stripe.com/v1/billing_portal/configurations?limit=100',
+  { headers: { Authorization: `Bearer ${readKey()}`, 'Stripe-Version': '2025-03-31.basil' } },
+);
+const portalList = (await portalResponse.json()) as { data: PortalConfiguration[] };
+const portal =
+  portalList.data.find((c) => c.metadata?.pitchbox === 'portal') ??
+  portalList.data.find((c) => c.is_default);
+
+if (!portal) {
+  console.log('portal: no configuration on the account');
+  drift += 1;
+} else {
+  const update = portal.features.subscription_update;
+  const conditions = (update.schedule_at_period_end?.conditions ?? []).map((c) => c.type);
+  const missing = REQUIRED_CONDITIONS.filter((c) => !conditions.includes(c));
+  if (!update.enabled) {
+    console.log(`portal ${portal.id}: subscription_update is disabled, no plan switching at all`);
+    drift += 1;
+  } else if (missing.length > 0) {
+    console.log(
+      `portal ${portal.id}: a downgrade applies IMMEDIATELY - missing schedule_at_period_end condition(s) ${missing.join(', ')}`,
+    );
+    drift += 1;
+  } else {
+    console.log(`portal ${portal.id}: ok (defers on ${conditions.join(', ')})`);
   }
 }
 

--- a/scripts/stripe-setup.ts
+++ b/scripts/stripe-setup.ts
@@ -358,6 +358,25 @@ async function ensurePortal(catalogue: { product: StripeProduct; prices: StripeP
         enabled: true,
         default_allowed_updates: ['price'],
         proration_behavior: 'create_prorations',
+        // What makes a downgrade keep what the customer already paid for. With
+        // these conditions the portal does not apply a cheaper price straight
+        // away: it builds a Subscription Schedule whose second phase starts at
+        // `current_period_end`, leaves the subscription on its current price
+        // until then, and releases itself once the new phase begins. An
+        // upgrade is unaffected and stays immediate with proration, since
+        // neither condition matches it.
+        //
+        // `decreasing_item_amount` covers a cheaper plan, `shortening_interval`
+        // a move from yearly to monthly. Measured against the real test account
+        // on 2026-09-10: it defers **across products** as well, which is what
+        // #613 assumed was impossible - the portal's own confirmation reads
+        // "Your subscription will be updated at the end of your current billing
+        // period", and the resulting schedule carries Growth until period end
+        // and Solo after it. So Solo/Growth/Scale stay three products, and this
+        // app owns no scheduling code.
+        schedule_at_period_end: {
+          conditions: [{ type: 'decreasing_item_amount' }, { type: 'shortening_interval' }],
+        },
         products: catalogue.map(({ product, prices }) => ({
           product: product.id,
           prices: prices.map((p) => p.id),

--- a/shared/tests/fixtures/stripe/catalogue.json
+++ b/shared/tests/fixtures/stripe/catalogue.json
@@ -31,6 +31,38 @@
       }
     }
   },
+  "pitchbox_solo_yearly": {
+    "price": {
+      "id": "price_1UDgxkPbW9e1kAHzUFWCJwie",
+      "lookup_key": "pitchbox_solo_yearly",
+      "unit_amount": 29000,
+      "currency": "eur",
+      "recurring": {
+        "interval": "year",
+        "interval_count": 1,
+        "meter": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      }
+    },
+    "product": {
+      "id": "prod_VE9GiXplzTBzJR",
+      "name": "Pitchbox Solo",
+      "metadata": {
+        "limit_budget_usd": "10",
+        "limit_concurrency": "2",
+        "limit_devices": "3",
+        "limit_premium_models": "false",
+        "limit_projects": "3",
+        "limit_retention_days": "30",
+        "limit_runs": "500",
+        "limit_seats": "1",
+        "limit_suggestions": "500",
+        "plan": "solo",
+        "tax_code_note": "SaaS business use"
+      }
+    }
+  },
   "pitchbox_growth_monthly": {
     "price": {
       "id": "price_1UDgxkPbW9e1kAHzqte5gL1y",
@@ -103,6 +135,38 @@
       "currency": "eur",
       "recurring": {
         "interval": "month",
+        "interval_count": 1,
+        "meter": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      }
+    },
+    "product": {
+      "id": "prod_VE9GOLwLC23uUF",
+      "name": "Pitchbox Scale",
+      "metadata": {
+        "limit_budget_usd": "70",
+        "limit_concurrency": "8",
+        "limit_devices": "0",
+        "limit_premium_models": "true",
+        "limit_projects": "30",
+        "limit_retention_days": "180",
+        "limit_runs": "8000",
+        "limit_seats": "10",
+        "limit_suggestions": "8000",
+        "plan": "scale",
+        "tax_code_note": "SaaS business use"
+      }
+    }
+  },
+  "pitchbox_scale_yearly": {
+    "price": {
+      "id": "price_1UDgxlPbW9e1kAHzfLrdSXuZ",
+      "lookup_key": "pitchbox_scale_yearly",
+      "unit_amount": 199000,
+      "currency": "eur",
+      "recurring": {
+        "interval": "year",
         "interval_count": 1,
         "meter": null,
         "trial_period_days": null,


### PR DESCRIPTION
Closes #613.

The issue asked me to choose between collapsing the catalogue to one product with six prices, or scheduling the downgrade myself with the Subscription Schedule API. Before writing either, I checked what the portal can actually do on `2025-03-31.basil`, and the premise turned out to be wrong: `features[subscription_update][schedule_at_period_end][conditions]` defers a downgrade **across products**.

What I measured against the real test account, driving the portal from Growth monthly down to Solo monthly:

- the confirmation page reads "Your subscription will be updated at the end of your current billing period on October 10, 2026. You will have access to your current subscription's features until then";
- after confirming, the subscription stays on `pitchbox_growth_monthly` and Stripe creates `sub_sched_...` with two phases, Growth until period end and Solo after, `end_behavior: release`;
- the portal's own summary then says "Your service will be updated on October 10, 2026. Your next estimated payment will be EUR 29.00".

So `decreasing_item_amount` (a cheaper plan) plus `shortening_interval` (yearly to monthly) is the whole fix, Solo/Growth/Scale stay three products, and this app owns no scheduling code. An upgrade is unaffected: neither condition matches it, so it stays immediate with proration.

The other half is that nothing in this repo can see whether that configuration is still right. The app only passes a configuration id to `billing_portal/sessions`; a configuration that lost the conditions applies a downgrade immediately and looks identical from here. `scripts/stripe-probe.ts` now reads it back and fails when a condition is missing. I verified that check bites by stripping the conditions from the test account and re-running it:

```
portal bpc_...: a downgrade applies IMMEDIATELY - missing schedule_at_period_end condition(s) decreasing_item_amount, shortening_interval
```

then ran the setup script and it went green again. It deliberately does **not** check `subscription_update[products]`: that field is accepted on write and not returned on read (the object comes back with `enabled`, `default_allowed_updates`, `proration_behavior`, `schedule_at_period_end`, `billing_cycle_anchor`, `trial_update_behavior`, nothing else), so reading it back would prove nothing. The probe now covers all six prices too, since the two yearly ones were the pair nothing looked at.

Already applied to both accounts, since a portal configuration is data and not code: test mode, and the live configuration prod actually pins (`bpc_1UDi1R...`, read back with `livemode: true` and both conditions present). No deploy is needed for this to take effect.

One gap this opens, filed separately rather than widened in here: `/settings/billing` still shows only the current plan, so a customer who schedules a downgrade sees it in the portal and not in the app. `org_subscriptions` mirrors the live subscription, and the pending phase lives on a schedule this app never reads.

Verification: `shared/tests/billing-checkout-portal.test.ts`, `shared/tests/billing-webhook.test.ts` and `web/tests/billing-routes-gating.test.ts` green (25 tests), prettier and eslint clean on the touched files, `pnpm run stripe:probe` green against the test account.