### PR TITLE
fix(scripts,shared,docs): one Stripe webhook endpoint per mode

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -56,7 +56,8 @@ That choice is not just a fee, it constrains the integration:
 
 `scripts/stripe-setup.ts` is the source of truth for the catalogue and creates or
 reconciles every object the app needs: three products, six prices, the customer
-portal configuration, the two webhook endpoints, and the Stripe Tax defaults.
+portal configuration, this run's own webhook endpoint, and the Stripe Tax
+defaults.
 
 | Plan   | Monthly | Annual | Projects | Runs / month | Suggestions / month | Seats |
 | ------ | ------- | ------ | -------- | ------------ | ------------------- | ----- |
@@ -181,7 +182,7 @@ metadata change.
 # see what would change, against either mode
 STRIPE_SECRET_KEY=sk_test_... pnpm exec tsx scripts/stripe-setup.ts --dry-run
 
-# apply, capturing any webhook signing secret it has to create
+# apply, capturing the webhook signing secret if it has to create one
 STRIPE_SECRET_KEY=sk_live_... pnpm exec tsx scripts/stripe-setup.ts \
   --secrets-out ~/.config/pitchbox-stripe-live-webhooks.env
 ```
@@ -191,6 +192,14 @@ A price whose amount changed cannot be edited (Stripe prices are immutable), so
 the script creates the new price, moves the lookup key onto it, and deactivates
 the old one. Subscriptions already on the old price keep it until they are
 migrated on purpose.
+
+The mode of the key decides which webhook endpoint this run owns (see
+"Webhooks" below): a live key never creates or touches the preview endpoint,
+and a test key never creates or touches the production one. If the account
+still holds an _enabled_ endpoint for the other mode, this run reports it and
+disables it - never deletes it, so it stays visible in the dashboard - rather
+than leaving it to retry a signature it can never verify until Stripe disables
+it on its own.
 
 A webhook signing secret is returned only when the endpoint is created. Pass
 `--secrets-out` or copy it from the run output; Stripe never shows it again.
@@ -241,6 +250,13 @@ database.
 Production and preview have **separate webhook endpoints with separate signing
 secrets** on purpose: a preview deployment holding the production secret could
 write production billing state. Never copy one into the other.
+
+Which endpoint exists in which mode is derived, not chosen: `scripts/stripe-setup.ts`
+reads the mode off the `sk_live_`/`sk_test_` prefix of the key it is given and creates
+or reconciles only that mode's own endpoint, so there is exactly one enabled
+webhook endpoint per mode, never both origins in both modes (LOR-156, fixing an
+account that held all four - the wrong-mode pair could never verify a signature
+and got retried until Stripe disabled them).
 
 A Docker deployment needs each of those four in **both** compose files, not
 only in `.env`: `docker-compose.app.yml` enumerates the container's

--- a/scripts/stripe-probe.ts
+++ b/scripts/stripe-probe.ts
@@ -16,7 +16,11 @@
  *     any other way (#613);
  *   - the recorded catalogue in shared/tests/fixtures/stripe/catalogue.json
  *     still matches the account, which is what keeps the hermetic mapping test
- *     honest.
+ *     honest;
+ *   - the account holds no *enabled* webhook endpoint for the other mode's
+ *     deployment (LOR-156) - that endpoint can never verify a signature here,
+ *     and `scripts/stripe-setup.ts` only disables it on the run that notices,
+ *     never automatically.
  *
  * Run it before a billing release, and after any change to the price
  * catalogue: `pnpm run stripe:probe`. Nothing here writes to the app database.
@@ -25,6 +29,14 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { createStripeClient } from '../shared/src/stripe/client.js';
+import {
+  endpointBelongsToMode,
+  stripeModeFromKey,
+  webhookEndpointTargets,
+} from '../shared/src/stripe/webhook-endpoints.js';
+
+const APP_ORIGIN = process.env.PITCHBOX_APP_ORIGIN ?? 'https://app.pitchbox.app';
+const PREVIEW_ORIGIN = process.env.PITCHBOX_PREVIEW_ORIGIN ?? 'https://preview.pitchbox.app';
 
 const KEY_PATH = join(homedir(), '.config/pitchbox-stripe-test.key');
 const FIXTURE = join(import.meta.dirname, '../shared/tests/fixtures/stripe/catalogue.json');
@@ -154,6 +166,35 @@ if (!portal) {
   } else {
     console.log(`portal ${portal.id}: ok (defers on ${conditions.join(', ')})`);
   }
+}
+
+// LOR-156: this key's mode should hold exactly its own webhook endpoint,
+// never the other deployment's - a real event posted to the wrong-mode
+// endpoint gets a 400 invalid_signature and retries until Stripe disables
+// it, and nothing in this repo would notice until that happens.
+const mode = stripeModeFromKey(readKey());
+const origins = { app: APP_ORIGIN, preview: PREVIEW_ORIGIN };
+const knownTargets = webhookEndpointTargets(origins);
+const webhookResponse = await fetch('https://api.stripe.com/v1/webhook_endpoints?limit=100', {
+  headers: { Authorization: `Bearer ${readKey()}`, 'Stripe-Version': '2025-03-31.basil' },
+});
+const webhookList = (await webhookResponse.json()) as {
+  data: { id: string; url: string; status: string }[];
+};
+const mismatched = webhookList.data.find(
+  (w) =>
+    w.status === 'enabled' &&
+    knownTargets.some((t) => t.url === w.url) &&
+    !endpointBelongsToMode(w.url, mode, origins),
+);
+if (mismatched) {
+  const wrongTarget = knownTargets.find((t) => t.url === mismatched.url)!;
+  console.log(
+    `webhook ${mismatched.id}: ${mismatched.url} is the ${wrongTarget.label} endpoint (${wrongTarget.mode} mode), but this key is ${mode} mode - disable it (a stripe-setup.ts run in ${mode} mode does this)`,
+  );
+  drift += 1;
+} else {
+  console.log(`webhook: no enabled endpoint for the other mode visible to this ${mode}-mode key`);
 }
 
 if (refresh) {

--- a/scripts/stripe-setup.ts
+++ b/scripts/stripe-setup.ts
@@ -1,11 +1,22 @@
 // Create or reconcile the Stripe objects Pitchbox billing depends on: the plan
-// catalogue (products + prices), the customer portal configuration, the two
-// webhook endpoints, and the Stripe Tax defaults.
+// catalogue (products + prices), the customer portal configuration, this run's
+// own webhook endpoint, and the Stripe Tax defaults.
 //
 // This file is the source of truth for the catalogue. The app never hardcodes a
 // price id: it resolves prices by `lookup_key` and reads entitlements from the
 // product metadata this script writes, so test mode and live mode can be brought
 // to the same shape by running it twice with different keys.
+//
+// The mode of the key decides which webhook endpoint is "own": a live key
+// (production, app.pitchbox.app) never creates the preview endpoint, and a
+// test key (preview.pitchbox.app) never creates the production one - each
+// deployment holds only its own mode's signing secret, so the other
+// endpoint's deliveries could never verify a signature anyway (docs/billing.md
+// "Production and preview have separate webhook endpoints"). If the account
+// already holds the other mode's endpoint from before this was mode-aware,
+// this run reports it and disables it (never deletes, so it stays visible in
+// the dashboard) rather than leaving it to retry and eventually get disabled
+// by Stripe itself.
 //
 //   STRIPE_SECRET_KEY=sk_test_... pnpm exec tsx scripts/stripe-setup.ts --dry-run
 //   STRIPE_SECRET_KEY=sk_live_... pnpm exec tsx scripts/stripe-setup.ts \
@@ -21,6 +32,11 @@
 // dashboard, and are deliberately not repo-facing. `--head-office` reads the
 // address from the environment when it has to be set from a script.
 import { writeFile } from 'node:fs/promises';
+import {
+  stripeModeFromKey,
+  webhookEndpointTargets,
+  type StripeMode,
+} from '../shared/src/stripe/webhook-endpoints.js';
 
 type Money = { eur: number; usd: number };
 
@@ -165,7 +181,14 @@ if (!KEY) {
   console.error('STRIPE_SECRET_KEY is required (sk_test_... or sk_live_...)');
   process.exit(1);
 }
-const LIVE = KEY.startsWith('sk_live_');
+let MODE: StripeMode;
+try {
+  MODE = stripeModeFromKey(KEY);
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
+const LIVE = MODE === 'live';
 
 function form(value: unknown, prefix = '', out = new URLSearchParams()): URLSearchParams {
   if (value === null || value === undefined) return out;
@@ -406,8 +429,7 @@ async function ensurePortal(catalogue: { product: StripeProduct; prices: StripeP
   return saved;
 }
 
-async function ensureWebhook(url: string, label: string) {
-  const list = await stripe<StripeList<StripeWebhookEndpoint>>('webhook_endpoints?limit=100');
+async function ensureWebhook(list: StripeList<StripeWebhookEndpoint>, url: string, label: string) {
   const existing = list.data.find((w) => w.url === url);
   if (existing) {
     const sameEvents =
@@ -450,6 +472,29 @@ async function ensureWebhook(url: string, label: string) {
   log('created', `webhook ${label} ${created.id}`);
   // The signing secret comes back only on creation, never again.
   return { endpoint: created, secret: created.secret ?? null };
+}
+
+// The other mode's endpoint is never created here, only reported and (on a
+// real run) disabled - never deleted, so it stays visible in the dashboard.
+// A fresh `--dry-run` after a real run should report nothing left to do.
+async function disableMismatchedWebhook(
+  list: StripeList<StripeWebhookEndpoint>,
+  target: { url: string; label: string },
+) {
+  const existing = list.data.find((w) => w.url === target.url);
+  if (!existing || existing.status !== 'enabled') {
+    log('ok', `no enabled ${target.label} webhook at ${target.url} (wrong mode for this run)`);
+    return;
+  }
+  if (DRY_RUN) {
+    log(
+      'disable',
+      `webhook ${target.label} ${existing.id} ${target.url} (wrong mode for this run)`,
+    );
+    return;
+  }
+  await stripe<StripeWebhookEndpoint>(`webhook_endpoints/${existing.id}`, { disabled: true });
+  log('disabled', `webhook ${target.label} ${existing.id} ${target.url} (wrong mode for this run)`);
 }
 
 async function ensureTax() {
@@ -509,13 +554,19 @@ async function main() {
   console.log('');
 
   const portal = await ensurePortal(catalogue);
-  const production = await ensureWebhook(`${APP_ORIGIN}/api/stripe/webhook`, 'production');
-  const preview = await ensureWebhook(`${PREVIEW_ORIGIN}/api/stripe/webhook`, 'preview');
+
+  const targets = webhookEndpointTargets({ app: APP_ORIGIN, preview: PREVIEW_ORIGIN });
+  const ownTarget = targets.find((t) => t.mode === MODE)!;
+  const mismatchedTarget = targets.find((t) => t.mode !== MODE)!;
+  const webhookList = await stripe<StripeList<StripeWebhookEndpoint>>(
+    'webhook_endpoints?limit=100',
+  );
+  const webhook = await ensureWebhook(webhookList, ownTarget.url, ownTarget.label);
+  await disableMismatchedWebhook(webhookList, mismatchedTarget);
   await ensureTax();
 
   const secrets: string[] = [];
-  if (production.secret) secrets.push(`STRIPE_WEBHOOK_SECRET=${production.secret}`);
-  if (preview.secret) secrets.push(`STRIPE_WEBHOOK_SECRET_PREVIEW=${preview.secret}`);
+  if (webhook.secret) secrets.push(`STRIPE_WEBHOOK_SECRET=${webhook.secret}`);
 
   console.log('');
   console.log('catalogue');
@@ -524,8 +575,9 @@ async function main() {
     for (const p of prices) console.log(`    ${(p.lookup_key ?? '-').padEnd(24)} ${p.id}`);
   }
   console.log(`  portal   ${portal.id}`);
-  console.log(`  webhook  ${production.endpoint.id} -> ${production.endpoint.url}`);
-  console.log(`  webhook  ${preview.endpoint.id} -> ${preview.endpoint.url}`);
+  console.log(
+    `  webhook  ${webhook.endpoint.id} -> ${webhook.endpoint.url} (${ownTarget.label}, ${MODE} mode)`,
+  );
 
   if (secrets.length && SECRETS_OUT) {
     await writeFile(SECRETS_OUT, `${secrets.join('\n')}\n`, { mode: 0o600 });

--- a/shared/src/stripe/webhook-endpoints.ts
+++ b/shared/src/stripe/webhook-endpoints.ts
@@ -1,0 +1,51 @@
+/**
+ * A Stripe webhook endpoint is invoked in the mode it was created in, and a
+ * deployment only ever holds one mode's signing secret - so exactly one
+ * endpoint belongs to each mode. `scripts/stripe-setup.ts` used to create
+ * both `app.pitchbox.app` and `preview.pitchbox.app` in whichever mode it
+ * ran, leaving the account with four endpoints: production and preview
+ * registered in live mode, and again in test mode. Half of those deliveries
+ * can never verify a signature (docs/billing.md "Production and preview have
+ * separate webhook endpoints"), and a real payment posting to the wrong-mode
+ * endpoint gets retried on a 400 `invalid_signature` until Stripe disables it.
+ *
+ * These two functions are the pure decision the fix turns on: which mode a
+ * secret key names, and which of the two known origins belongs to that mode.
+ * Kept out of `scripts/stripe-setup.ts` and `scripts/stripe-probe.ts`, both
+ * of which call the real Stripe API at import time, so this can be
+ * unit-tested without a network call or a credential.
+ */
+export type StripeMode = 'live' | 'test';
+
+export function stripeModeFromKey(secretKey: string): StripeMode {
+  if (secretKey.startsWith('sk_live_')) return 'live';
+  if (secretKey.startsWith('sk_test_')) return 'test';
+  throw new Error(
+    `STRIPE_SECRET_KEY does not look like a Stripe secret key (expected sk_live_... or sk_test_...): ${secretKey.slice(0, 8)}...`,
+  );
+}
+
+export type WebhookOrigins = { app: string; preview: string };
+
+export type WebhookEndpointTarget = { mode: StripeMode; label: string; url: string };
+
+/** The one webhook endpoint each mode owns: live mode gets the production
+ * origin, test mode gets preview - never both, and never swapped, since
+ * preview only ever holds a test-mode signing secret. */
+export function webhookEndpointTargets(origins: WebhookOrigins): WebhookEndpointTarget[] {
+  return [
+    { mode: 'live', label: 'production', url: `${origins.app}/api/stripe/webhook` },
+    { mode: 'test', label: 'preview', url: `${origins.preview}/api/stripe/webhook` },
+  ];
+}
+
+/** True when `url` is the endpoint `mode` is supposed to hold; false for the
+ * other mode's endpoint (which must be reported and disabled, never
+ * created) and for a URL naming neither known origin. */
+export function endpointBelongsToMode(
+  url: string,
+  mode: StripeMode,
+  origins: WebhookOrigins,
+): boolean {
+  return webhookEndpointTargets(origins).some((t) => t.mode === mode && t.url === url);
+}

--- a/shared/tests/stripe-webhook-endpoints.test.ts
+++ b/shared/tests/stripe-webhook-endpoints.test.ts
@@ -1,0 +1,82 @@
+// LOR-156: scripts/stripe-setup.ts used to create both the production and the
+// preview webhook endpoint in whichever mode it ran, leaving the account with
+// four endpoints - half of which can never verify a signature, since a
+// deployment only ever holds its own mode's signing secret. These are the
+// pure decisions the fix turns on, unit-tested here because both scripts call
+// the real Stripe API at import time and cannot be exercised without a
+// credential.
+import { describe, expect, it } from 'vitest';
+import {
+  endpointBelongsToMode,
+  stripeModeFromKey,
+  webhookEndpointTargets,
+} from '../src/stripe/webhook-endpoints.js';
+
+const ORIGINS = { app: 'https://app.pitchbox.app', preview: 'https://preview.pitchbox.app' };
+
+describe('stripeModeFromKey', () => {
+  it('reads live mode off a live secret key', () => {
+    expect(stripeModeFromKey('sk_live_abc123')).toBe('live');
+  });
+
+  it('reads test mode off a test secret key', () => {
+    expect(stripeModeFromKey('sk_test_abc123')).toBe('test');
+  });
+
+  it('throws on a key that is neither live nor test', () => {
+    expect(() => stripeModeFromKey('whsec_abc123')).toThrow(
+      /does not look like a Stripe secret key/,
+    );
+  });
+});
+
+describe('webhookEndpointTargets', () => {
+  it('gives live mode the app origin and test mode the preview origin', () => {
+    const targets = webhookEndpointTargets(ORIGINS);
+    expect(targets).toContainEqual({
+      mode: 'live',
+      label: 'production',
+      url: 'https://app.pitchbox.app/api/stripe/webhook',
+    });
+    expect(targets).toContainEqual({
+      mode: 'test',
+      label: 'preview',
+      url: 'https://preview.pitchbox.app/api/stripe/webhook',
+    });
+  });
+});
+
+describe('endpointBelongsToMode', () => {
+  it('accepts the production URL for live mode', () => {
+    expect(
+      endpointBelongsToMode('https://app.pitchbox.app/api/stripe/webhook', 'live', ORIGINS),
+    ).toBe(true);
+  });
+
+  it('accepts the preview URL for test mode', () => {
+    expect(
+      endpointBelongsToMode('https://preview.pitchbox.app/api/stripe/webhook', 'test', ORIGINS),
+    ).toBe(true);
+  });
+
+  // This is the exact bug: stripe-setup.ts created the preview endpoint even
+  // when it was handed a live key, and the reverse in test mode. A regression
+  // here means the setup script starts recreating the mismatched pair again.
+  it('rejects the preview URL for live mode', () => {
+    expect(
+      endpointBelongsToMode('https://preview.pitchbox.app/api/stripe/webhook', 'live', ORIGINS),
+    ).toBe(false);
+  });
+
+  it('rejects the production URL for test mode', () => {
+    expect(
+      endpointBelongsToMode('https://app.pitchbox.app/api/stripe/webhook', 'test', ORIGINS),
+    ).toBe(false);
+  });
+
+  it('rejects a URL naming neither known origin', () => {
+    expect(
+      endpointBelongsToMode('https://staging.pitchbox.app/api/stripe/webhook', 'live', ORIGINS),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes LOR-156. Wave 1, lane C.

`stripe-setup.ts` used to create both the prod and the preview endpoint in whichever mode it ran, so the account held four and half of them could never verify a signature. It now derives the mode from the key it was given (`sk_live_` / `sk_test_`, validated before any network call) and converges instead of only creating: it registers the endpoint belonging to that mode, and reports and **disables** an enabled endpoint belonging to the other one. Never deletes, so it stays visible in the dashboard. `stripe-probe.ts` fails on the same condition, so this cannot silently come back.

The mode decision and the "does this endpoint belong to this mode" predicate are pure functions in `shared/src/stripe/webhook-endpoints.ts`, which is what makes them testable without a key: 9 tests, proven to bite by making the predicate always accept (3 fail).

No credential was read by the agent that wrote this. What is left for me to run against the real account, once per mode, is in the issue: a `--dry-run` to see what it would disable, then the real run, then `pnpm run stripe:probe`.