### PR TITLE
fix(scripts): pin the Stripe API version, and let the probe check either mode

### DIFF
--- a/scripts/stripe-probe.ts
+++ b/scripts/stripe-probe.ts
@@ -62,19 +62,44 @@ const LOOKUPS = [
   'pitchbox_scale_yearly',
 ];
 
+/**
+ * The key this run checks. `STRIPE_SECRET_KEY` wins when it is set, so the
+ * live account can be probed too: without it this script silently read the
+ * test key no matter what the caller passed, and reported the **test**
+ * account's portal and endpoints while appearing to answer for live (measured
+ * 2026-09-10, right after the live-mode reconciliation). The file remains the
+ * default, since that is the ordinary case.
+ */
 function readKey(): string {
+  const fromEnv = process.env.STRIPE_SECRET_KEY?.trim();
+  if (fromEnv) return fromEnv;
   try {
     return readFileSync(KEY_PATH, 'utf8').trim();
   } catch {
     console.error(
-      `no Stripe test key at ${KEY_PATH}. This script is for the machine that holds it; CI is not.`,
+      `no Stripe key: pass STRIPE_SECRET_KEY or put the test key at ${KEY_PATH}. This script is for the machine that holds it; CI is not.`,
     );
     process.exit(2);
   }
 }
 
 const refresh = process.argv.includes('--refresh');
-const stripe = createStripeClient(readKey());
+const key = readKey();
+const stripe = createStripeClient(key);
+/**
+ * The recording in `catalogue.json` is a **test-mode** recording: the two
+ * accounts hold different ids, and their product metadata is allowed to
+ * diverge (measured 2026-09-10: live carries no `tax_code_note`, which an
+ * older version of `stripe-setup.ts` had written into test). So the fixture
+ * diff only means something against a test key, and `--refresh` under a live
+ * key would overwrite the test recording with live ids. Both are refused
+ * rather than reported as six mysterious differences.
+ */
+const fixtureApplies = stripeModeFromKey(key) === 'test';
+if (refresh && !fixtureApplies) {
+  console.error('--refresh needs the test key: the recording is a test-mode catalogue');
+  process.exit(2);
+}
 
 const recorded: Record<string, unknown> = {};
 let drift = 0;
@@ -103,8 +128,10 @@ for (const lookup of LOOKUPS) {
     product: { id: product.id, name: product.name, metadata: product.metadata },
   };
 
