### PR TITLE
chore(scripts,shared,docs): a single-use 100 percent off coupon for exercising the live billing path

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -236,6 +236,42 @@ mode and looking at the page. Run the probe before a billing release and after
 any change to the price catalogue or the portal. It never writes to the app
 database.
 
+## Exercising the live billing path without paying
+
+Once a Stripe grant is off (LOR-187), testing the live path - Checkout, the
+webhook, the mirrored `org_subscriptions` row - would otherwise mean a real
+charge to whoever runs it, a real Managed Payments fee, and a real invoice to
+reconcile, for a subscription bought only to watch the webhook fire.
+`scripts/stripe-setup.ts` provisions a single-use, 100%-off coupon for
+exactly that instead (LOR-188), in both modes: the pure decision behind it -
+the code, the redemption cap, the expiry - lives in
+`shared/src/stripe/live-verification-coupon.ts`, unit-tested without a key.
+
+The promotion code is `PITCHBOX-VERIFY-N4K7QZX9WT`. Type it into Checkout's
+"Add promotion code" field (`allow_promotion_codes: true` is already set,
+`shared/src/billing/checkout.ts`) to bring any plan's first invoice to zero.
+It is named here on purpose rather than left for someone to find
+undocumented, and it is restricted the same way documenting it demands:
+
+- **100% off, `duration: once`** - only the first invoice is free; the
+  subscription renews at full price afterward, so cancel it once verified
+  rather than relying on the discount to keep it free.
+- **`max_redemptions: 1`** on both the coupon and its promotion code - one
+  real redemption is exactly what proves the webhook path once, and a second
+  is already the leak this guards against.
+- **An expiry** 30 days after the setup script creates it. Past that instant
+  the coupon is not deleted, only inert; delete it in the dashboard and
+  re-run the setup script to mint a fresh one if the window is missed.
+
+A subscription redeemed with it still mirrors normally: the discount changes
+what the invoice collects, not the subscription's price or product, so the
+webhook (`shared/src/billing/webhook.ts`) records it `active` with the
+plan's real limits, the same as a full-price subscription. `pnpm run
+stripe:probe` reports the coupon's and promotion code's presence and
+restrictions, but only in test mode ("Verifying against the real account"
+above, it never holds a live key), so verify a live redemption by hand,
+once, before relying on it.
+
 ## Environment
 
 | Variable                      | Where             | What                                                                                                                       |

--- a/scripts/stripe-probe.ts
+++ b/scripts/stripe-probe.ts
@@ -20,7 +20,12 @@
  *   - the account holds no *enabled* webhook endpoint for the other mode's
  *     deployment (LOR-156) - that endpoint can never verify a signature here,
  *     and `scripts/stripe-setup.ts` only disables it on the run that notices,
- *     never automatically.
+ *     never automatically;
+ *   - the LOR-188 live-verification coupon and its promotion code are still
+ *     present with the restrictions that keep them from leaking into a real
+ *     sale (100% off, single redemption, an expiry) - all four of those are
+ *     immutable in Stripe once created, so a wrong value here means the
+ *     object has to be deleted and re-created, not patched.
  *
  * Run it before a billing release, and after any change to the price
  * catalogue: `pnpm run stripe:probe`. Nothing here writes to the app database.
@@ -29,6 +34,11 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { createStripeClient } from '../shared/src/stripe/client.js';
+import {
+  LIVE_VERIFICATION_COUPON_ID,
+  LIVE_VERIFICATION_MAX_REDEMPTIONS,
+  LIVE_VERIFICATION_PROMOTION_CODE,
+} from '../shared/src/stripe/live-verification-coupon.js';
 import {
   endpointBelongsToMode,
   stripeModeFromKey,
@@ -107,6 +117,82 @@ for (const lookup of LOOKUPS) {
     drift += 1;
   } else {
     console.log(`${lookup}: ok (${price.unit_amount} ${price.currency})`);
+  }
+}
+
+// LOR-188: the 100%-off coupon docs/billing.md names for exercising the live
+// billing path without a real charge. scripts/stripe-setup.ts creates it;
+// this only ever reads it back, the same as the portal configuration below -
+// percent_off, duration, max_redemptions and the expiry are all immutable
+// once the coupon or its promotion code exist, so a wrong value here means
+// delete-and-rerun, not something this probe could ever fix.
+type Coupon = {
+  id: string;
+  valid: boolean;
+  percent_off: number | null;
+  duration: string;
+  max_redemptions: number | null;
+  redeem_by: number | null;
+};
+type PromotionCode = {
+  id: string;
+  code: string;
+  active: boolean;
+  max_redemptions: number | null;
+  coupon: { id: string };
+};
+
+const couponResponse = await fetch(
+  `https://api.stripe.com/v1/coupons/${LIVE_VERIFICATION_COUPON_ID}`,
+  { headers: { Authorization: `Bearer ${readKey()}`, 'Stripe-Version': '2025-03-31.basil' } },
+);
+if (!couponResponse.ok) {
+  console.log(`coupon ${LIVE_VERIFICATION_COUPON_ID}: not on the account (run stripe-setup.ts)`);
+  drift += 1;
+} else {
+  const coupon = (await couponResponse.json()) as Coupon;
+  const issues: string[] = [];
+  if (coupon.percent_off !== 100) issues.push(`percent_off=${coupon.percent_off}`);
+  if (coupon.max_redemptions !== LIVE_VERIFICATION_MAX_REDEMPTIONS) {
+    issues.push(`max_redemptions=${coupon.max_redemptions}`);
+  }
+  if (!coupon.redeem_by) issues.push('no expiry (redeem_by)');
+  if (!coupon.valid) issues.push('no longer valid (expired or exhausted)');
+  if (issues.length > 0) {
+    console.log(`coupon ${coupon.id}: ${issues.join(', ')}`);
+    drift += 1;
+  } else {
+    console.log(
+      `coupon ${coupon.id}: ok (100% off, ${coupon.duration}, max_redemptions=${coupon.max_redemptions}, expires ${new Date(coupon.redeem_by! * 1000).toISOString().slice(0, 10)})`,
+    );
+  }
+
+  const promoResponse = await fetch(
+    `https://api.stripe.com/v1/promotion_codes?code=${encodeURIComponent(LIVE_VERIFICATION_PROMOTION_CODE)}&limit=1`,
+    { headers: { Authorization: `Bearer ${readKey()}`, 'Stripe-Version': '2025-03-31.basil' } },
+  );
+  const promoList = (await promoResponse.json()) as { data: PromotionCode[] };
+  const promo = promoList.data[0];
+  if (!promo) {
+    console.log(
+      `promotion code ${LIVE_VERIFICATION_PROMOTION_CODE}: not on the account (run stripe-setup.ts)`,
+    );
+    drift += 1;
+  } else {
+    const promoIssues: string[] = [];
+    if (promo.coupon.id !== coupon.id) {
+      promoIssues.push(`points at coupon ${promo.coupon.id}, not ${coupon.id}`);
+    }
+    if (!promo.active) promoIssues.push('inactive');
+    if (promo.max_redemptions !== LIVE_VERIFICATION_MAX_REDEMPTIONS) {
+      promoIssues.push(`max_redemptions=${promo.max_redemptions}`);
+    }
+    if (promoIssues.length > 0) {
+      console.log(`promotion code ${promo.code}: ${promoIssues.join(', ')}`);
+      drift += 1;
+    } else {
+      console.log(`promotion code ${promo.code}: ok -> coupon ${coupon.id}`);
+    }
   }
 }
 

