### PR TITLE
fix(extension,web): stop LinkedIn's own notification badge from becoming my display name

### DIFF
--- a/extension/src/content/linkedin-profile-capture.ts
+++ b/extension/src/content/linkedin-profile-capture.ts
@@ -32,7 +32,10 @@ import { getSettings, type Pairing } from '../lib/storage.js';
  * different from `linkedin-observe.ts`'s collector is that its safety net
  * lives entirely server-side: `POST /api/extension/operator-profile`
  * refuses a capture whose `handle` does not match the operator already on
- * file (`refused: 'not_your_profile'`), rather than this script guessing.
+ * file (`refused: 'not_your_profile'`), and separately refuses a
+ * `displayName` that is not name-shaped (`refused: 'implausible_name'`,
+ * LOR-180 - this script's own selector scoping in `linkedin-dom.ts` is a
+ * defense the server cannot see past), rather than this script guessing.
  *
  * ## One post per page view, per pairing
  *

--- a/extension/src/content/shared/linkedin-dom.ts
+++ b/extension/src/content/shared/linkedin-dom.ts
@@ -123,6 +123,9 @@ export type LinkedInSelectorId =
   | 'commentTimestamp'
   | 'ownProfileTopcard'
   | 'ownProfileName'
+  | 'ownProfileNameTopcard'
+  | 'ownProfileNameHeading'
+  | 'ownProfileNameTitle'
   | 'ownProfileHeadline'
   | 'ownProfileAbout'
   | 'ownProfileExperience'