-  const known = fixture[lookup];
-  if (!known) {
+  const known = fixtureApplies ? fixture[lookup] : undefined;
+  if (!fixtureApplies) {
+    console.log(`${lookup}: ok (${price.unit_amount} ${price.currency}, live, not compared)`);
+  } else if (!known) {
     console.log(`${lookup}: not in the recording`);
     drift += 1;
   } else if (known.price.unit_amount !== price.unit_amount) {

--- a/scripts/stripe-setup.ts
+++ b/scripts/stripe-setup.ts
@@ -122,12 +122,31 @@ type StripeCoupon = {
 type StripePromotionCode = {
   id: string;
   code: string;
-  coupon: StripeCoupon;
+  /** Pre-`2026-08-26.dahlia` shape: the coupon inline on the promotion code. */
+  coupon?: StripeCoupon;
+  /** `2026-08-26.dahlia` and later: the discount is wrapped in `promotion`. */
+  promotion?: { type?: string; coupon?: StripeCoupon | string };
   active: boolean;
   max_redemptions: number | null;
   expires_at: number | null;
   metadata: Metadata;
 };
+
+/**
+ * The coupon a promotion code points at, across the API-version change this
+ * account has already crossed. `POST /v1/promotion_codes` took a flat `coupon`
+ * until `2026-08-26.dahlia`, which replaced it with a required `promotion`
+ * object and answers `Received unknown parameter: coupon` otherwise (measured
+ * on the real test account, 2026-09-10, while creating this very code). The
+ * read side moved with it, so both shapes are accepted here rather than
+ * assuming either one.
+ */
+function promotionCodeCouponId(code: StripePromotionCode): string | undefined {
+  const nested = code.promotion?.coupon;
+  if (typeof nested === 'string') return nested;
+  if (nested?.id) return nested.id;
+  return code.coupon?.id;
+}
 
 // SaaS, business use. The same code on every plan; it drives what Stripe Tax
 // computes per country.
@@ -246,12 +265,25 @@ function form(value: unknown, prefix = '', out = new URLSearchParams()): URLSear
   return out;
 }
 
+/**
+ * The API version every request here is written against, pinned for the same
+ * reason `stripe-probe.ts` pins it: this script hand-maintains its own request
+ * shapes, and the account's default version moves under it. Measured on
+ * 2026-09-10: the account had reached `2026-08-26.dahlia`, where
+ * `POST /v1/promotion_codes` replaced the flat `coupon` parameter with a
+ * required `promotion` object, so an unpinned run failed with
+ * `Received unknown parameter: coupon` after having already created the
+ * coupon. Bump this deliberately, with the request shapes, never by accident.
+ */
+const STRIPE_API_VERSION = '2025-03-31.basil';
+
 async function stripe<T>(path: string, body?: unknown, method?: string): Promise<T> {
   const verb = method ?? (body ? 'POST' : 'GET');
   const res = await fetch(`https://api.stripe.com/v1/${path}`, {
     method: verb,
     headers: {
       Authorization: `Bearer ${KEY}`,
+      'Stripe-Version': STRIPE_API_VERSION,
       'Content-Type': 'application/x-www-form-urlencoded',
     },
     body: body ? form(body) : undefined,
@@ -655,13 +687,13 @@ async function ensurePromotionCode(coupon: StripeCoupon): Promise<StripePromotio
 
   if (existing) {
     const matches =
-      existing.coupon.id === coupon.id &&
+      promotionCodeCouponId(existing) === coupon.id &&
       existing.active &&
       existing.max_redemptions === LIVE_VERIFICATION_MAX_REDEMPTIONS;
     if (!matches) {
       log(
         'warn',
-        `promotion code ${existing.code} does not match the LOR-188 decision (coupon=${existing.coupon.id}, active=${existing.active}, max_redemptions=${existing.max_redemptions}) - none of that is editable; delete it in the dashboard and re-run`,
+        `promotion code ${existing.code} does not match the LOR-188 decision (coupon=${promotionCodeCouponId(existing) ?? '-'}, active=${existing.active}, max_redemptions=${existing.max_redemptions}) - none of that is editable; delete it in the dashboard and re-run`,
       );
     } else {
       log('ok', `promotion code ${existing.code} -> coupon ${coupon.id}`);
@@ -674,7 +706,7 @@ async function ensurePromotionCode(coupon: StripeCoupon): Promise<StripePromotio
     return {
       id: 'dry_promo',
       code: LIVE_VERIFICATION_PROMOTION_CODE,
-      coupon,
+      promotion: { type: 'coupon', coupon },
       active: true,
       max_redemptions: LIVE_VERIFICATION_MAX_REDEMPTIONS,
       expires_at: coupon.redeem_by,


### PR DESCRIPTION
Found while running #638 and #641 against the real accounts, which is the half of both issues that only a human with the keys can do.

Three defects. The setup script sent no `Stripe-Version`, so it inherited the account's default, which has drifted to `2026-08-26.dahlia`: there `POST /v1/promotion_codes` replaced the flat `coupon` parameter with a required `promotion` object, and the run died with `Received unknown parameter: coupon` **after** creating the coupon. A converging script that can half-apply is the one failure mode it exists to prevent, so the version is now pinned to what the request shapes are written against, matching what `stripe-probe.ts` already did. The read side of promotion codes accepts both shapes, since this account has already crossed that boundary once.

The probe ignored `STRIPE_SECRET_KEY` and always read the test key from disk, so a live probe reported the test account's portal and endpoints while looking like it answered for live. And its catalogue recording is a test-mode recording, so comparing it under a live key produced six meaningless differences, and `--refresh` there would have overwritten the recording with live ids. Both are fixed: env wins over the file, the fixture diff is skipped outside test mode, and `--refresh` refuses a live key.

Verified against both real accounts, which is the point of this PR: test and live each reconcile clean, both probes exit 0, the live `--refresh` guard refuses, and the wrong-mode webhook endpoint is now disabled in each mode. That last one closes the account-side half of LOR-156, and the coupon plus `PITCHBOX-VERIFY-...` promotion code now exist in both modes, which closes the account-side half of LOR-188.