### PR TITLE
docs(billing): payment method updates now point at the Stripe-hosted page

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -287,6 +287,7 @@ Subscriptions and emails, dashboard only - no API key reaches it):
 | Emails about expiring cards                     | on                                |
 | Emails when card payments fail                  | on                                |
 | Emails when bank debit payments fail            | on                                |
+| Payment method updates                          | link to a Stripe-hosted page      |
 | Link for customers to manage their subscription | on, to the Stripe customer portal |
 | Trial reminder                                  | off - there is no trial           |
 
@@ -302,11 +303,16 @@ read-only at day 14, so the order is: failure and email, 14 days of grace,
 read-only, then the cancellation arrives as
 `customer.subscription.deleted` and drops the org to Free, a working plan.
 
-One knob is deliberately left alone. **Payment method updates** still points at
-`https://pitchbox.app` for every email (the legacy "mix of both" setup);
-switching it to the Stripe-hosted page is the right destination, but the
-dashboard warns the change "cannot be reversed", so it is Lorenzo's call rather
-than a settings edit.
+**Payment method updates is a one-way door, and it is now through it.** Until
+2026-09-10 the account was on the legacy "mix of both" setup, where all four
+emails pointed at `https://pitchbox.app`, the marketing homepage, where no card
+can be updated. It is now the Stripe-hosted page: the customer updates the card
+without signing in to the app, and the destination stops depending on our
+deploy. The dashboard confirms that switch with "this change cannot be
+reversed", and it means it - the legacy option is gone from the page
+afterward, and the custom-URL fields with it. The only remaining choice there
+is a single custom link, which would need an authenticated page of ours that
+can actually take a card, which Managed Payments does not give us.
 
 Two consequences worth knowing before support is promised anywhere:
 


### PR DESCRIPTION
Follow-up to #631, and the last Stripe-side piece of #587.

The customer emails I turned on in #631 carry an "update your payment method" link. On this account that link was the legacy "mix of both" setup, with all four URLs pointing at `https://pitchbox.app`: the marketing homepage, where nobody can update a card. So a customer whose card expired got a correct email to a useless destination.

It is now **Link to a Stripe-hosted page**. The customer updates the card without signing in to the app, which matters most exactly when their payment is broken, and the destination no longer depends on our deploy.

This was a one-way door, so it was Lorenzo's call rather than a settings edit. The dashboard confirms with "this change cannot be reversed", and it means it: after confirming, the legacy option and the custom-URL fields are gone from the page. The only alternative left would be a single custom link, which would need an authenticated page of ours that can take a card, and Managed Payments does not give us one.

Verified on the live account (live mode): reloaded the page after confirming, the radio comes back on the Stripe-hosted page, "mix of both" is absent, and no pitchbox.app custom URL is left. The five email toggles are unchanged.

Docs only: `pnpm run docs:build` says `build complete`.