### PR TITLE
fix(extension): the in-page panel hung on any post with an image, and never got Inter

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -17,7 +17,7 @@ import {
 import { api, type DmSyncFanout } from './lib/api.js';
 import { logEvent } from './lib/activity.js';
 import { getSettings as getExtensionSettings, type ExtensionSettings } from './lib/settings.js';
-import { hasLinkedInPermission } from './lib/permissions.js';
+import { hasImageCapturePermission, hasLinkedInPermission } from './lib/permissions.js';
 import { recordLinkedInAccess } from './lib/linkedin-access.js';
 import linkedinCommentScriptPath from './content/linkedin-comment.ts?script';
 import linkedinObserveScriptPath from './content/linkedin-observe.ts?script';
@@ -493,13 +493,22 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       sendResponse({ ok: false });
       return false;
     }
-    captureAndCropTabRegion({
-      tabId,
-      windowId,
-      rect: msg.rect,
-      devicePixelRatio: msg.devicePixelRatio,
-      maxLongEdgePx: msg.maxLongEdgePx,
-    })
+    // The grant is checked here rather than in the content script that asked:
+    // `chrome.permissions` is not exposed to a content script at all (it threw
+    // there and hung the panel, 2026-09-10), and this is the side that both
+    // holds the API and performs the capture.
+    hasImageCapturePermission()
+      .then((granted) =>
+        granted
+          ? captureAndCropTabRegion({
+              tabId,
+              windowId,
+              rect: msg.rect,
+              devicePixelRatio: msg.devicePixelRatio,
+              maxLongEdgePx: msg.maxLongEdgePx,
+            })
+          : { ok: false as const },
+      )
       .then(sendResponse)
       .catch(() => sendResponse({ ok: false }));
     return true;

--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -526,7 +526,23 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
     }
   }
 
+  /**
+   * A throw anywhere below leaves the panel in `streaming` forever, since
+   * nothing else ever writes its state - which is exactly what a
+   * `chrome.permissions` call from a content script did on every LinkedIn post
+   * carrying an image (2026-09-10): "Reading the post..." with no error, no
+   * request, and no way back. The failure is named here rather than trusted
+   * not to happen.
+   */
   async function requestSuggestion(retune?: RetuneDirection): Promise<void> {
+    try {
+      await runSuggestion(retune);
+    } catch (e) {
+      void setRefused('generation_failed', { threw: (e as Error)?.message ?? String(e) });
+    }
+  }
+
+  async function runSuggestion(retune?: RetuneDirection): Promise<void> {
     if (!capturedPost) {
       void setRefused('selector_health_degraded');
       return;

--- a/extension/src/content/linkedin-post-assist.ts
+++ b/extension/src/content/linkedin-post-assist.ts
@@ -261,7 +261,18 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
     }
   }
 
