### PR TITLE
chore(ci): catch a forked drizzle snapshot chain on the PR path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Workspace versions in lockstep (#207)
         run: pnpm run version:check
+      # Metadata only, no database, so it belongs on the PR path: a forked
+      # snapshot chain from two migrations in one wave reached main once and
+      # was found by the next `migrate:generate` rather than by CI (#206).
+      - name: Migration metadata chain
+        run: pnpm run migrations:check
       - name: LinkedIn compliance boundary (#308)
         run: pnpm run test:linkedin-compliance
       - name: Lint (eslint + prettier)

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "brand:render": "tsx scripts/render-brand.ts",
     "plans:export": "tsx scripts/export-plan-catalogue.ts",
     "set-version": "node scripts/set-version.mjs",
-    "version:check": "node scripts/set-version.mjs --check"
+    "version:check": "node scripts/set-version.mjs --check",
+    "migrations:check": "pnpm -F shared migrations:check"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/shared/package.json
+++ b/shared/package.json
@@ -108,7 +108,8 @@
     "migrate": "tsx src/db/migrate.ts",
     "migrate:generate": "drizzle-kit generate",
     "seed:core": "tsx src/db/seed-core.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "migrations:check": "tsx src/db/check-migration-chain.ts"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.1.0",

--- a/shared/src/db/check-migration-chain.ts
+++ b/shared/src/db/check-migration-chain.ts
@@ -1,0 +1,17 @@
+/**
+ * CLI wrapper for `checkMigrationChain`, wired as `pnpm run migrations:check`
+ * and run by CI's `quality` job. Takes an optional directory so it can be
+ * pointed at something other than this repo's own migrations.
+ */
+import { checkMigrationChain, MIGRATIONS_DIR } from './migration-chain.js';
+
+const dir = process.argv[2] ?? MIGRATIONS_DIR;
+const problems = checkMigrationChain(dir);
+
+if (problems.length > 0) {
+  console.error(`migration metadata is inconsistent in ${dir}:`);
+  for (const problem of problems) console.error(`  ${problem}`);
+  process.exit(1);
+}
+
+console.log('migration metadata: chain, order and identity all sound');

--- a/shared/src/db/migration-chain.ts
+++ b/shared/src/db/migration-chain.ts
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Guards drizzle-kit's own migration metadata against the wave collision
+ * `AGENTS.md` already documents, which reached `main` once (#543/#544).
+ *
+ * `0025_supreme_molecule_man` and `0026_email_verification_tokens` were both
+ * generated against the same base snapshot and merged one after the other with
+ * neither regenerated on top of the other, so `0026_snapshot.json`'s `prevId`
+ * pointed at `0025`'s parent instead of at `0025`'s own `id`: a fork, not a
+ * chain. Both `.sql` files applied cleanly in either order, so no deploy and
+ * no test noticed. The next person to run `pnpm run migrate:generate` was the
+ * one who found out, and the error named a snapshot collision rather than the
+ * pair that caused it.
+ *
+ * This is metadata only and touches no database, which is what lets it run in
+ * the PR-time `quality` job. `migration-audit.ts` next door is the complement:
+ * it needs a database with history, so it runs at migrate time instead.
+ */
+
+const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
+
+export const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), 'migrations');
+
+interface JournalEntry {
+  idx: number;
+  when: number;
+  tag: string;
+}
+
+/** One line per problem. Empty means the metadata is sound. */
+export function checkMigrationChain(dir: string = MIGRATIONS_DIR): string[] {
+  const journalPath = join(dir, 'meta/_journal.json');
+  if (!existsSync(journalPath)) return [`no journal at ${journalPath}`];
+  const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as { entries?: JournalEntry[] };
+  const entries = journal.entries ?? [];
+  if (entries.length === 0) return ['journal has no entries'];
+
+  const problems: string[] = [];
+  const seen = new Map<number, string>();
+  let prevId = ZERO_UUID;
+  let prevSnapshotTag = '(none)';
+
+  for (const [i, entry] of entries.entries()) {
+    const claimed = seen.get(entry.idx);
+    if (claimed) {
+      problems.push(
+        `duplicate idx ${entry.idx}: ${claimed} and ${entry.tag} both claim it, which is two migrations generated in the same wave`,
+      );
+    }
+    seen.set(entry.idx, entry.tag);
+
+    if (!existsSync(join(dir, `${entry.tag}.sql`))) {
+      problems.push(`${entry.tag}: in the journal with no matching .sql file`);
+    }
+
+    // Drizzle applies a migration only when its `when` exceeds the newest one
+    // already applied, so a non-increasing pair is a migration that skips in
+    // silence. `0013` carries a deliberate future timestamp (#493), which is
+    // why this checks the sequence rather than comparing against the clock.
+    if (i > 0 && entry.when <= entries[i - 1].when) {
+      problems.push(
+        `${entry.tag}: when=${entry.when} is not greater than ${entries[i - 1].tag}'s ${entries[i - 1].when}, so drizzle will skip it`,
+      );
+    }
+
+    // A hand-authored migration has no snapshot at all, and four real ones do
+    // not, so a missing snapshot must never read as a fork: the chain simply
+    // continues from the last snapshot that exists.
+    const snapshotPath = join(dir, `meta/${String(entry.idx).padStart(4, '0')}_snapshot.json`);
+    if (!existsSync(snapshotPath)) continue;
+    const snapshot = JSON.parse(readFileSync(snapshotPath, 'utf8')) as {
+      id: string;
+      prevId: string;
+    };
+    if (snapshot.prevId !== prevId) {
+      problems.push(
+        `${entry.tag}: snapshot prevId is ${snapshot.prevId}, expected ${prevId} (${prevSnapshotTag}'s id). The chain forked, so regenerate this migration on top of the other one rather than editing the snapshot`,
+      );
+    }
+    prevId = snapshot.id;
+    prevSnapshotTag = entry.tag;
+  }
+
+  return problems;
+}

--- a/shared/tests/migration-chain.test.ts
+++ b/shared/tests/migration-chain.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkMigrationChain, MIGRATIONS_DIR } from '../src/db/migration-chain.js';
+
+/**
+ * The wave collision `AGENTS.md` documents reached `main` once (#543/#544):
+ * two migrations generated against the same base snapshot, merged one after
+ * the other, neither regenerated. Both `.sql` files applied cleanly in either
+ * order, so no deploy and no test noticed; the next `migrate:generate` was
+ * what found out, and it reported a snapshot collision rather than the pair
+ * that caused it.
+ *
+ * These cases are built as throwaway metadata rather than as fixtures under
+ * the real migrations directory, because a fixture that looks like a migration
+ * is a fixture drizzle-kit will one day try to chain.
+ */
+
+const ZERO = '00000000-0000-0000-0000-000000000000';
+const id = (n: number) => `1111111${n}-0000-0000-0000-00000000000${n}`;
+
+type Entry = { idx: number; when: number; tag: string; breakpoints: boolean };
+
+function write(
+  entries: Entry[],
+  snapshots: Record<string, { id: string; prevId: string }>,
+  opts: { omitSql?: string[] } = {},
+): string {
+  const dir = mkdtempSync(join(tmpdir(), 'migchain-'));
+  mkdirSync(join(dir, 'meta'));
+  writeFileSync(
+    join(dir, 'meta/_journal.json'),
+    JSON.stringify({ version: '7', dialect: 'postgresql', entries }),
+  );
+  for (const e of entries) {
+    if (opts.omitSql?.includes(e.tag)) continue;
+    writeFileSync(join(dir, `${e.tag}.sql`), '-- noop\n');
+  }
+  for (const [idx, snap] of Object.entries(snapshots)) {
+    writeFileSync(join(dir, `meta/${idx}_snapshot.json`), JSON.stringify(snap));
+  }
+  return dir;
+}
+
+const entry = (idx: number, when: number, tag: string): Entry => ({
+  idx,
+  when,
+  tag,
+  breakpoints: true,
+});
+
+describe('checkMigrationChain', () => {
+  it('accepts a sound chain', () => {
+    const dir = write([entry(0, 100, '0000_first'), entry(1, 200, '0001_second')], {
+      '0000': { id: id(1), prevId: ZERO },
+      '0001': { id: id(2), prevId: id(1) },
+    });
+    expect(checkMigrationChain(dir)).toEqual([]);
+  });
+
+  it('reports the fork when two migrations share a parent snapshot', () => {
+    const dir = write(
+      [entry(0, 100, '0000_first'), entry(1, 200, '0001_a'), entry(2, 300, '0002_b')],
+      {
+        '0000': { id: id(1), prevId: ZERO },
+        '0001': { id: id(2), prevId: id(1) },
+        // Generated against 0000 as well, never regenerated on top of 0001.
+        '0002': { id: id(3), prevId: id(1) },
+      },
+    );
+    const problems = checkMigrationChain(dir);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('0002_b');
+    expect(problems[0]).toContain('The chain forked');
+  });
+
+  it('accepts a hand-authored migration that has no snapshot at all', () => {
+    // Four real migrations are like this, so a missing snapshot must not read
+    // as a fork: the chain continues from the last snapshot that exists.
+    const dir = write(
+      [
+        entry(0, 100, '0000_first'),
+        entry(1, 200, '0001_hand_written'),
+        entry(2, 300, '0002_generated'),
+      ],
+      { '0000': { id: id(1), prevId: ZERO }, '0002': { id: id(2), prevId: id(1) } },
+    );
+    expect(checkMigrationChain(dir)).toEqual([]);
+  });
+
+  it('reports a when value that would make drizzle skip the migration', () => {
+    const dir = write([entry(0, 100, '0000_first'), entry(1, 100, '0001_same_when')], {
+      '0000': { id: id(1), prevId: ZERO },
+      '0001': { id: id(2), prevId: id(1) },
+    });
+    const problems = checkMigrationChain(dir);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('will skip it');
+  });
+
+  it('reports a journal entry whose sql file is missing', () => {
+    const dir = write(
+      [entry(0, 100, '0000_first')],
+      { '0000': { id: id(1), prevId: ZERO } },
+      {
+        omitSql: ['0000_first'],
+      },
+    );
+    expect(checkMigrationChain(dir).join(' ')).toContain('no matching .sql file');
+  });
+
+  it('reports two entries claiming the same index', () => {
+    const dir = write([entry(1, 100, '0001_mine'), entry(1, 200, '0001_yours')], {
+      '0001': { id: id(1), prevId: ZERO },
+    });
+    expect(checkMigrationChain(dir).join(' ')).toContain('duplicate idx 1');
+  });
+
+  it('holds against the repo it guards', () => {
+    // The real metadata, which is the only case that can regress on a merge.
+    expect(checkMigrationChain(MIGRATIONS_DIR)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes LOR-206.

Two migrations generated in one wave against the same base snapshot, merged sequentially with neither regenerated, fork drizzle-kit's snapshot chain. That reached `main` once: both `.sql` files applied cleanly in either order, so nothing failed at deploy time or in a test, and the next `migrate:generate` was what found out, from an error naming a snapshot collision rather than the pair that caused it.

The check is metadata only and touches no database, which is what lets it sit in the PR-time `quality` job rather than in the trunk suite. It asserts three things: each snapshot's `prevId` is the previous snapshot's `id`, the journal's `when` values strictly increase (a non-increasing pair is a migration drizzle skips in silence, #493), and every entry has a unique `idx` and a `.sql` file that exists. It is the complement of `migration-audit.ts`, which needs a database with history and so runs at migrate time.

One detail worth knowing for anyone extending it: four real migrations are hand-authored and have no snapshot at all, so a missing snapshot must not read as a fork. The chain is checked across the snapshots that exist.

Proven to bite twice rather than once. Seven unit cases over throwaway metadata (the fork, a missing snapshot, an equal `when`, a missing sql file, a duplicate idx), plus a copy of the **real** migrations directory with one `prevId` repointed, which the checker rejects naming both tags. The real directory passes, and `pnpm run migrations:check` is green on this branch.