--- a/scripts/stripe-setup.ts
+++ b/scripts/stripe-setup.ts
@@ -1,6 +1,7 @@
 // Create or reconcile the Stripe objects Pitchbox billing depends on: the plan
 // catalogue (products + prices), the customer portal configuration, this run's
-// own webhook endpoint, and the Stripe Tax defaults.
+// own webhook endpoint, the Stripe Tax defaults, and the LOR-188 live-verification
+// coupon that lets the live billing path be exercised without a real charge.
 //
 // This file is the source of truth for the catalogue. The app never hardcodes a
 // price id: it resolves prices by `lookup_key` and reads entitlements from the
@@ -31,7 +32,26 @@
 // registrations and the payout account are set once during activation, in the
 // dashboard, and are deliberately not repo-facing. `--head-office` reads the
 // address from the environment when it has to be set from a script.
+//
+// LOR-188: `--dry-run`/a real run also reports on a single 100%-off coupon and
+// its promotion code, so the live billing path (Checkout, the webhook, the
+// mirrored `org_subscriptions` row) can be driven against the real account
+// without a real charge, fee, or invoice - see docs/billing.md "Exercising
+// the live billing path without paying". The decision of what the code,
+// redemption cap and expiry are lives in
+// `shared/src/stripe/live-verification-coupon.ts`, pure and unit-tested
+// without a key; none of it is editable after creation (Stripe's own rule,
+// not ours), so a coupon or promotion code found not to match is reported,
+// never patched or deleted - the same restraint `disableMismatchedWebhook`
+// already takes with a wrong-mode webhook endpoint.
 import { writeFile } from 'node:fs/promises';