+  /** Same guard as the comment panel's: nothing else ever writes this panel's
+   * state, so a throw below would leave it in `streaming` forever rather than
+   * saying what went wrong. */
   async function requestSuggestion(retune?: RetuneDirection): Promise<void> {
+    try {
+      await runSuggestion(retune);
+    } catch (e) {
+      void setRefused('generation_failed', { threw: (e as Error)?.message ?? String(e) });
+    }
+  }
+
+  async function runSuggestion(retune?: RetuneDirection): Promise<void> {
     handle.update({ state: { phase: 'streaming', status: 'reading', reasoning: '', draft: '' } });
 
     const assistRes = await api.linkedinAssist();

--- a/extension/src/content/panel.css
+++ b/extension/src/content/panel.css
@@ -441,6 +441,12 @@
   border-radius: var(--radius-sm);
   background: var(--li-accent);
   color: var(--li-accent-foreground);
+  /* A `<button>` does not inherit `font-family`: the UA stylesheet sets its
+   * own, so without this the one control the panel exists for rendered in
+   * Arial while every line around it was Inter. Measured on the real feed,
+   * 2026-09-10 (`getComputedStyle(button).fontFamily` came back `Arial`),
+   * which is also why `.assist-textarea` and `.assist-why` already carry it. */
+  font-family: inherit;
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;

--- a/extension/src/content/shared/media-capture.ts
+++ b/extension/src/content/shared/media-capture.ts
@@ -39,6 +39,36 @@ const MIN_VIEWPORT_OVERLAP_PX = 40;
 
 type CaptureMessageResponse = { ok: true; dataUrl: string } | { ok: false };
 
+/**
+ * Whether it is worth paying the round trip to the background worker at all.
+ *
+ * `chrome.permissions` is **not** part of the API surface a content script
+ * gets, so `hasImageCapturePermission()` throws
+ * `Cannot read properties of undefined (reading 'contains')` in here. That
+ * was not theoretical: it hung the in-page panel on "Reading the post..."
+ * forever on any LinkedIn post carrying an image, because the rejection
+ * escaped `requestSuggestion` before the suggest call was ever made
+ * (measured on the real feed, 2026-09-10, against a preview build).
+ * `media-capture.test.ts` stubbed `chrome.permissions` and so could never
+ * see it.
+ *
+ * When the API is absent we answer `true` and let the worker decide: it
+ * holds the grant, checks it, and answers `{ ok: false }` without the
+ * permission, which lands on exactly the same fallback as a refusal here.
+ * The check survives only as the cheap early-out it was written to be, for
+ * the contexts that do expose the API.
+ */
+async function worthAsking(): Promise<boolean> {
+  if (typeof chrome === 'undefined' || typeof chrome.permissions?.contains !== 'function') {
+    return true;
+  }
+  try {
+    return await hasImageCapturePermission();
+  } catch {
+    return true;
+  }
+}
+
 /** The rect `chrome.tabs.captureVisibleTab`'s image actually covers -
  * `getBoundingClientRect()`'s coordinates are already viewport-relative, so
  * this only clips to what is currently on screen. `null` when what remains
@@ -84,7 +114,7 @@ export async function captureObservedImage(
   // grant from the base LinkedIn permission. Checked before even computing
   // whether the media is on screen, so a device that never turned this on
   // never pays for the viewport math either.
-  if (!(await hasImageCapturePermission())) return fallback;
+  if (!(await worthAsking())) return fallback;
   const rect = viewportOverlap(media.element.getBoundingClientRect());
   if (!rect) return fallback;
 

--- a/extension/src/content/shared/panel-fonts.ts
+++ b/extension/src/content/shared/panel-fonts.ts
@@ -53,25 +53,36 @@ export function ensurePanelFont(): Promise<void> {
     for (const face of document.fonts) {
       if (unquote(face.family) === FAMILY) return;
     }
+
+    // Three shapes reach this line, and the difference is not cosmetic.
+    //
     // Under @crxjs the import above is already an absolute
-    // `chrome-extension://` URL. The fallbacks are for a path that came back
-    // root-relative: inside an extension it is resolved against the
-    // extension's own origin, and outside one (the smoke harness, a plain Vite
-    // build) against the page's, which is also what makes this path checkable
-    // in a browser at all.
+    // `chrome-extension://` URL. In the panel content scripts it is a
+    // `data:font/woff2;base64,...`, because those are built as a single-file
+    // IIFE (`build.lib`, see extension/vite-plugins/panel-content-scripts.ts)
+    // and Vite inlines a lib build's assets rather than emitting them. And in
+    // the smoke harness or a plain Vite build it can be root-relative, which
+    // is what makes this path checkable in a browser at all.
+    //
+    // The scheme test therefore has to be "has a scheme", not "has `://`":
+    // a `data:` URL has no authority, so an `://` test sent it down the
+    // `getURL` branch and produced
+    // `chrome-extension://<id>/data:font/woff2;base64,...`, a 404. Measured on
+    // the real LinkedIn feed on 2026-09-10, where the panel logged
+    // "panel font unavailable NetworkError" on every mount and rendered in the
+    // fallback stack instead of Inter.
     //
     // `typeof chrome`, not `chrome?.`: optional chaining does not protect
     // against an *undeclared* identifier, so `chrome?.runtime` throws a
     // ReferenceError outside an extension rather than yielding undefined. That
     // is not hypothetical - it is what made this branch unverifiable until it
     // was measured.
+    const absolute = /^[a-z][a-z0-9+.-]*:/i.test(interLatin);
     const extensionUrl =
-      typeof chrome !== 'undefined'
+      !absolute && typeof chrome !== 'undefined'
         ? chrome.runtime?.getURL?.(interLatin.replace(/^\/+/, ''))
         : undefined;
-    const url = /^[a-z-]+:\/\//i.test(interLatin)
-      ? interLatin
-      : (extensionUrl ?? new URL(interLatin, location.href).href);
+    const url = absolute ? interLatin : (extensionUrl ?? new URL(interLatin, location.href).href);
     const face = new FontFace(FAMILY, `url(${url})`, {
       weight: '100 900',
       style: 'normal',

--- a/extension/tests/content/media-capture.test.ts
+++ b/extension/tests/content/media-capture.test.ts
@@ -110,6 +110,31 @@ describe('captureObservedImage (#569)', () => {
     expect(image).toEqual({ alt: 'a chart', kind: 'image', partial: false });
   });
 
+  // The real content-script world, which every test above quietly was not:
+  // `chrome.permissions` is not part of the API surface a content script
+  // gets, so the pre-check threw `Cannot read properties of undefined
+  // (reading 'contains')` and the rejection escaped into the assist
+  // controller, which left the in-page panel on "Reading the post..."
+  // forever on any post carrying an image (measured on the real feed,
+  // 2026-09-10). Stubbing `chrome.permissions` is what hid it.
+  it('still asks the background worker when chrome.permissions is absent, as it is in a content script', async () => {
+    globalWithChrome.chrome = {
+      runtime: { sendMessage: sendMessageMock, lastError: undefined },
+    } as unknown as typeof chrome;
+    document.body.innerHTML = '<div id="post"><img id="media" alt="a chart" /></div>';
+    const post = document.getElementById('post')!;
+    stubRect(document.getElementById('media')!, 400, 300, true);
+    respondWith({ ok: true, dataUrl: 'data:image/jpeg;base64,AAAA' });
+    const image = await captureObservedImage(post, document);
+    expect(sendMessageMock).toHaveBeenCalled();
+    expect(image).toEqual({
+      alt: 'a chart',
+      kind: 'image',
+      partial: false,
+      dataUrl: 'data:image/jpeg;base64,AAAA',
+    });
+  });
+
   // Hostile fixture (#569 acceptance): a background worker (or a crafted
   // response from an untrusted extension context) that hands back a
   // dataUrl past the extension's own cap must never have that cap silently

--- a/extension/tests/content/panel-fonts.test.ts
+++ b/extension/tests/content/panel-fonts.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * `ensurePanelFont` registers Inter for the in-page panel through the FontFace
+ * API, because an `@font-face` inside a shadow root is ignored.
+ *
+ * What is under test is the one line that decides *which URL* the face is
+ * built from, and it is not a detail: the panel content scripts are built as a
+ * single-file IIFE (`build.lib`), and Vite inlines a lib build's assets, so
+ * the import resolves to `data:font/woff2;base64,...` rather than to a path.
+ * The old scheme test required `://`, so a `data:` URL fell through to
+ * `chrome.runtime.getURL()` and produced
+ * `chrome-extension://<id>/data:font/woff2;base64,...`, a 404. Measured on the
+ * real LinkedIn feed on 2026-09-10: the panel logged "panel font unavailable
+ * NetworkError" on every mount and rendered in its fallback stack, never Inter.
+ */
+
+type FontFaceCall = { family: string; source: string };
+const calls: FontFaceCall[] = [];
+const globalWithChrome = globalThis as unknown as { chrome?: typeof chrome };
+
+class FakeFontFace {
+  family: string;
+  constructor(family: string, source: string) {
+    this.family = family;
+    calls.push({ family, source });
+  }
+  load(): Promise<FakeFontFace> {
+    return Promise.resolve(this);
+  }
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  vi.resetModules();
+  vi.stubGlobal('FontFace', FakeFontFace as unknown as typeof FontFace);
+  // jsdom implements no `document.fonts`, and the module needs both the
+  // iteration (its "already registered" check) and `add`.
+  Object.defineProperty(document, 'fonts', {
+    configurable: true,
+    value: {
+      add: () => {},
+      [Symbol.iterator]: () => [][Symbol.iterator](),
+    },
+  });
+  globalWithChrome.chrome = {
+    runtime: { getURL: (p: string) => `chrome-extension://abc/${p}` },
+  } as unknown as typeof chrome;
+});
+
+afterEach(() => {
+  delete globalWithChrome.chrome;
+  vi.unstubAllGlobals();
+});
+
+/**
+ * Reloads the module with the asset import resolved to `resolved`, which is
+ * what Vite substitutes at build time and therefore the only input that
+ * decides the branch under test.
+ *
+ * A static import cannot work here: the value being varied *is* a module-level
+ * import of the module under test, so each case needs the module evaluated
+ * again against a different mock.
+ */
+async function loadWithAsset(resolved: string) {
+  vi.doMock('@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url', () => ({
+    default: resolved,
+  }));
+  return await import('../../src/content/shared/panel-fonts.js');
+}
+
+describe('ensurePanelFont URL resolution', () => {
+  it('uses an inlined data URL verbatim rather than resolving it against the extension origin', async () => {
+    const dataUrl = 'data:font/woff2;base64,d09GMgABAAAA';
+    const mod = await loadWithAsset(dataUrl);
+    mod.resetPanelFontForTests();
+    await mod.ensurePanelFont();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].source).toBe(`url(${dataUrl})`);
+    expect(calls[0].source).not.toContain('chrome-extension://');
+  });
+
+  it('resolves a root-relative path against the extension origin, which is what getURL is for', async () => {
+    const mod = await loadWithAsset('/assets/inter-latin-wght-normal-abc123.woff2');
+    mod.resetPanelFontForTests();
+    await mod.ensurePanelFont();
+    expect(calls[0].source).toBe(
+      'url(chrome-extension://abc/assets/inter-latin-wght-normal-abc123.woff2)',
+    );
+  });
+
+  it('uses an absolute chrome-extension URL verbatim, as @crxjs already emits one', async () => {
+    const url = 'chrome-extension://abc/assets/inter-latin-wght-normal-abc123.woff2';
+    const mod = await loadWithAsset(url);
+    mod.resetPanelFontForTests();
+    await mod.ensurePanelFont();
+    expect(calls[0].source).toBe(`url(${url})`);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Closes LOR-176, closes LOR-177.

Both of these were found by loading the built extension into a real Chrome profile and driving it on the LinkedIn feed against `preview.pitchbox.app`, right after shipping #633. Neither is from that change; both had been live for a while, and both sit exactly on the surface I had just been asked to make good.

**The panel hung forever on any post with an image.** Click into a comment box, get "Reading the post..." and nothing else: no draft, no error, no refusal. CDP network capture on the page target shows only `GET /api/extension/linkedin-assist` (200) going out, `POST /api/extension/suggest` never, and no `assist_usage` row appears server-side. The page's own exception log has it: `TypeError: Cannot read properties of undefined (reading 'contains')` inside `captureObservedImage`. `chrome.permissions` is not exposed to content scripts, and that call only happens when the post has media, which is why a text post looked fine. The rejection escaped `requestSuggestion`, and nothing else ever writes the panel's state.

The permission check moves to the side that has the API and takes the pixels (`background.ts`), the content script asks only when the API exists, and both assist controllers now wrap the request so a throw becomes a named refusal instead of a frozen panel. `media-capture.test.ts` never caught this because every case stubbed `chrome.permissions`; there is now a case that does not.

**The panel never got Inter on LinkedIn.** Every mount logged `panel font unavailable NetworkError` and rendered in the fallback stack. It is not CSP and not the manifest: from that same document, the woff2 fetches 200 and a `FontFace` on either URL loads. The panel content scripts are built as a single-file IIFE, so Vite inlines the asset as `data:font/woff2;base64,...`, and the scheme test required `://`, which a data URL has no authority for. It fell through to `chrome.runtime.getURL()` and requested `chrome-extension://<id>/data:font/woff2;base64,...`. The test is now "has a scheme"; the root-relative case still goes through `getURL`.

Same area, same reason nobody had seen it: `.assist-button` had `font-size` and `font-weight` but no `font-family`, and a `<button>` does not inherit one, so the primary action rendered in Arial. `getComputedStyle` on the live panel said `Arial`; it now says `"Inter Variable"`.

Verification:

- Both tests fail with the fix reverted and pass with it: reverting the scheme test and the permission guard produced exactly 2 failures out of 12.
- 76 tests green across the two assist suites, media-capture and the new panel-fonts suite; `pnpm run test:linkedin-compliance` 15 green; `pnpm -F @pitchbox/extension check` clean.
- Live, after the fix, on the same feed: the panel reaches `ready` with a real draft, no exceptions in the page, `document.fonts` carries `Inter Variable`, and the Insert button computes to `"Inter Variable"` on the LinkedIn-blue accent.

Release 0.14.1.
