### PR TITLE
feat(shared,web,extension,cli): the server picks the project from the post, and Write as project goes away

### DIFF
--- a/cli/src/mcp/assist-server.ts
+++ b/cli/src/mcp/assist-server.ts
@@ -6,12 +6,12 @@
 // `cli/src/mcp/server.ts`, the campaign MCP server - deliberately not built
 // on top of it or importing any of its tool registrations, because the two
 // planes carry different privileges (26 tools, most of them writers, bound
-// to a `runs` row, vs seven read-only tools bound to an org and a project).
+// to a `runs` row, vs seven read-only tools bound to an org).
 // Handing the assistant `drafts_create` or `run_finish` because they happen
 // to share a process would undo the isolation #520 exists for.
 //
-// This server's session binds to an organization and a bound project rather
-// than a run, campaign or `PITCHBOX_RUN_ID`/`PITCHBOX_CAMPAIGN_ID` - there is
+// This server's session binds to an organization rather than a run,
+// campaign or `PITCHBOX_RUN_ID`/`PITCHBOX_CAMPAIGN_ID` - there is
 // no run row on this plane (`web/src/lib/server/suggest.ts` spawns no `runs`
 // row for a suggestion). The observed target (the post, its thread, its
 // image crop) and the operator persona are both too large and too
@@ -35,21 +35,17 @@ import type { OperatorPersona } from '@pitchbox/shared/assist/context';
  * Session binding for the assist MCP tools. An explicit context (the SDK
  * side, if it ever reused this server in-process) wins over the session env
  * a spawned subprocess reads, the same precedence `PitchboxMcpContext`