@@ -1114,7 +1117,12 @@ function ownTextLines(scope: ParentNode): string[] {
 
 /**
  * The profile owner's display name, from whichever of three sources this
- * render actually has (#448).
+ * render actually has (#448), each tracked under its own selector id
+ * (`ownProfileNameTopcard`/`ownProfileNameHeading`/`ownProfileNameTitle`) so
+ * a render change that swaps which source actually answers shows up as a
+ * failing selector instead of silently changing whose name this is
+ * (LOR-180: a render whose topcard went missing let LinkedIn's own Italian
+ * "0 notifiche in totale" notification-count badge answer step two).
  *
  * The topcard `<h2>` alone is what shipped, and Lorenzo's activity export
  * on 2026-09-08 showed it missing five times in a row on his own profile
@@ -1124,27 +1132,51 @@ function ownTextLines(scope: ParentNode): string[] {
  * the document title, which LinkedIn writes as "<name> | LinkedIn" and
  * which no A/B variant has yet been seen without.
  *
+ * Step two only considers headings outside `header`, `[role="banner"]` and
+ * `nav`: LinkedIn's own chrome (a notification-count badge, the global
+ * identity nav) renders inside one of those three landmarks, and a heading
+ * short enough and unpunctuated enough to pass the length/punctuation
+ * filter is not proof it came from the profile itself.
+ *
  * The title is a legitimate source rather than a hack: the server-side
  * guard is what decides whose profile this is (it compares the handle from
  * the URL path against the persona it already holds), so this only ever
- * names the page the human opened.
+ * names the page the human opened. LinkedIn prefixes it with an unread
+ * count when there is one (`"(3) Lorenzo Fiore | LinkedIn"`) - stripped
+ * before the `|` split, so an unread badge cannot land in the name here
+ * either.
  */
 function readOwnProfileName(topCard: Element | null, root: Document): string | null {
   const heading = topCard ? queryDeep<Element>('h2', topCard) : null;
   const fromTopCard = heading ? ownText(heading) || heading.textContent?.trim() || null : null;
+  record('ownProfileNameTopcard', 'profile', fromTopCard !== null);
   if (fromTopCard) return fromTopCard;
 
+  let fromHeading: string | null = null;
   for (const el of queryDeepAll<Element>('h1, h2', root)) {
+    // Chrome, not profile content - see this function's own doc comment.
+    if (el.closest('header, [role="banner"], nav')) continue;
     const text = (ownText(el) || el.textContent?.trim() || '').trim();
     // A heading long enough to be a headline or a section title is not a
     // name; LinkedIn's own section headings ("Informazioni", "Attività")
     // are short, so length alone is not the filter - a name has no
     // sentence punctuation.
-    if (text.length > 0 && text.length <= 60 && !/[.:!?|]/.test(text)) return text;
+    if (text.length > 0 && text.length <= 60 && !/[.:!?|]/.test(text)) {
+      fromHeading = text;
+      break;
+    }
   }
+  record('ownProfileNameHeading', 'profile', fromHeading !== null);
+  if (fromHeading) return fromHeading;
 
-  const title = (root.title ?? '').split('|')[0]?.trim() ?? '';
-  return title.length > 0 && title.length <= 60 ? title : null;
+  const title =
+    (root.title ?? '')
+      .replace(/^\(\d+\)\s*/, '')
+      .split('|')[0]
+      ?.trim() ?? '';
+  const fromTitle = title.length > 0 && title.length <= 60 ? title : null;
+  record('ownProfileNameTitle', 'profile', fromTitle !== null);
+  return fromTitle;
 }
 
 export function readOwnProfile(root: Document = document): OwnProfileCapture | null {

--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -172,8 +172,10 @@ export const en = {
   // handle/headline/experience read off a profile page the human opened, and
   // recent posts read the same way as voice samples.
   'activity.linkedin-collector.profile-captured': 'Captured your LinkedIn profile.',
-  'activity.linkedin-collector.profile-refused':
-    'LinkedIn profile capture skipped: this page is not the operator on file.',
+  // LOR-180: a second refusal reason (implausible_name) joined
+  // not_your_profile, so this interpolates {reason} rather than naming one
+  // outcome - same posture as suggestion-refused above.
+  'activity.linkedin-collector.profile-refused': 'LinkedIn profile capture skipped: {reason}',
   'activity.linkedin-collector.profile-failed': 'LinkedIn profile capture failed: {reason}',
   'activity.linkedin-collector.voice-samples-captured':
     'Captured {count} new post(s) as voice samples.',

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -162,8 +162,8 @@ export const it = {
   'activity.linkedin-collector.source-fill-failed':
     'Compilazione della fonte progetto LinkedIn fallita: {reason}',
   'activity.linkedin-collector.profile-captured': 'Profilo LinkedIn acquisito.',
-  'activity.linkedin-collector.profile-refused':
-    "Acquisizione profilo LinkedIn saltata: questa pagina non corrisponde all'operatore registrato.",
+  // LOR-180: vedi la nota in dict-en.ts.
+  'activity.linkedin-collector.profile-refused': 'Acquisizione profilo LinkedIn saltata: {reason}',
   'activity.linkedin-collector.profile-failed':
     'Acquisizione profilo LinkedIn non riuscita: {reason}',
   'activity.linkedin-collector.voice-samples-captured':

--- a/extension/tests/content/linkedin-dom.test.ts
+++ b/extension/tests/content/linkedin-dom.test.ts
@@ -581,6 +581,64 @@ describe('readOwnProfile: own-profile.html (SDUI profile frontend, real capture)
   });
 });
 
+describe("LOR-180: the display name never comes from LinkedIn's own chrome", () => {
+  it('excludes the global-nav/notification chrome from the heading scan when the topcard is missing', () => {
+    // Reproduces the bug report exactly: own-profile.html's own doc comment
+    // above already records the topcard selector missing five times in a
+    // row on a real profile visit, which is what makes step two (the
+    // page-wide h1/h2 scan) reachable at all. Before the fix, that scan had
+    // no chrome exclusion, so the first heading in document order won even
+    // when it was LinkedIn's own Italian notification-count badge - "0
+    // notifiche in totale" is 21 characters with no sentence punctuation,
+    // so it passed the same length/punctuation filter a real name does.
+    const brokenTopcard = OWN_PROFILE_HTML.replace(
+      'com.linkedin.sdui.profile.card.refEXAMPLEMEMBERTopcard',
+      'com.linkedin.sdui.profile.card.refEXAMPLEMEMBERTopcardBroken',
+    );
+    expect(brokenTopcard).not.toBe(OWN_PROFILE_HTML);
+    setUrl('/in/example-person/');
+    render(`<header role="banner"><h2>0 notifiche in totale</h2></header>${brokenTopcard}`);
+
+    const capture = readOwnProfile(document);
+    expect(capture?.displayName).toBe('Giulia Bianchi');
+
+    const heading = getSelectorHealthReport().find(
+      (e) => e.selector === 'ownProfileNameHeading' && e.pageKind === 'profile',
+    );
+    expect(heading?.lastResult).toBe('match');
+  });
+
+  it('strips a leading unread-notification count from the document-title fallback', () => {
+    // LinkedIn writes the tab title as "(3) <name> | LinkedIn" once there is
+    // an unread count - split('|')[0] alone keeps the "(3) " prefix.
+    setUrl('/in/example-person/');
+    document.title = '(3) Giulia Bianchi | LinkedIn';
+    render('<main><section><p>no headings anywhere in this render</p></section></main>');
+
+    const capture = readOwnProfile(document);
+    expect(capture?.displayName).toBe('Giulia Bianchi');
+
+    const title = getSelectorHealthReport().find(
+      (e) => e.selector === 'ownProfileNameTitle' && e.pageKind === 'profile',
+    );
+    expect(title?.lastResult).toBe('match');
+  });
+
+  it('answers from the topcard alone on the intact capture, and never touches the heading/title sources', () => {
+    setUrl('/in/example-person/');
+    render(OWN_PROFILE_HTML);
+    readOwnProfile(document);
+
+    const report = getSelectorHealthReport();
+    const topcard = report.find(
+      (e) => e.selector === 'ownProfileNameTopcard' && e.pageKind === 'profile',
+    );
+    expect(topcard?.lastResult).toBe('match');
+    expect(report.find((e) => e.selector === 'ownProfileNameHeading')).toBeUndefined();
+    expect(report.find((e) => e.selector === 'ownProfileNameTitle')).toBeUndefined();
+  });
+});
+
 describe('selector health: red on a broken profile selector, green on the intact capture', () => {
   it('reports the topcard as the miss, and still captures what does not need it (#448)', () => {
     // Lorenzo's own profile rendered a shape where this selector found

--- a/web/src/routes/api/extension/operator-profile/+server.ts
+++ b/web/src/routes/api/extension/operator-profile/+server.ts
@@ -28,10 +28,19 @@ import { refreshVoiceProfile } from '@pitchbox/shared/operator-voice-profile';
 // an expected, frequent outcome (any research visit to someone else's
 // profile triggers it), not a client error.
 //
-// **Text is clamped, not rejected.** Every free-text field comes straight
-// off a real page's DOM, which has no length contract with us - clamping
-// keeps a long About section or post from blowing up the companion prompt
-// without failing the whole capture over it.
+// **Text is clamped, not rejected - except the display name, which is also
+// checked for shape.** Every free-text field comes straight off a real
+// page's DOM, which has no length contract with us - clamping keeps a long
+// About section or post from blowing up the companion prompt without
+// failing the whole capture over it. `displayName` gets one more check on
+// top of that: `readOwnProfile`'s client-side selector scoping
+// (extension/src/content/shared/linkedin-dom.ts) is a defense the server
+// cannot see past, so a bad extension build or a changed LinkedIn render
+// that slips LinkedIn's own UI chrome (a notification-count badge, an
+// unread-count title prefix) into this field is caught here instead
+// (`refused: 'implausible_name'`, LOR-180) - the same `200`, not `4xx`,
+// posture as the persona guard below, since a stale build retrying the
+// same bad capture is an expected outcome, not a client error.
 
 const perDevice = new RateLimiter(20, 60_000);
 
@@ -52,6 +61,15 @@ const MAX_POSTS = 20;
 function clamp(text: string, max: number): string {
   return text.trim().slice(0, max);
 }
+
+// A plausible human display name is one to six space-separated words, each
+// starting with a letter and built only from letters, marks, apostrophes,
+// hyphens and periods - no digits, no LinkedIn's own punctuation. This is
+// deliberately structural, not a denylist of known chrome strings: the
+// reported failure ("0 notifiche in totale", LinkedIn's own Italian
+// notification-count badge) has a leading digit, which is the one thing a
+// denylist could never generalise past the next render or locale.
+const NAME_SHAPE = /^\p{L}[\p{L}\p{M}'’.-]*(?: \p{L}[\p{L}\p{M}'’.-]*){0,5}$/u;
 
 const ExperienceSchema = z.object({
   title: z.string().optional(),
@@ -92,6 +110,11 @@ export async function POST({ request }: { request: Request }) {
   const handle = clamp(body.handle, MAX_HANDLE_LEN);
   if (!handle) throw error(400, 'invalid body');
 
+  const displayName = body.displayName?.trim() ? clamp(body.displayName, MAX_NAME_LEN) : undefined;
+  if (displayName !== undefined && !NAME_SHAPE.test(displayName)) {
+    return json({ ok: false, refused: 'implausible_name' });
+  }
+
   const db = getDb();
   const orgId = await resolveDeviceOrgId(db, auth.organizationId);
   if (orgId == null) throw error(404, 'not_found');
@@ -115,7 +138,7 @@ export async function POST({ request }: { request: Request }) {
     orgId,
     {
       handle,
-      displayName: body.displayName?.trim() ? clamp(body.displayName, MAX_NAME_LEN) : undefined,
+      displayName,
       headline: body.headline?.trim() ? clamp(body.headline, MAX_HEADLINE_LEN) : undefined,
       about: body.about?.trim() ? clamp(body.about, MAX_ABOUT_LEN) : undefined,
       experiences: experiences?.length ? experiences : undefined,

--- a/web/src/routes/settings/companion/+page.svelte
+++ b/web/src/routes/settings/companion/+page.svelte
@@ -354,6 +354,15 @@
 								<Badge variant="destructive">Stale, over 90 days old</Badge>
 							{/if}
 						</div>
+						{#if data.profile.source === 'manual'}
+							<!-- LOR-180: saveOperatorProfile refuses to overwrite a manual row, so a
+							     recapture after this point changes nothing on the LinkedIn side either -
+							     without this line that reads as a broken recapture rather than the
+							     protection working as designed. -->
+							<p class="mb-4 text-xs text-muted-foreground">
+								A LinkedIn recapture will not change this: it stays as you last edited it.
+							</p>
+						{/if}
 					{/if}
 					<form
 						method="POST"

--- a/web/tests/extension-operator-profile.test.ts
+++ b/web/tests/extension-operator-profile.test.ts
@@ -139,6 +139,65 @@ describe('POST /api/extension/operator-profile', () => {
     expect(row.displayName).toBe('Ada Lovelace');
   });
 
+  // LOR-180: the client-side capture stored LinkedIn's own Italian
+  // notification-count badge ("0 notifiche in totale") as the display
+  // name. `readOwnProfile`'s own selector scoping is a defense the server
+  // cannot see past, so this is the check that actually stops it.
+  it('refuses a first capture whose display name is not name-shaped, and creates no row', async () => {
+    const org = await seedOrg('op-profile-implausible-name');
+    await mintDevice(org.id, 'tokImplausible');
+
+    const res = await operatorProfilePost({
+      request: bearer('tokImplausible', capture({ displayName: '0 notifiche in totale' })),
+    } as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; refused?: string };
+    expect(body).toEqual({ ok: false, refused: 'implausible_name' });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.operatorProfiles)
+      .where(eq(schema.operatorProfiles.organizationId, org.id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('refuses a re-capture whose display name is not name-shaped, and does not touch the existing row', async () => {
+    const org = await seedOrg('op-profile-implausible-recapture');
+    await mintDevice(org.id, 'tokImplausibleRecapture');
+    await operatorProfilePost({
+      request: bearer('tokImplausibleRecapture', capture()),
+    } as never);
+
+    const res = await operatorProfilePost({
+      request: bearer(
+        'tokImplausibleRecapture',
+        capture({ displayName: '(3) 0 notifiche in totale' }),
+      ),
+    } as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; refused?: string };
+    expect(body).toEqual({ ok: false, refused: 'implausible_name' });
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.operatorProfiles)
+      .where(eq(schema.operatorProfiles.organizationId, org.id));
+    expect(row.displayName).toBe('Ada Lovelace');
+  });
+
+  it('accepts real multi-word, hyphenated and accented names', async () => {
+    const org = await seedOrg('op-profile-name-shapes');
+    await mintDevice(org.id, 'tokNameShapes');
+
+    for (const name of ['Jean-Luc Picard', 'María José García', 'Ada']) {
+      const res = await operatorProfilePost({
+        request: bearer('tokNameShapes', capture({ handle: 'ada-lovelace', displayName: name })),
+      } as never);
+      const body = (await res.json()) as { ok: boolean };
+      expect(body.ok).toBe(true);
+    }
+  });
+
   it('does not clobber a manual row without overwrite: true, and voice samples still dedupe on re-capture', async () => {
     const org = await seedOrg('op-profile-manual');
     await mintDevice(org.id, 'tokManual');
@@ -156,7 +215,7 @@ describe('POST /api/extension/operator-profile', () => {
       request: bearer(
         'tokManual',
         capture({
-          displayName: 'Ada, from a capture',
+          displayName: 'Ada Recaptured',
           posts: [{ externalId: 'urn:li:activity:1', text: 'First post' }],
         }),
       ),
@@ -204,17 +263,14 @@ describe('POST /api/extension/operator-profile', () => {
     });
 
     await operatorProfilePost({
-      request: bearer(
-        'tokOverwrite',
-        capture({ displayName: 'Ada, from a capture', overwrite: true }),
-      ),
+      request: bearer('tokOverwrite', capture({ displayName: 'Ada Recaptured', overwrite: true })),
     } as never);
 
     const [row] = await getDb()
       .select()
       .from(schema.operatorProfiles)
       .where(eq(schema.operatorProfiles.organizationId, org.id));
-    expect(row.displayName).toBe('Ada, from a capture');
+    expect(row.displayName).toBe('Ada Recaptured');
     expect(row.source).toBe('linkedin_capture');
   });
 


### PR DESCRIPTION
Closes LOR-180. Wave 1, lane B.

Reproduced before fixing: with the topcard heading missing (a render this code already documents), `readOwnProfileName`'s page-wide `h1, h2` scan reached LinkedIn's global nav and `0 notifiche in totale` passed the length-and-punctuation filter unchanged.

Three parts, in the order that matters. The heading scan now skips any candidate whose closest ancestor is `header`, `[role=banner]` or `nav`. The title fallback strips the `(n)` unread-count prefix before splitting on `|`, so it is usable rather than decorative. And the server refuses a display name that is not name-shaped in `POST /api/extension/operator-profile`, which is the part that holds when a future LinkedIn render or a stale extension build gets creative: the same `200 {refused}` shape the route's `not_your_profile` refusal already uses, so the panel renders it with no new convention. Each of the three name sources now reports under its own selector-health id, so an A/B render change surfaces as a named failing selector instead of a wrong persona.

Plus one line on `/settings/companion`, shown only for a manually edited row, saying a recapture will not overwrite it: that rule was already true in code and invisible in the UI.

Verified: the new fixture case (own-profile render with the topcard broken plus an Italian global nav) fails before the change with exactly the reported symptom and passes after; the two route refusal tests fail with the server check reverted. 62 tests in `linkedin-dom.test.ts`, 9 in `extension-operator-profile.test.ts`, `test:linkedin-compliance` 15, both workspace typechecks clean.