### PR TITLE
fix(extension,web,shared): the reply box gets the same assistant as a post comment, and a retry can recover

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -23,6 +23,7 @@ import {
   findParentCommentId,
   findPostComments,
   findPostComposerModal,
+  findReplyTargetCommentId,
   readCommentAuthor,
   readCommentBody,
   readCommentRelativeTime,
@@ -451,13 +452,30 @@ export function composerHasOwnText(composer: HTMLElement): boolean {
  */
 function mountAssistPanel(composer: HTMLElement, post?: Element): void {
   const anchor = resolveAnchor(composer);
-  // #569: the same element `readAssistPostFromCard`/`readAssistPost` above
-  // resolved from, kept around so a suggestion request can also capture its
-  // attached media - image capture is async (a round trip through the
-  // background worker) so it happens at request time, not folded into
-  // `capturedPost`'s own synchronous read.
-  const postElement = post ?? findFeedPosts(document)[0];
-  const capturedPost = post ? readAssistPostFromCard(post, document) : readAssistPost(document);
+  // LOR-198: which comment this composer replies to, when it is a reply
+  // box - a fixed property of where LinkedIn rendered the composer, not
+  // something that changes across a retry the way the post's own text can
+  // (see `captureCurrentPost` below). `undefined` for the post's own
+  // composer, exactly as the request carried before this field existed.
+  const replyToCommentId = findReplyTargetCommentId(composer) ?? undefined;
+  // LOR-197: read fresh on every call that grounds a request, never once
+  // here and reused for the panel's whole lifetime. `capturedPost` used to
+  // be a `const` computed exactly once at mount time, so a page whose
+  // content was still arriving when the human clicked stayed refused
+  // forever: `runSuggestion`'s `!capturedPost` check and `Try again`'s
+  // `onRequest` both read the same closed-over `null`, and nothing ever
+  // re-read the page to find out it was no longer true (measured
+  // 2026-09-10: a comment permalink page whose post text was on screen,
+  // refusing every retry with `selector_health_degraded`). `postElement`
+  // (#569, used only for the image capture below) is read fresh alongside
+  // it for the same reason.
+  function captureCurrentPost(): AssistPost | null {
+    return post ? readAssistPostFromCard(post, document) : readAssistPost(document);
+  }
+  function currentPostElement(): Element | undefined {
+    return post ?? findFeedPosts(document)[0];
+  }
+  const initialPost = captureCurrentPost();
   for (const event of selectorHealthActivityEvents()) logFromContent(event);
 
   let currentReasoning = '';
@@ -484,7 +502,7 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
   const autoRequest = !cached && !composerHasOwnText(composer);
 
   const props: CommentAssistPanelProps = {
-    subject: capturedPost?.authorName ?? undefined,
+    subject: initialPost?.authorName ?? undefined,
     state: initial,
     onRequest: () => void requestSuggestion(),
     onEditChange: (text) => {
@@ -543,6 +561,11 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
   }
 
   async function runSuggestion(retune?: RetuneDirection): Promise<void> {
+    // LOR-197: re-read here, not the mount-time snapshot above - see the
+    // doc comment on `captureCurrentPost`. This is what makes `Try again`
+    // (and a retune, and the auto-request on mount) each a real attempt
+    // rather than a replay of whatever the first read found.
+    const capturedPost = captureCurrentPost();
     if (!capturedPost) {
       void setRefused('selector_health_degraded');
       return;
@@ -580,6 +603,7 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
     // the one field on this request that costs a round trip through the
     // background worker - see media-capture.ts's own doc comment for the
     // three outcomes this can resolve to.
+    const postElement = currentPostElement();
     const image = postElement ? await captureObservedImage(postElement, document) : undefined;
     if (!handle.alive) return;
 
@@ -600,6 +624,10 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
           commentCount: capturedPost.commentCount,
           thread: capturedPost.thread,
           image,
+          // LOR-198: names which comment this suggestion answers, so the
+          // server writes a reply to that commenter rather than a second
+          // comment on the post itself (`buildSuggestionPrompt`'s `taskFor`).
+          replyToCommentId,
         },
         retune,
         sessionId: lastSessionId,
@@ -653,6 +681,9 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
   }
 
   async function acceptAndInsert(): Promise<void> {
+    // LOR-197: same re-read as `runSuggestion` - see `captureCurrentPost`'s
+    // own doc comment.
+    const capturedPost = captureCurrentPost();
     if (!capturedPost) {
       void setRefused('selector_health_degraded');
       return;
@@ -839,12 +870,26 @@ const CARD_MAX_DEPTH = 14;
  *
  * First `findFeedPosts`, which is the recognised shape and the one that
  * scopes the readers best. Then the known post-container roles. Then, and
- * this is the part that matters on an unfamiliar feed variant (#447), a
- * structural walk: the largest ancestor that still contains exactly one
- * comment composer, which is precisely the boundary between "this post" and
- * "the feed". Two composers means the walk has left the card, so the last
- * single-composer ancestor is as wide as it can honestly go - grounding a
- * suggestion in somebody else's post would be worse than not grounding it.
+ * this is the part that matters on an unfamiliar feed variant (#447) or a
+ * comment permalink whose reply box opened under one specific comment
+ * (LOR-197), a structural walk: the largest ancestor that still contains
+ * exactly one *top-level* comment composer, which is precisely the
+ * boundary between "this post" and "the feed". Two top-level composers
+ * means the walk has left the card, so the last single-composer ancestor
+ * is as wide as it can honestly go - grounding a suggestion in somebody
+ * else's post would be worse than not grounding it.
+ *
+ * "Top-level" is LOR-197's own fix: a reply box under a comment is a
+ * second composer by a plain element count, the same as a different
+ * card's own composer would be, but it is not a different card - it and
+ * the post's own "Add a comment" box both belong to the one card the
+ * comment renders inside. Counting it anyway broke on exactly that shape
+ * (measured 2026-09-10, a comment permalink page whose open reply box
+ * refused every request): the walk gave up one level before it ever
+ * reached the post's own boundary, which is the only place the two
+ * composers are ever seen together. `findReplyTargetCommentId`
+ * (linkedin-dom.ts) is what tells a reply box apart from a top-level one
+ * here, independent of whether the page's own kind classifies at all.
  */
 function resolveCardFor(composer: HTMLElement): Element | null {
   for (const card of findFeedPosts(document)) {
@@ -856,7 +901,10 @@ function resolveCardFor(composer: HTMLElement): Element | null {
   let candidate: Element | null = null;
   let node: Element | null = composer.parentElement;
   for (let depth = 0; node && depth < CARD_MAX_DEPTH; depth += 1, node = node.parentElement) {
-    if (node.querySelectorAll('[contenteditable="true"][role="textbox"]').length > 1) break;
+    const topLevelComposers = Array.from(
+      node.querySelectorAll<HTMLElement>('[contenteditable="true"][role="textbox"]'),
+    ).filter((c) => findReplyTargetCommentId(c) === null);
+    if (topLevelComposers.length > 1) break;
     if (node.tagName === 'MAIN' || node.tagName === 'BODY') break;
     const own = (node.textContent ?? '').replace(composer.textContent ?? '', '').trim();
     if (own.length >= CARD_MIN_TEXT) candidate = node;

--- a/extension/src/content/shared/linkedin-dom.ts
+++ b/extension/src/content/shared/linkedin-dom.ts
@@ -686,6 +686,25 @@ export function findParentCommentId(comment: Element, root: ParentNode = documen
 }
 
 /**
+ * The id of the comment article `composer` is nested inside, when
+ * `composer` is a reply box under one specific comment rather than the
+ * post's own top-level composer (LOR-198's own field on the suggestion
+ * request, and the signal `resolveCardFor` in `linkedin-comment-assist.ts`
+ * was missing - LOR-197).
+ *
+ * Uses `COMMENT_ARTICLE_SELECTOR` directly rather than going through
+ * `findPostComments`, which gates on `detectPageKind`: knowing a composer
+ * sits inside a comment does not require knowing which LinkedIn frontend
+ * rendered the page, only the comment article's own shape, and gating
+ * this the same way would report `null` on exactly the page kind
+ * `resolveCardFor`'s own structural fallback exists for - an
+ * unclassified page is not the same thing as a page with no comments.
+ */
+export function findReplyTargetCommentId(composer: Element): string | null {
+  return composer.closest(COMMENT_ARTICLE_SELECTOR)?.getAttribute('data-id') ?? null;
+}
+
+/**
  * `queryDeepAll` scoped to `comment` itself, excluding anything that
  * actually belongs to a reply nested inside it - a reply's own header/body
  * must never leak into its parent's reading, and `querySelectorAll` cannot

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -131,6 +131,12 @@ export type SuggestPost = {
   commentCount?: string;
   thread?: SuggestThread;
   image?: SuggestImage;
+  /** The id of the comment this suggestion replies to, when the human
+   * opened a reply box under one specific comment rather than the post's
+   * own composer (LOR-198) - mirrors
+   * shared/src/assist/suggest-prompt.ts's `ObservedPost.replyToCommentId`
+   * by hand. Absent for the post's own composer. */
+  replyToCommentId?: string;
 };
 
 /** What /suggest/accept sends back: the same post context, minus `text` -

--- a/extension/tests/content/linkedin-comment-assist.test.ts
+++ b/extension/tests/content/linkedin-comment-assist.test.ts
@@ -1195,6 +1195,137 @@ describe('per-card wiring on the feed (2026-09-07 overlay/feed rework)', () => {
   });
 });
 
+describe('LOR-197: a comment permalink whose reply box opened under a comment', () => {
+  /** A comment-permalink page shape reconstructed from the issue's own
+   * report (a `/feed/update/urn:li:activity:.../?dashCommentUrn=...` page,
+   * LinkedIn's own reply box open under one specific comment). No live
+   * LinkedIn session was available to capture this page, so this is a
+   * synthetic reconstruction, not an anonymised capture like
+   * post-detail.html - same posture the #447 "unfamiliar feed variant"
+   * fixture above takes. It carries no `[role="article"][data-urn]`/
+   * `[role="listitem"]` on the card itself, so neither `findFeedPosts` nor
+   * `resolveCardFor`'s known-role fallback can resolve it - only the
+   * structural walk can, and only once it stops treating the reply box as
+   * a second card's own composer.
+   */
+  function renderCommentPermalink(): { composer: HTMLElement; commentId: string } {
+    const commentId = 'urn:li:comment:(activity:7000000000000000001,7000000000000000002)';
+    document.body.innerHTML = `
+      <div data-view-name="feed-full-update">
+        <article>
+          <div><a href="/in/marco-rossi/"><span aria-hidden="true">Marco Rossi</span></a></div>
+          <div class="update-components-text">We shipped the new retry budget across every
+          worker this week, and the false-positive throttling rate dropped by a factor
+          nobody on the team expected going in. The part that actually mattered was not
+          the algorithm change itself, it was watching which requests were the ones
+          getting throttled.</div>
+          <form><div contenteditable="true" role="textbox" aria-label="Aggiungi un commento"></div></form>
+          <div>
+            <article data-id="${commentId}">
+              <h3><span>Giulia Bianchi</span></h3>
+              <section>Which endpoints saw the biggest drop?</section>
+              <form><div contenteditable="true" role="textbox" aria-label="Rispondi a Giulia Bianchi"></div></form>
+            </article>
+          </div>
+        </article>
+      </div>`;
+    const composers = document.querySelectorAll<HTMLElement>(
+      '[contenteditable="true"][role="textbox"]',
+    );
+    return { composer: composers[1], commentId };
+  }
+
+  it('resolves the post card through the reply box, where the old composer-count walk gave up, and names the post author as subject (LOR-198)', async () => {
+    const { composer } = renderCommentPermalink();
+    // No selector recognises this shape - only the structural walk can.
+    expect(findFeedPosts(document)).toEqual([]);
+    suggest.mockImplementation(
+      streamingSuggest('Checked the dashboard for it.', 'The write path was the one that moved.'),
+    );
+
+    delegateComposerClicks();
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(shadows().length).toBe(1);
+    expect(suggest).toHaveBeenCalledTimes(1);
+    expect(panelText()).not.toMatch(/layout changed/i);
+    expect(shadow().querySelector('.subject')?.textContent).toBe('Marco Rossi');
+  });
+
+  it('names the parent comment id on the request, not just the post', async () => {
+    const { composer, commentId } = renderCommentPermalink();
+    suggest.mockImplementation(streamingSuggest('r', 'd'));
+
+    delegateComposerClicks();
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(suggest).toHaveBeenCalledTimes(1);
+    // vi.fn mock call built entirely by this test, not external input.
+    const call = suggest.mock.calls[0][0] as { post: { replyToCommentId?: string } };
+    expect(call.post.replyToCommentId).toBe(commentId);
+  });
+
+  it("the post's own composer on the same page carries no replyToCommentId", async () => {
+    const { composer } = renderCommentPermalink();
+    const mainComposer = document.querySelectorAll<HTMLElement>(
+      '[contenteditable="true"][role="textbox"]',
+    )[0];
+    expect(mainComposer).not.toBe(composer);
+    suggest.mockImplementation(streamingSuggest('r', 'd'));
+
+    delegateComposerClicks();
+    mainComposer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(suggest).toHaveBeenCalledTimes(1);
+    const call = suggest.mock.calls[0][0] as { post: { replyToCommentId?: string } };
+    expect(call.post.replyToCommentId).toBeUndefined();
+  });
+});
+
+describe('LOR-197: a refusal from a page still loading recovers on retry', () => {
+  it('re-reads the page on Try again instead of replaying the mount-time null capture', async () => {
+    document.body.innerHTML = `
+      <div role="article" data-urn="urn:li:activity:7000000000000000099">
+        <div id="post-text"></div>
+        <form><div contenteditable="true" role="textbox"></div></form>
+      </div>`;
+    const composer = document.querySelector<HTMLElement>(
+      '[contenteditable="true"][role="textbox"]',
+    )!;
+
+    wireCommentAssist(composer);
+    composer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    expect(suggest).not.toHaveBeenCalled();
+    const refusal = logged.find(
+      (e) => e.message === 'activity.linkedin-action.suggestion-refused',
+    ) as { meta?: Record<string, unknown> } | undefined;
+    expect(refusal?.meta?.reason).toBe('selector_health_degraded');
+    expect(shadow().querySelector('.assist-button')?.textContent?.trim()).toBe($tRetry());
+
+    // The page finishes rendering: substantial post text arrives where
+    // there was none at mount time.
+    document.querySelector('#post-text')!.textContent =
+      'We shipped the new retry budget across every worker this week, and the ' +
+      'false-positive throttling rate dropped by a factor we did not expect going in.';
+    suggest.mockImplementation(
+      streamingSuggest('Because they measured it.', 'A real reply, once the text was there.'),
+    );
+
+    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
+    await settle();
+
+    expect(suggest).toHaveBeenCalledTimes(1);
+    expect(shadow().querySelector('textarea')?.value).toBe(
+      'A real reply, once the text was there.',
+    );
+  });
+});
+
 function $tRetry(): string {
   // Mirrors dict-en.ts's 'assist.action.retry' literally, so this test does
   // not have to import the whole i18n runtime just to name one button.

--- a/extension/tests/content/linkedin-comment-reading.test.ts
+++ b/extension/tests/content/linkedin-comment-reading.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
+  detectPageKind,
   findFeedPosts,
   findPostComments,
   findParentCommentId,
+  findReplyTargetCommentId,
   readCommentAuthor,
   readCommentBody,
   readCommentRelativeTime,
@@ -95,6 +97,37 @@ describe('post-detail.html: comment/reply reading (#307, real capture)', () => {
     // the reason a caller must never treat this string as parseable in
     // general (see LinkedInComment.relativeTime's doc comment).
     expect(Number.isNaN(Date.parse(relativeTime!))).toBe(true);
+  });
+});
+
+describe('findReplyTargetCommentId (LOR-197/LOR-198): which comment a reply box belongs to', () => {
+  it('returns null for the post\u2019s own composer, which is not inside any comment', () => {
+    render(POST_DETAIL_HTML);
+    const composer = document.querySelector('[contenteditable="true"][role="textbox"]')!;
+    expect(findReplyTargetCommentId(composer)).toBeNull();
+  });
+
+  it('resolves the id of the comment article a reply composer is nested inside', () => {
+    render(POST_DETAIL_HTML);
+    const [topLevel] = findPostComments(document);
+    const reply = document.createElement('div');
+    reply.setAttribute('contenteditable', 'true');
+    reply.setAttribute('role', 'textbox');
+    topLevel.appendChild(reply);
+    expect(findReplyTargetCommentId(reply)).toBe(topLevel.getAttribute('data-id'));
+  });
+
+  it('resolves a reply composer even on a page whose kind cannot be classified - unlike findPostComments, which finds nothing there (LOR-197)', () => {
+    document.body.innerHTML = `
+      <article data-id="urn:li:comment:(activity:7000000000000000001,9)">
+        <div contenteditable="true" role="textbox"></div>
+      </article>`;
+    expect(detectPageKind(document)).toBe('unknown');
+    expect(findPostComments(document)).toEqual([]);
+    const composer = document.querySelector('[contenteditable="true"][role="textbox"]')!;
+    expect(findReplyTargetCommentId(composer)).toBe(
+      'urn:li:comment:(activity:7000000000000000001,9)',
+    );
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -75,6 +75,14 @@ export interface ObservedPost {
   /** The visible comment thread (#568), when the page had one to read - the
    * SDUI feed never does (see linkedin-dom.ts's module header). */
   thread?: ObservedThread;
+  /** The id of the comment this suggestion replies to, when the human
+   * opened a reply box under one specific comment rather than the post's
+   * own top-level composer (LOR-198). `buildSuggestionPrompt`'s `taskFor`
+   * is what turns this into an instruction - present only for a
+   * `post_comment` suggestion whose thread actually rendered the comment
+   * named here; a `post` suggestion has no reply target and this is
+   * ignored for that kind. */
+  replyToCommentId?: string;
   /** The post's own attached media, captured as pixels from the human's
    * rendered tab (#569) - never fetched from a licdn URL, by either side;
    * see docs/design/in-page-agent.md's "capture the rendered tab, never
@@ -250,6 +258,23 @@ const TASK: Record<SuggestionKind, string> = {
     'Write one comment to leave on the post below. One paragraph, two at most. It has to add something the author or another reader would not already know: a specific experience, a number, a disagreement worth having. If you have nothing to add, say so in one sentence instead of padding.',
   post: 'Write one short post for this account, taking the post below as the starting point rather than something to summarise. Say one thing and stop.',
 };
+
+/**
+ * `post_comment`'s own task, sharpened into a reply when the human opened
+ * a reply box under one specific comment rather than the post's own
+ * composer (LOR-198). A reply addresses that commenter, not the post's
+ * author, and reads as either ignoring them or repeating what they
+ * already said if the model cannot tell a reply from a comment on the
+ * post - the two `post_comment` requests used to be identical past this
+ * point. Names the id rather than the words: the thread's own text is
+ * `read_thread`'s job, not this prompt's.
+ */
+function taskFor(kind: SuggestionKind, replyToCommentId?: string): string {
+  if (kind === 'post_comment' && replyToCommentId) {
+    return `Write one reply to the comment with id "${replyToCommentId}" in the thread below (call read_thread to see who wrote it and what it says) - not a comment on the post itself. One paragraph, two at most. It has to add something that commenter or another reader would not already know: a specific experience, a number, a disagreement worth having. If you have nothing to add, say so in one sentence instead of padding.`;
+  }
+  return TASK[kind];
+}
 
 /**
  * How each named tone (#405) is asked for. Written as one sentence each,
@@ -480,7 +505,7 @@ export function buildSuggestionPrompt(args: {
     ].join('\n'),
   );
 
-  parts.push(`Your task: ${TASK[kind]}`);
+  parts.push(`Your task: ${taskFor(kind, post.replyToCommentId)}`);
 
   // The tone, after the task and before the operator's steer, because that is
   // the precedence: house style outranks the tone, the operator's typed steer

--- a/shared/tests/suggest-prompt.test.ts
+++ b/shared/tests/suggest-prompt.test.ts
@@ -395,6 +395,47 @@ describe('buildSuggestionPrompt', () => {
   });
 });
 
+// LOR-198: a reply box under a comment is still a `post_comment` request,
+// named additively - `replyToCommentId` sharpens the task into answering
+// that one commenter rather than inventing a second `SuggestionKind`.
+describe('a reply names its parent comment (LOR-198)', () => {
+  it('sharpens the task around the named comment id, and drops the plain post_comment task', () => {
+    const prompt = buildSuggestionPrompt({
+      kind: 'post_comment',
+      post: { ...post, replyToCommentId: 'urn:li:comment:(activity:1,2)' },
+      currentProject,
+      ...noContext,
+    });
+    expect(prompt).toContain(
+      'Write one reply to the comment with id "urn:li:comment:(activity:1,2)"',
+    );
+    expect(prompt).toContain('read_thread');
+    expect(prompt).not.toContain('Write one comment to leave on the post below');
+  });
+
+  it('leaves the ordinary post_comment task alone when nothing names a reply target', () => {
+    const prompt = buildSuggestionPrompt({
+      kind: 'post_comment',
+      post,
+      currentProject,
+      ...noContext,
+    });
+    expect(prompt).toContain('Write one comment to leave on the post below');
+    expect(prompt).not.toContain('Write one reply to the comment with id');
+  });
+
+  it('is ignored for a "post" suggestion, which has no comment thread to reply into', () => {
+    const prompt = buildSuggestionPrompt({
+      kind: 'post',
+      post: { ...post, replyToCommentId: 'urn:li:comment:(activity:1,2)' },
+      currentProject,
+      ...noContext,
+    });
+    expect(prompt).toContain('Write one short post for this account');
+    expect(prompt).not.toContain('Write one reply to the comment with id');
+  });
+});
+
 // #405: the tone the operator picked in Settings, and #406's register reading
 // behind its default option. The property worth pinning is that the option
 // changes the instruction, that "match the room" says something specific about

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.15.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -105,6 +105,12 @@ const BodySchema = z
       reactionCount: z.string().max(100).optional(),
       commentCount: z.string().max(100).optional(),
       thread: ThreadSchema.optional(),
+      // LOR-198: names which comment (by id) this suggestion replies to,
+      // when the human opened a reply box under one specific comment -
+      // `buildSuggestionPrompt`'s `taskFor` sharpens the task around it.
+      // Absent for the post's own composer, exactly as before this field
+      // existed.
+      replyToCommentId: z.string().max(200).optional(),
       // #569: the post's attached media - see ImageSchema's own doc comment
       // for what each combination of present/absent sub-fields means.
       image: ImageSchema.optional(),

--- a/web/tests/extension-suggest-thread.test.ts
+++ b/web/tests/extension-suggest-thread.test.ts
@@ -31,11 +31,13 @@ const REASONING = 'Noticed the cache change and the specific number.';
 const DRAFT = 'A specific thing that happened.';
 const ENVELOPE_CHUNKS = [`${REASONING}\n`, DRAFT_MARKER, '\n', DRAFT];
 let responseChunks: string[] = ENVELOPE_CHUNKS;
+let lastOptions: AgentRunOptions | null = null;
 
 vi.mock('@pitchbox/shared/agents/registry', () => ({
   createAgentRunner: (_slug: string, _config: RunnerConfig): AgentRunner => ({
     slug: 'fake',
     run(opts: AgentRunOptions): AgentRunHandle {
+      lastOptions = opts;
       for (const c of responseChunks) opts.onTextChunk?.(c);
       return {
         result: Promise.resolve({ exitCode: 0, logPath: '/dev/null' }),
@@ -186,5 +188,54 @@ describe('the visible thread (#568): the schema rejects what the caps forbid', (
         }),
       } as never),
     ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+// LOR-198: a reply box under a comment sends `post.replyToCommentId`
+// alongside the thread it is a part of - the schema accepts it additively
+// (still `kind: 'post_comment'`, no new kind), and the prompt names the
+// comment it answers rather than treating every post_comment request the
+// same way.
+describe('a reply names its parent comment on the request (LOR-198)', () => {
+  beforeEach(reset);
+
+  it('accepts replyToCommentId and sharpens the prompt around it', async () => {
+    const { org, project } = await seedOrgProject('org-reply-target');
+    await mintDevice(org.id, 'tok-reply-target');
+
+    const res = await suggest({
+      request: request('tok-reply-target', {
+        ...POST_BODY,
+        projectId: project.id,
+        post: {
+          ...POST_BODY.post,
+          thread: threadOf(2, 80),
+          replyToCommentId: 'urn:li:comment:(activity:1,0)',
+        },
+      }),
+    } as never);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    await res.text();
+
+    expect(lastOptions?.prompt ?? '').toContain(
+      'Write one reply to the comment with id "urn:li:comment:(activity:1,0)"',
+    );
+  });
+
+  it('keeps the plain post_comment task when no reply target is named', async () => {
+    const { org, project } = await seedOrgProject('org-no-reply-target');
+    await mintDevice(org.id, 'tok-no-reply-target');
+
+    const res = await suggest({
+      request: request('tok-no-reply-target', {
+        ...POST_BODY,
+        projectId: project.id,
+        post: { ...POST_BODY.post, thread: threadOf(2, 80) },
+      }),
+    } as never);
+    await res.text();
+
+    expect(lastOptions?.prompt ?? '').toContain('Write one comment to leave on the post below');
+    expect(lastOptions?.prompt ?? '').not.toContain('Write one reply to the comment with id');
   });
 });


### PR DESCRIPTION
Closes LOR-197, closes LOR-198. Wave 3, lane A. Same code path, so one PR.

**LOR-197 (P1).** Clicking LinkedIn's own reply box under a comment mounted the panel and refused immediately with "LinkedIn's layout changed and Pitchbox could not read this post reliably", and `Try again` refused again, forever. Two defects behind it.

The retry was a guaranteed no-op: `mountAssistPanel` read the post once into a closure `const`, and both the request and `Try again` replayed that same frozen null. On a page whose content arrives after mount, which is every LinkedIn page, that turns a transient miss into a permanently dead panel. The read now happens inside the request, on every auto-request, retry and retune.

And nothing resolved a post card on that page: `resolveCardFor`'s structural walk gave up as soon as it saw a second composer, which is exactly what a reply box under a comment looks like, so it stopped one level before the post's real boundary. Reply composers are now excluded from that count, and `findReplyTargetCommentId` identifies the comment being replied to without depending on `detectPageKind`.

**LOR-198 (P2).** With the card resolving, the reply flow gets what the post-comment flow already had: the post author as the panel subject instead of a bare "Pitchbox", the post text, and the thread. The request now carries `replyToCommentId`, and `buildSuggestionPrompt` sharpens the `post_comment` task to name that comment and tell the model to answer that person. Deliberately **not** a new `SuggestionKind`: a reply is a comment with a named parent, and the existing `read_thread` tool already returns the comment list, so `shared/src/assist/tools.ts` is untouched.

Verified: 162 tests across the five touched suites, with three revert-and-watch-it-fail proofs (the reply-target reader, the sharpened prompt, and the server accepting and forwarding the id). `test:linkedin-compliance` 15 green, all three workspace typechecks clean.

Not verified here, and mine to do: the real page. This gets driven on a live comment permalink in a logged-in Chrome once it is on preview, which is how LOR-197 was found in the first place.