- * (./server.ts) follows. `boundProjectId` is optional (#523): a suggestion
- * about no particular product still runs, with `project_knowledge` simply
- * refusing every call since it has nothing to validate a project id
- * against.
+ * (./server.ts) follows.
  */
 export interface AssistMcpContext {
   organizationId?: number;
-  boundProjectId?: number;
   /** Path to the JSON context file, shaped `AssistRequestPayload` below. */
   contextFile?: string;
 }
 
 /** What the context file carries: everything server-resolved before the
  * loop starts, that a tool handler needs but cannot re-derive from
- * `organizationId`/`boundProjectId` alone. */
+ * `organizationId` alone. */
 export interface AssistRequestPayload {
   observedTarget: AssistObservedTarget | null;
   operator: OperatorPersona | null;
@@ -67,10 +63,6 @@ export function createAssistMcpServer(ctx: AssistMcpContext = {}): McpServer {
   const rawOrgId = Number(process.env.PITCHBOX_ASSIST_ORG_ID);
   const organizationId =
     ctx.organizationId ?? (Number.isInteger(rawOrgId) && rawOrgId > 0 ? rawOrgId : undefined);
-  const rawProjectId = Number(process.env.PITCHBOX_ASSIST_PROJECT_ID);
-  const boundProjectId =
-    ctx.boundProjectId ??
-    (Number.isInteger(rawProjectId) && rawProjectId > 0 ? rawProjectId : undefined);
   const contextFile = ctx.contextFile ?? process.env.PITCHBOX_ASSIST_CONTEXT_FILE;
 
   // Read once per server instance (a fresh process per suggestion, same
@@ -122,7 +114,6 @@ export function createAssistMcpServer(ctx: AssistMcpContext = {}): McpServer {
         const toolCtx: AssistToolContext = {
           db: getDb(),
           orgId: organizationId,
-          boundProjectId: boundProjectId ?? null,
           observedTarget,
           operator,
         };

--- a/cli/tests/mcp/assist-server.test.ts
+++ b/cli/tests/mcp/assist-server.test.ts
@@ -12,9 +12,9 @@ import { createPitchboxMcpServer } from '../../src/mcp/server.js';
 // #567: the assist MCP entry point. What matters here, beyond `shared/tests/
 // assist-tools.test.ts`'s coverage of the handlers themselves, is the
 // transport contract: exactly the seven assist tools are advertised, none of
-// the campaign server's, and the session-bound org/project plus the context
-// file actually reach a handler through this server rather than only
-// through a direct function call.
+// the campaign server's, and the session-bound org plus the context file
+// actually reach a handler through this server rather than only through a
+// direct function call.
 
 type CallResult = { content: { type: string; text?: string }[]; isError?: boolean };
 
@@ -60,7 +60,7 @@ describe('cli/src/mcp/assist-server', () => {
 
   it('advertises exactly the seven assist tools and none of the campaign server\u2019s', async () => {
     const orgId = await defaultOrgId();
-    const assistClient = await connectAssistClient({ organizationId: orgId, boundProjectId: 1 });
+    const assistClient = await connectAssistClient({ organizationId: orgId });
     const { tools } = await assistClient.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -84,15 +84,15 @@ describe('cli/src/mcp/assist-server', () => {
     for (const name of names) expect(campaignNames.has(name)).toBe(false);
   });
 
-  it('refuses every tool call when the session has no bound organization/project', async () => {
+  it('refuses every tool call when the session has no bound organization', async () => {
     const client = await connectAssistClient({});
     const res = await call(client, 'check_style', { text: 'A clean sentence.' });
     expect(res.isError).toBe(true);
   });
 
-  it('runs check_style end to end with no session binding required beyond org/project', async () => {
+  it('runs check_style end to end with no session binding required beyond org', async () => {
     const orgId = await defaultOrgId();
-    const client = await connectAssistClient({ organizationId: orgId, boundProjectId: 1 });
+    const client = await connectAssistClient({ organizationId: orgId });
     const res = await call(client, 'check_style', { text: 'This is great \u2014 really great.' });
     expect(res.isError).toBeFalsy();
     const answer = parse(res) as { ok: boolean; data?: { findings: unknown[] } };
@@ -114,7 +114,6 @@ describe('cli/src/mcp/assist-server', () => {
       );
       const client = await connectAssistClient({
         organizationId: orgId,
-        boundProjectId: 1,
         contextFile,
       });
       const res = await call(client, 'read_thread', {});
@@ -129,7 +128,7 @@ describe('cli/src/mcp/assist-server', () => {
 
   it('answers read_thread with an explicit refusal when no context file was given', async () => {
     const orgId = await defaultOrgId();
-    const client = await connectAssistClient({ organizationId: orgId, boundProjectId: 1 });
+    const client = await connectAssistClient({ organizationId: orgId });
     const res = await call(client, 'read_thread', {});
     expect(res.isError).toBeFalsy();
     const answer = parse(res) as { ok: boolean; reason?: string };

--- a/extension/src/content/linkedin-comment-assist.ts
+++ b/extension/src/content/linkedin-comment-assist.ts
@@ -103,13 +103,14 @@ import CommentAssistPanel from './linkedin-comment-assist-panel.svelte';
  * is "no marker means no draft", closing #382 (a refusal used to arrive as
  * insertable reasoning text).
  *
- * ## Where an accepted suggestion is filed (#523)
+ * ## Where an accepted suggestion is filed (LOR-181)
  *
- * `boundProjectId` (`assist.projectId`, the same value used to request the
- * suggestion) is what accept sends too - there is no separate "personal"
- * project to fall back to. A suggestion naming no project at all is not a
- * lesser case of one that does: it is a legitimate suggestion filed under
- * no product, and `getOrgUsage` still counts it exactly once.
+ * `done.projectId` - the server's own choice, from the post, never a
+ * project this client bound itself to - is what accept sends. There is no
+ * separate "personal" project to fall back to. A suggestion naming no
+ * project at all is not a lesser case of one that does: it is a legitimate
+ * suggestion filed under no product, and `getOrgUsage` still counts it
+ * exactly once.
  */
 
 const COMMENT_KIND = 'post_comment';
@@ -250,13 +251,13 @@ export function readAssistPost(root: ParentNode = document): AssistPost | null {
 
 /** Every refusal this panel can render, honestly and distinctly: the assist
  * gate's own reasons, the accept path's own three, plus four this client
- * detects itself. `project_required` and `no_recent_activity` are excluded:
- * both only ever answer a `kind: 'post'` request (#315's post composer
- * assist grounds itself server-side; this comment assist always supplies
- * its own post text, so it can never hit either). A `done` event with no
- * draft is never a refusal - see `CommentAssistState.no_draft` below. */
+ * detects itself. `no_recent_activity` is excluded: it only ever answers a
+ * `kind: 'post'` request (#315's post composer assist grounds itself
+ * server-side; this comment assist always supplies its own post text, so
+ * it can never hit it). A `done` event with no draft is never a refusal -
+ * see `CommentAssistState.no_draft` below. */
 export type AssistRefusal =
-  | Exclude<SuggestRefusalReason, 'project_required' | 'no_recent_activity'>
+  | Exclude<SuggestRefusalReason, 'no_recent_activity'>
   | AcceptRefusalReason
   | 'backend_unreachable'
   | 'selector_health_degraded'
@@ -266,7 +267,6 @@ export type AssistRefusal =
 const KNOWN_REFUSALS: Record<AssistRefusal, true> = {
   assist_disabled: true,
   kill_switch: true,
-  project_not_bound: true,
   blocked: true,
   uncontactable: true,
   recently_contacted: true,
@@ -480,7 +480,9 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
 
   let currentReasoning = '';
   let currentDraft = '';
-  let boundProjectId: number | null = null;
+  // LOR-181: captured from `done.projectId` once the model states its
+  // choice - never a bound project of this client's own.
+  let lastResolvedProjectId: number | null = null;
   let lastUsage: SuggestUsage | undefined;
   let lastMs: number | undefined;
   // #576: the live session id from the last `done` event, if any - handed
@@ -593,11 +595,11 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
       void setRefused('assist_disabled');
       return;
     }
-    // #523: a null `assist.projectId` is not a refusal - the assistant
-    // binds to the operator, and a suggestion with no project just files
-    // under none. Naming a project is context only, so it travels through
-    // exactly as read, never coerced to a refusal on this side.
-    boundProjectId = assist.projectId;
+    // LOR-181: `assist.projectId` is no longer read here - it is the
+    // observation collector's own attribution target now, not a
+    // suggestion's context. Which project (if any) this suggestion is
+    // about is the server's own choice, reported back on `done.projectId`
+    // below.
 
     // #569: captured here, not folded into `capturedPost`, because it is
     // the one field on this request that costs a round trip through the
@@ -611,7 +613,6 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
     let draft = '';
     const res = await api.suggest(
       {
-        projectId: boundProjectId ?? undefined,
         kind: COMMENT_KIND,
         post: {
           urn: capturedPost.urn,
@@ -649,6 +650,7 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
             lastUsage = event.usage;
             lastMs = event.ms;
             lastSessionId = event.sessionId;
+            lastResolvedProjectId = event.projectId;
             currentReasoning = event.reasoning;
             if (event.draft === null) {
               logNoDraft(event.skipped);
@@ -692,7 +694,7 @@ function mountAssistPanel(composer: HTMLElement, post?: Element): void {
       state: { phase: 'accepting', reasoning: currentReasoning, draft: currentDraft },
     });
     const res = await api.acceptSuggestion({
-      projectId: boundProjectId ?? undefined,
+      projectId: lastResolvedProjectId ?? undefined,
       kind: COMMENT_KIND,
       post: {
         urn: capturedPost.urn,

--- a/extension/src/content/linkedin-post-assist.ts
+++ b/extension/src/content/linkedin-post-assist.ts
@@ -48,11 +48,13 @@ import PostAssistPanel from './linkedin-post-assist-panel.svelte';
  * endpoint (which would make this script's own DOM reach much larger, and
  * duplicate what the passive observation collector, `linkedin-observe.ts`,
  * already does more carefully with `IntersectionObserver` gating and
- * dedup), the suggestion endpoint grounds `kind: 'post'` itself, server-side,
- * in the most recent thing the observation buffer has actually collected for
- * this project (`shared/src/observed-targets.ts`'s `loadRecentObservedTarget`,
- * wired into `POST /api/extension/suggest`). This script sends only the
- * current page URL for context - never post text it read itself.
+ * dedup), the suggestion endpoint grounds `kind: 'post'` itself,
+ * server-side, in the most recent thing the observation buffer has
+ * actually collected anywhere in the organization (LOR-181: org-wide, not
+ * one bound project's buffer - `shared/src/observed-targets.ts`'s
+ * `loadRecentObservedTarget`, wired into `POST /api/extension/suggest`).
+ * This script sends only the current page URL for context - never post
+ * text it read itself.
  *
  * ## Never unprompted, twice over
  *
@@ -84,33 +86,34 @@ import PostAssistPanel from './linkedin-post-assist-panel.svelte';
  * only ever sends `draft`, and a `done` event whose `draft` is `null`
  * renders no insert affordance - see `no_draft` below.
  *
- * ## Where an accepted suggestion is filed (#523)
+ * ## Where an accepted suggestion is filed (LOR-181)
  *
- * Same routing as the comment assist: `api.acceptSuggestion` sends
- * `boundProjectId` (`assist.projectId`), the same value used to request the
- * suggestion - there is no separate personal project to fall back to.
- * Unlike the comment assist, this kind can never actually reach accept with
- * no project bound: `api.suggest` already refuses with `project_required`
- * before the panel ever has a draft to offer (this kind grounds itself in a
- * project's own observation buffer, see above) - #523 makes a project
- * optional for the plane overall, not for the one kind that has nothing
- * else to ground itself in.
+ * Same routing as the comment assist: `api.acceptSuggestion` sends the
+ * project `done.projectId` named on this suggestion's own request - the
+ * server's own choice, from the post, not a project this client bound
+ * itself to. There is no separate personal project to fall back to: a
+ * `null` `done.projectId` files under none, exactly as the comment assist
+ * does. Unlike the comment assist, this kind still has one project-shaped
+ * refusal of its own - `no_recent_activity` - because the observation
+ * buffer this kind grounds itself in (see the module doc comment) can be
+ * empty; it is no longer about whether a project is bound, since nothing
+ * is bound here any more.
  */
 
 const POST_KIND = 'post';
 
 /** Every refusal this panel can render, honestly and distinctly. A subset of
- * the comment assist's own `AssistRefusal` (LI-17) plus the two refusals
+ * the comment assist's own `AssistRefusal` (LI-17) plus the one refusal
  * `SuggestRefusalReason` carries that only a `kind: 'post'` request can
  * hit: a `post` suggestion never targets one person, so the accept path's
  * `uncontactable`/`recently_contacted` refusals (only reachable with a
  * `targetUser`, see `shared/src/assist-accept.ts`) can never fire here, and
  * this script never reads post content off the page, so
- * `selector_health_degraded` cannot fire either. `project_required` and
- * `no_recent_activity` are the two new ones: the observation buffer this
- * suggestion grounds in (see the module doc comment) needs a real project
- * with something recent in it. A `done` event with no draft is never a
- * refusal - see `PostAssistState.no_draft` below. */
+ * `selector_health_degraded` cannot fire either. `no_recent_activity` is
+ * the new one: the observation buffer this suggestion grounds in (see the
+ * module doc comment) needs something recent in it, org-wide (LOR-181). A
+ * `done` event with no draft is never a refusal - see
+ * `PostAssistState.no_draft` below. */
 export type PostAssistRefusal =
   | Exclude<AcceptRefusalReason, 'uncontactable' | 'recently_contacted'>
   | SuggestRefusalReason
@@ -120,8 +123,6 @@ export type PostAssistRefusal =
 const KNOWN_REFUSALS: Record<PostAssistRefusal, true> = {
   assist_disabled: true,
   kill_switch: true,
-  project_not_bound: true,
-  project_required: true,
   no_recent_activity: true,
   blocked: true,
   backend_unreachable: true,
@@ -215,7 +216,9 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
 
   let currentReasoning = '';
   let currentDraft = '';
-  let boundProjectId: number | null = null;
+  // LOR-181: captured from `done.projectId` once the model states its
+  // choice - never a bound project of this client's own.
+  let lastResolvedProjectId: number | null = null;
   let lastUsage: SuggestUsage | undefined;
   let lastMs: number | undefined;
   // #576: the live session id from the last `done` event, if any.
@@ -290,11 +293,10 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
       void setRefused('assist_disabled');
       return;
     }
-    // #523: a null `assist.projectId` is not a refusal here either - only
-    // `no_recent_activity`/`project_required` from the server itself (this
-    // kind's own grounding needs, distinct from #523's general optionality)
-    // can stop a request for lack of a project.
-    boundProjectId = assist.projectId;
+    // LOR-181: `assist.projectId` is no longer read here - it is the
+    // observation collector's own attribution target now, not a suggestion's
+    // context. Which project (if any) this suggestion is about is the
+    // server's own choice, reported back on `done.projectId` below.
 
     let reasoning = '';
     let draft = '';
@@ -303,7 +305,6 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
     // `post` here is informational context only.
     const res = await api.suggest(
       {
-        projectId: boundProjectId ?? undefined,
         kind: POST_KIND,
         post: { url: location.href },
         retune,
@@ -326,6 +327,7 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
             lastUsage = event.usage;
             lastMs = event.ms;
             lastSessionId = event.sessionId;
+            lastResolvedProjectId = event.projectId;
             currentReasoning = event.reasoning;
             if (event.draft === null) {
               logNoDraft(event.skipped);
@@ -362,7 +364,7 @@ function mountAssistPanel(editor: HTMLElement, modal: Element): void {
       state: { phase: 'accepting', reasoning: currentReasoning, draft: currentDraft },
     });
     const res = await api.acceptSuggestion({
-      projectId: boundProjectId ?? undefined,
+      projectId: lastResolvedProjectId ?? undefined,
       kind: POST_KIND,
       // No urn (a post has none until it publishes), no authorHandle/authorName
       // (this is the operator's own voice, not a reply to someone) - see

--- a/extension/src/lib/api.ts
+++ b/extension/src/lib/api.ts
@@ -13,11 +13,11 @@ type DraftSummary = {
 };
 
 /** The exact shape served by GET /api/extension/linkedin-assist (LI-19, #316).
- * `projectId` is context only (#523): which product the assistant speaks
- * for, used for grounding, examples and voice. No `personalProjectId` -
- * an accepted suggestion files under `projectId` if it names one, or under
- * no project at all if it does not; there is no fallback project to land on
- * either way. */
+ * LOR-181: `projectId` is no longer which product a suggestion speaks for -
+ * the server decides that itself, per suggestion, from the post (see
+ * `SuggestEvent`'s `done.projectId`). It stays only as the passive
+ * observation collector's own attribution target
+ * (`linkedin-observe.ts`) - `null` when nothing is bound there. */
 export type LinkedInAssistState = {
   enabled: boolean;
   collectorEnabled: boolean;
@@ -190,16 +190,13 @@ export type AssistStatusPhase =
  * (`quota_exhausted`, tied to a project's bound LinkedIn account) along with the
  * `drafts` row it was a proxy for - what bounds a suggestion now is the
  * per-device/per-org rate limiter and the plan's own suggestions ceiling below.
- * `project_required` and `no_recent_activity` only ever answer a `kind: 'post'`
- * request: #523 makes a project optional for the plane overall, but a `post`
- * suggestion has no post of its own to ground in, so it still needs a real
- * project (`project_required`) with something recent in its observation buffer
- * (`no_recent_activity`). */
+ * LOR-181 retired `project_not_bound` and `project_required`: there is no
+ * bound project left to be refused for, and a `kind: 'post'` suggestion with
+ * nothing recent to ground in refuses with `no_recent_activity` alone now,
+ * org-wide rather than for one project. */
 export type SuggestRefusalReason =
   | 'assist_disabled'
   | 'kill_switch'
-  | 'project_not_bound'
-  | 'project_required'
   | 'no_recent_activity'
   // #556: the plan's own ceiling and a failed payment past its grace window -
   // distinct from each other, so the panel can say which one stopped it and
@@ -208,15 +205,15 @@ export type SuggestRefusalReason =
   | 'plan_payment_required';
 
 /** Every `refused` value POST /api/extension/suggest/accept can answer with: the
- * same assist gate as /suggest (minus its two kind:'post'-only refusals, which
- * grounding a suggestion has no equivalent of once there is text to accept), plus
- * `shared/src/assist-accept.ts`'s own refusals for a suggestion the ledger will
- * not write. #521 retired `no_account`: the accept path no longer needs a bound
- * LinkedIn account to file against. */
+ * same assist gate as /suggest, plus `shared/src/assist-accept.ts`'s own
+ * refusals for a suggestion the ledger will not write. #521 retired
+ * `no_account`: the accept path no longer needs a bound LinkedIn account to
+ * file against. LOR-181 retired `project_not_bound`: an accept no longer
+ * checks a client-named project against anything bound - there is nothing
+ * bound to check it against any more. */
 export type AcceptRefusalReason =
   | 'assist_disabled'
   | 'kill_switch'
-  | 'project_not_bound'
   | 'plan_payment_required'
   | 'blocked'
   | 'uncontactable'
@@ -247,6 +244,13 @@ export type SuggestEvent =
       skipped: boolean;
       usage?: SuggestUsage;
       ms: number;
+      // LOR-181: the project the server resolved this suggestion under -
+      // the model's own choice, validated against the org (see
+      // `resolveSuggestionProject` in web/src/lib/server/suggest.ts). Null
+      // when it is filed under none. Hand this back on `acceptSuggestion`
+      // so the accepted row lands under the same project - there is no
+      // bound project of this client's own to send instead.
+      projectId: number | null;
       // #576: hand this back on the next retune/hint so the loop continues
       // instead of starting over. Absent when there was nothing to persist.
       sessionId?: string;
@@ -395,6 +399,7 @@ export function parseSuggestSseFrame(frame: string): SuggestEvent | null {
             skipped: data.skipped,
             usage: data.usage as SuggestUsage | undefined,
             ms: typeof data.ms === 'number' ? data.ms : 0,
+            projectId: typeof data.projectId === 'number' ? data.projectId : null,
             sessionId: typeof data.sessionId === 'string' ? data.sessionId : undefined,
             budgetExhausted:
               typeof data.budgetExhausted === 'boolean' ? data.budgetExhausted : undefined,
@@ -623,12 +628,14 @@ export const api = {
 
   /**
    * GET /api/extension/linkedin-assist (#316): whether the org has turned
-   * on the assistant/collector and which project a suggestion or an
-   * observation writes as. #302's passive collector polls this - see
-   * content/linkedin-observe.ts's own doc comment for the poll cadence it
-   * defends. No backendUrl-targeted variant beyond the single-pairing
-   * default: unlike armed/sent, this call never carries a compose-time
-   * draft URL to resolve a specific backend from.
+   * on the assistant/collector and which project the passive collector
+   * attributes an observation to (LOR-181: no longer which project a
+   * suggestion writes as - the server decides that itself, per suggestion).
+   * #302's passive collector polls this - see content/linkedin-observe.ts's
+   * own doc comment for the poll cadence it defends. No backendUrl-targeted
+   * variant beyond the single-pairing default: unlike armed/sent, this call
+   * never carries a compose-time draft URL to resolve a specific backend
+   * from.
    */
   linkedinAssist: async (
     backendUrl?: string,
@@ -703,9 +710,12 @@ export const api = {
    * render a partial answer instead of a spinner for the five-to-ten-second
    * (measured: 10-14s, #360) wait before the first token. The server can
    * also answer a plain `200 {refused}` ahead of the stream (kill switch, an
-   * exhausted plan ceiling, a project that does not match the bound one) -
-   * both shapes fold into the same `onEvent` calls, so the caller has one
-   * place to switch on `event.kind`.
+   * exhausted plan ceiling) - both shapes fold into the same `onEvent`
+   * calls, so the caller has one place to switch on `event.kind`.
+   *
+   * LOR-181: carries no project any more - which one (if any) a suggestion
+   * is about is the server's own choice, from the post, and it comes back
+   * on `done.projectId` for `acceptSuggestion` to reuse.
    *
    * The outer `ApiResult` reports only transport-level success: a network
    * failure or non-2xx status short-circuits before `onEvent` ever fires.
@@ -717,8 +727,6 @@ export const api = {
    */
   suggest: async (
     params: {
-      /** #523: context only - omit to draft with no product in mind. */
-      projectId?: number;
       kind: SuggestionKind;
       post: SuggestPost;
       hint?: string;
@@ -798,7 +806,13 @@ export const api = {
    */
   acceptSuggestion: async (
     params: {
-      /** #523: context only - omit to file under no project at all. */
+      /** LOR-181: the project `done.projectId` named on this suggestion's
+       * own `suggest` call, echoed back so the ledger files it under the
+       * same one - omit to file under no project at all. Validated only
+       * against this org's own projects (never against a bound one - there
+       * is no such binding left), so an id belonging to another
+       * organization is rejected but naming any of this org's own projects
+       * is always honoured, unlike the old contract this replaces. */
       projectId?: number;
       kind: SuggestionKind;
       post: SuggestPostRef;

--- a/extension/src/lib/i18n/dict-en.ts
+++ b/extension/src/lib/i18n/dict-en.ts
@@ -373,7 +373,6 @@ export const en = {
   // with its own remedy, never a generic failure.
   'assist.refusal.assist_disabled': 'The Pitchbox assistant is turned off for this workspace.',
   'assist.refusal.kill_switch': 'An admin stopped the assistant.',
-  'assist.refusal.project_not_bound': 'No project is bound to the assistant yet.',
   'assist.refusal.blocked': 'This person is on the blocklist.',
   'assist.refusal.uncontactable': 'This person was marked uncontactable.',
   'assist.refusal.recently_contacted': 'Already contacted recently, so this is being skipped.',
@@ -397,10 +396,6 @@ export const en = {
   'assist.refusal.extension_reloaded':
     'Pitchbox was reloaded or updated - reload this page to reconnect.',
   'assist.refusal.unknown': 'The assistant refused this request ({reason}).',
-  // Post-only (#523): a post suggestion has no post of its own to ground
-  // in, so unlike every other kind it still needs a real project even
-  // though a project is optional for the plane overall.
-  'assist.refusal.project_required': 'Bind a project to the assistant to suggest a post.',
   // Post-only: the observation buffer this suggestion grounds in (#315) had
   // nothing recent enough to draft from.
   'assist.refusal.no_recent_activity':

--- a/extension/src/lib/i18n/dict-it.ts
+++ b/extension/src/lib/i18n/dict-it.ts
@@ -334,7 +334,6 @@ export const it = {
   // stati ritirati insieme alla quota per account.
   'assist.refusal.assist_disabled': "L'assistente Pitchbox è disattivato per questo workspace.",
   'assist.refusal.kill_switch': "Un amministratore ha fermato l'assistente.",
-  'assist.refusal.project_not_bound': "Nessun progetto è collegato all'assistente.",
   'assist.refusal.blocked': 'Questa persona è nella blocklist.',
   'assist.refusal.uncontactable': 'Questa persona è stata segnata come non contattabile.',
   'assist.refusal.recently_contacted': 'Contattata di recente, quindi viene saltata.',
@@ -353,8 +352,6 @@ export const it = {
   'assist.refusal.extension_reloaded':
     'Pitchbox è stato ricaricato o aggiornato - ricarica questa pagina per riconnetterti.',
   'assist.refusal.unknown': "L'assistente ha rifiutato questa richiesta ({reason}).",
-  // Post-only (#523): vedi il commento su `project_required` in dict-en.ts.
-  'assist.refusal.project_required': "Collega un progetto all'assistente per suggerire un post.",
   'assist.refusal.no_recent_activity':
     'Ancora nulla di recente da cui scrivere un post. Esplora la tua rete per un po’, poi riprova.',
   // #438: see the comment in dict-en.ts.

--- a/extension/tests/content/linkedin-comment-assist.test.ts
+++ b/extension/tests/content/linkedin-comment-assist.test.ts
@@ -113,14 +113,15 @@ async function settle(times = 6): Promise<void> {
 }
 
 /** A suggestion delivered as the route delivers it (#382): reasoning chunks,
- * then draft chunks, then done. */
-function streamingSuggest(reasoning: string, draft: string) {
+ * then draft chunks, then done. `projectId` mirrors `done.projectId` - the
+ * server's own resolved choice (LOR-181), undefined when it named none. */
+function streamingSuggest(reasoning: string, draft: string, projectId?: number) {
   return async (_body: unknown, onEvent: (event: Record<string, unknown>) => void) => {
     onEvent({ kind: 'status', phase: 'writing' });
     if (reasoning) onEvent({ kind: 'chunk', text: reasoning, section: 'reasoning' });
     onEvent({ kind: 'chunk', text: draft.slice(0, 20), section: 'draft' });
     onEvent({ kind: 'chunk', text: draft.slice(20), section: 'draft' });
-    onEvent({ kind: 'done', reasoning, draft, skipped: false, ms: 900 });
+    onEvent({ kind: 'done', reasoning, draft, skipped: false, ms: 900, projectId });
     return { ok: true as const, data: { ok: true } };
   };
 }
@@ -466,7 +467,7 @@ describe('accept, insert, and the button the human presses', () => {
   it('writes the text into LinkedIn own composer and dispatches no click or submit', async () => {
     const composer = renderPost();
     const text = 'We saw the same thing, but the cause was PR size.';
-    suggest.mockImplementation(streamingSuggest('', text));
+    suggest.mockImplementation(streamingSuggest('', text, 2));
     acceptSuggestion.mockResolvedValue({
       ok: true,
       data: { accepted: true, id: 4242, dedupWarning: null },
@@ -496,9 +497,9 @@ describe('accept, insert, and the button the human presses', () => {
 
     expect(composer.textContent).toContain('PR size');
     expect(acceptSuggestion).toHaveBeenCalledTimes(1);
-    // #521/#523: an accepted suggestion lands under `boundProjectId` (the
-    // same value used to request it, projectId 2 above) - there is no
-    // separate personal project to fall back to.
+    // #521/#523: an accepted suggestion lands under `done.projectId` (LOR-181:
+    // the server's own resolved choice, echoed straight back) - there is no
+    // bound project of this client's own to send instead.
     expect(acceptSuggestion.mock.calls[0][0]).toMatchObject({ projectId: 2 });
     expect(clicks).toEqual([]);
     expect(submits).toEqual([]);
@@ -746,7 +747,6 @@ describe('every refusal says which one it is', () => {
     const keys = [
       'assist_disabled',
       'kill_switch',
-      'project_not_bound',
       'blocked',
       'backend_unreachable',
       'selector_health_degraded',

--- a/extension/tests/content/linkedin-post-assist.test.ts
+++ b/extension/tests/content/linkedin-post-assist.test.ts
@@ -99,14 +99,15 @@ async function settle(times = 6): Promise<void> {
 }
 
 /** A suggestion delivered as the route delivers it (#382): reasoning chunks,
- * then draft chunks, then done. */
-function streamingSuggest(reasoning: string, draft: string) {
+ * then draft chunks, then done. `projectId` mirrors `done.projectId` - the
+ * server's own resolved choice (LOR-181), undefined when it named none. */
+function streamingSuggest(reasoning: string, draft: string, projectId?: number) {
   return async (_body: unknown, onEvent: (event: Record<string, unknown>) => void) => {
     onEvent({ kind: 'status', phase: 'writing' });
     if (reasoning) onEvent({ kind: 'chunk', text: reasoning, section: 'reasoning' });
     onEvent({ kind: 'chunk', text: draft.slice(0, 20), section: 'draft' });
     onEvent({ kind: 'chunk', text: draft.slice(20), section: 'draft' });
-    onEvent({ kind: 'done', reasoning, draft, skipped: false, ms: 900 });
+    onEvent({ kind: 'done', reasoning, draft, skipped: false, ms: 900, projectId });
     return { ok: true as const, data: { ok: true } };
   };
 }
@@ -235,7 +236,7 @@ describe('accept, insert, and the button the human presses', () => {
   it('writes the text into LinkedIn own composer and dispatches no click or submit', async () => {
     const { editor, modal } = renderModal();
     const text = 'Shipped the post composer assist tonight.';
-    suggest.mockImplementation(streamingSuggest('', text));
+    suggest.mockImplementation(streamingSuggest('', text, 2));
     acceptSuggestion.mockResolvedValue({
       ok: true,
       data: { accepted: true, id: 5150, dedupWarning: null },
@@ -268,10 +269,10 @@ describe('accept, insert, and the button the human presses', () => {
     expect(editor.textContent).toContain('post composer assist');
     expect(acceptSuggestion).toHaveBeenCalledTimes(1);
     // No urn/authorHandle/authorName in the accept body: a post has none of
-    // those until it publishes, and it is the operator's own voice. It
-    // lands under `boundProjectId` (#521/#523: the same value used to
-    // request the suggestion, projectId 2 above - there is no separate
-    // personal project to fall back to).
+    // those until it publishes, and it is the operator's own voice. It lands
+    // under `done.projectId` (LOR-181: the server's own resolved choice,
+    // echoed straight back - there is no bound project of this client's own
+    // to send instead).
     expect(acceptSuggestion.mock.calls[0][0]).toMatchObject({
       kind: 'post',
       post: {},
@@ -434,16 +435,10 @@ describe('no draft: #382, the fail-safe is "no marker means no draft"', () => {
 });
 
 describe('every refusal says which one it is', () => {
-  it("gives project_required its own key, distinct from the comment assist's refusals", () => {
-    expect(refusalMessage('project_required').key).toBe('assist.refusal.project_required');
-  });
-
-  it('maps every other known reason to its own distinct message key', () => {
+  it('maps every known reason to its own distinct message key', () => {
     const keys = [
       'assist_disabled',
       'kill_switch',
-      'project_not_bound',
-      'project_required',
       'no_recent_activity',
       'blocked',
       'backend_unreachable',
@@ -460,24 +455,6 @@ describe('every refusal says which one it is', () => {
 });
 
 describe('refusal rendering: post-specific, not the comment assist copy', () => {
-  it('renders a distinct message when this kind needs a project the comment assist never requires (#523)', async () => {
-    const { editor, modal } = renderModal();
-    suggest.mockImplementation(
-      async (_body: unknown, onEvent: (e: Record<string, unknown>) => void) => {
-        onEvent({ kind: 'refused', reason: 'project_required', detail: {} });
-        return { ok: true, data: {} };
-      },
-    );
-
-    wirePostAssist(editor, modal);
-    editor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    await settle();
-    shadow().querySelector<HTMLButtonElement>('.assist-button')!.click();
-    await settle();
-
-    expect(panelText()).toMatch(/bind a project/i);
-  });
-
   it('renders a distinct message when the observation buffer has nothing recent to ground a post in', async () => {
     const { editor, modal } = renderModal();
     suggest.mockImplementation(

--- a/extension/tests/lib/api-suggest.test.ts
+++ b/extension/tests/lib/api-suggest.test.ts
@@ -73,6 +73,7 @@ describe('parseSuggestSseFrame', () => {
       skipped: false,
       usage: { outputTokens: 12 },
       ms: 2200,
+      projectId: null,
     });
   });
 
@@ -88,6 +89,7 @@ describe('parseSuggestSseFrame', () => {
       skipped: true,
       usage: undefined,
       ms: 900,
+      projectId: null,
     });
   });
 
@@ -152,7 +154,7 @@ describe('api.suggest', () => {
 
     const events: SuggestEvent[] = [];
     const res = await api.suggest(
-      { projectId: 1, kind: 'post_comment', post: { text: 'a post' } },
+      { kind: 'post_comment', post: { text: 'a post' } },
       (e) => events.push(e),
     );
 
@@ -169,6 +171,7 @@ describe('api.suggest', () => {
         skipped: false,
         usage: undefined,
         ms: 2200,
+        projectId: null,
       },
     ]);
   });
@@ -190,7 +193,7 @@ describe('api.suggest', () => {
     );
 
     const events: SuggestEvent[] = [];
-    await api.suggest({ projectId: 1, kind: 'post_comment', post: { text: 'a post' } }, (e) =>
+    await api.suggest({ kind: 'post_comment', post: { text: 'a post' } }, (e) =>
       events.push(e),
     );
 
@@ -221,7 +224,7 @@ describe('api.suggest', () => {
 
     const events: SuggestEvent[] = [];
     const res = await api.suggest(
-      { projectId: 1, kind: 'post_comment', post: { text: 'a post' } },
+      { kind: 'post_comment', post: { text: 'a post' } },
       (e) => events.push(e),
     );
 
@@ -245,7 +248,7 @@ describe('api.suggest', () => {
 
     const onEvent = vi.fn();
     const res = await api.suggest(
-      { projectId: 1, kind: 'post_comment', post: { text: 'a post' } },
+      { kind: 'post_comment', post: { text: 'a post' } },
       onEvent,
     );
 

--- a/extension/tests/lib/api-suggest.test.ts
+++ b/extension/tests/lib/api-suggest.test.ts
@@ -153,9 +153,8 @@ describe('api.suggest', () => {
     );
 
     const events: SuggestEvent[] = [];
-    const res = await api.suggest(
-      { kind: 'post_comment', post: { text: 'a post' } },
-      (e) => events.push(e),
+    const res = await api.suggest({ kind: 'post_comment', post: { text: 'a post' } }, (e) =>
+      events.push(e),
     );
 
     expect(res.ok).toBe(true);
@@ -193,9 +192,7 @@ describe('api.suggest', () => {
     );
 
     const events: SuggestEvent[] = [];
-    await api.suggest({ kind: 'post_comment', post: { text: 'a post' } }, (e) =>
-      events.push(e),
-    );
+    await api.suggest({ kind: 'post_comment', post: { text: 'a post' } }, (e) => events.push(e));
 
     expect(events).toEqual([
       { kind: 'chunk', text: 'a fairly long chunk of streamed text here', section: 'draft' },
@@ -223,9 +220,8 @@ describe('api.suggest', () => {
     );
 
     const events: SuggestEvent[] = [];
-    const res = await api.suggest(
-      { kind: 'post_comment', post: { text: 'a post' } },
-      (e) => events.push(e),
+    const res = await api.suggest({ kind: 'post_comment', post: { text: 'a post' } }, (e) =>
+      events.push(e),
     );
 
     expect(res.ok).toBe(true);
@@ -247,10 +243,7 @@ describe('api.suggest', () => {
     );
 
     const onEvent = vi.fn();
-    const res = await api.suggest(
-      { kind: 'post_comment', post: { text: 'a post' } },
-      onEvent,
-    );
+    const res = await api.suggest({ kind: 'post_comment', post: { text: 'a post' } }, onEvent);
 
     expect(res.ok).toBe(false);
     expect(onEvent).not.toHaveBeenCalled();

--- a/shared/src/assist/context.ts
+++ b/shared/src/assist/context.ts
@@ -27,12 +27,24 @@
 //     hand in Settings;
 //   - voice profile: derived from the persona's own voice samples plus
 //     messages, drafts and templates already on file - no new capture;
-//   - projects: this organization's own rows;
+//   - projects: this organization's own rows, each with the latest
+//     `project_insights.summary_md` on file for it (LOR-181, 2026-09-10) -
+//     the cheapest real upgrade over a bare name and description, and the
+//     material the model needs to pick which project (if any) a suggestion
+//     is actually about;
 //   - repositories: GitHub's public API, read server-side and cached in
 //     `github_sources`. No credential, by decision - a private repo waits for
 //     the optional GitHub App.
+//
+// 2026-09-10 (LOR-181): `loadCompanionContext` stopped taking a
+// `currentProjectId` and `ProjectBrief` stopped carrying `isCurrent`. Which
+// project a suggestion is about is no longer known before this call runs -
+// the model decides it, inside the same turn, from the post and this exact
+// project list (`suggest-prompt.ts`, `assist/envelope.ts`'s `PROJECT_MARKER`).
+// Every project in the org is loaded on equal footing; none is marked ahead
+// of time.
 
-import { and, asc, desc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray } from 'drizzle-orm';
 import { schema, type Db } from '../db/client.js';
 import { loadVoiceProfile } from '../operator-voice-profile.js';
 
@@ -65,8 +77,12 @@ export type ProjectBrief = {
   id: number;
   name: string;
   description?: string | null;
-  /** True for the project this suggestion is being written under. */
-  isCurrent: boolean;
+  /** The most recent `project_insights.summary_md` on file for this project
+   * (LOR-181), or null when the project-insighter playbook has never run
+   * for it. The cheapest real signal the model has for judging whether a
+   * post is actually about this project, beyond its own name/description -
+   * see `suggest-prompt.ts`'s project listing for how it is rendered. */
+  insightSummary?: string | null;
 };
 
 export type CodeRepo = {
@@ -129,16 +145,15 @@ function asCommits(value: unknown): Array<{ message: string; committedAt?: strin
 /**
  * Loads everything the companion is allowed to know for one organization.
  *
- * `currentProjectId` only marks which project the suggestion is being written
- * under - every project in the organization is loaded either way, because the
- * point is that the assistant can talk about the operator's other work when
- * that is the honest thing to say. Null (#523: a suggestion may name no
- * project at all) simply means no project marks as current. Nothing crosses
- * an organization boundary.
+ * Every project in the organization is loaded, each with its own latest
+ * insight - the point is that the assistant can talk about the operator's
+ * other work when that is the honest thing to say, and can judge which one
+ * (if any) a suggestion is actually about (LOR-181). Nothing crosses an
+ * organization boundary.
  */
 export async function loadCompanionContext(
   db: Db,
-  args: { organizationId: number; currentProjectId: number | null },
+  args: { organizationId: number },
 ): Promise<CompanionContext> {
   const [profileRow] = await db
     .select()
@@ -153,6 +168,35 @@ export async function loadCompanionContext(
     .from(schema.projects)
     .where(eq(schema.projects.organizationId, args.organizationId))
     .orderBy(asc(schema.projects.id));
+
+  // Latest `project_insights` row per project, LOR-181: `projectInsights`
+  // carries no organization id of its own, so scoping through the project
+  // ids just loaded is what keeps this from reaching across a tenant
+  // boundary. Ordered by generatedAt desc and reduced in JS to "first seen
+  // per project id" rather than a DISTINCT ON - simpler, and an org's own
+  // project count is small enough that this never has to be its own query
+  // per project either.
+  const latestInsightByProject = new Map<number, string>();
+  if (projectRows.length > 0) {
+    const insightRows = await db
+      .select({
+        projectId: schema.projectInsights.projectId,
+        summaryMd: schema.projectInsights.summaryMd,
+      })
+      .from(schema.projectInsights)
+      .where(
+        inArray(
+          schema.projectInsights.projectId,
+          projectRows.map((p) => p.id),
+        ),
+      )
+      .orderBy(desc(schema.projectInsights.generatedAt));
+    for (const row of insightRows) {
+      if (!latestInsightByProject.has(row.projectId)) {
+        latestInsightByProject.set(row.projectId, row.summaryMd);
+      }
+    }
+  }
 
   const repoRows = await db
     .select()
@@ -188,7 +232,7 @@ export async function loadCompanionContext(
       id: p.id,
       name: p.name,
       description: p.description,
-      isCurrent: p.id === args.currentProjectId,
+      insightSummary: latestInsightByProject.get(p.id) ?? null,
     })),
     // A repo that failed to fetch has no text to contribute, so it is left out
     // of the prompt rather than carried as an empty entry. Settings is where

--- a/shared/src/assist/envelope.ts
+++ b/shared/src/assist/envelope.ts
@@ -1,5 +1,6 @@
-// Splits a suggestion into the model's reasoning and the draft the human may
-// actually insert (#382, decided 2026-09-07).
+// Splits a suggestion into the project it is actually about, the model's
+// reasoning, and the draft the human may actually insert (#382, decided
+// 2026-09-07; the project field joined it for LOR-181, 2026-09-10).
 //
 // The problem this exists for: the assistant used to stream one blob of text
 // straight into an editable box with an Insert button under it. When the model
@@ -10,18 +11,32 @@
 // The design constraint is that a model asked to emit an exact format gets it
 // wrong some of the time, so the separation cannot rest on it complying
 // (~/.config/agents/skills/moving-work-out-of-the-model). Everything here is
-// therefore written so that the WORST case is no draft at all:
+// therefore written so that the WORST case is no draft at all, and - since
+// LOR-181 - no project claim at all either:
 //
 //   - the draft is whatever follows `DRAFT_MARKER`, and nothing else ever is;
 //   - no marker in the response means `draft: null`, so the panel has nothing
 //     to insert and says so, rather than falling back to "insert it all";
 //   - `SKIP_MARKER` is the model declining, which is a state and not text;
-//   - a marker that leaks into the draft body is stripped, because a marker is
-//     never something the human wants to post.
+//   - a marker that leaked into the draft body is stripped, because a marker is
+//     never something the human wants to post;
+//   - `PROJECT_MARKER`, when present, is the very first thing in the response -
+//     ahead of the reasoning, so a wrong or missing project never delays or
+//     corrupts what the panel shows. `projectChoice` is the model's raw,
+//     unvalidated claim (a bare id or the literal `personal`) - this module
+//     knows nothing about which projects exist, so it never resolves the claim
+//     against anything real. `web/src/lib/server/suggest.ts` does that: an id
+//     that is not one of the organization's own projects falls back to
+//     personal and is logged, exactly like a missing marker falls back to no
+//     draft rather than guessing one.
 //
 // Pure and synchronous, so the property "reasoning can never reach the
 // composer" is testable without a model, a database or a browser.
 
+/** The line the model puts, alone on the very first line of its reply,
+ * ahead of everything else - see `extractProjectChoice` for the shape that
+ * follows it. */
+export const PROJECT_MARKER = '---PITCHBOX-PROJECT---';
 /** The line the model puts between its reasoning and the draft. */
 export const DRAFT_MARKER = '---PITCHBOX-DRAFT---';
 /** The line the model puts instead of a draft when it declines to write one. */
@@ -31,6 +46,12 @@ export const SKIP_MARKER = '---PITCHBOX-SKIP---';
  * back before it can be sure a marker is not being cut in half. */
 const MAX_MARKER_LEN = Math.max(DRAFT_MARKER.length, SKIP_MARKER.length);
 
+/** Longest a stated project value (a bare id, or `personal`) is ever allowed
+ * to be before parsing gives up on it - generous for either, and short
+ * enough that a model that never emits the closing newline cannot hold back
+ * an unbounded amount of text from the panel. */
+const MAX_PROJECT_VALUE_LEN = 40;
+
 export type SuggestionEnvelope = {
   /** Why the model wrote what it wrote. Shown, never insertable. */
   reasoning: string;
@@ -38,6 +59,12 @@ export type SuggestionEnvelope = {
   draft: string | null;
   /** True when the model explicitly declined to write a draft. */
   skipped: boolean;
+  /** The model's raw, unvalidated claim about which project this suggestion
+   * is about - a bare project id, the literal `personal`, or null when
+   * `PROJECT_MARKER` never appeared at the very start of the response, or
+   * nothing usable followed it. Never resolved against real data here -
+   * see the module header. */
+  projectChoice: string | null;
 };
 
 /** Strips both markers wherever they appear, so no marker can ever be posted. */
@@ -50,12 +77,35 @@ function clean(text: string): string {
 }
 
 /**
+ * Reads a project claim off the very start of `text`, if one is there -
+ * `PROJECT_MARKER` alone, immediately followed by a newline and the claimed
+ * value on the next line. Anything else (no marker, an empty or overlong
+ * value) is `projectChoice: null` - the module's own worst-case-safe
+ * posture applied to this field too. `rest` is `text` with the marker and
+ * its value line removed, ready for the ordinary reasoning/draft split.
+ */
+function extractProjectChoice(text: string): { projectChoice: string | null; rest: string } {
+  if (!text.startsWith(PROJECT_MARKER)) return { projectChoice: null, rest: text };
+  // The marker is alone on its own line, so the first newline after it (if
+  // any) closes the marker's line rather than the value's - skip past it
+  // before looking for the newline that actually ends the value.
+  let after = text.slice(PROJECT_MARKER.length);
+  if (after.startsWith('\n')) after = after.slice(1);
+  const nl = after.indexOf('\n');
+  const valueSource = nl === -1 ? after : after.slice(0, nl);
+  const rest = nl === -1 ? '' : after.slice(nl + 1);
+  const value = valueSource.trim();
+  return { projectChoice: value && value.length <= MAX_PROJECT_VALUE_LEN ? value : null, rest };
+}
+
+/**
  * Splits a complete response. `draft` is non-null only when the draft marker
  * was present AND what followed it has content.
  */
 export function splitSuggestion(text: string): SuggestionEnvelope {
-  const skipAt = text.indexOf(SKIP_MARKER);
-  const draftAt = text.indexOf(DRAFT_MARKER);
+  const { projectChoice, rest } = extractProjectChoice(text);
+  const skipAt = rest.indexOf(SKIP_MARKER);
+  const draftAt = rest.indexOf(DRAFT_MARKER);
 
   // Whichever marker comes first is the one the model meant; a response
   // carrying both is a model that changed its mind mid-answer, and the
@@ -64,9 +114,10 @@ export function splitSuggestion(text: string): SuggestionEnvelope {
     return {
       // Text after a skip marker is more of the explanation, not a draft, so
       // it stays in the reasoning where it cannot be inserted.
-      reasoning: clean(text),
+      reasoning: clean(rest),
       draft: null,
       skipped: true,
+      projectChoice,
     };
   }
 
@@ -74,14 +125,15 @@ export function splitSuggestion(text: string): SuggestionEnvelope {
     // No structure at all. Everything is reasoning: this is the fail-safe the
     // module exists for, and it is deliberately not a heuristic guess at where
     // a draft might begin.
-    return { reasoning: clean(text), draft: null, skipped: false };
+    return { reasoning: clean(rest), draft: null, skipped: false, projectChoice };
   }
 
-  const draft = clean(text.slice(draftAt + DRAFT_MARKER.length));
+  const draft = clean(rest.slice(draftAt + DRAFT_MARKER.length));
   return {
-    reasoning: clean(text.slice(0, draftAt)),
+    reasoning: clean(rest.slice(0, draftAt)),
     draft: draft.length > 0 ? draft : null,
     skipped: false,
+    projectChoice,
   };
 }
 
@@ -112,6 +164,51 @@ export class EnvelopeSplitter {
   private draft = '';
   private inDraft = false;
   private didSkip = false;
+  private projectResolved = false;
+  private projectChoice: string | null = null;
+
+  /**
+   * Consumes a leading `PROJECT_MARKER` and its value line from `pending`,
+   * once the bytes seen so far can already decide one way or the other -
+   * mirrors `extractProjectChoice` but incrementally, since the whole point
+   * is to never hold back more than `PROJECT_MARKER.length - 1` characters
+   * from a response that is not using the field at all. Returns `true` once
+   * resolved (the caller's loop should `continue`), `false` when there is
+   * not yet enough to tell (the caller's loop should `break` and wait for
+   * more input).
+   */
+  private resolveProjectPrefix(): boolean {
+    if (this.pending.length < PROJECT_MARKER.length) {
+      if (PROJECT_MARKER.startsWith(this.pending)) return false;
+      this.projectResolved = true;
+      return true;
+    }
+    if (!this.pending.startsWith(PROJECT_MARKER)) {
+      this.projectResolved = true;
+      return true;
+    }
+    let after = this.pending.slice(PROJECT_MARKER.length);
+    // The marker is alone on its own line, so its first character - once it
+    // has arrived - is the newline that closes the marker's own line, not
+    // the value's. Not yet arrived is not yet resolvable either way.
+    if (after.length === 0) return false;
+    if (after[0] === '\n') after = after.slice(1);
+    const nl = after.indexOf('\n');
+    if (nl === -1) {
+      // No closing newline yet - keep waiting, unless the value has already
+      // run well past anything a real id or `personal` could be.
+      if (after.length <= MAX_PROJECT_VALUE_LEN) return false;
+      this.projectChoice = null;
+      this.pending = '';
+      this.projectResolved = true;
+      return true;
+    }
+    const value = after.slice(0, nl).trim();
+    this.projectChoice = value && value.length <= MAX_PROJECT_VALUE_LEN ? value : null;
+    this.pending = after.slice(nl + 1);
+    this.projectResolved = true;
+    return true;
+  }
 
   push(chunk: string): EnvelopeChunk {
     this.pending += chunk;
@@ -121,6 +218,10 @@ export class EnvelopeSplitter {
     // Loop rather than one pass: a single chunk can carry the marker plus the
     // start of the draft, and both halves have to be routed in this call.
     for (;;) {
+      if (!this.projectResolved) {
+        if (!this.resolveProjectPrefix()) break;
+        continue;
+      }
       if (this.didSkip) {
         // Everything after a skip is explanation. Route it to reasoning.
         outReasoning += this.pending;
@@ -182,6 +283,16 @@ export class EnvelopeSplitter {
 
   /** Flushes the held-back tail and returns the final envelope. */
   finish(): SuggestionEnvelope {
+    if (!this.projectResolved) {
+      // A response short enough that `push()` never saw `PROJECT_MARKER.length`
+      // bytes at once (or was never called at all) still gets a real answer
+      // here, the same way `splitSuggestion` would give one to the whole text.
+      const { projectChoice, rest } = extractProjectChoice(this.pending);
+      this.projectChoice = projectChoice;
+      this.pending = rest;
+      this.projectResolved = true;
+    }
+
     if (this.pending.length > 0) {
       // The tail can still complete a marker, so it goes back through the
       // whole-response splitter rather than being appended blindly.
@@ -192,6 +303,9 @@ export class EnvelopeSplitter {
       } else if (this.inDraft) {
         this.draft += stripMarkers(rest);
       } else {
+        // Already past the project prefix above, so this only ever splits
+        // reasoning from a draft/skip marker - `tail.projectChoice` is
+        // never anything but the `null` a mid-reasoning tail resolves to.
         const tail = splitSuggestion(rest);
         this.reasoning += tail.reasoning;
         if (tail.skipped) this.didSkip = true;
@@ -203,12 +317,14 @@ export class EnvelopeSplitter {
     }
 
     const reasoning = clean(this.reasoning);
-    if (this.didSkip) return { reasoning, draft: null, skipped: true };
+    const projectChoice = this.projectChoice;
+    if (this.didSkip) return { reasoning, draft: null, skipped: true, projectChoice };
     const draft = clean(this.draft);
     return {
       reasoning,
       draft: this.inDraft && draft.length > 0 ? draft : null,
       skipped: false,
+      projectChoice,
     };
   }
 }
@@ -220,9 +336,13 @@ export class EnvelopeSplitter {
  */
 export function envelopeInstruction(): string {
   return [
-    'Answer in two parts, in this exact shape:',
+    'Answer in this exact shape.',
     '',
-    'First, at most three sentences on what you noticed in the post and the angle you picked. Write it for the operator, not for the reader of the comment, and write it in the language the operator writes in - the same language as your draft below.',
+    `First, alone on the very first line of your reply, ${PROJECT_MARKER}`,
+    '',
+    "Then, alone on the next line, the id of the project this suggestion is actually about - copy it exactly from the list above, digits only - or the word personal if none of them are what this is about and you are writing in the operator's own voice instead. Pick exactly one, even when more than one could arguably apply: the project the post is actually about.",
+    '',
+    'Then, at most three sentences on what you noticed in the post and the angle you picked. Write it for the operator, not for the reader of the comment, and write it in the language the operator writes in - the same language as your draft below.',
     '',
     `Then, alone on its own line, ${DRAFT_MARKER}`,
     '',

--- a/shared/src/assist/session.ts
+++ b/shared/src/assist/session.ts
@@ -12,11 +12,14 @@
 // short lifetime rather than persisted anywhere.
 //
 // A session id is not a capability by itself: `getAssistSession` also checks
-// the org, the project the suggestion is filed under and the suggestion kind
-// against the caller's own request, so a foreign or stale id (or a stolen
-// device token replaying somebody else's id) never gets to lean on a
-// different tenant's gathered context - it falls back to a full re-gather,
-// exactly as an expired session does.
+// the org and the suggestion kind against the caller's own request, so a
+// foreign or stale id (or a stolen device token replaying somebody else's
+// id) never gets to lean on a different tenant's gathered context - it
+// falls back to a full re-gather, exactly as an expired session does.
+// LOR-181 (2026-09-10) dropped the project from this scope along with it:
+// nothing external asserts a project before the turn runs any more (the
+// model states one as part of the very conversation a session persists), so
+// there is nothing left for a project check here to validate against.
 
 import type { ModelMessage } from 'ai';
 import type { SuggestionKind } from './suggest-prompt.js';
@@ -33,17 +36,12 @@ export const ASSIST_SESSION_TTL_MS = 10 * 60 * 1000;
 interface AssistSessionEntry {
   messages: ModelMessage[];
   orgId: number | null;
-  /** #523: a suggestion with no project bound continues one just as well - a
-   * session scoped to `null` matches only another `null`-scoped request,
-   * never a real project id or the other way around. */
-  projectId: number | null;
   kind: SuggestionKind;
   createdAt: number;
 }
 
 interface AssistSessionScope {
   orgId: number | null;
-  projectId: number | null;
   kind: SuggestionKind;
 }
 
@@ -71,20 +69,16 @@ export function createAssistSession(scope: AssistSessionScope, messages: ModelMe
 
 /**
  * Reads back a session for continuation, or `null` when it never existed,
- * expired, or was scoped to a different org/project/kind than this request -
- * every one of those is treated the same way by the caller: fall back to a
- * full re-gather rather than answer from stale or foreign context.
+ * expired, or was scoped to a different org/kind than this request - every
+ * one of those is treated the same way by the caller: fall back to a full
+ * re-gather rather than answer from stale or foreign context.
  */
 export function getAssistSession(id: string, scope: AssistSessionScope): ModelMessage[] | null {
   const now = Date.now();
   purgeExpired(now);
   const entry = sessions.get(id);
   if (!entry) return null;
-  if (
-    entry.orgId !== scope.orgId ||
-    entry.projectId !== scope.projectId ||
-    entry.kind !== scope.kind
-  ) {
+  if (entry.orgId !== scope.orgId || entry.kind !== scope.kind) {
     return null;
   }
   return entry.messages;

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -425,7 +425,7 @@ export function buildSuggestionPrompt(args: {
   if (projects.length > 0) {
     parts.push(
       [
-        "What the operator is building, across the whole organization. Pick the id of whichever one this suggestion is actually about, or personal if it is about none of them:",
+        'What the operator is building, across the whole organization. Pick the id of whichever one this suggestion is actually about, or personal if it is about none of them:',
         ...projects.slice(0, MAX_PROJECTS).map((p) => {
           const desc = p.description?.trim()
             ? `: ${clamp(p.description, PROJECT_DESCRIPTION_MAX)}`

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -163,15 +163,6 @@ export interface ObservedThread {
   truncated: boolean;
 }
 
-/** The project the suggestion is filed under, described the way the old
- * single-project prompt described it. Kept separate from `projects` (every
- * project in the org) because this is the one whose description is worth
- * quoting in full; the others get a one-line mention. */
-export interface CurrentProject {
-  name: string;
-  description?: string | null;
-}
-
 /** Hard ceiling on the post text we forward. A LinkedIn post is short; anything
  * past this is either a pasted article or a hostile payload, and neither
  * improves the suggestion. */
@@ -233,15 +224,23 @@ const COMMIT_SUBJECT_MAX = 120;
  * project in the org went in regardless of count. Measured 2026-09-08 (#443):
  * twelve projects, a plausible count after a few years of side projects, cost
  * ~1.6KB on a realistic fixture even with each description already capped
- * below, and that grows without bound as an account ages. The current
- * project and the personal project are ranked ahead of the cut in
- * buildSuggestionPrompt below, because those are the two a suggestion can
- * actually depend on; the rest is honest context, not a requirement, so
- * losing one to the cap costs nothing the suggestion needs. */
+ * below, and that grows without bound as an account ages. LOR-181
+ * (2026-09-10) retired the old ranking that put the bound project ahead of
+ * the cut - there is no bound project any more, so the list is just the
+ * org's first MAX_PROJECTS by id; losing a project past the cap to a large
+ * org is honest context lost, never a suggestion that can no longer name
+ * itself, since the model reads the whole list before it picks.
+ */
 export const MAX_PROJECTS = 6;
-/** A project mention in the "what they are building" list is a one-liner, not
- * a second copy of `CurrentProject`'s full description. */
+/** A project mention in the "what they are building" list is a one-liner,
+ * not the project's whole description. */
 const PROJECT_DESCRIPTION_MAX = 300;
+/** Ceiling on a project's own latest insight summary as it reaches this
+ * list (LOR-181) - same spirit as PROJECT_DESCRIPTION_MAX, generous enough
+ * to carry a real judgement about what the project's outreach history shows
+ * without letting an org with several well-instrumented projects bloat the
+ * prompt past what the choice actually needs. */
+const PROJECT_INSIGHT_MAX = 400;
 /** Same reasoning, for a repo's own description line. */
 const REPO_DESCRIPTION_MAX = 300;
 /** How many of a repo's recent commits are worth naming. Past this it reads
@@ -327,10 +326,6 @@ const RETUNE_INSTRUCTION: Record<RetuneDirection, string> = {
 export function buildSuggestionPrompt(args: {
   kind: SuggestionKind;
   post: ObservedPost;
-  /** Null when the suggestion names no project (#523: a project is
-   * optional context, never a requirement) - the operator's own voice on
-   * no particular subject. */
-  currentProject: CurrentProject | null;
   /** Null when the operator has never captured a profile or typed one in by
    * hand - a smaller prompt, not a guessed one. */
   persona: OperatorPersona | null;
@@ -338,7 +333,10 @@ export function buildSuggestionPrompt(args: {
    * honest about how the operator writes - a smaller prompt, not a guessed
    * one. */
   voiceProfile: VoiceProfileSummary | null;
-  /** Every project in the organization, including the current one. */
+  /** Every project in the organization (LOR-181: none marked as "the one" -
+   * the model picks, from this list and the post below, which project (if
+   * any) the suggestion is actually about, and states its choice per
+   * `envelopeInstruction()`). */
   projects: ProjectBrief[];
   repos: CodeRepo[];
   /** Active few-shot templates for this project, already filtered by kind -
@@ -368,22 +366,13 @@ export function buildSuggestionPrompt(args: {
    */
   retune?: RetuneDirection;
 }): string {
-  const { kind, post, currentProject, persona, voiceProfile, projects, repos } = args;
+  const { kind, post, persona, voiceProfile, projects, repos } = args;
   const tone: AssistTone = args.tone ?? DEFAULT_ASSIST_TONE;
   const parts: string[] = [];
 
-  if (currentProject) {
-    parts.push(
-      `You are drafting for ${currentProject.name}, whose operator will read what you write, edit it if they want, and post it themselves under their own name. Nothing you write is sent by anyone but them.`,
-    );
-    if (currentProject.description?.trim()) {
-      parts.push(`What ${currentProject.name} is:\n${clamp(currentProject.description, 1200)}`);
-    }
-  } else {
-    parts.push(
-      "You are drafting in the operator's own voice, on their own subject, not about any particular product they build. The operator will read what you write, edit it if they want, and post it themselves under their own name. Nothing you write is sent by anyone but them.",
-    );
-  }
+  parts.push(
+    "You are drafting for the operator, who will read what you write, edit it if they want, and post it themselves under their own name. Nothing you write is sent by anyone but them. They may work on more than one thing - decide, from the post below and the list of their projects further down, which project (if any) this suggestion is actually about. It may be none of them: writing in the operator's own voice, on their own subject, is a real answer too, not a fallback. State that choice in the exact shape given at the end of these instructions, before anything else.",
+  );
 
   // Who the operator is: headline, about, experience and their own notes on
   // how they want to sound. Nothing here is guessed - it is either captured
@@ -427,27 +416,24 @@ export function buildSuggestionPrompt(args: {
     );
   }
 
-  // What they are building: every project in the organization, so the
-  // assistant can speak honestly about the operator's other work instead of
-  // acting as if this product is the only thing they do. Ranked before the
-  // MAX_PROJECTS cut so the current project always survives it regardless of
-  // how many other projects the organization has - everything else is
-  // honest context that is fine to lose past the ceiling.
+  // What they are building: every project in the organization, with its own
+  // id (so the model has something exact to cite when it states its choice)
+  // and its latest insight, when one is on file (LOR-181) - the cheapest
+  // real material for judging whether a post is actually about it, beyond a
+  // name and a description. No ranking and no "(this one)" marker any more:
+  // nothing is known to be current before the model decides.
   if (projects.length > 0) {
-    const rankedProjects = [...projects].sort((a, b) => {
-      const aRank = a.isCurrent ? 0 : 1;
-      const bRank = b.isCurrent ? 0 : 1;
-      return aRank - bRank;
-    });
     parts.push(
       [
-        'What the operator is building, across the whole organization. This suggestion is filed under the project marked "(this one)":',
-        ...rankedProjects.slice(0, MAX_PROJECTS).map((p) => {
-          const marker = p.isCurrent ? ' (this one)' : '';
+        "What the operator is building, across the whole organization. Pick the id of whichever one this suggestion is actually about, or personal if it is about none of them:",
+        ...projects.slice(0, MAX_PROJECTS).map((p) => {
           const desc = p.description?.trim()
             ? `: ${clamp(p.description, PROJECT_DESCRIPTION_MAX)}`
             : '';
-          return `- ${p.name}${marker}${desc}`;
+          const insight = p.insightSummary?.trim()
+            ? `\n  What its own outreach history shows: ${clamp(p.insightSummary, PROJECT_INSIGHT_MAX)}`
+            : '';
+          return `- [id ${p.id}] ${p.name}${desc}${insight}`;
         }),
       ].join('\n'),
     );

--- a/shared/src/assist/tools.ts
+++ b/shared/src/assist/tools.ts
@@ -10,12 +10,16 @@
 // and refuse.
 //
 // Every tool takes its authority from `AssistToolContext`, never from a
-// model-supplied argument: the org id, the bound project id, the observed
-// target and the operator persona are all resolved server-side before the
-// loop ever starts. `project_knowledge`'s `projectId` is the one exception,
-// and it is validated against the binding rather than trusted (see its
-// handler below) - an org id or a project id accepted from the model would
-// be a cross-tenant hole one hallucination wide.
+// model-supplied argument: the org id, the observed target and the operator
+// persona are all resolved server-side before the loop ever starts.
+// `project_knowledge`'s `projectId` is the one argument a tool trusts from
+// the model, and it is validated against the caller's own organization
+// rather than trusted outright (see its handler below) - an org id accepted
+// from the model would be a cross-tenant hole one hallucination wide. Since
+// LOR-181 (2026-09-10) there is no longer a single project "the suggestion
+// is filed under" to also check it against: the model is free to look up
+// any of the organization's own projects while it is still deciding which
+// one (if any) this suggestion is about.
 //
 // A tool that has nothing to say returns `{ ok: false, reason }` - an
 // explicit nothing, never `{ ok: true, data: <empty> }` - because "no prior
@@ -88,9 +92,6 @@ export interface AssistToolContext {
   /** The organization this suggestion belongs to. Every query below filters
    * on this - never on anything a tool argument could name. */
   orgId: number;
-  /** The project this suggestion is filed under, or null when none is bound
-   * (#523: a project is optional context, never a requirement). */
-  boundProjectId: number | null;
   /** Null when nothing was captured for this device (a fresh binding, nothing
    * scrolled since the collector was last on) - every tool that reads it
    * refuses explicitly rather than fabricating a post. */
@@ -491,9 +492,15 @@ const authorHistory: AssistTool<Record<string, never>, AuthorHistoryResult> = {
     }
 
     const [blocklistResult, contactRows, draftRows, acceptedRows, messageRows] = await Promise.all([
+      // No project id: nothing is bound before the model decides one, so
+      // this only ever sees the organization's global blocklist entries -
+      // a project-scoped block only takes effect once the accept path
+      // resolves a real project for this suggestion (`assist-accept.ts`),
+      // the same enforce-where-the-effect-happens posture the rest of the
+      // plane follows.
       isBlocklisted(ctx.db, {
         platformId,
-        projectId: ctx.boundProjectId,
+        projectId: null,
         targetUser: authorHandle,
       }),
       ctx.db
@@ -742,19 +749,9 @@ export interface ProjectKnowledgeResult {
 const projectKnowledge: AssistTool<{ projectId: number }, ProjectKnowledgeResult> = {
   name: 'project_knowledge',
   description:
-    "The named project's brief, the organization's public repos and their recent commits, and that project's insights. Only usable for the project this suggestion is filed under - fetch this when the post is actually about that product, skip it otherwise.",
+    "One of the organization's projects, by id - its brief, the organization's public repos and their recent commits, and that project's own insights. Fetch this for a project listed above when its brief alone is not enough to tell whether the post is actually about it, or once you have decided it is and want more to draft from. The id is checked against this organization only, never trusted otherwise.",
   schema: { projectId: z.number().int().positive() },
   async handler(ctx, args) {
-    if (ctx.boundProjectId == null) {
-      return { ok: false, reason: 'no project is bound to this suggestion' };
-    }
-    if (args.projectId !== ctx.boundProjectId) {
-      return {
-        ok: false,
-        reason: `project ${args.projectId} is not the project this suggestion is filed under`,
-      };
-    }
-
     const [projectRow] = await ctx.db
       .select({
         id: schema.projects.id,

--- a/shared/src/linkedin-assist.ts
+++ b/shared/src/linkedin-assist.ts
@@ -6,12 +6,25 @@ import { projectBelongsToOrg } from './orgs.js';
 // The org-level off switch and owner for the in-page LinkedIn assistant
 // (LI-19, #316, docs/linkedin-integration-design.md). Until this exists the
 // collector (#302) and the panel (#314) have no legitimate way to know
-// whether they should be running or which project they write as.
+// whether they should be running.
+//
+// LOR-181 (2026-09-10): `projectId` stopped being "the project a suggestion
+// writes as" - the assist plane no longer binds to one at all, since the
+// model now picks which project (if any) a suggestion is about from the
+// post itself (`assist/envelope.ts`'s `PROJECT_MARKER`,
+// `web/src/lib/server/suggest.ts`'s `resolveSuggestionProject`). The field
+// stays only because the passive observation collector (#301/#302) still
+// has to attribute every sighting it writes to a real project
+// (`observed_targets.project_id` is `NOT NULL`, and #304's scout-candidate
+// drain is genuinely per-project) - it never had anything to do with which
+// project a suggestion cites, and removing it here would leave the
+// collector no project to write with.
 //
 // Stored in app_config the same way quota_defaults is (shared/src/quota.ts):
 // one row, keyed by a sub-entity inside the jsonb blob. quota_defaults keys
 // by platform slug because it is instance-wide; this keys by organization id
-// because assist is a per-org setting (bound project, per-org caps).
+// because assist is a per-org setting (the collector's project, per-org
+// caps).
 
 const CONFIG_KEY = 'linkedin_assist';
 
@@ -42,7 +55,13 @@ import type { AssistTone } from './assist/tone.js';
 export type LinkedInAssistSettings = {
   /** Whether the in-page assistant may be used at all. Off by default: a fresh install must not start collecting. */
   enabled: boolean;
-  /** The project a suggestion is written as. A suggestion has to be written as some project's voice, so `enabled` cannot be saved true without one. */
+  /** LOR-181: no longer the project a suggestion writes as - the model
+   * decides that per suggestion, from the post itself. What is left to bind
+   * here is the passive observation collector's own attribution target: a
+   * sighting `collectorEnabled` writes has to land in some project's
+   * `observed_targets` buffer (`NOT NULL`, and #304's scout-candidate drain
+   * is genuinely per-project), and this is that project. Never required for
+   * `enabled` (the assistant) - only meaningful when `collectorEnabled`. */
   projectId: number | null;
   /** Whether the passive observation collector runs. Independent of `enabled` so an operator can gather observations without yet exposing suggestions, or vice versa. */
   collectorEnabled: boolean;
@@ -128,13 +147,13 @@ export async function saveLinkedInAssistSettings(
 
 /** The exact shape served to the extension by GET /api/extension/linkedin-assist. */
 export type LinkedInAssistDeviceState = {
-  /** Effective, not raw: false whenever `killSwitch` is set, even if the stored flag is true. #523: no longer requires a live bound project - the assistant binds to the operator, and a project is optional context a suggestion may name. */
+  /** Effective, not raw: false whenever `killSwitch` is set, even if the stored flag is true. LOR-181: never requires a project - the model decides which one (if any) a suggestion is about, per suggestion, from the post itself. */
   enabled: boolean;
-  /** Effective: also requires `enabled`. Unlike `enabled` itself, the collector still needs nothing about a project - it only ever wrote to `observed_targets`. */
+  /** Effective: also requires `enabled`. LOR-181: still gated on `projectId` below at the call site that actually writes an observation (`POST /api/extension/observations`) - the collector's own attribution target, unrelated to what a suggestion cites. */
   collectorEnabled: boolean;
   /** Raw flag, exposed separately so a consumer can render "stopped by an admin" distinctly from "never turned on". */
   killSwitch: boolean;
-  /** Null when unbound or when the stored project id no longer resolves in this org. Context only (#523): a suggestion works with this null, and files under no project when it is. */
+  /** LOR-181: no longer a suggestion's context - null when nothing is bound or the stored id no longer resolves in this org. The passive observation collector's own attribution target (see `LinkedInAssistSettings.projectId`'s doc comment); a suggestion neither reads nor sends this any more. */
   projectId: number | null;
   dailyCommentCap: number;
   dailyPostCap: number;
@@ -175,17 +194,22 @@ export type EffectiveVoice = {
 
 /**
  * Resolves the voice a suggestion should be written in, given the project it
- * is actually being filed under - which may be null (#523: a suggestion can
- * be about no product at all), and need not be the org's bound project.
- * Precedence: the project's own override if it set one, else the org's
- * `linkedin_assist` tone, which itself already falls back to
- * `DEFAULT_ASSIST_TONE` when nothing was ever saved (`loadLinkedInAssistSettings`
- * above) - so this is the one place all three levels collapse into a single
- * answer, rather than each caller re-deriving the fallback chain itself.
+ * is actually being filed under - which may be null (a suggestion can be
+ * about no product at all, or LOR-181: about a product not yet known when
+ * this runs). Precedence: the project's own override if it set one, else
+ * the org's `linkedin_assist` tone, which itself already falls back to
+ * `DEFAULT_ASSIST_TONE` when nothing was ever saved
+ * (`loadLinkedInAssistSettings` above) - so this is the one place all
+ * three levels collapse into a single answer, rather than each caller
+ * re-deriving the fallback chain itself.
  *
  * `project` only needs its two voice columns, not a full row, so a caller
- * that already selected the project (the suggest route does, to enforce the
- * binding) can pass it straight through with no second query. Pass
+ * that already has the project row in hand can pass it straight through
+ * with no second query. LOR-181: `POST /api/extension/suggest` always
+ * passes `{ voiceTone: null, voiceToneNotes: null }` now - which project (if
+ * any) a suggestion is about is the model's own choice, extracted only
+ * after the turn already ran, so there is no project row left to read an
+ * override from before generation starts. Pass
  * `{ voiceTone: null, voiceToneNotes: null }` when no project is filed at all.
  *
  * An unrecognised `voiceTone` (a column written by an older build, or a

--- a/shared/src/observed-targets.ts
+++ b/shared/src/observed-targets.ts
@@ -127,22 +127,31 @@ export async function ingestObservedTargets(
 }
 
 /**
- * The single most recently observed post with readable text, for `projectId`
- * on `platformId`. What `POST /api/extension/suggest` grounds a `kind: 'post'`
- * suggestion in (#315): the post composer itself has nothing to riff off - it
- * is a blank box, not a post the human is reading - so a `post` suggestion is
- * grounded server-side in what the observation buffer (#301/#302) already
- * collected while the human scrolled, rather than the panel handing over
- * whatever it could scrape live off the page it happens to be on. Ignores
- * `consumedByRunId`: a scout-candidate drain (#304) consuming a row for a
- * campaign has nothing to do with whether that sighting is still recent
- * enough to ground a suggestion. Text-less sightings (a real, documented gap
- * - see `linkedin-dom.ts`'s "What is checked against a real capture") are
- * excluded, since there is nothing in them to draft from.
+ * The single most recently observed post with readable text, for the whole
+ * organization on `platformId`. What `POST /api/extension/suggest` grounds a
+ * `kind: 'post'` suggestion in (#315): the post composer itself has nothing
+ * to riff off - it is a blank box, not a post the human is reading - so a
+ * `post` suggestion is grounded server-side in what the observation buffer
+ * (#301/#302) already collected while the human scrolled, rather than the
+ * panel handing over whatever it could scrape live off the page it happens
+ * to be on. Ignores `consumedByRunId`: a scout-candidate drain (#304)
+ * consuming a row for a campaign has nothing to do with whether that
+ * sighting is still recent enough to ground a suggestion. Text-less
+ * sightings (a real, documented gap - see `linkedin-dom.ts`'s "What is
+ * checked against a real capture") are excluded, since there is nothing in
+ * them to draft from.
+ *
+ * LOR-181 (2026-09-10): dropped the `projectId` filter this used to carry.
+ * A `post` suggestion is grounded exactly the same way a `post_comment` one
+ * is now - in a single post, org-wide, with no project known ahead of the
+ * model's own choice (`assist/envelope.ts`'s `PROJECT_MARKER`) - so which
+ * project the collector happened to attribute a given sighting to (still a
+ * real, required column - #304's candidate drain still needs it) no longer
+ * narrows what this reads.
  */
 export async function loadRecentObservedTarget(
   db: Db,
-  input: { organizationId: number; projectId: number; platformId: number },
+  input: { organizationId: number; platformId: number },
 ): Promise<{
   authorHandle: string | null;
   authorName: string | null;
@@ -159,13 +168,7 @@ export async function loadRecentObservedTarget(
     .from(observedTargets)
     .where(
       and(
-        // Organization as well as project, even though a project belongs to
-        // exactly one organization and the caller has already checked it:
-        // `organization_id` is carried on this row directly for precisely
-        // this reason (#263), and a read that has to be reasoned about to be
-        // safe is one somebody will get wrong later.
         eq(observedTargets.organizationId, input.organizationId),
-        eq(observedTargets.projectId, input.projectId),
         eq(observedTargets.platformId, input.platformId),
         isNotNull(observedTargets.text),
       ),

--- a/shared/tests/assist-envelope.test.ts
+++ b/shared/tests/assist-envelope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   DRAFT_MARKER,
+  PROJECT_MARKER,
   SKIP_MARKER,
   EnvelopeSplitter,
   envelopeInstruction,
@@ -55,6 +56,52 @@ describe('splitSuggestion', () => {
   it('strips a marker that leaked into the draft body', () => {
     const env = splitSuggestion(`r\n${DRAFT_MARKER}\nkeep this ${SKIP_MARKER} and this`);
     expect(env.draft).toBe('keep this  and this');
+  });
+});
+
+// LOR-181: the model states which project (or `personal`) a suggestion is
+// about as the very first thing in its reply, ahead of the reasoning - see
+// the module header for why. `projectChoice` here is always the model's raw,
+// unvalidated claim; resolving it against real projects is
+// `web/src/lib/server/suggest.ts`'s job, not this module's.
+describe('splitSuggestion: project choice', () => {
+  it('reads a project id off the marker', () => {
+    const env = splitSuggestion(
+      `${PROJECT_MARKER}\n42\nThis is clearly about that product.\n${DRAFT_MARKER}\nHere is the draft.`,
+    );
+    expect(env.projectChoice).toBe('42');
+    expect(env.reasoning).toBe('This is clearly about that product.');
+    expect(env.draft).toBe('Here is the draft.');
+  });
+
+  it('reads the literal personal', () => {
+    const env = splitSuggestion(`${PROJECT_MARKER}\npersonal\nJust me, no product.`);
+    expect(env.projectChoice).toBe('personal');
+  });
+
+  it('is null when the model never states one', () => {
+    const env = splitSuggestion('No marker at all here, just an answer.');
+    expect(env.projectChoice).toBeNull();
+  });
+
+  it('is null when the marker is there but the value line is empty', () => {
+    const env = splitSuggestion(`${PROJECT_MARKER}\n\nreasoning follows`);
+    expect(env.projectChoice).toBeNull();
+    // The blank value line must not leak into what the human-facing reasoning shows.
+    expect(env.reasoning).toBe('reasoning follows');
+  });
+
+  it('is null when the value is absurdly long, and never blocks the rest of the response', () => {
+    const overlong = '1'.repeat(200);
+    const env = splitSuggestion(`${PROJECT_MARKER}\n${overlong}\nreasoning\n${DRAFT_MARKER}\ndraft`);
+    expect(env.projectChoice).toBeNull();
+    expect(env.draft).toBe('draft');
+  });
+
+  it('only recognises the marker at the very start - not mid-reasoning', () => {
+    const env = splitSuggestion(`I noticed this first. ${PROJECT_MARKER}\n7\nmore text`);
+    expect(env.projectChoice).toBeNull();
+    expect(env.reasoning).toContain(PROJECT_MARKER);
   });
 });
 
@@ -122,12 +169,40 @@ describe('EnvelopeSplitter', () => {
     expect(out.draft).toBe('');
     expect(s.finish().draft).toBeNull();
   });
+
+  it('reads a streamed project id and never streams the marker as reasoning', () => {
+    const r = stream([`${PROJECT_MARKER}\n`, '9', '\nreasoning here\n', DRAFT_MARKER, '\ndraft']);
+    expect(r.env.projectChoice).toBe('9');
+    expect(r.env.reasoning).toBe('reasoning here');
+    expect(r.streamedReasoning).not.toContain('PITCHBOX-PROJECT');
+    expect(r.streamedReasoning).not.toContain('9');
+  });
+
+  it('survives the project marker arriving one character at a time', () => {
+    const text = `${PROJECT_MARKER}\n3\nwhy\n${DRAFT_MARKER}\nbody`;
+    const r = stream(text.split(''));
+    expect(r.env.projectChoice).toBe('3');
+    expect(r.env.reasoning).toBe('why');
+    expect(r.env.draft).toBe('body');
+  });
+
+  it('resolves to no project without holding back reasoning past the ordinary marker-length lag', () => {
+    const r = stream(['nothing to add here', ', it is a repost']);
+    expect(r.env.projectChoice).toBeNull();
+    expect(r.env.reasoning).toBe('nothing to add here, it is a repost');
+    // Only the ordinary DRAFT/SKIP-marker holdback delays anything here - the
+    // project phase itself resolves "no marker" on the very first push, since
+    // this text diverges from PROJECT_MARKER at its first character.
+    expect(r.streamedReasoning.length).toBeGreaterThan(0);
+  });
 });
 
 describe('envelopeInstruction', () => {
-  it('names both markers, so prompt and parser cannot drift', () => {
+  it('names every marker, so prompt and parser cannot drift', () => {
     const text = envelopeInstruction();
+    expect(text).toContain(PROJECT_MARKER);
     expect(text).toContain(DRAFT_MARKER);
     expect(text).toContain(SKIP_MARKER);
   });
 });
+

--- a/shared/tests/assist-envelope.test.ts
+++ b/shared/tests/assist-envelope.test.ts
@@ -93,7 +93,9 @@ describe('splitSuggestion: project choice', () => {
 
   it('is null when the value is absurdly long, and never blocks the rest of the response', () => {
     const overlong = '1'.repeat(200);
-    const env = splitSuggestion(`${PROJECT_MARKER}\n${overlong}\nreasoning\n${DRAFT_MARKER}\ndraft`);
+    const env = splitSuggestion(
+      `${PROJECT_MARKER}\n${overlong}\nreasoning\n${DRAFT_MARKER}\ndraft`,
+    );
     expect(env.projectChoice).toBeNull();
     expect(env.draft).toBe('draft');
   });
@@ -205,4 +207,3 @@ describe('envelopeInstruction', () => {
     expect(text).toContain(SKIP_MARKER);
   });
 });
-

--- a/shared/tests/assist-session.test.ts
+++ b/shared/tests/assist-session.test.ts
@@ -15,7 +15,7 @@ import type { ModelMessage } from 'ai';
  * created for.
  */
 
-const SCOPE = { orgId: 1, projectId: 10, kind: 'post_comment' as const };
+const SCOPE = { orgId: 1, kind: 'post_comment' as const };
 const MESSAGES: ModelMessage[] = [{ role: 'assistant', content: 'gathered context' }];
 
 afterEach(() => {
@@ -33,10 +33,9 @@ describe('createAssistSession / getAssistSession', () => {
     expect(getAssistSession('not-a-real-session', SCOPE)).toBeNull();
   });
 
-  it('refuses a mismatched org, project or kind rather than leaking cross-tenant context', () => {
+  it('refuses a mismatched org or kind rather than leaking cross-tenant context', () => {
     const id = createAssistSession(SCOPE, MESSAGES);
     expect(getAssistSession(id, { ...SCOPE, orgId: 2 })).toBeNull();
-    expect(getAssistSession(id, { ...SCOPE, projectId: 11 })).toBeNull();
     expect(getAssistSession(id, { ...SCOPE, kind: 'post' })).toBeNull();
     // The real scope still works - the mismatched reads above didn't consume it.
     expect(getAssistSession(id, SCOPE)).toEqual(MESSAGES);

--- a/shared/tests/assist-tools.test.ts
+++ b/shared/tests/assist-tools.test.ts
@@ -49,7 +49,7 @@ async function makeProject(orgId: number, slug: string, description?: string): P
 }
 
 function baseCtx(
-  overrides: Partial<AssistToolContext> & { orgId: number; boundProjectId: number },
+  overrides: Partial<AssistToolContext> & { orgId: number },
 ): AssistToolContext {
   return { db: getDb(), observedTarget: null, operator: null, ...overrides };
 }
@@ -59,7 +59,7 @@ describe('shared/src/assist/tools', () => {
 
   describe('read_thread', () => {
     it('refuses with an explicit nothing when no thread was captured', async () => {
-      const ctx = baseCtx({ orgId: 1, boundProjectId: 1, observedTarget: null });
+      const ctx = baseCtx({ orgId: 1, observedTarget: null });
       const result = await ASSIST_TOOLS_BY_NAME.read_thread.handler(ctx, {});
       expect(result.ok).toBe(false);
     });
@@ -83,7 +83,7 @@ describe('shared/src/assist/tools', () => {
           truncated: false,
         },
       };
-      const ctx = baseCtx({ orgId: 1, boundProjectId: 1, observedTarget });
+      const ctx = baseCtx({ orgId: 1, observedTarget });
       const result = await ASSIST_TOOLS_BY_NAME.read_thread.handler(ctx, {});
       expect(result.ok).toBe(true);
       if (!result.ok) return;
@@ -99,7 +99,7 @@ describe('shared/src/assist/tools', () => {
         text: 'Hello world',
         thread: { comments: [], renderedCount: 40, truncated: true },
       };
-      const ctx = baseCtx({ orgId: 1, boundProjectId: 1, observedTarget });
+      const ctx = baseCtx({ orgId: 1, observedTarget });
       const result = await ASSIST_TOOLS_BY_NAME.read_thread.handler(ctx, {});
       expect(result.ok).toBe(true);
       if (!result.ok) return;
@@ -111,7 +111,6 @@ describe('shared/src/assist/tools', () => {
     it('refuses with an explicit nothing when the post has no image at all', async () => {
       const ctx = baseCtx({
         orgId: 1,
-        boundProjectId: 1,
         observedTarget: { text: 'no image here' },
       });
       const result = await ASSIST_TOOLS_BY_NAME.look_at_image.handler(ctx, {});
@@ -121,7 +120,6 @@ describe('shared/src/assist/tools', () => {
     it('refuses with an explicit nothing when the image exists but nothing was captured', async () => {
       const ctx = baseCtx({
         orgId: 1,
-        boundProjectId: 1,
         observedTarget: { text: 'x', image: { kind: 'image' } },
       });
       const result = await ASSIST_TOOLS_BY_NAME.look_at_image.handler(ctx, {});
@@ -131,7 +129,6 @@ describe('shared/src/assist/tools', () => {
     it('describes from alt text with no model call when only alt text is present', async () => {
       const ctx = baseCtx({
         orgId: 1,
-        boundProjectId: 1,
         observedTarget: {
           text: 'x',
           image: { kind: 'image', alt: 'A bar chart showing quarterly growth' },
@@ -151,7 +148,6 @@ describe('shared/src/assist/tools', () => {
       try {
         const ctx = baseCtx({
           orgId: 1,
-          boundProjectId: 1,
           observedTarget: {
             text: 'x',
             image: { kind: 'image', dataUrl: 'data:image/png;base64,AAAA' },
@@ -193,7 +189,6 @@ describe('shared/src/assist/tools', () => {
       const projA = await makeProject(orgA, 'at-proj-a');
       const ctx = baseCtx({
         orgId: orgA,
-        boundProjectId: projA,
         observedTarget: { authorHandle: 'shared-handle', text: 'x' },
       });
       const result = await ASSIST_TOOLS_BY_NAME.author_history.handler(ctx, {});
@@ -209,7 +204,6 @@ describe('shared/src/assist/tools', () => {
       const projA = await makeProject(orgA, 'at-proj-empty');
       const ctx = baseCtx({
         orgId: orgA,
-        boundProjectId: projA,
         observedTarget: { authorHandle: 'nobody-seen-before', text: 'x' },
       });
       const result = await ASSIST_TOOLS_BY_NAME.author_history.handler(ctx, {});
@@ -229,7 +223,6 @@ describe('shared/src/assist/tools', () => {
       });
       const ctx = baseCtx({
         orgId: orgA,
-        boundProjectId: projA,
         observedTarget: { authorHandle: 'spammer', text: 'x' },
       });
       const result = await ASSIST_TOOLS_BY_NAME.author_history.handler(ctx, {});
@@ -243,7 +236,6 @@ describe('shared/src/assist/tools', () => {
     it('refuses with an explicit nothing when the captured post has no author handle', async () => {
       const ctx = baseCtx({
         orgId: 1,
-        boundProjectId: 1,
         observedTarget: { text: 'no author here' },
       });
       const result = await ASSIST_TOOLS_BY_NAME.author_history.handler(ctx, {});
@@ -254,7 +246,7 @@ describe('shared/src/assist/tools', () => {
   describe('operator_voice', () => {
     it('reports an honest default, never an invented voice, when the corpus is thin', async () => {
       const orgA = await ensureOrg('ov-org-thin');
-      const ctx = baseCtx({ orgId: orgA, boundProjectId: 1 });
+      const ctx = baseCtx({ orgId: orgA});
       const result = await ASSIST_TOOLS_BY_NAME.operator_voice.handler(ctx, {});
       expect(result.ok).toBe(true);
       if (!result.ok) return;
@@ -265,61 +257,49 @@ describe('shared/src/assist/tools', () => {
 
     it('always answers - never refuses, even with nothing on file', async () => {
       const orgA = await ensureOrg('ov-org-never-refuses');
-      const ctx = baseCtx({ orgId: orgA, boundProjectId: 1 });
+      const ctx = baseCtx({ orgId: orgA});
       const result = await ASSIST_TOOLS_BY_NAME.operator_voice.handler(ctx, {});
       expect(result.ok).toBe(true);
     });
   });
 
   describe('project_knowledge', () => {
-    it('refuses a project id that is neither the bound project nor the personal project', async () => {
+    // LOR-181: retired the old "bound project" restriction along with the
+    // binding it used to check against - a suggestion has no project bound
+    // ahead of the model's own turn any more, so this tool now answers for
+    // any of the organization's own projects, not just one distinguished
+    // one. This is the property that changed; the org-scoping test below it
+    // (a real security boundary) is unaffected.
+    it("answers for any of the organization's own projects, not just one bound project", async () => {
       const orgA = await ensureOrg('pk-org-a');
-      const projBound = await makeProject(orgA, 'pk-bound');
-      const projOther = await makeProject(orgA, 'pk-other');
-      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBound });
+      await makeProject(orgA, 'pk-first');
+      const projSecond = await makeProject(orgA, 'pk-second', 'A product that does X');
+      const ctx = baseCtx({ orgId: orgA });
       const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
-        projectId: projOther,
-      });
-      expect(result.ok).toBe(false);
-    });
-
-    it("refuses another organization's project id even though it is a valid row", async () => {
-      const orgA = await ensureOrg('pk-org-x');
-      const orgB = await ensureOrg('pk-org-y');
-      const projBoundA = await makeProject(orgA, 'pk-bound-a');
-      const projB = await makeProject(orgB, 'pk-proj-b', "org B's own product");
-      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBoundA });
-      const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
-        projectId: projB,
-      });
-      expect(result.ok).toBe(false);
-    });
-
-    it('answers for the bound project with its description', async () => {
-      const orgA = await ensureOrg('pk-org-b');
-      const projBound = await makeProject(orgA, 'pk-bound2', 'A product that does X');
-      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBound });
-      const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
-        projectId: projBound,
+        projectId: projSecond,
       });
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.data.project.description).toBe('A product that does X');
     });
 
-    // #523 retired the personal project and, with it, project_knowledge's
-    // bypass for it - a non-bound project id now always refuses, no
-    // exceptions. Deleted rather than re-pinned to a plain seeded project:
-    // the behaviour this test defended (a distinguished project id that
-    // skips the binding check) no longer exists in the handler at all, and
-    // the two tests above already cover the real current contract (a bound
-    // project answers, any other one refuses).
+    it("refuses another organization's project id even though it is a valid row", async () => {
+      const orgA = await ensureOrg('pk-org-x');
+      const orgB = await ensureOrg('pk-org-y');
+      const projB = await makeProject(orgB, 'pk-proj-b', "org B's own product");
+      const ctx = baseCtx({ orgId: orgA });
+      const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
+        projectId: projB,
+      });
+      expect(result.ok).toBe(false);
+    });
+
     it('refuses with an explicit nothing when the project has no description, repos or insights', async () => {
       const orgA = await ensureOrg('pk-org-empty');
-      const projBound = await makeProject(orgA, 'pk-bound-empty');
-      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBound });
+      const projEmpty = await makeProject(orgA, 'pk-empty');
+      const ctx = baseCtx({ orgId: orgA });
       const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
-        projectId: projBound,
+        projectId: projEmpty,
       });
       expect(result.ok).toBe(false);
     });
@@ -336,14 +316,14 @@ describe('shared/src/assist/tools', () => {
         active: true,
         fetchedAt: new Date(),
       });
-      const projBound = await makeProject(
+      const proj = await makeProject(
         orgA,
-        'pk-bound-repo',
+        'pk-repo',
         'A product with no repos of its own',
       );
-      const ctx = baseCtx({ orgId: orgA, boundProjectId: projBound });
+      const ctx = baseCtx({ orgId: orgA });
       const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
-        projectId: projBound,
+        projectId: proj,
       });
       expect(result.ok).toBe(true);
       if (!result.ok) return;
@@ -365,7 +345,7 @@ describe('shared/src/assist/tools', () => {
           text: "Org B's own database migration story, never seen by org A.",
         },
       ]);
-      const ctx = baseCtx({ orgId: orgA, boundProjectId: 1 });
+      const ctx = baseCtx({ orgId: orgA});
       const result = await ASSIST_TOOLS_BY_NAME.my_prior_takes.handler(ctx, {
         query: 'database migration',
       });
@@ -377,7 +357,7 @@ describe('shared/src/assist/tools', () => {
 
     it('refuses with an explicit nothing when nothing matches', async () => {
       const orgA = await ensureOrg('pt-org-empty');
-      const ctx = baseCtx({ orgId: orgA, boundProjectId: 1 });
+      const ctx = baseCtx({ orgId: orgA});
       const result = await ASSIST_TOOLS_BY_NAME.my_prior_takes.handler(ctx, {
         query: 'quantum photosynthesis',
       });
@@ -386,7 +366,7 @@ describe('shared/src/assist/tools', () => {
 
     it('refuses with an explicit nothing when the query has no searchable words', async () => {
       const orgA = await ensureOrg('pt-org-nowords');
-      const ctx = baseCtx({ orgId: orgA, boundProjectId: 1 });
+      const ctx = baseCtx({ orgId: orgA});
       const result = await ASSIST_TOOLS_BY_NAME.my_prior_takes.handler(ctx, { query: 'a an it' });
       expect(result.ok).toBe(false);
     });
@@ -394,7 +374,7 @@ describe('shared/src/assist/tools', () => {
 
   describe('check_style', () => {
     it('never refuses - a clean draft gets an empty findings list', async () => {
-      const ctx = baseCtx({ orgId: 1, boundProjectId: 1 });
+      const ctx = baseCtx({ orgId: 1});
       const result = await ASSIST_TOOLS_BY_NAME.check_style.handler(ctx, {
         text: 'A clean, direct sentence.',
       });
@@ -404,7 +384,7 @@ describe('shared/src/assist/tools', () => {
     });
 
     it('surfaces a real house-style finding', async () => {
-      const ctx = baseCtx({ orgId: 1, boundProjectId: 1 });
+      const ctx = baseCtx({ orgId: 1});
       const result = await ASSIST_TOOLS_BY_NAME.check_style.handler(ctx, {
         text: 'This is great \u2014 really great.',
       });

--- a/shared/tests/assist-tools.test.ts
+++ b/shared/tests/assist-tools.test.ts
@@ -48,9 +48,7 @@ async function makeProject(orgId: number, slug: string, description?: string): P
   return p!.id;
 }
 
-function baseCtx(
-  overrides: Partial<AssistToolContext> & { orgId: number },
-): AssistToolContext {
+function baseCtx(overrides: Partial<AssistToolContext> & { orgId: number }): AssistToolContext {
   return { db: getDb(), observedTarget: null, operator: null, ...overrides };
 }
 
@@ -186,7 +184,7 @@ describe('shared/src/assist/tools', () => {
           uncontactable: true,
           uncontactableReason: "org B's own private fact",
         });
-      const projA = await makeProject(orgA, 'at-proj-a');
+      await makeProject(orgA, 'at-proj-a');
       const ctx = baseCtx({
         orgId: orgA,
         observedTarget: { authorHandle: 'shared-handle', text: 'x' },
@@ -201,7 +199,7 @@ describe('shared/src/assist/tools', () => {
 
     it('refuses with an explicit nothing when there is no prior contact', async () => {
       const orgA = await ensureOrg('at-org-empty');
-      const projA = await makeProject(orgA, 'at-proj-empty');
+      await makeProject(orgA, 'at-proj-empty');
       const ctx = baseCtx({
         orgId: orgA,
         observedTarget: { authorHandle: 'nobody-seen-before', text: 'x' },
@@ -212,7 +210,7 @@ describe('shared/src/assist/tools', () => {
 
     it('surfaces a blocklisted handle even with no contact history on file', async () => {
       const orgA = await ensureOrg('at-org-blocked');
-      const projA = await makeProject(orgA, 'at-proj-blocked');
+      await makeProject(orgA, 'at-proj-blocked');
       const linkedin = await platformId('linkedin');
       await getDb().insert(schema.blocklist).values({
         platformId: linkedin,
@@ -246,7 +244,7 @@ describe('shared/src/assist/tools', () => {
   describe('operator_voice', () => {
     it('reports an honest default, never an invented voice, when the corpus is thin', async () => {
       const orgA = await ensureOrg('ov-org-thin');
-      const ctx = baseCtx({ orgId: orgA});
+      const ctx = baseCtx({ orgId: orgA });
       const result = await ASSIST_TOOLS_BY_NAME.operator_voice.handler(ctx, {});
       expect(result.ok).toBe(true);
       if (!result.ok) return;
@@ -257,7 +255,7 @@ describe('shared/src/assist/tools', () => {
 
     it('always answers - never refuses, even with nothing on file', async () => {
       const orgA = await ensureOrg('ov-org-never-refuses');
-      const ctx = baseCtx({ orgId: orgA});
+      const ctx = baseCtx({ orgId: orgA });
       const result = await ASSIST_TOOLS_BY_NAME.operator_voice.handler(ctx, {});
       expect(result.ok).toBe(true);
     });
@@ -316,11 +314,7 @@ describe('shared/src/assist/tools', () => {
         active: true,
         fetchedAt: new Date(),
       });
-      const proj = await makeProject(
-        orgA,
-        'pk-repo',
-        'A product with no repos of its own',
-      );
+      const proj = await makeProject(orgA, 'pk-repo', 'A product with no repos of its own');
       const ctx = baseCtx({ orgId: orgA });
       const result = await ASSIST_TOOLS_BY_NAME.project_knowledge.handler(ctx, {
         projectId: proj,
@@ -345,7 +339,7 @@ describe('shared/src/assist/tools', () => {
           text: "Org B's own database migration story, never seen by org A.",
         },
       ]);
-      const ctx = baseCtx({ orgId: orgA});
+      const ctx = baseCtx({ orgId: orgA });
       const result = await ASSIST_TOOLS_BY_NAME.my_prior_takes.handler(ctx, {
         query: 'database migration',
       });
@@ -357,7 +351,7 @@ describe('shared/src/assist/tools', () => {
 
     it('refuses with an explicit nothing when nothing matches', async () => {
       const orgA = await ensureOrg('pt-org-empty');
-      const ctx = baseCtx({ orgId: orgA});
+      const ctx = baseCtx({ orgId: orgA });
       const result = await ASSIST_TOOLS_BY_NAME.my_prior_takes.handler(ctx, {
         query: 'quantum photosynthesis',
       });
@@ -366,7 +360,7 @@ describe('shared/src/assist/tools', () => {
 
     it('refuses with an explicit nothing when the query has no searchable words', async () => {
       const orgA = await ensureOrg('pt-org-nowords');
-      const ctx = baseCtx({ orgId: orgA});
+      const ctx = baseCtx({ orgId: orgA });
       const result = await ASSIST_TOOLS_BY_NAME.my_prior_takes.handler(ctx, { query: 'a an it' });
       expect(result.ok).toBe(false);
     });
@@ -374,7 +368,7 @@ describe('shared/src/assist/tools', () => {
 
   describe('check_style', () => {
     it('never refuses - a clean draft gets an empty findings list', async () => {
-      const ctx = baseCtx({ orgId: 1});
+      const ctx = baseCtx({ orgId: 1 });
       const result = await ASSIST_TOOLS_BY_NAME.check_style.handler(ctx, {
         text: 'A clean, direct sentence.',
       });
@@ -384,7 +378,7 @@ describe('shared/src/assist/tools', () => {
     });
 
     it('surfaces a real house-style finding', async () => {
-      const ctx = baseCtx({ orgId: 1});
+      const ctx = baseCtx({ orgId: 1 });
       const result = await ASSIST_TOOLS_BY_NAME.check_style.handler(ctx, {
         text: 'This is great \u2014 really great.',
       });

--- a/shared/tests/assist/loop.test.ts
+++ b/shared/tests/assist/loop.test.ts
@@ -24,7 +24,6 @@ function fakeCtx(): AssistToolContext {
   return {
     db: {} as AssistToolContext['db'],
     orgId: 1,
-    boundProjectId: 1,
     observedTarget: null,
     operator: null,
   };

--- a/shared/tests/observed-targets.test.ts
+++ b/shared/tests/observed-targets.test.ts
@@ -258,7 +258,7 @@ describe('ingestObservedTargets', () => {
   });
 });
 
-describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds in)', () => {
+describe('loadRecentObservedTarget (#315, LOR-181: what a kind: "post" suggestion grounds in)', () => {
   let linkedinId: number;
   let orgAId: number;
   let orgBId: number;
@@ -276,10 +276,9 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
     projectBId = await makeProject(orgBId, 'recent-obs-proj-b');
   });
 
-  it('returns null for a project the collector has never seen anything for', async () => {
+  it('returns null for an organization the collector has never seen anything for', async () => {
     const result = await loadRecentObservedTarget(getDb(), {
       organizationId: orgAId,
-      projectId: projectAId,
       platformId: linkedinId,
     });
     expect(result).toBeNull();
@@ -308,7 +307,6 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
 
     const result = await loadRecentObservedTarget(db, {
       organizationId: orgAId,
-      projectId: projectAId,
       platformId: linkedinId,
     });
     expect(result?.text).toBe('the newest sighting');
@@ -337,28 +335,31 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
 
     const result = await loadRecentObservedTarget(db, {
       organizationId: orgAId,
-      projectId: projectAId,
       platformId: linkedinId,
     });
     expect(result?.text).toBe('readable content');
   });
 
-  it('never crosses a project boundary within the same org', async () => {
+  // LOR-181 retires the old project-isolation test here: a `post`
+  // suggestion is no longer grounded through a bound project, so which
+  // project the collector happened to attribute a sighting to (still a
+  // real, required column - #304's candidate drain still needs it) must no
+  // longer keep it from grounding a suggestion for the rest of the org.
+  it('reads across every project in the organization, not just one', async () => {
     const db = getDb();
     const otherProjectId = await makeProject(orgAId, 'recent-obs-proj-a2');
     await ingestObservedTargets(db, {
       organizationId: orgAId,
       projectId: otherProjectId,
       platformId: linkedinId,
-      observations: [observation({ text: 'seen for the other project only' })],
+      observations: [observation({ text: 'seen while attributed to a different project' })],
     });
 
     const result = await loadRecentObservedTarget(db, {
       organizationId: orgAId,
-      projectId: projectAId,
       platformId: linkedinId,
     });
-    expect(result).toBeNull();
+    expect(result?.text).toBe('seen while attributed to a different project');
   });
 
   it('never crosses an organization boundary', async () => {
@@ -372,29 +373,6 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
 
     const result = await loadRecentObservedTarget(db, {
       organizationId: orgAId,
-      projectId: projectAId,
-      platformId: linkedinId,
-    });
-    expect(result).toBeNull();
-  });
-
-  it('refuses a mismatched organization and project pair rather than trusting the project id', async () => {
-    const db = getDb();
-    await ingestObservedTargets(db, {
-      organizationId: orgAId,
-      projectId: projectAId,
-      platformId: linkedinId,
-      observations: [observation({ text: 'org A saw this' })],
-    });
-
-    // A project belongs to exactly one organization, so this pair cannot
-    // arise from real data: it can only arise from a caller that resolved
-    // one of the two from somewhere else. The row carries `organization_id`
-    // directly (#263) so the query can refuse rather than be reasoned about,
-    // and this is the assertion that keeps that filter honest.
-    const result = await loadRecentObservedTarget(db, {
-      organizationId: orgBId,
-      projectId: projectAId,
       platformId: linkedinId,
     });
     expect(result).toBeNull();
@@ -419,7 +397,6 @@ describe('loadRecentObservedTarget (#315: what a kind: "post" suggestion grounds
 
     const result = await loadRecentObservedTarget(db, {
       organizationId: orgAId,
-      projectId: projectAId,
       platformId: linkedinId,
     });
     expect(result?.text).toBe('already drained into a scout run');

--- a/shared/tests/suggest-prompt.test.ts
+++ b/shared/tests/suggest-prompt.test.ts
@@ -7,7 +7,6 @@ import {
   README_EXCERPT_MAX,
   RETUNE_DIRECTIONS,
   VOICE_PROFILE_MAX,
-  type CurrentProject,
 } from '../src/assist/suggest-prompt.js';
 import { HOUSE_STYLE_SECTION } from '../src/house-style.js';
 import { DRAFT_MARKER, SKIP_MARKER } from '../src/assist/envelope.js';
@@ -32,12 +31,15 @@ import type {
 // `persona` to a derived `voiceProfile` passed alongside it. The persona
 // fixture below carries no voice samples any more - `assist-voice-profile`
 // tests own deriving one, this file only owns rendering it into the prompt.
+//
+// 2026-09-10 (LOR-181): `buildSuggestionPrompt` dropped `currentProject` -
+// which project (if any) a suggestion is about is no longer known ahead of
+// the call, it is the model's own choice, stated per `envelope.ts`'s
+// `PROJECT_MARKER`. `ProjectBrief` dropped `isCurrent` along with it: every
+// project in `projects` is listed on equal footing, none marked as "the
+// one" or ranked ahead of the cut.
 
 const post = { text: 'We cut p99 in half by dropping a cache.', authorName: 'Giulia Bianchi' };
-const currentProject: CurrentProject = {
-  name: 'Embertold',
-  description: 'A world wiki for tabletop GMs.',
-};
 const noContext = { persona: null, voiceProfile: null, projects: [], repos: [] };
 
 const persona: OperatorPersona = {
@@ -67,13 +69,12 @@ const projects: ProjectBrief[] = [
     id: 1,
     name: 'Embertold',
     description: 'A world wiki for tabletop GMs.',
-    isCurrent: true,
+    insightSummary: 'Comments mentioning search speed get replies; pricing posts do not.',
   },
   {
     id: 2,
     name: 'Runecast',
     description: 'Dice roller for remote tables.',
-    isCurrent: false,
   },
 ];
 
@@ -97,7 +98,6 @@ describe('buildSuggestionPrompt', () => {
     const prompt = buildSuggestionPrompt({
       kind: 'post_comment',
       post,
-      currentProject,
       ...noContext,
     });
     expect(prompt).toContain(HOUSE_STYLE_SECTION);
@@ -107,7 +107,6 @@ describe('buildSuggestionPrompt', () => {
     const prompt = buildSuggestionPrompt({
       kind: 'post_comment',
       post,
-      currentProject,
       ...noContext,
     });
     expect(prompt).toContain(DRAFT_MARKER);
@@ -124,25 +123,34 @@ describe('buildSuggestionPrompt', () => {
     const prompt = buildSuggestionPrompt({
       kind: 'post_comment',
       post,
-      currentProject,
       ...noContext,
     });
     expect(prompt).toMatch(/post it themselves under their own name/);
   });
 
-  // #523: a project is optional context, not a requirement - a suggestion
-  // can name none at all, and the prompt has to say something other than a
-  // lie about a product that was never named.
-  it('frames a null current project as the operator\u2019s own voice on no particular subject', () => {
-    const prompt = buildSuggestionPrompt({
+  // LOR-181: the model, not a client-asserted binding, decides which project
+  // (if any) a suggestion is about - so the instruction asking it to decide
+  // is unconditional, present whether or not the org has any projects at
+  // all, and it says explicitly that naming none is a real answer.
+  it('always asks the model to decide which project, if any, this is about, and that naming none is a real answer', () => {
+    const withoutProjects = buildSuggestionPrompt({
       kind: 'post_comment',
       post,
-      currentProject: null,
       ...noContext,
     });
-    expect(prompt).toMatch(/own voice, on their own subject, not about any particular product/);
-    expect(prompt).toMatch(/post it themselves under their own name/);
-    expect(prompt).not.toContain('You are drafting for');
+    const withProjects = buildSuggestionPrompt({
+      kind: 'post_comment',
+      post,
+      persona: null,
+      voiceProfile: null,
+      projects,
+      repos: [],
+    });
+    for (const prompt of [withoutProjects, withProjects]) {
+      expect(prompt).toMatch(/decide.*which project.*this suggestion is actually about/s);
+      expect(prompt).toMatch(/writing in the operator's own voice.*is a real answer too/s);
+      expect(prompt).toMatch(/post it themselves under their own name/);
+    }
   });
 
   it('truncates a post longer than the cap instead of forwarding it whole', () => {
@@ -150,7 +158,6 @@ describe('buildSuggestionPrompt', () => {
     const prompt = buildSuggestionPrompt({
       kind: 'post_comment',
       post: { text: long },
-      currentProject,
       ...noContext,
     });
     expect(prompt).toContain('[truncated]');
@@ -170,7 +177,6 @@ describe('buildSuggestionPrompt', () => {
     const prompt = buildSuggestionPrompt({
       kind: 'post_comment',
       post,
-      currentProject,
       ...noContext,
       examples,
     });
@@ -182,7 +188,6 @@ describe('buildSuggestionPrompt', () => {
     const prompt = buildSuggestionPrompt({
       kind: 'post_comment',
       post,
-      currentProject,
       ...noContext,
       hint: 'be blunt about the cache',
     });
@@ -194,10 +199,9 @@ describe('buildSuggestionPrompt', () => {
     const comment = buildSuggestionPrompt({
       kind: 'post_comment',
       post,
-      currentProject,
       ...noContext,
     });
-    const standalone = buildSuggestionPrompt({ kind: 'post', post, currentProject, ...noContext });
+    const standalone = buildSuggestionPrompt({ kind: 'post', post, ...noContext });
     expect(comment).not.toBe(standalone);
     expect(comment).toMatch(/comment to leave on the post/);
     expect(standalone).toMatch(/short post for this account/);
@@ -207,7 +211,6 @@ describe('buildSuggestionPrompt', () => {
     const prompt = buildSuggestionPrompt({
       kind: 'post_comment',
       post,
-      currentProject,
       persona,
       voiceProfile,
       projects,
@@ -224,7 +227,6 @@ describe('buildSuggestionPrompt', () => {
       const prompt = buildSuggestionPrompt({
         kind: 'post_comment',
         post,
-        currentProject,
         persona,
         voiceProfile,
         projects,
@@ -237,11 +239,13 @@ describe('buildSuggestionPrompt', () => {
       // How they write: the derived summary, not a raw post.
       expect(prompt).toContain(voiceProfile.summary);
       expect(prompt).toMatch(/based on what they have actually written/);
-      // Every project, including the sibling not bound to this suggestion,
-      // with the current one marked.
-      expect(prompt).toContain('Embertold (this one)');
-      expect(prompt).toContain('Runecast');
+      // Every project, each with its own id and, when it has one, its latest
+      // insight - LOR-181: no "(this one)" marker, nothing is bound ahead of
+      // the model's own choice.
+      expect(prompt).toContain('[id 1] Embertold');
+      expect(prompt).toContain('[id 2] Runecast');
       expect(prompt).toContain('Dice roller for remote tables.');
+      expect(prompt).toContain('Comments mentioning search speed get replies');
       // What they have shipped.
       expect(prompt).toContain('giuliab/embertold');
       expect(prompt).toContain('Embertold indexes campaign notes');
@@ -252,7 +256,6 @@ describe('buildSuggestionPrompt', () => {
       const prompt = buildSuggestionPrompt({
         kind: 'post_comment',
         post,
-        currentProject,
         ...noContext,
       });
       expect(prompt).not.toContain('Who is writing this');
@@ -265,7 +268,6 @@ describe('buildSuggestionPrompt', () => {
       const prompt = buildSuggestionPrompt({
         kind: 'post_comment',
         post,
-        currentProject,
         persona,
         voiceProfile: null,
         projects: [],
@@ -281,7 +283,6 @@ describe('buildSuggestionPrompt', () => {
       const prompt = buildSuggestionPrompt({
         kind: 'post_comment',
         post,
-        currentProject,
         persona: { ...persona, about: longAbout },
         voiceProfile: null,
         projects: [],
@@ -291,34 +292,18 @@ describe('buildSuggestionPrompt', () => {
       expect(prompt).toContain('[truncated]');
     });
 
-    it('caps the project list at MAX_PROJECTS, keeping only the current project', () => {
-      const filler: ProjectBrief[] = Array.from({ length: MAX_PROJECTS + 5 }, (_, i) => ({
+    // LOR-181 retired the old ranking that put the bound project ahead of the
+    // cut - there is no bound project any more, so the list is just the
+    // org's first MAX_PROJECTS in the order the caller passed them.
+    it('keeps only the first MAX_PROJECTS in list order, with no project singled out', () => {
+      const manyProjects: ProjectBrief[] = Array.from({ length: MAX_PROJECTS + 5 }, (_, i) => ({
         id: 100 + i,
-        name: `Filler ${i}`,
-        description: `Filler project ${i}.`,
-        isCurrent: false,
+        name: `Project ${i}`,
+        description: `Project ${i}'s own description.`,
       }));
-      // Current is last in the input on purpose: a plain slice(0, MAX_PROJECTS)
-      // with no ranking would drop it.
-      const manyProjects: ProjectBrief[] = [
-        ...filler,
-        {
-          id: 1,
-          name: 'Embertold',
-          description: 'The bound project.',
-          isCurrent: true,
-        },
-        {
-          id: 2,
-          name: 'Runecast',
-          description: 'A sibling project, ranked like any other one now.',
-          isCurrent: false,
-        },
-      ];
       const prompt = buildSuggestionPrompt({
         kind: 'post_comment',
         post,
-        currentProject,
         persona: null,
         voiceProfile: null,
         projects: manyProjects,
@@ -326,13 +311,12 @@ describe('buildSuggestionPrompt', () => {
       });
       const shown = manyProjects.filter((p) => prompt.includes(p.name));
       expect(shown).toHaveLength(MAX_PROJECTS);
-      expect(prompt).toContain('Embertold (this one)');
-      // #523 retired the personal project and, with it, the only other
-      // survival guarantee this ranking ever gave: 'Runecast' sits after the
-      // current project in the input with no special status of its own now,
-      // so it falls past the cap exactly like the trailing filler entries do.
-      expect(prompt).not.toContain('Runecast');
-      expect(prompt).not.toContain(`Filler ${filler.length - 1}`);
+      // The first MAX_PROJECTS survive, in order - a project past the cut is
+      // honest context lost, never something the model reorders to save.
+      for (let i = 0; i < MAX_PROJECTS; i++) expect(prompt).toContain(`Project ${i}`);
+      for (let i = MAX_PROJECTS; i < manyProjects.length; i++) {
+        expect(prompt).not.toContain(`Project ${i}`);
+      }
     });
 
     it('clamps the voice profile summary the same regardless of how far past the cap it runs', () => {
@@ -342,7 +326,6 @@ describe('buildSuggestionPrompt', () => {
       const promptJustOver = buildSuggestionPrompt({
         kind: 'post_comment',
         post,
-        currentProject,
         persona: null,
         voiceProfile: { summary: justOver },
         projects: [],
@@ -351,7 +334,6 @@ describe('buildSuggestionPrompt', () => {
       const promptWayOver = buildSuggestionPrompt({
         kind: 'post_comment',
         post,
-        currentProject,
         persona: null,
         voiceProfile: { summary: wayOver },
         projects: [],
@@ -372,7 +354,6 @@ describe('buildSuggestionPrompt', () => {
       const promptJustOver = buildSuggestionPrompt({
         kind: 'post_comment',
         post,
-        currentProject,
         persona: null,
         voiceProfile: null,
         projects: [],
@@ -381,7 +362,6 @@ describe('buildSuggestionPrompt', () => {
       const promptWayOver = buildSuggestionPrompt({
         kind: 'post_comment',
         post,
-        currentProject,
         persona: null,
         voiceProfile: null,
         projects: [],
@@ -403,7 +383,6 @@ describe('a reply names its parent comment (LOR-198)', () => {
     const prompt = buildSuggestionPrompt({
       kind: 'post_comment',
       post: { ...post, replyToCommentId: 'urn:li:comment:(activity:1,2)' },
-      currentProject,
       ...noContext,
     });
     expect(prompt).toContain(
@@ -417,7 +396,6 @@ describe('a reply names its parent comment (LOR-198)', () => {
     const prompt = buildSuggestionPrompt({
       kind: 'post_comment',
       post,
-      currentProject,
       ...noContext,
     });
     expect(prompt).toContain('Write one comment to leave on the post below');
@@ -428,7 +406,6 @@ describe('a reply names its parent comment (LOR-198)', () => {
     const prompt = buildSuggestionPrompt({
       kind: 'post',
       post: { ...post, replyToCommentId: 'urn:li:comment:(activity:1,2)' },
-      currentProject,
       ...noContext,
     });
     expect(prompt).toContain('Write one short post for this account');
@@ -442,7 +419,7 @@ describe('a reply names its parent comment (LOR-198)', () => {
 // the post rather than the phrase "match the room" on its own, and that the
 // house style still outranks all of it.
 describe('tone (#405)', () => {
-  const args = { kind: 'post_comment' as const, post, currentProject, ...noContext };
+  const args = { kind: 'post_comment' as const, post, ...noContext };
 
   it('defaults to the mix when no tone is passed, matching the stored default', () => {
     const prompt = buildSuggestionPrompt(args);
@@ -528,7 +505,7 @@ describe('tone (#405)', () => {
 // different per direction, and it is ordered so it outranks the tone
 // without deleting or rewriting the tone's own instruction.
 describe('retune (#409)', () => {
-  const args = { kind: 'post_comment' as const, post, currentProject, ...noContext };
+  const args = { kind: 'post_comment' as const, post, ...noContext };
 
   it('adds nothing when no direction was asked for', () => {
     const prompt = buildSuggestionPrompt(args);

--- a/web/src/lib/server/suggest.ts
+++ b/web/src/lib/server/suggest.ts
@@ -16,7 +16,6 @@ import { resolveEntitlements } from '@pitchbox/shared/plans';
 import {
   buildSuggestionPrompt,
   buildRetunePrompt,
-  type CurrentProject,
   type ObservedPost,
   type RetuneDirection,
   type SuggestionKind,
@@ -82,6 +81,13 @@ export interface SuggestionResult {
   styleFindings?: StyleFinding[];
   /** True when the model explicitly declined to write a draft. */
   skipped: boolean;
+  /** The project this suggestion resolved to (LOR-181), or null when it is
+   * filed under none - either the model's own explicit `personal`, or a
+   * fallback: no claim stated, or a claim that named an id outside this
+   * organization's own projects. The caller (`resolveSuggestionProject`)
+   * is what tells those apart for logging; this field only carries the
+   * outcome, already validated against the organization. */
+  projectId: number | null;
   ms: number;
   /** The model this suggestion actually asked for - resolveAssistRunnerConfig's
    * result, so an unpinned runner reports ASSIST_DEFAULT_MODEL rather than
@@ -163,6 +169,38 @@ export function resolveAssistRunnerConfig(
 }
 
 /**
+ * Resolves the model's own raw project claim (`envelope.projectChoice`,
+ * `shared/src/assist/envelope.ts`) against the organization's real projects
+ * (LOR-181). The server decides what it accepts, never the model: an id the
+ * model names that is not one of `projects` falls back to `personal` exactly
+ * as a missing or unparseable claim does - `source` is what lets the caller
+ * tell those apart to log the one case worth explaining (`invalid`, where
+ * the model asked for something real that just was not this organization's).
+ *
+ * Pure and synchronous on purpose, mirroring `envelope.ts`'s own posture:
+ * this is a lookup against the exact list the prompt already sent, not a
+ * second database round trip, and it is testable without one either.
+ */
+export type SuggestionProjectResolution =
+  | { projectId: number; source: 'chosen' }
+  | { projectId: null; source: 'personal' }
+  | { projectId: null; source: 'unstated' }
+  | { projectId: null; source: 'invalid'; rawChoice: string };
+
+export function resolveSuggestionProject(
+  rawChoice: string | null,
+  projects: ProjectBrief[],
+): SuggestionProjectResolution {
+  if (rawChoice == null) return { projectId: null, source: 'unstated' };
+  if (rawChoice === 'personal') return { projectId: null, source: 'personal' };
+  const id = Number(rawChoice);
+  if (Number.isInteger(id) && id > 0 && projects.some((p) => p.id === id)) {
+    return { projectId: id, source: 'chosen' };
+  }
+  return { projectId: null, source: 'invalid', rawChoice };
+}
+
+/**
  * The single targeted-rewrite round trip #572 asks for: one more turn on the
  * same runner that wrote the draft, naming the remaining structural
  * findings once, no streaming and no MCP tools attached - the same shape as
@@ -216,9 +254,11 @@ async function runStyleRewrite(
 export function runSuggestion(args: {
   kind: SuggestionKind;
   post: ObservedPost;
-  currentProject: CurrentProject | null;
   persona: OperatorPersona | null;
   voiceProfile: VoiceProfileSummary | null;
+  /** Every project in the organization - LOR-181: also what the model's own
+   * `projectChoice` (`assist/envelope.ts`) is validated against once the
+   * turn finishes. `SuggestionResult.projectId` is the outcome. */
   projects: ProjectBrief[];
   repos: CodeRepo[];
   examples?: ExampleCandidate[];
@@ -237,7 +277,6 @@ export function runSuggestion(args: {
    */
   tone?: AssistTone;
   toneNotes?: string;
-  projectId: number | null;
   orgId?: number;
   runnerSlug: string;
   /** One callback per model chunk, already split into its reasoning/draft
@@ -248,7 +287,7 @@ export function runSuggestion(args: {
    * still live, this call continues that turn's own gathered context
    * instead of rebuilding the whole prompt (`buildRetunePrompt` rather than
    * `buildSuggestionPrompt`). Absent, expired, or scoped to a different
-   * org/project/kind falls back to today's full rebuild. */
+   * org/kind falls back to today's full rebuild. */
   continueSessionId?: string;
   /** #573: fires with the tool name(s) the loop is running, as soon as they
    * are known. Undefined for the ACP path, which has no equivalent hook. */
@@ -354,7 +393,6 @@ export function runSuggestion(args: {
         ? buildAssistToolSet(ASSIST_TOOLS, {
             db,
             orgId: toolOrgId,
-            boundProjectId: args.projectId,
             observedTarget: args.post,
             operator: args.persona,
           })
@@ -363,15 +401,11 @@ export function runSuggestion(args: {
     // #576: reading a session also consumes it - a retune uses its prior
     // context at most once, so a second concurrent request against the same
     // id falls back to a full rebuild rather than racing this one for it.
-    // Scoped to this org/project/kind: a foreign or mismatched id is treated
-    // exactly like an expired one, never trusted.
+    // Scoped to this org/kind: a foreign or mismatched id is treated exactly
+    // like an expired one, never trusted.
     const continuedSession =
       args.continueSessionId && toolSet
-        ? getAssistSession(args.continueSessionId, {
-            orgId: toolOrgId,
-            projectId: args.projectId,
-            kind: args.kind,
-          })
+        ? getAssistSession(args.continueSessionId, { orgId: toolOrgId, kind: args.kind })
         : null;
     if (continuedSession && args.continueSessionId) deleteAssistSession(args.continueSessionId);
     const priorMessages = continuedSession ?? undefined;
@@ -384,7 +418,6 @@ export function runSuggestion(args: {
       : buildSuggestionPrompt({
           kind: args.kind,
           post: args.post,
-          currentProject: args.currentProject,
           persona: args.persona,
           voiceProfile: args.voiceProfile,
           projects: args.projects,
@@ -473,6 +506,20 @@ export function runSuggestion(args: {
       }
       const envelope = splitter.finish();
 
+      // LOR-181: the server decides what it accepts, never the model - see
+      // `resolveSuggestionProject`'s own doc comment. `invalid` is the one
+      // outcome worth a log line: a model that named a real id outside this
+      // organization is a wrong pick that would otherwise be unexplainable
+      // once it only shows up as `projectId: null` on the ledger.
+      const projectResolution = resolveSuggestionProject(envelope.projectChoice, args.projects);
+      if (projectResolution.source === 'invalid') {
+        console.warn(
+          `[assist/suggest] model claimed project "${projectResolution.rawChoice}", which is not ` +
+            `one of this organization's own project ids (${args.projects.map((p) => p.id).join(', ') || 'none'}) - filing under personal instead.`,
+        );
+      }
+      const projectId = projectResolution.projectId;
+
       // #572: everything the human may insert is held to the same
       // deterministic house-style check a campaign draft is. Only `draft`
       // goes through it - `reasoning` is operator-facing and never posted,
@@ -507,14 +554,11 @@ export function runSuggestion(args: {
       // something to persist.
       let sessionId: string | undefined;
       if (toolSet && run.responseMessages && run.responseMessages.length > 0) {
-        sessionId = createAssistSession(
-          { orgId: toolOrgId, projectId: args.projectId, kind: args.kind },
-          [
-            ...(priorMessages ?? []),
-            { role: 'user', content: prompt },
-            ...(run.responseMessages as ModelMessage[]),
-          ],
-        );
+        sessionId = createAssistSession({ orgId: toolOrgId, kind: args.kind }, [
+          ...(priorMessages ?? []),
+          { role: 'user', content: prompt },
+          ...(run.responseMessages as ModelMessage[]),
+        ]);
       }
 
       return {
@@ -522,6 +566,7 @@ export function runSuggestion(args: {
         draft,
         styleFindings: styleFindings.length > 0 ? styleFindings : undefined,
         skipped: envelope.skipped,
+        projectId,
         ms: Date.now() - started,
         model: resolvedConfig.model,
         usage: run.usage

--- a/web/src/routes/api/extension/linkedin-assist/+server.ts
+++ b/web/src/routes/api/extension/linkedin-assist/+server.ts
@@ -8,25 +8,26 @@ import { getOrgUsage } from '@pitchbox/shared/usage';
 import { isOrgReadOnly, PLAN_CATALOGUE } from '@pitchbox/shared/plans';
 
 // The read path #302's collector and #314's panel poll to learn whether they
-// should be running at all and which project a suggestion writes as (LI-19,
-// #316). No auth story of its own: it reuses the device bearer token every
-// other /api/extension/* route already requires. There is no cache between
-// this route and app_config, so a flipped kill switch is visible on the very
-// next poll - "a kill switch that takes ten minutes to apply is not a kill
-// switch" (docs/linkedin-integration-design.md).
+// should be running at all (LI-19, #316). No auth story of its own: it
+// reuses the device bearer token every other /api/extension/* route already
+// requires. There is no cache between this route and app_config, so a
+// flipped kill switch is visible on the very next poll - "a kill switch
+// that takes ten minutes to apply is not a kill switch"
+// (docs/linkedin-integration-design.md).
 //
 // Response shape (see PR body for the frozen contract):
 //   { assist: LinkedInAssistDeviceState, plan: LinkedInAssistPlanState }
-// LinkedInAssistDeviceState (shared/src/linkedin-assist.ts) carries booleans,
-// the bound project id, the org's `personal` project id (2026-09-07 - where
-// an accepted suggestion files when it is not about a product) and the two
-// daily caps - nothing org-scoped beyond what the device already handles in
-// observations/suggest bodies. `plan` is #556: the panel and the side panel
-// need the plan's name, the suggestion allowance and how much of it is left,
-// and whether the org is read-only, purely for display - extending this
-// endpoint rather than adding a second poll. Anything cached from it is a
-// hint: `/suggest` refuses on its own read of the same numbers regardless of
-// what a stale poll here still shows.
+// LinkedInAssistDeviceState (shared/src/linkedin-assist.ts) carries booleans
+// and the two daily caps - nothing org-scoped beyond what the device already
+// handles in observations/suggest bodies. LOR-181: `projectId` is no longer
+// a suggestion's context - the model decides which project (if any) a
+// suggestion is about, from the post itself. It stays only as the
+// observation collector's own attribution target (#302/#304). `plan` is
+// #556: the panel and the side panel need the plan's name, the suggestion
+// allowance and how much of it is left, and whether the org is read-only,
+// purely for display - extending this endpoint rather than adding a second
+// poll. Anything cached from it is a hint: `/suggest` refuses on its own
+// read of the same numbers regardless of what a stale poll here still shows.
 
 // Polled on an interval by a background script, not user-driven, so this is
 // tighter than /suggest's perDevice(20, 60_000) while still generous for any

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -1,7 +1,7 @@
 import { error, json } from '@sveltejs/kit';
 import type { RequestEvent } from '@sveltejs/kit';
 import { z } from 'zod';
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { getDb, schema } from '$lib/server/db.js';
 import { requireExtensionAuth, resolveDeviceOrgId } from '$lib/server/extension-auth.js';
 import { RateLimiter } from '$lib/server/rate-limit.js';
@@ -194,7 +194,6 @@ export async function POST(event: RequestEvent) {
   const orgId = await resolveDeviceOrgId(db, auth.organizationId);
   if (orgId == null) throw error(404, 'organization not found');
 
-
   const period = await billingPeriodFor(db, orgId);
   const usage = await getOrgUsage(db, orgId, period);
   // #557: a courtesy notification never blocks a suggestion, admitted or
@@ -262,7 +261,6 @@ export async function POST(event: RequestEvent) {
     }
   }
 
-
   // A `post` suggestion has no post to riff off the way a `post_comment`
   // does - the composer is a blank box - so it is grounded in the most
   // recent thing the observation buffer (#301/#302) actually saw anywhere
@@ -277,7 +275,10 @@ export async function POST(event: RequestEvent) {
   // exhausted quota does rather than asking the model to invent a subject.
   let groundedPost: ObservedPost;
   if (body.kind === 'post') {
-    const recent = await loadRecentObservedTarget(db, { organizationId: orgId, platformId: platform.id });
+    const recent = await loadRecentObservedTarget(db, {
+      organizationId: orgId,
+      platformId: platform.id,
+    });
     if (!recent) {
       return json({ refused: 'no_recent_activity', platform: platform.slug });
     }

--- a/web/src/routes/api/extension/suggest/+server.ts
+++ b/web/src/routes/api/extension/suggest/+server.ts
@@ -87,7 +87,12 @@ const ImageSchema = z.object({
 
 const BodySchema = z
   .object({
-    projectId: z.number().int().positive().optional(),
+    // LOR-181: no longer read - the server picks the project from the post
+    // itself, inside the same turn (`buildSuggestionPrompt`,
+    // `assist/envelope.ts`'s `PROJECT_MARKER`). Not `.strict()`'d, so an
+    // older extension build that still sends this is silently dropped by
+    // zod rather than trusted - exactly the "ignored, not honoured" the
+    // issue asks for.
     kind: z.enum(['post_comment', 'post']),
     post: z.object({
       urn: z.string().max(200).optional(),
@@ -182,31 +187,13 @@ export async function POST(event: RequestEvent) {
 
   const db = getDb();
 
-  // Org scoping: a device bound to an org may only write as one of its own
-  // projects, and an unknown project is a 404 rather than a 403 so it leaks
-  // nothing about other tenants' ids. A null-org device (self-host, auth
-  // off) is unrestricted, mirroring requireRole. #523: `projectId` is
-  // optional context now, not a requirement - a request naming none
-  // resolves the org directly rather than through a project row.
+  // Org scoping only now (LOR-181): a device bound to an org may draft about
+  // any of its own projects, or none - which one, if any, is the model's own
+  // decision inside this turn, never a client-asserted id. A null-org
+  // device (self-host, auth off) is unrestricted, mirroring requireRole.
   const orgId = await resolveDeviceOrgId(db, auth.organizationId);
   if (orgId == null) throw error(404, 'organization not found');
 
-  const project =
-    body.projectId != null
-      ? (
-          await db
-            .select()
-            .from(schema.projects)
-            .where(
-              and(
-                eq(schema.projects.id, body.projectId),
-                eq(schema.projects.organizationId, orgId),
-              ),
-            )
-            .limit(1)
-        )[0]
-      : undefined;
-  if (body.projectId != null && !project) throw error(404, 'project not found');
 
   const period = await billingPeriodFor(db, orgId);
   const usage = await getOrgUsage(db, orgId, period);
@@ -273,43 +260,24 @@ export async function POST(event: RequestEvent) {
         platform: platform.slug,
       });
     }
-    // A suggestion naming a project is written as that project's voice, so
-    // naming a different project of the same org than the one bound is not
-    // a narrower case of the binding, it bypasses it (#523: naming none at
-    // all is not a bypass - it makes no binding claim, and is always
-    // allowed).
-    if (body.projectId != null && assist.projectId !== body.projectId) {
-      return json({
-        refused: 'project_not_bound',
-        platform: platform.slug,
-        boundProjectId: assist.projectId,
-      });
-    }
   }
+
 
   // A `post` suggestion has no post to riff off the way a `post_comment`
   // does - the composer is a blank box - so it is grounded in the most
-  // recent thing the observation buffer (#301/#302) actually saw this
-  // project's account scroll past, read through the server rather than
-  // trusting the panel to have scraped and forwarded a pile of observed
-  // posts itself. That buffer is project-scoped (`observed_targets`), so
-  // unlike `post_comment`, a `post` suggestion still needs a real project
-  // to draft from (#523 makes the project optional for the plane overall,
-  // not for this one kind that has nothing else to ground itself in). An
-  // empty buffer (a fresh binding, or nothing sighted since the collector
-  // was last on) is a real, distinct refusal: there is nothing honest to
-  // write a "starting point" prompt from, so this refuses the same way an
+  // recent thing the observation buffer (#301/#302) actually saw anywhere
+  // in the org, read through the server rather than trusting the panel to
+  // have scraped and forwarded a pile of observed posts itself. LOR-181:
+  // org-wide, not project-scoped, the same shift as everything else on this
+  // route - which project (if any) the grounded post is about is the
+  // model's own judgement, made from the post exactly like a `post_comment`
+  // already is. An empty buffer (nothing sighted since the collector was
+  // last on) is a real, distinct refusal: there is nothing honest to write
+  // a "starting point" prompt from, so this refuses the same way an
   // exhausted quota does rather than asking the model to invent a subject.
   let groundedPost: ObservedPost;
   if (body.kind === 'post') {
-    if (!project) {
-      return json({ refused: 'project_required', platform: platform.slug });
-    }
-    const recent = await loadRecentObservedTarget(db, {
-      organizationId: orgId,
-      projectId: project.id,
-      platformId: platform.id,
-    });
+    const recent = await loadRecentObservedTarget(db, { organizationId: orgId, platformId: platform.id });
     if (!recent) {
       return json({ refused: 'no_recent_activity', platform: platform.slug });
     }
@@ -324,46 +292,49 @@ export async function POST(event: RequestEvent) {
     groundedPost = { ...body.post, text: body.post.text as string };
   }
 
+  // Everything the companion is allowed to know beyond this one post: the
+  // operator's own persona and voice, every project in the org (each with
+  // its own latest insight, LOR-181), and the public repos GitHub read
+  // cached (shared/src/assist/context.ts). Loaded once, right before the
+  // spawn, so a refusal above never pays for it - and before `examples`
+  // below, which needs the org's own project list.
+  const context = await loadCompanionContext(db, { organizationId: orgId });
+
   // #578: id and createdAt travel too, not just title/body -
   // `buildSuggestionPrompt` (`shared/src/assist/example-selection.ts`) picks
   // which of these actually reach the prompt, by topical closeness to
-  // `groundedPost` rather than by this array's order. No project, no
-  // templates to draw from.
-  const examples = project
-    ? (
-        await loadActiveTemplates(db, {
-          projectId: project.id,
-          kind: body.kind === 'post' ? 'post' : 'comment',
-        })
-      ).map((t) => ({ id: t.id, title: t.title, body: t.body, createdAt: t.createdAt }))
-    : [];
+  // `groundedPost` rather than by this array's order. LOR-181: templates
+  // from every project in the org, not one bound project - nothing is bound
+  // before the model decides, so the only honest candidate pool left is
+  // "every example this organization has", exactly as `selectExamples`
+  // already narrows a pool larger than MAX_EXAMPLES down to the ones that
+  // actually match this post.
+  const templateKind = body.kind === 'post' ? 'post' : 'comment';
+  const templateRows = (
+    await Promise.all(
+      context.projects.map((p) => loadActiveTemplates(db, { projectId: p.id, kind: templateKind })),
+    )
+  ).flat();
+  const examples = templateRows.map((t) => ({
+    id: t.id,
+    title: t.title,
+    body: t.body,
+    createdAt: t.createdAt,
+  }));
 
-  // Everything the companion is allowed to know beyond this one post:
-  // the operator's own persona and voice, every project in the org, and the
-  // public repos GitHub read cached (shared/src/assist/context.ts). Loaded
-  // once, right before the spawn, so a refusal above never pays for it.
-  const context = await loadCompanionContext(db, {
-    organizationId: orgId,
-    currentProjectId: project?.id ?? null,
-  });
-
-  // The tone (#405) is read here, resolved against the project this
-  // suggestion is actually being filed under (#408) - never from `body`: the
-  // panel is not an enforcement boundary for it, exactly as it is not for
-  // `enabled`, `killSwitch` or the reasoning/draft split. That is also what
-  // keeps a panel-level retune (#409) an explicit feature rather than
-  // something a crafted request already gets for free. `project` here is
-  // the filed-under project, which need not be the org's bound project the
-  // device state names, and may be absent entirely (#523) - the org's own
-  // `linkedin_assist` tone is what an unset project falls back to.
-  const voice = await resolveEffectiveVoice(
-    db,
-    orgId,
-    project ?? { voiceTone: null, voiceToneNotes: null },
-  );
-  // No project bound, no `defaultAgentRunner` column to read - the instance
-  // (or edition) default is what a fresh project would have gotten anyway.
-  const runnerSlug = project?.defaultAgentRunner ?? (await resolveDefaultRunnerSlug(db));
+  // The tone (#405) is read here, never from `body`: the panel is not an
+  // enforcement boundary for it, exactly as it is not for `enabled`,
+  // `killSwitch` or the reasoning/draft split. LOR-181: always the org's own
+  // `linkedin_assist` tone now - a project's own voice override
+  // (`resolveEffectiveVoice`'s project branch, #408) can no longer be
+  // resolved ahead of a turn that has not yet decided which project, if
+  // any, this is; nothing else changes about how the org level resolves.
+  const voice = await resolveEffectiveVoice(db, orgId, { voiceTone: null, voiceToneNotes: null });
+  // LOR-181: no project bound before the turn runs, so no `defaultAgentRunner`
+  // column to read either - the instance (or edition) default is what every
+  // suggestion gets now, the same fallback a project-less suggestion already
+  // used before this issue.
+  const runnerSlug = await resolveDefaultRunnerSlug(db);
 
   let cancel: () => void = () => {};
   let settled = false;
@@ -388,7 +359,6 @@ export async function POST(event: RequestEvent) {
       const handle = runSuggestion({
         kind: body.kind as SuggestionKind,
         post: groundedPost,
-        currentProject: project ? { name: project.name, description: project.description } : null,
         persona: context.persona,
         voiceProfile: context.voiceProfile,
         projects: context.projects,
@@ -398,7 +368,6 @@ export async function POST(event: RequestEvent) {
         retune: body.retune,
         tone: voice.tone,
         toneNotes: voice.toneNotes,
-        projectId: project?.id ?? null,
         orgId: auth.organizationId ?? undefined,
         runnerSlug,
         continueSessionId: body.sessionId,
@@ -441,7 +410,10 @@ export async function POST(event: RequestEvent) {
             .insert(schema.assistUsage)
             .values({
               organizationId: auth.organizationId,
-              projectId: project?.id ?? null,
+              // LOR-181: the project the server resolved from the model's
+              // own turn, not a client-asserted id - see
+              // `resolveSuggestionProject` in `web/src/lib/server/suggest.ts`.
+              projectId: res.projectId,
               deviceId: auth.deviceId,
               platformId: platform.id,
               kind: body.kind,
@@ -464,6 +436,11 @@ export async function POST(event: RequestEvent) {
               skipped: res.skipped,
               usage: res.usage,
               ms: res.ms,
+              // LOR-181: the project the server resolved this suggestion
+              // under, so the accept call can file it under the same one -
+              // the extension no longer has a bound project of its own to
+              // send instead.
+              projectId: res.projectId,
               // #576: the panel hands this back on the next retune/hint so
               // the loop continues instead of starting over. Absent when no
               // tool set was attached or the run never settled into one.

--- a/web/src/routes/api/extension/suggest/accept/+server.ts
+++ b/web/src/routes/api/extension/suggest/accept/+server.ts
@@ -115,27 +115,23 @@ export async function POST(event: RequestEvent) {
   if (!platform) throw error(400, `unknown platform: ${body.platform}`);
 
   // The assist gate (#359's enforcement pattern, applied here too): an org
-  // whose assistant is off, whose kill switch is engaged, or that names a
-  // project other than the bound one must be refused just as firmly as a
-  // suggestion is - a suggestion that cannot be produced but can still be
-  // accepted is a hole in the same switch. Scoped to `linkedin` for the same
-  // reason /suggest scopes it: `linkedin_assist` is a LinkedIn-only setting.
+  // whose assistant is off or whose kill switch is engaged must be refused
+  // just as firmly as a suggestion is - a suggestion that cannot be
+  // produced but can still be accepted is a hole in the same switch.
+  // Scoped to `linkedin` for the same reason /suggest scopes it:
+  // `linkedin_assist` is a LinkedIn-only setting. LOR-181: no longer checks
+  // `body.projectId` against a bound project - there is no such binding
+  // left to check. An old extension build that still sends the project it
+  // used to bind to is ignored exactly like /suggest already ignores it:
+  // `body.projectId` above is validated only against this org's own
+  // projects (never trusted for anything past that), and travels onto the
+  // ledger as context alone.
   if (platform.slug === 'linkedin') {
     const assist = await loadLinkedInAssistDeviceState(db, orgId);
     if (!assist.enabled) {
       return json({
         refused: assist.killSwitch ? 'kill_switch' : 'assist_disabled',
         platform: platform.slug,
-      });
-    }
-    // Same carve-out /suggest makes for the same reason: naming no project
-    // at all is never a bypass of the binding (#523), only naming a
-    // *different* one of the same org is.
-    if (body.projectId != null && assist.projectId !== body.projectId) {
-      return json({
-        refused: 'project_not_bound',
-        platform: platform.slug,
-        boundProjectId: assist.projectId,
       });
     }
   }

--- a/web/src/routes/api/settings/linkedin-assist/+server.ts
+++ b/web/src/routes/api/settings/linkedin-assist/+server.ts
@@ -13,8 +13,10 @@ import {
 } from '@pitchbox/shared/linkedin-assist';
 
 // GET + POST the caller's own org's LinkedIn assist settings (LI-19, #316):
-// on/off, the bound project, the observation collector on/off, daily caps and
-// the kill switch. Org-scoped via requireOrgId (never from the request body)
+// on/off, the observation collector's own project attribution (LOR-181: no
+// longer a suggestion's bound project - see shared/src/linkedin-assist.ts's
+// header comment), the observation collector on/off, daily caps and the
+// kill switch. Org-scoped via requireOrgId (never from the request body)
 // and role-gated to admin, same level as Retention/Security
 // (docs/permissions.md) - this is org structural config, not something a
 // member should even view, unlike the platform-wide Quota page.

--- a/web/src/routes/settings/linkedin-assist/+page.svelte
+++ b/web/src/routes/settings/linkedin-assist/+page.svelte
@@ -106,13 +106,13 @@
 
 <Seo
 	title="Settings - LinkedIn assist"
-	description="On/off, bound project, daily caps and the kill switch for the in-page LinkedIn assistant."
+	description="On/off, daily caps and the kill switch for the in-page LinkedIn assistant."
 />
 
 <PageContainer size="default">
 	<PageHeader
 		title="LinkedIn assist"
-		description="Controls the in-page assistant on linkedin.com: who it writes as, how much it may send, and a kill switch that applies immediately."
+		description="Controls the in-page assistant on linkedin.com: how much it may send, and a kill switch that applies immediately."
 	/>
 
 	{#if s.killSwitch}
@@ -131,9 +131,9 @@
 			<Card.Header>
 				<Card.Title>Assist</Card.Title>
 				<Card.Description>
-					Off by default. Writes as you, the operator - a project is optional context for a
-					suggestion that is genuinely about one of your products, never a requirement to turn
-					this on.
+					Off by default. Writes as you, the operator - it decides which of your projects (if
+					any) a suggestion is actually about from the post itself, so there is nothing to bind
+					here.
 				</Card.Description>
 			</Card.Header>
 			<Card.Content class="flex flex-col gap-4">
@@ -141,16 +141,6 @@
 					<Checkbox checked={s.enabled} onCheckedChange={(v) => (s.enabled = !!v)} />
 					Assist enabled
 				</label>
-				<div class="grid gap-1.5">
-					<span class="text-sm font-medium">Writes as project</span>
-					<SelectField
-						value={s.projectId ?? undefined}
-						onValueChange={(v) => (s.projectId = v as number)}
-						options={projectOptions}
-						placeholder="No project bound"
-						fullWidth
-					/>
-				</div>
 				<label class="flex items-center gap-2 text-sm">
 					<Checkbox
 						checked={s.collectorEnabled}
@@ -158,6 +148,21 @@
 					/>
 					Observation collector enabled
 				</label>
+				<div class="grid gap-1.5">
+					<span class="text-sm font-medium">Collector attributes sightings to</span>
+					<SelectField
+						value={s.projectId ?? undefined}
+						onValueChange={(v) => (s.projectId = v as number)}
+						options={projectOptions}
+						placeholder="No project bound"
+						fullWidth
+					/>
+					<p class="text-xs text-muted-foreground">
+						Only used by the observation collector, to file what it scrolls past under one of
+						your projects for that project's own campaigns to draw candidates from. Unrelated to
+						what a suggestion writes about.
+					</p>
+				</div>
 			</Card.Content>
 		</Card.Root>
 

--- a/web/tests/extension-suggest-accept.test.ts
+++ b/web/tests/extension-suggest-accept.test.ts
@@ -137,23 +137,6 @@ describe('POST /api/extension/suggest/accept', () => {
     expect(await res.json()).toMatchObject({ refused: 'kill_switch' });
   });
 
-  it('refuses to write as a project of the same org that is not the bound one', async () => {
-    const { org, project } = await seedOrgProject('acc-bound');
-    const [other] = await getDb()
-      .insert(schema.projects)
-      .values({ organizationId: org.id, slug: 'p-other', name: 'other', description: 'other' })
-      .returning();
-    await mintDevice(org.id, 'tokBound');
-
-    const res = await accept({
-      request: request('tokBound', { ...POST_BODY, projectId: other.id }),
-    } as never);
-    expect(await res.json()).toMatchObject({
-      refused: 'project_not_bound',
-      boundProjectId: project.id,
-    });
-  });
-
   // #523: naming no project at all makes no binding claim, so it is never a
   // bypass of the binding the way naming a *different* project of the same
   // org is (the previous test) - it is always allowed, filed under no

--- a/web/tests/extension-suggest-loop-wiring.test.ts
+++ b/web/tests/extension-suggest-loop-wiring.test.ts
@@ -72,17 +72,15 @@ describe('runSuggestion: assist tool surface wiring (#566)', () => {
   beforeEach(reset);
 
   it('attaches exactly the seven assist tools and the exact ASSIST_* budget - never the campaign tool set', async () => {
-    const { org, project } = await seedOrgProject('org-loop-wiring');
+    const { org } = await seedOrgProject('org-loop-wiring');
 
     const handle = runSuggestion({
       kind: 'post_comment',
       post: { urn: 'urn:li:activity:1', authorName: 'A', text: 'hi' },
-      currentProject: { name: project.name, description: project.description },
       persona: null,
       voiceProfile: null,
       projects: [],
       repos: [],
-      projectId: project.id,
       orgId: org.id,
       runnerSlug: 'cloud',
     });
@@ -103,8 +101,8 @@ describe('runSuggestion: assist tool surface wiring (#566)', () => {
     });
   });
 
-  it('scopes the tool context to the bound project and the observed post, never a model-supplied id', async () => {
-    const { org, project } = await seedOrgProject('org-loop-ctx');
+  it('scopes the tool context to the org and the observed post, never a model-supplied org id', async () => {
+    const { org } = await seedOrgProject('org-loop-ctx');
     const { project: otherProject } = await seedOrgProject('org-loop-ctx-other');
 
     const handle = runSuggestion({
@@ -115,12 +113,10 @@ describe('runSuggestion: assist tool surface wiring (#566)', () => {
         text: 'hi',
         thread: { comments: [{ body: 'nice post' }], renderedCount: 1, truncated: false },
       },
-      currentProject: { name: project.name, description: project.description },
       persona: null,
       voiceProfile: null,
       projects: [],
       repos: [],
-      projectId: project.id,
       orgId: org.id,
       runnerSlug: 'cloud',
     });
@@ -139,9 +135,10 @@ describe('runSuggestion: assist tool surface wiring (#566)', () => {
     expect(threadResult.ok).toBe(true);
     expect(threadResult.data.comments).toHaveLength(1);
 
-    // project_knowledge validates a model-supplied project id against the
-    // binding - a project belonging to a different org must be refused
-    // rather than answered.
+    // project_knowledge validates a model-supplied project id against this
+    // suggestion's own organization - a project belonging to a different
+    // org must be refused rather than answered, even though nothing is
+    // bound ahead of the model's own choice any more (LOR-181).
     const otherResult = (await tools.project_knowledge.execute(
       { projectId: otherProject.id },
       {},

--- a/web/tests/extension-suggest-loop.test.ts
+++ b/web/tests/extension-suggest-loop.test.ts
@@ -193,16 +193,14 @@ async function seedOrgProject(slug: string) {
   return { org, project };
 }
 
-function suggestionArgs(post: ObservedPost, projectId: number, orgId: number) {
+function suggestionArgs(post: ObservedPost, orgId: number) {
   return {
     kind: 'post_comment' as const,
     post,
-    currentProject: { name: 'p', description: null },
     persona: null,
     voiceProfile: null,
     projects: [],
     repos: [],
-    projectId,
     orgId,
     runnerSlug: 'cloud',
   };
@@ -217,7 +215,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
   });
 
   it('a suggestion needing the thread and the image takes multiple steps, dispatching independent tool calls together', async () => {
-    const { org, project } = await seedOrgProject('org-loop-multistep');
+    const { org } = await seedOrgProject('org-loop-multistep');
     // Captured at the write step (the one whose prompt already carries every
     // earlier tool result) so the assertions below can check the *results*
     // actually reached the model - a step count alone cannot tell "the
@@ -248,7 +246,6 @@ describe('runSuggestion: the agent loop (#566)', () => {
           },
           image: { alt: 'A latency chart trending down', kind: 'image' },
         },
-        project.id,
         org.id,
       ),
     );
@@ -271,7 +268,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
   });
 
   it('a plain text post still takes exactly one model turn when the model asks for no tools', async () => {
-    const { org, project } = await seedOrgProject('org-loop-singleturn');
+    const { org } = await seedOrgProject('org-loop-singleturn');
     const { callCount } = useModel(() =>
       textStep(`Straightforward.\n${DRAFT_MARKER}\nCongrats on shipping this.`),
     );
@@ -279,7 +276,6 @@ describe('runSuggestion: the agent loop (#566)', () => {
     const handle = runSuggestion(
       suggestionArgs(
         { urn: 'urn:li:activity:3', authorName: 'A', text: 'Shipped a small thing today.' },
-        project.id,
         org.id,
       ),
     );
@@ -290,7 +286,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
   });
 
   it('cancelling from the panel stops the loop mid-step: no further tool handler starts and no further model turn is requested', async () => {
-    const { org, project } = await seedOrgProject('org-loop-cancel');
+    const { org } = await seedOrgProject('org-loop-cancel');
     let resolveStarted: () => void = () => {};
     const started = new Promise<void>((resolve) => {
       resolveStarted = resolve;
@@ -309,7 +305,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
     });
 
     const handle = runSuggestion(
-      suggestionArgs({ urn: 'urn:li:activity:4', authorName: 'A', text: 'hi' }, project.id, org.id),
+      suggestionArgs({ urn: 'urn:li:activity:4', authorName: 'A', text: 'hi' }, org.id),
     );
     await started;
     handle.cancel();
@@ -319,7 +315,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
   });
 
   it('hitting the step budget forces the model to answer with what it has, yielding a usable draft', async () => {
-    const { org, project } = await seedOrgProject('org-loop-steps');
+    const { org } = await seedOrgProject('org-loop-steps');
     const { callCount } = useModel((_step, options) => {
       if (options.toolChoice?.type === 'none') {
         return textStep(`Wrapping up.\n${DRAFT_MARKER}\nHere is what I found in time.`);
@@ -328,7 +324,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
     });
 
     const handle = runSuggestion(
-      suggestionArgs({ urn: 'urn:li:activity:5', authorName: 'A', text: 'hi' }, project.id, org.id),
+      suggestionArgs({ urn: 'urn:li:activity:5', authorName: 'A', text: 'hi' }, org.id),
     );
     const result = await handle.result;
 
@@ -341,7 +337,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
 
   it('crossing the soft wall-clock budget forces the model to answer with what it has, yielding a usable draft', async () => {
     vi.useFakeTimers();
-    const { org, project } = await seedOrgProject('org-loop-soft');
+    const { org } = await seedOrgProject('org-loop-soft');
     const { callCount } = useModel(async (_step, options) => {
       if (options.toolChoice?.type === 'none') {
         return textStep(`Time is up.\n${DRAFT_MARKER}\nHere is my answer given the time I had.`);
@@ -354,7 +350,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
     });
 
     const handle = runSuggestion(
-      suggestionArgs({ urn: 'urn:li:activity:6', authorName: 'A', text: 'hi' }, project.id, org.id),
+      suggestionArgs({ urn: 'urn:li:activity:6', authorName: 'A', text: 'hi' }, org.id),
     );
     const result = await handle.result;
 
@@ -363,7 +359,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
   });
 
   it('crossing the token budget forces the model to answer with what it has, yielding a usable draft', async () => {
-    const { org, project } = await seedOrgProject('org-loop-tokens');
+    const { org } = await seedOrgProject('org-loop-tokens');
     const { callCount } = useModel((_step, options) => {
       if (options.toolChoice?.type === 'none') {
         return textStep(
@@ -379,7 +375,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
     });
 
     const handle = runSuggestion(
-      suggestionArgs({ urn: 'urn:li:activity:7', authorName: 'A', text: 'hi' }, project.id, org.id),
+      suggestionArgs({ urn: 'urn:li:activity:7', authorName: 'A', text: 'hi' }, org.id),
     );
     const result = await handle.result;
 
@@ -388,7 +384,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
   });
 
   it('crossing the cost ceiling forces the model to answer with what it has, yielding a usable draft', async () => {
-    const { org, project } = await seedOrgProject('org-loop-cost');
+    const { org } = await seedOrgProject('org-loop-cost');
     useModel(
       (_step, options) => {
         if (options.toolChoice?.type === 'none') {
@@ -409,7 +405,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
     );
 
     const handle = runSuggestion(
-      suggestionArgs({ urn: 'urn:li:activity:9', authorName: 'A', text: 'hi' }, project.id, org.id),
+      suggestionArgs({ urn: 'urn:li:activity:9', authorName: 'A', text: 'hi' }, org.id),
     );
     const result = await handle.result;
 
@@ -427,7 +423,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
   });
 
   it('a normal multi-step suggestion completes on its own - real pricing wired keeps the cost ceiling from forcing an early answer', async () => {
-    const { org, project } = await seedOrgProject('org-loop-cost-cheap');
+    const { org } = await seedOrgProject('org-loop-cost-cheap');
     const { callCount } = useModel(
       (step, options) => {
         if (options.toolChoice?.type === 'none') {
@@ -472,7 +468,6 @@ describe('runSuggestion: the agent loop (#566)', () => {
           text: 'hi',
           thread: { comments: [{ body: 'nice' }], renderedCount: 1, truncated: false },
         },
-        project.id,
         org.id,
       ),
     );
@@ -498,7 +493,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
   });
 
   it('usage is the sum across steps, not just the last one', async () => {
-    const { org, project } = await seedOrgProject('org-loop-usage');
+    const { org } = await seedOrgProject('org-loop-usage');
     useModel((step) => {
       if (step === 0) {
         return toolCallStep([{ name: 'check_style', args: { text: 'draft' } }], {
@@ -510,7 +505,7 @@ describe('runSuggestion: the agent loop (#566)', () => {
     });
 
     const handle = runSuggestion(
-      suggestionArgs({ urn: 'urn:li:activity:8', authorName: 'A', text: 'hi' }, project.id, org.id),
+      suggestionArgs({ urn: 'urn:li:activity:8', authorName: 'A', text: 'hi' }, org.id),
     );
     const result = await handle.result;
 

--- a/web/tests/extension-suggest-voice.test.ts
+++ b/web/tests/extension-suggest-voice.test.ts
@@ -14,14 +14,23 @@ import { buildSuggestionPrompt } from '@pitchbox/shared/assist/suggest-prompt';
 import { DRAFT_MARKER } from '@pitchbox/shared/assist/envelope';
 
 /**
- * #408: a per-project voice override, resolved against the project a
- * suggestion is actually being filed under, or the org's own default when
- * none is named at all (#523 made naming a project optional). Kept in
- * its own file rather than folded into extension-suggest.test.ts because
- * that file's `perDevice` rate limiter (20/60s) is a module-level singleton
- * shared by every test in the process that imports it, and its own tests
- * already run it close to the cap (see the comment on its last describe
- * block) - a fresh file gets a fresh import and a fresh limiter.
+ * #408 introduced a per-project voice override, resolved against the
+ * project a suggestion was filed under. LOR-181 retired that resolution at
+ * this route: which project (if any) a suggestion is about is now the
+ * model's own judgement, made *during* the turn (`assist/envelope.ts`'s
+ * `PROJECT_MARKER`), never known ahead of building the prompt - so a
+ * project's own voice override (`resolveEffectiveVoice`'s project branch,
+ * still real and still covered directly by
+ * `shared/tests/linkedin-assist-voice.test.ts`) can no longer be reached
+ * from here. What this file defends now is the opposite of what it used
+ * to: the org's own tone is what every suggestion gets, regardless of any
+ * project-level override and regardless of a stale `projectId` an old
+ * extension build still sends. Kept in its own file rather than folded
+ * into extension-suggest.test.ts because that file's `perDevice` rate
+ * limiter (20/60s) is a module-level singleton shared by every test in the
+ * process that imports it, and its own tests already run it close to the
+ * cap (see the comment on its last describe block) - a fresh file gets a
+ * fresh import and a fresh limiter.
  */
 
 const REASONING = 'Noticed the cache change and the specific number.';
@@ -117,12 +126,12 @@ const POST_BODY = {
 describe('per-project voice (#408)', () => {
   beforeEach(reset);
 
-  it('the same post answered under the product project and with no project produces different registers', async () => {
+  it('a project-level voice override no longer reaches the prompt, since no project is resolved before the turn runs', async () => {
     const { org, project: product } = await seedOrgProject('voice-product');
-    // Org default is 'warm'; the product project overrides to 'technical'.
-    // A request naming no project at all gets no override, so it inherits
-    // the org's 'warm' (#523: naming none is never a bypass of the binding,
-    // and resolves voice the same way an unset project override would).
+    // Org default is 'warm'; the product project's own override to
+    // 'technical' is real (`shared/tests/linkedin-assist-voice.test.ts`
+    // still exercises `resolveEffectiveVoice`'s project branch directly)
+    // but this route no longer has a project to resolve it against.
     await saveLinkedInAssistSettings(getDb(), org.id, {
       ...defaultLinkedInAssistSettings(),
       enabled: true,
@@ -132,13 +141,14 @@ describe('per-project voice (#408)', () => {
     await setProjectVoice(product.id, 'technical');
     await mintDevice(org.id, 'tok-product-vs-personal');
 
-    const productRes = await suggest({
+    // A stale extension build that still names the project in the request
+    // body produces the exact same prompt as one that names none at all -
+    // the field is inert either way (LOR-181).
+    const withProjectRes = await suggest({
       request: request('tok-product-vs-personal', { ...POST_BODY, projectId: product.id }),
     } as never);
-    // Drains the SSE body so the fake runner's synchronous write to
-    // `lastOptions` is guaranteed to have happened before this reads it.
-    await productRes.text();
-    const productPrompt = lastOptions?.prompt ?? '';
+    await withProjectRes.text();
+    const withProjectPrompt = lastOptions?.prompt ?? '';
 
     const noProjectRes = await suggest({
       request: request('tok-product-vs-personal', POST_BODY),
@@ -146,13 +156,12 @@ describe('per-project voice (#408)', () => {
     await noProjectRes.text();
     const noProjectPrompt = lastOptions?.prompt ?? '';
 
-    expect(productPrompt).toContain('mechanisms, numbers and tradeoffs');
-    expect(productPrompt).not.toContain('address the author as a person');
-
+    // The org's own 'warm' tone, never the product project's 'technical'
+    // override - both requests land on it identically.
+    expect(withProjectPrompt).toContain('address the author as a person');
+    expect(withProjectPrompt).not.toContain('mechanisms, numbers and tradeoffs');
     expect(noProjectPrompt).toContain('address the author as a person');
     expect(noProjectPrompt).not.toContain('mechanisms, numbers and tradeoffs');
-
-    expect(productPrompt).not.toBe(noProjectPrompt);
   });
 
   it('a project with no override produces the exact prompt as before this change, byte for byte', async () => {
@@ -202,11 +211,12 @@ describe('per-project voice (#408)', () => {
   });
 
   // Same enforcement rule as #405 (`enabled`, `killSwitch`, the org tone): a
-  // project-level voice is resolved server-side too, and the extension does
-  // not get a say. Distinct from the #405 test in extension-suggest.test.ts
-  // because here a project override is actually in play - proving the body
-  // can't override *that* either, not just the org-level fallback.
-  it('ignores a tone injected into the request body even when a project override is set', async () => {
+  // tone in the request body is inert. LOR-181: so is a project-level
+  // voice override reached through this route - there is no project known
+  // yet to resolve one against, so the org's own default tone
+  // (`match-room`, unset here) is what a suggestion gets regardless of
+  // either.
+  it('ignores both a tone injected into the request body and a project-level override', async () => {
     const { org, project } = await seedOrgProject('voice-inject');
     await setProjectVoice(project.id, 'plain');
     await mintDevice(org.id, 'tok-voice-inject');
@@ -222,7 +232,8 @@ describe('per-project voice (#408)', () => {
     await res.text();
     const prompt = lastOptions?.prompt ?? '';
 
-    expect(prompt).toContain('Write plainly');
+    expect(prompt).toContain('Match the room');
+    expect(prompt).not.toContain('Write plainly');
     expect(prompt).not.toContain('mechanisms, numbers and tradeoffs');
     expect(prompt).not.toContain('pirate');
   });

--- a/web/tests/extension-suggest-voice.test.ts
+++ b/web/tests/extension-suggest-voice.test.ts
@@ -179,7 +179,6 @@ describe('per-project voice (#408)', () => {
     const db = getDb();
     const context = await loadCompanionContext(db, {
       organizationId: project.organizationId,
-      currentProjectId: project.id,
     });
     const examples = (
       await loadActiveTemplates(db, { projectId: project.id, kind: 'comment' })
@@ -187,7 +186,6 @@ describe('per-project voice (#408)', () => {
     const expected = buildSuggestionPrompt({
       kind: 'post_comment',
       post: POST_BODY.post,
-      currentProject: { name: project.name, description: project.description },
       persona: context.persona,
       // #407: the prompt carries the derived profile instead of the raw
       // sample list, and this test only cares about the tone half.

--- a/web/tests/extension-suggest.test.ts
+++ b/web/tests/extension-suggest.test.ts
@@ -203,30 +203,43 @@ describe('POST /api/extension/suggest', () => {
   beforeEach(reset);
 
   it('refuses a request with no bearer token', async () => {
-    await expect(
-      suggest({ request: request(null, { ...POST_BODY, projectId: 1 }) } as never),
-    ).rejects.toMatchObject({ status: 401 });
+    await expect(suggest({ request: request(null, POST_BODY) } as never)).rejects.toMatchObject({
+      status: 401,
+    });
   });
 
-  it('404s a project outside the device org, so it leaks no other tenant ids', async () => {
+  // LOR-181: the client no longer sends a project at all, and an older
+  // extension build that still does is ignored rather than trusted or
+  // rejected - the schema silently drops the field (see BodySchema's own
+  // comment) and the server resolves the project itself from the model's
+  // own PROJECT_MARKER choice. A stale/foreign id in the payload must never
+  // 404, and must never leak into the resolved project either.
+  it('ignores a projectId an old extension build still sends, even one from another org', async () => {
     const { project: bProject } = await seedOrgProject('org-b');
     const { org: orgA } = await seedOrgProject('org-a');
     await mintDevice(orgA.id, 'tokA');
 
-    await expect(
-      suggest({ request: request('tokA', { ...POST_BODY, projectId: bProject.id }) } as never),
-    ).rejects.toMatchObject({ status: 404 });
+    const res = await suggest({
+      request: request('tokA', { ...POST_BODY, projectId: bProject.id }),
+    } as never);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const events = await readEvents(res);
+    const done = events.at(-1)!.data as { projectId: number | null };
+    // The fake model's response never emits PROJECT_MARKER, so the server's
+    // own resolution is "unstated" (null) - never `bProject.id`, the
+    // client-sent value from an org this device cannot even see.
+    expect(done.projectId).toBeNull();
   });
 
   it('streams the suggestion in chunks and closes with a terminal event', async () => {
-    const { org, project } = await seedOrgProject('org-a');
+    const { org } = await seedOrgProject('org-a');
     await mintDevice(org.id, 'tok');
     // #576: a tool set was attached and produced something to persist -
     // the route's `done` payload should carry the session id back.
     responseMessagesToReturn = [{ role: 'assistant', content: 'gathered context' }];
 
     const res = await suggest({
-      request: request('tok', { ...POST_BODY, projectId: project.id }),
+      request: request('tok', POST_BODY),
     } as never);
     expect(res.headers.get('content-type')).toContain('text/event-stream');
 
@@ -266,14 +279,14 @@ describe('POST /api/extension/suggest', () => {
   // once actual draft text starts - never for reasoning, which must never
   // read as something the human could insert.
   it('tags each chunk with its section and flips to writing only when the draft begins', async () => {
-    const { org, project } = await seedOrgProject('org-section');
+    const { org } = await seedOrgProject('org-section');
     await mintDevice(org.id, 'tok-section');
     // #573: a tool step the route must translate into its own status event,
     // before the draft ever starts.
     toolStepsToEmit = [['read_thread', 'look_at_image']];
 
     const res = await suggest({
-      request: request('tok-section', { ...POST_BODY, projectId: project.id }),
+      request: request('tok-section', POST_BODY),
     } as never);
     const events = await readEvents(res);
 
@@ -322,12 +335,12 @@ describe('POST /api/extension/suggest', () => {
   // instruction, or was never asked - see the "prove it bites" note below)
   // must never hand the panel something to insert.
   it('arrives as done with draft: null when the model never emits the marker', async () => {
-    const { org, project } = await seedOrgProject('org-unstructured');
+    const { org } = await seedOrgProject('org-unstructured');
     await mintDevice(org.id, 'tok-unstructured');
     responseChunks = ['Just some prose with no marker at all.'];
 
     const res = await suggest({
-      request: request('tok-unstructured', { ...POST_BODY, projectId: project.id }),
+      request: request('tok-unstructured', POST_BODY),
     } as never);
     const events = await readEvents(res);
 
@@ -356,12 +369,12 @@ describe('POST /api/extension/suggest', () => {
   // A model that explicitly declines: SKIP_MARKER, not silence. Also arrives
   // with draft: null, distinguished only by `skipped`.
   it('arrives as done with draft: null and skipped: true when the model declines', async () => {
-    const { org, project } = await seedOrgProject('org-skipped');
+    const { org } = await seedOrgProject('org-skipped');
     await mintDevice(org.id, 'tok-skipped');
     responseChunks = ['Nothing worth adding here.\n', SKIP_MARKER, '\nExplained above.'];
 
     const res = await suggest({
-      request: request('tok-skipped', { ...POST_BODY, projectId: project.id }),
+      request: request('tok-skipped', POST_BODY),
     } as never);
     const events = await readEvents(res);
     const done = events.at(-1)!.data as {
@@ -374,11 +387,9 @@ describe('POST /api/extension/suggest', () => {
   });
 
   it('attaches no MCP server and passes a prompt rather than a playbook', async () => {
-    const { org, project } = await seedOrgProject('org-a');
+    const { org } = await seedOrgProject('org-a');
     await mintDevice(org.id, 'tok');
-    await readEvents(
-      await suggest({ request: request('tok', { ...POST_BODY, projectId: project.id }) } as never),
-    );
+    await readEvents(await suggest({ request: request('tok', POST_BODY) } as never));
 
     expect(lastOptions?.attachMcp).toBe(false);
     expect(lastOptions?.playbookPath).toBeUndefined();
@@ -391,11 +402,9 @@ describe('POST /api/extension/suggest', () => {
   });
 
   it('writes no runs row and no draft', async () => {
-    const { org, project } = await seedOrgProject('org-a');
+    const { org } = await seedOrgProject('org-a');
     await mintDevice(org.id, 'tok');
-    await readEvents(
-      await suggest({ request: request('tok', { ...POST_BODY, projectId: project.id }) } as never),
-    );
+    await readEvents(await suggest({ request: request('tok', POST_BODY) } as never));
 
     const runs = await getDb().select().from(schema.runs);
     const drafts = await getDb().select().from(schema.drafts);
@@ -430,12 +439,10 @@ describe('POST /api/extension/suggest', () => {
     const handle = runSuggestion({
       kind: 'post_comment',
       post: POST_BODY.post,
-      currentProject: { name: project.name, description: project.description },
       persona: null,
       voiceProfile: null,
       projects: [],
       repos: [],
-      projectId: project.id,
       runnerSlug: project.defaultAgentRunner,
     });
     handle.cancel();
@@ -446,12 +453,12 @@ describe('POST /api/extension/suggest', () => {
   });
 
   it('cancels a running agent when the client disconnects after it spawned', async () => {
-    const { org, project } = await seedOrgProject('org-a');
+    const { org } = await seedOrgProject('org-a');
     await mintDevice(org.id, 'tok');
     hangForever = true;
 
     const res = await suggest({
-      request: request('tok', { ...POST_BODY, projectId: project.id }),
+      request: request('tok', POST_BODY),
     } as never);
     const reader = res.body!.getReader();
     await reader.read(); // the padding
@@ -466,11 +473,11 @@ describe('POST /api/extension/suggest', () => {
   // it. All three of these returned a full streamed suggestion on the code as
   // #357 left it, with the org's assistant off.
   it('refuses to suggest for an org that never turned the assistant on', async () => {
-    const { org, project } = await seedOrgProject('org-off', { assist: false });
+    const { org } = await seedOrgProject('org-off', { assist: false });
     await mintDevice(org.id, 'tokOff');
 
     const res = await suggest({
-      request: request('tokOff', { ...POST_BODY, projectId: project.id }),
+      request: request('tokOff', POST_BODY),
     } as never);
     expect(await res.json()).toMatchObject({ refused: 'assist_disabled' });
     // No model call at all, which is the point: a refusal that still spawns an
@@ -489,14 +496,14 @@ describe('POST /api/extension/suggest', () => {
     await mintDevice(org.id, 'tokKilled');
 
     const res = await suggest({
-      request: request('tokKilled', { ...POST_BODY, projectId: project.id }),
+      request: request('tokKilled', POST_BODY),
     } as never);
     expect(await res.json()).toMatchObject({ refused: 'kill_switch' });
     expect(lastOptions).toBeNull();
   });
 
-  it('refuses to write as a project of the same org that is not the bound one', async () => {
-    const { org, project } = await seedOrgProject('org-bound');
+  it("serves a request naming a different project of the same org, since the choice is the model's alone (#523)", async () => {
+    const { org } = await seedOrgProject('org-bound');
     const [other] = await getDb()
       .insert(schema.projects)
       .values({ organizationId: org.id, slug: 'p-other', name: 'other', description: 'other' })
@@ -506,18 +513,8 @@ describe('POST /api/extension/suggest', () => {
     const res = await suggest({
       request: request('tokBound', { ...POST_BODY, projectId: other.id }),
     } as never);
-    expect(await res.json()).toMatchObject({
-      refused: 'project_not_bound',
-      boundProjectId: project.id,
-    });
-    expect(lastOptions).toBeNull();
-
-    // The bound project still streams from the same device.
-    const ok = await suggest({
-      request: request('tokBound', { ...POST_BODY, projectId: project.id }),
-    } as never);
-    expect(ok.headers.get('content-type')).toContain('text/event-stream');
-    await ok.text();
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    await res.text();
   });
 
   // #523: naming no project at all makes no binding claim, so it is never a
@@ -544,34 +541,34 @@ describe('POST /api/extension/suggest', () => {
   // the registry, not against the resolver in isolation: the resolver being
   // correct and never called is the failure mode worth catching.
   it('asks for the fast assist model when no operator pinned one', async () => {
-    const { org, project } = await seedOrgProject('org-model-default');
+    const { org } = await seedOrgProject('org-model-default');
     await mintDevice(org.id, 'tokModel');
 
     const res = await suggest({
-      request: request('tokModel', { ...POST_BODY, projectId: project.id }),
+      request: request('tokModel', POST_BODY),
     } as never);
     await res.text();
     expect(lastConfig).toMatchObject({ model: ASSIST_DEFAULT_MODEL });
   });
 
   it('leaves an operator-pinned model alone, including for suggestions', async () => {
-    const { org, project } = await seedOrgProject('org-model-pinned');
+    const { org } = await seedOrgProject('org-model-pinned');
     await mintDevice(org.id, 'tokPinned');
     await saveRunnerConfig(getDb(), 'claude-code', { model: 'opus', maxTurns: 3 });
 
     const res = await suggest({
-      request: request('tokPinned', { ...POST_BODY, projectId: project.id }),
+      request: request('tokPinned', POST_BODY),
     } as never);
     await res.text();
     expect(lastConfig).toMatchObject({ model: 'opus', maxTurns: 3 });
   });
   describe('kind: "post" - grounded server-side in the observation buffer, #315', () => {
     it('refuses with a renderable body, not a 500, when the buffer has nothing recent', async () => {
-      const { org, project } = await seedOrgProject('org-post-empty');
+      const { org } = await seedOrgProject('org-post-empty');
       await mintDevice(org.id, 'tokPostEmpty');
 
       const res = await suggest({
-        request: request('tokPostEmpty', { kind: 'post', projectId: project.id, post: {} }),
+        request: request('tokPostEmpty', { kind: 'post', post: {} }),
       } as never);
       expect(res.headers.get('content-type')).toContain('application/json');
       expect(await res.json()).toMatchObject({ refused: 'no_recent_activity' });
@@ -605,7 +602,6 @@ describe('POST /api/extension/suggest', () => {
       const res = await suggest({
         request: request('tokPostGrounded', {
           kind: 'post',
-          projectId: project.id,
           // A pile of client-supplied text - the route must ignore this
           // entirely for kind "post" and use the observation buffer instead.
           post: { text: 'whatever the panel scraped off the current page' },
@@ -641,12 +637,10 @@ describe('runSuggestion narrates its own steps and budget (#573)', () => {
     const cutShort = await runSuggestion({
       kind: 'post_comment',
       post: POST_BODY.post,
-      currentProject: { name: project.name, description: project.description },
       persona: null,
       voiceProfile: null,
       projects: [],
       repos: [],
-      projectId: project.id,
       orgId: project.organizationId,
       runnerSlug: project.defaultAgentRunner,
     }).result;
@@ -657,12 +651,10 @@ describe('runSuggestion narrates its own steps and budget (#573)', () => {
     const clean = await runSuggestion({
       kind: 'post_comment',
       post: POST_BODY.post,
-      currentProject: { name: project.name, description: project.description },
       persona: null,
       voiceProfile: null,
       projects: [],
       repos: [],
-      projectId: project.id,
       orgId: project.organizationId,
       runnerSlug: project.defaultAgentRunner,
     }).result;
@@ -677,12 +669,10 @@ describe('runSuggestion narrates its own steps and budget (#573)', () => {
     await runSuggestion({
       kind: 'post_comment',
       post: POST_BODY.post,
-      currentProject: { name: project.name, description: project.description },
       persona: null,
       voiceProfile: null,
       projects: [],
       repos: [],
-      projectId: project.id,
       orgId: project.organizationId,
       runnerSlug: project.defaultAgentRunner,
       onToolStep: (toolNames) => seen.push(toolNames),
@@ -709,12 +699,10 @@ describe('runSuggestion session continuation (#576)', () => {
     return {
       kind: 'post_comment' as const,
       post: POST_BODY.post,
-      currentProject: { name: project.name, description: project.description },
       persona: null,
       voiceProfile: null,
       projects: [],
       repos: [],
-      projectId: project.id,
       orgId: project.organizationId,
       runnerSlug: project.defaultAgentRunner,
     };
@@ -840,12 +828,10 @@ describe('runSuggestion refuses a local runner in the cloud edition (#410)', () 
     const handle = runSuggestion({
       kind: 'post_comment',
       post: { urn: 'urn:li:activity:1', authorName: 'A', text: 'hi' },
-      currentProject: { name: 'p', description: null },
       persona: null,
       voiceProfile: null,
       projects: [],
       repos: [],
-      projectId: 1,
       runnerSlug: 'claude-code',
     });
 
@@ -897,7 +883,7 @@ describe('tone comes from the org settings, not the request (#405)', () => {
     await mintDevice(org.id, 'tokT');
 
     const res = await suggest({
-      request: request('tokT', { ...POST_BODY, projectId: project.id }),
+      request: request('tokT', POST_BODY),
     } as never);
     await readEvents(res);
     expect(lastOptions?.prompt).toContain('mechanisms, numbers and tradeoffs');

--- a/web/tests/suggest-style-check.test.ts
+++ b/web/tests/suggest-style-check.test.ts
@@ -56,12 +56,10 @@ function baseArgs() {
   return {
     kind: 'post_comment' as const,
     post: { urn: 'urn:li:activity:1', authorName: 'A', text: 'hi' },
-    currentProject: { name: 'p', description: null },
     persona: null,
     voiceProfile: null,
     projects: [],
     repos: [],
-    projectId: 1,
     runnerSlug: 'claude-code',
   };
 }


### PR DESCRIPTION
Closes LOR-181. The last open pitchbox feature, and the largest: it took three passes, and the branch is squashed from three WIP commits.

The binding is gone. A suggestion's project is now chosen per post instead of set once in a form: the model states its choice through a `PROJECT_MARKER` at the head of its reply, parsed by the same envelope splitter that already separates the draft from the reasoning, and the server validates that claim against the org's own projects. An id that is not one of them, or no claim at all, resolves to personal and is logged with the raw claim next to the org's real ids, so a wrong pick is explainable after the fact. `assist_usage.projectId` already recorded the project per suggestion, so the choice is auditable with no schema change.

Why the envelope and not a tool call: the ACP transport attaches no tools at all, so a tool-only mechanism could never signal a project on that backend. Raw streamed text reaches both backends uniformly.

The model also got something to read. `project_insights.summaryMd` existed, was written by the project-insighter playbook, and never reached the prompt; it does now, which is the cheapest real upgrade to a choice that previously had only a name and a description per project.

**One deliberate deviation from the issue text, and it is the thing to review.** The issue says to delete the settings page's project field "once nothing reads it". That premise is false: `POST /api/extension/observations` and `linkedin-observe.ts` need a real project to attribute a sighting to, and `observed_targets.project_id` is `NOT NULL`. Deleting the field would have broken the observation collector with no replacement source for the id. So the field stays, rescoped in code and in the UI to exactly that job ("Collector attributes sightings to", next to the collector switch), and it is out of the suggestion path entirely. `Writes as project` is gone, and assist can be enabled with no project bound, which is what the issue actually wanted.

Also removed as dead: the `project_not_bound` and `project_required` refusals, their i18n strings in both dictionaries, and the accept route's bound-project gate. The quota and kill-switch refusal shapes are asserted unchanged rather than assumed.

Verified after rebasing onto main, by me and not only by the agents: four typechecks clean (shared, cli, web on 6114 files, extension on 791), `prettier --check .` clean repo-wide, `test:linkedin-compliance` green, and 132 tests across the eight suites that touch this contract. The new test the issue asked for and neither earlier pass wrote is there: the server ignores a `projectId` an old extension build still sends.

Not verified here, and mine: driving the built extension on the real feed. That is the only check that has ever caught anything on this plane, and I will run it against preview once this deploys.