+import {
+  LIVE_VERIFICATION_COUPON_DURATION,
+  LIVE_VERIFICATION_COUPON_ID,
+  LIVE_VERIFICATION_MAX_REDEMPTIONS,
+  LIVE_VERIFICATION_PROMOTION_CODE,
+  liveVerificationExpiresAt,
+} from '../shared/src/stripe/live-verification-coupon.js';
 import {
   stripeModeFromKey,
   webhookEndpointTargets,
@@ -88,6 +108,26 @@ type StripeWebhookEndpoint = {
 };
 
 type StripeTaxSettings = { status: string };
+
+type StripeCoupon = {
+  id: string;
+  valid: boolean;
+  percent_off: number | null;
+  duration: 'forever' | 'once' | 'repeating';
+  max_redemptions: number | null;
+  redeem_by: number | null;
+  metadata: Metadata;
+};
+
+type StripePromotionCode = {
+  id: string;
+  code: string;
+  coupon: StripeCoupon;
+  active: boolean;
+  max_redemptions: number | null;
+  expires_at: number | null;
+  metadata: Metadata;
+};
 
 // SaaS, business use. The same code on every plan; it drives what Stripe Tax
 // computes per country.
@@ -534,6 +574,124 @@ async function ensureTax() {
   return saved;
 }
 
+// LOR-188: a single-use, 100%-off coupon that lets the live billing path be
+// exercised against the real account without a real charge. Looked up by its
+// custom id the same way a price is looked up by `lookup_key`. Every field
+// Stripe would reject an edit to (`percent_off`, `duration`,
+// `max_redemptions`, `redeem_by`) is decided once in
+// `shared/src/stripe/live-verification-coupon.ts`, so an existing coupon
+// that does not match it cannot be repaired here - it is reported, the same
+// as `disableMismatchedWebhook` reports rather than fixes a wrong-mode
+// endpoint.
+async function ensureCoupon(): Promise<StripeCoupon> {
+  const list = await stripe<StripeList<StripeCoupon>>('coupons?limit=100');
+  const existing = list.data.find((c) => c.id === LIVE_VERIFICATION_COUPON_ID);
+  const redeemBy = Math.floor(liveVerificationExpiresAt(new Date()).getTime() / 1000);
+
+  if (existing) {
+    const matches =
+      existing.percent_off === 100 &&
+      existing.duration === LIVE_VERIFICATION_COUPON_DURATION &&
+      existing.max_redemptions === LIVE_VERIFICATION_MAX_REDEMPTIONS &&
+      existing.redeem_by !== null;
+    if (!matches) {
+      log(
+        'warn',
+        `coupon ${existing.id} does not match the LOR-188 decision (percent_off=${existing.percent_off}, duration=${existing.duration}, max_redemptions=${existing.max_redemptions}, redeem_by=${existing.redeem_by}) - none of that is editable; delete it in the dashboard and re-run`,
+      );
+    } else if (!existing.valid) {
+      log(
+        'warn',
+        `coupon ${existing.id} is no longer valid (expired or exhausted) - delete it in the dashboard and re-run to mint a fresh one`,
+      );
+    } else {
+      log(
+        'ok',
+        `coupon ${existing.id} (100% off, ${existing.duration}, max_redemptions=${existing.max_redemptions}, expires ${new Date(existing.redeem_by! * 1000).toISOString().slice(0, 10)})`,
+      );
+    }
+    return existing;
+  }
+
+  if (DRY_RUN) {
+    log(
+      'create',
+      `coupon ${LIVE_VERIFICATION_COUPON_ID} (100% off, ${LIVE_VERIFICATION_COUPON_DURATION}, max_redemptions=${LIVE_VERIFICATION_MAX_REDEMPTIONS}, expires ${new Date(redeemBy * 1000).toISOString().slice(0, 10)})`,
+    );
+    return {
+      id: LIVE_VERIFICATION_COUPON_ID,
+      valid: true,
+      percent_off: 100,
+      duration: LIVE_VERIFICATION_COUPON_DURATION,
+      max_redemptions: LIVE_VERIFICATION_MAX_REDEMPTIONS,
+      redeem_by: redeemBy,
+      metadata: { pitchbox: 'live-verification' },
+    };
+  }
+  const created = await stripe<StripeCoupon>('coupons', {
+    id: LIVE_VERIFICATION_COUPON_ID,
+    percent_off: 100,
+    duration: LIVE_VERIFICATION_COUPON_DURATION,
+    max_redemptions: LIVE_VERIFICATION_MAX_REDEMPTIONS,
+    redeem_by: redeemBy,
+    name: 'Pitchbox live billing path verification',
+    metadata: { pitchbox: 'live-verification' },
+  });
+  log(
+    'created',
+    `coupon ${created.id} (expires ${new Date(redeemBy * 1000).toISOString().slice(0, 10)})`,
+  );
+  return created;
+}
+
+// The promotion code that actually redeems the coupon above at Checkout.
+// Looked up by its exact `code` - Stripe's own `promotion_codes` list filter
+// on that field is an exact match, so this is one request either way.
+async function ensurePromotionCode(coupon: StripeCoupon): Promise<StripePromotionCode> {
+  const list = await stripe<StripeList<StripePromotionCode>>(
+    `promotion_codes?code=${encodeURIComponent(LIVE_VERIFICATION_PROMOTION_CODE)}&limit=1`,
+  );
+  const existing = list.data[0];
+
+  if (existing) {
+    const matches =
+      existing.coupon.id === coupon.id &&
+      existing.active &&
+      existing.max_redemptions === LIVE_VERIFICATION_MAX_REDEMPTIONS;
+    if (!matches) {
+      log(
+        'warn',
+        `promotion code ${existing.code} does not match the LOR-188 decision (coupon=${existing.coupon.id}, active=${existing.active}, max_redemptions=${existing.max_redemptions}) - none of that is editable; delete it in the dashboard and re-run`,
+      );
+    } else {
+      log('ok', `promotion code ${existing.code} -> coupon ${coupon.id}`);
+    }
+    return existing;
+  }
+
+  if (DRY_RUN) {
+    log('create', `promotion code ${LIVE_VERIFICATION_PROMOTION_CODE} -> coupon ${coupon.id}`);
+    return {
+      id: 'dry_promo',
+      code: LIVE_VERIFICATION_PROMOTION_CODE,
+      coupon,
+      active: true,
+      max_redemptions: LIVE_VERIFICATION_MAX_REDEMPTIONS,
+      expires_at: coupon.redeem_by,
+      metadata: { pitchbox: 'live-verification' },
+    };
+  }
+  const created = await stripe<StripePromotionCode>('promotion_codes', {
+    coupon: coupon.id,
+    code: LIVE_VERIFICATION_PROMOTION_CODE,
+    max_redemptions: LIVE_VERIFICATION_MAX_REDEMPTIONS,
+    expires_at: coupon.redeem_by,
+    metadata: { pitchbox: 'live-verification' },
+  });
+  log('created', `promotion code ${created.code} -> coupon ${coupon.id}`);
+  return created;
+}
+
 async function main() {
   const account = await stripe<StripeAccount>('account');
   console.log(
@@ -564,6 +722,8 @@ async function main() {
   const webhook = await ensureWebhook(webhookList, ownTarget.url, ownTarget.label);
   await disableMismatchedWebhook(webhookList, mismatchedTarget);
   await ensureTax();
+  const coupon = await ensureCoupon();
+  const promotionCode = await ensurePromotionCode(coupon);
 
   const secrets: string[] = [];
   if (webhook.secret) secrets.push(`STRIPE_WEBHOOK_SECRET=${webhook.secret}`);
@@ -578,6 +738,10 @@ async function main() {
   console.log(
     `  webhook  ${webhook.endpoint.id} -> ${webhook.endpoint.url} (${ownTarget.label}, ${MODE} mode)`,
   );
+  console.log(
+    `  coupon   ${coupon.id} (100% off, ${coupon.duration}, max_redemptions=${coupon.max_redemptions}, expires ${coupon.redeem_by ? new Date(coupon.redeem_by * 1000).toISOString().slice(0, 10) : 'never'})`,
+  );
+  console.log(`  promo    ${promotionCode.code} -> ${coupon.id}`);
 
   if (secrets.length && SECRETS_OUT) {
     await writeFile(SECRETS_OUT, `${secrets.join('\n')}\n`, { mode: 0o600 });

--- a/shared/src/stripe/client.ts
+++ b/shared/src/stripe/client.ts
@@ -52,6 +52,16 @@ export type StripeSubscription = {
     | 'unpaid'
     | 'paused';
   cancel_at_period_end: boolean;
+  /** IDs of every discount currently applied. `2025-03-31.basil` deprecated
+   * the singular `discount` field in favor of this array (up to 20
+   * stackable discounts). Never expanded or read by this module: a 100%-off
+   * coupon (`shared/src/stripe/live-verification-coupon.ts`, LOR-188)
+   * changes what Stripe collects on the invoice, not the item's price or
+   * product this module reads limits and the plan id from, so a discounted
+   * subscription mirrors exactly like a full-price one. Declared here so a
+   * real event's shape (`shared/tests/billing-webhook.test.ts`) does not
+   * need an unsafe cast to include it. */
+  discounts?: string[];
   metadata: StripeMetadata;
   items: { data: StripeSubscriptionItem[] };
 };

--- a/shared/src/stripe/live-verification-coupon.ts
+++ b/shared/src/stripe/live-verification-coupon.ts
@@ -1,0 +1,80 @@
+/**
+ * The 100%-off coupon `scripts/stripe-setup.ts` provisions so the live
+ * billing path (docs/billing.md "Exercising the live billing path without
+ * paying") can be driven against the real Stripe account - Checkout, the
+ * webhook, the mirrored `org_subscriptions` row - without a real charge, a
+ * real Managed Payments fee, or a real invoice to reconcile afterwards
+ * (LOR-188). Kept out of `scripts/stripe-setup.ts` and `scripts/stripe-probe.ts`
+ * for the same reason `webhook-endpoints.ts` keeps `stripeModeFromKey` out of
+ * them: both call the real Stripe API at import time, so a decision they
+ * need cannot be unit-tested from inside either one.
+ *
+ * The coupon and its promotion code are immutable once created: Stripe's own
+ * "Update a coupon" only lets `metadata`/`name` change afterwards, and
+ * "Update a promotion code" only `active`/`metadata`/`restrictions` - never
+ * `percent_off`, `duration`, `max_redemptions`, or either object's expiry
+ * (`redeem_by` / `expires_at`). So every constant below only ever takes
+ * effect on the object's first creation. Changing one does not migrate the
+ * existing Stripe object, it orphans it - delete the orphan by hand in the
+ * dashboard (the setup script never deletes it, the same restraint it
+ * already takes with a mismatched webhook endpoint) before re-running so the
+ * id/code below is free again.
+ */
+
+/** Custom coupon id, so the setup script looks this up the same way a price
+ * is looked up by `lookup_key` - one direct fetch, not a scan of every
+ * coupon on the account. The same id is used in both Stripe modes; test and
+ * live are separate accounts, so there is no collision to avoid. */
+export const LIVE_VERIFICATION_COUPON_ID = 'pitchbox_live_verification';
+
+/**
+ * The code typed into Checkout's "Add promotion code" field. Deliberately
+ * not a guessable word (`FREE100`, `TESTING`, `PITCHBOXFREE`): a stranger
+ * who finds this repo and tries it is refused the moment `max_redemptions`
+ * is spent, but the code itself should not be the weak link a real customer
+ * stumbles onto by chance. Fixed rather than generated per run - the setup
+ * script looks a promotion code up by this exact string
+ * (`GET /v1/promotion_codes?code=...`), so a random value would mint a new
+ * one on every run instead of converging on one, the opposite of the
+ * idempotent-by-lookup shape the price catalogue already uses.
+ */
+export const LIVE_VERIFICATION_PROMOTION_CODE = 'PITCHBOX-VERIFY-N4K7QZX9WT';
+
+/**
+ * Both the coupon and the promotion code carry this cap - belt and
+ * suspenders, since only one promotion code ever points at this coupon. One
+ * real redemption is exactly what proves the webhook path once; a second
+ * redemption is already the leak the issue asks to guard against.
+ */
+export const LIVE_VERIFICATION_MAX_REDEMPTIONS = 1;
+
+/**
+ * `duration: 'once'`: the discount applies to the subscription's first
+ * invoice only. This matches the ask - "a subscription I only want in order
+ * to watch the webhook work" - a subscription that is cancelled once
+ * verified, the same as any other test subscription, rather than one whose
+ * price silently stays free forever if cancelling it is forgotten.
+ */
+export const LIVE_VERIFICATION_COUPON_DURATION = 'once' as const;
+
+/**
+ * How many days after creation the coupon (and its promotion code, pinned
+ * to the same instant by the setup script) can still be redeemed. Stripe
+ * caps a coupon's `redeem_by` at 5 years out; this is deliberately far
+ * short of that - a bounded, unused window is the point (LOR-188:
+ * "restricted so it cannot leak into a real sale"). Once it passes, the
+ * object is not deleted, only inert, so a fresh window needs a fresh
+ * id/code (see the module comment above).
+ */
+export const LIVE_VERIFICATION_EXPIRY_DAYS = 30;
+
+/**
+ * The instant the coupon (and its promotion code) stop being redeemable, as
+ * a pure function of `now` rather than a date baked into a constant that
+ * would go stale - `scripts/stripe-setup.ts` calls this once, at the moment
+ * it actually creates the objects, and never again (Stripe will not let the
+ * expiry be edited afterwards).
+ */
+export function liveVerificationExpiresAt(now: Date): Date {
+  return new Date(now.getTime() + LIVE_VERIFICATION_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
+}

--- a/shared/tests/billing-webhook.test.ts
+++ b/shared/tests/billing-webhook.test.ts
@@ -804,3 +804,61 @@ describe('applyStripeEvent - grace window and read-only (#554)', () => {
     expect(isOrgReadOnly(entitlements)).toBe(false);
   });
 });
+
+describe('applyStripeEvent - a fully discounted (100% off) subscription (LOR-188)', () => {
+  it('mirrors the plan real limits, not a discounted or zeroed-out plan', async () => {
+    const org = await makeOrg();
+    const subscriptionId = `sub_${randomUUID()}`;
+    // Shaped the way Stripe actually answers once the LOR-188
+    // live-verification coupon is redeemed at Checkout: `discounts` carries
+    // the applied discount's id (2025-03-31.basil's replacement for the
+    // deprecated singular `discount` field), and the item's price/product
+    // are completely untouched by it - a 100% coupon changes what the
+    // invoice collects, never the price or product the webhook reads the
+    // plan and its limits from.
+    const sub: StripeSubscription = {
+      ...fakeSubscription({
+        id: subscriptionId,
+        customer: org.stripeCustomerId,
+        product: GROWTH_PRODUCT,
+      }),
+      discounts: [`di_${randomUUID()}`],
+    };
+
+    const result = await applyStripeEvent(getDb(), fakeStripeClient({ [subscriptionId]: sub }), {
+      id: `evt_${randomUUID()}`,
+      type: 'checkout.session.completed',
+      created: Math.floor(Date.now() / 1000),
+      data: { object: { subscription: subscriptionId, customer: org.stripeCustomerId } },
+    });
+    expect(result.outcome).toBe('applied');
+
+    const [row] = await getDb()
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.organizationId, org.id));
+    expect(row.status).toBe('active');
+    expect(row.planId).toBe('growth');
+    expect(row.limitRuns).toBe(2000);
+    expect(row.limitProjects).toBe(10);
+    expect(row.limitSeats).toBe(3);
+
+    const [freshOrg] = await getDb()
+      .select({ plan: schema.organizations.plan, planSource: schema.organizations.planSource })
+      .from(schema.organizations)
+      .where(eq(schema.organizations.id, org.id));
+    expect(freshOrg.plan).toBe('growth');
+    expect(freshOrg.planSource).toBe('stripe');
+
+    process.env.PITCHBOX_EDITION = 'cloud';
+    try {
+      const entitlements = await resolveEntitlements(getDb(), org.id);
+      expect(entitlements.planId).toBe('growth');
+      expect(entitlements.projects).toBe(10);
+      expect(entitlements.seats).toBe(3);
+      expect(entitlements.source).toBe('subscription');
+    } finally {
+      delete process.env.PITCHBOX_EDITION;
+    }
+  });
+});

--- a/shared/tests/stripe-live-verification-coupon.test.ts
+++ b/shared/tests/stripe-live-verification-coupon.test.ts
@@ -1,0 +1,64 @@
+// LOR-188: the restrictions that keep the live-verification coupon from
+// leaking into a real sale are decided here, pure and unit-tested without a
+// key, because scripts/stripe-setup.ts and scripts/stripe-probe.ts both call
+// the real Stripe API at import time and cannot be exercised without one -
+// the same reasoning shared/tests/stripe-webhook-endpoints.test.ts already
+// applies to stripeModeFromKey.
+import { describe, expect, it } from 'vitest';
+import {
+  LIVE_VERIFICATION_COUPON_DURATION,
+  LIVE_VERIFICATION_COUPON_ID,
+  LIVE_VERIFICATION_EXPIRY_DAYS,
+  LIVE_VERIFICATION_MAX_REDEMPTIONS,
+  LIVE_VERIFICATION_PROMOTION_CODE,
+  liveVerificationExpiresAt,
+} from '../src/stripe/live-verification-coupon.js';
+
+describe('the LOR-188 live-verification coupon decision', () => {
+  it('caps redemptions at exactly one, on both the coupon and the promotion code', () => {
+    // The issue's own restriction: one real redemption proves the webhook
+    // path once, a second is already the leak it guards against. A larger
+    // cap here would silently widen every place that reads this constant.
+    expect(LIVE_VERIFICATION_MAX_REDEMPTIONS).toBe(1);
+  });
+
+  it('discounts the first invoice only, not every future renewal', () => {
+    expect(LIVE_VERIFICATION_COUPON_DURATION).toBe('once');
+  });
+
+  it('uses a stable custom coupon id, not a placeholder Stripe would reject', () => {
+    // Stripe coupon/promotion-code ids and codes accept letters, digits,
+    // underscores and dashes; anything else is a real 400 on creation.
+    expect(LIVE_VERIFICATION_COUPON_ID).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(LIVE_VERIFICATION_COUPON_ID.length).toBeGreaterThan(0);
+  });
+
+  it('is not a guessable word a stranger could type into Checkout before the redemption cap catches it', () => {
+    // Stripe's own charset for a promotion code: letters, digits, dashes.
+    expect(LIVE_VERIFICATION_PROMOTION_CODE).toMatch(/^[A-Za-z0-9-]+$/);
+    // Long enough, and mixing letters with digits, to rule out a short
+    // dictionary word like "FREE100" or "PITCHBOXFREE" standing in for it.
+    expect(LIVE_VERIFICATION_PROMOTION_CODE.length).toBeGreaterThanOrEqual(16);
+    expect(LIVE_VERIFICATION_PROMOTION_CODE).toMatch(/[0-9]/);
+  });
+
+  it('expires a bounded number of days after creation, never immediately and never indefinitely', () => {
+    const now = new Date('2026-09-10T00:00:00Z');
+    const expiresAt = liveVerificationExpiresAt(now);
+
+    expect(expiresAt.getTime()).toBeGreaterThan(now.getTime());
+    expect(expiresAt.getTime() - now.getTime()).toBe(
+      LIVE_VERIFICATION_EXPIRY_DAYS * 24 * 60 * 60 * 1000,
+    );
+    // Stripe rejects a coupon's redeem_by more than 5 years out - staying
+    // far under that is what makes this "an expiry" rather than a decoration.
+    const fiveYearsMs = 5 * 365 * 24 * 60 * 60 * 1000;
+    expect(expiresAt.getTime() - now.getTime()).toBeLessThan(fiveYearsMs);
+  });
+
+  it('is a pure function of the instant it is called with, not the wall clock', () => {
+    const a = liveVerificationExpiresAt(new Date('2026-01-01T00:00:00Z'));
+    const b = liveVerificationExpiresAt(new Date('2026-01-01T00:00:00Z'));
+    expect(a.getTime()).toBe(b.getTime());
+  });
+});


### PR DESCRIPTION
Closes LOR-188. Wave 2, lane D.

Prod runs live keys, so exercising the billing path there means a real charge to myself for a subscription I only want in order to watch the webhook work. Checkout already accepts a promotion code; the coupon did not exist. `stripe-setup.ts` now reconciles it in both modes, idempotent by id and code the way the prices already are, and `stripe-probe.ts` checks its restrictions so a widened or expired coupon is drift rather than a surprise.

The restrictions are the point: 100 percent off, `duration: once`, **one redemption**, and an expiry. They live as an exported decision in `shared/src/stripe/live-verification-coupon.ts` rather than as literals in the script, which is what makes them testable without a key. 6 tests on that module, proven to bite by widening the redemption cap, shortening the code and stretching the expiry (3 of 6 fail).

The issue marked one expectation `[INFERENCE]`: that a fully discounted subscription arrives as `active` with the plan's real limits. It does, and it is now asserted rather than inferred. `shared/tests/billing-webhook.test.ts` gained a case with `discounts` present on the subscription, proven to bite by making `syncSubscriptionFromStripe` drop a discounted subscription to Free (the test fails with `expected "free" to be "growth"`). No production code needed fixing, which is the answer to the open question in the issue.

`shared/src/stripe/client.ts` gained the optional `discounts?: string[]` field the current API version actually sends, documented and deliberately not read by the webhook.

Verified: 20 tests across the two suites, shared typecheck clean, eslint and prettier clean, `docs:build` complete. No Stripe credential was read at any point. `docs/billing.md` names the code, its three restrictions and why it exists, since a coupon nobody documented is a coupon somebody finds.