### PR TITLE
chore: release 0.16.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/daemon",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/extension",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchbox",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitchbox/shared",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pitchbox/web",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only. Wave 3 plus the Stripe account reconciliation: #646 the pinned Stripe API version and a probe that can check either mode, #647 the reply-box assistant, #648 the companion as its own section, #649 the pending plan change on the billing page, #650 the suggest-loop assertions and the docs main landmark.