### PR TITLE
fix(docs): a bare placeholder in angle brackets breaks the VitePress build

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -299,7 +299,7 @@ cancellation at period end with a reason, invoice history), returning to
 `/settings/billing`.
 
 What the app does **not** show yet is a plan change the portal has scheduled: a
-customer who downgrades sees "Your service will be updated on <date>" in the
+customer who downgrades sees "Your service will be updated on `<date>`" in the
 portal, while `/settings/billing` keeps reporting the current plan with no hint
 that it changes at period end, because `org_subscriptions` mirrors the live
 subscription and the pending phase lives on a Subscription Schedule this app


### PR DESCRIPTION
Follow-up to #629, my own mistake.

VitePress compiles every markdown page as a Vue SFC, so the `<date>` placeholder I wrote inside a quoted sentence in `docs/billing.md` was parsed as an element: `docs/billing.md (346:68): Element is missing end tag`. The `docs` workflow failed on `main` while `ci` stayed green, because docs is a separate workflow and is not one of the jobs the aggregate `ci` check needs, so the docs site deploy went down without blocking anything.

Backticked. `pnpm run docs:build` now says `build complete`, which is the check I skipped before pushing a docs change.