### PR TITLE
fix(extension): stamp the build a bundle was made from (LOR-213)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,6 +426,18 @@ Two things worth stating here so nobody re-derives them mid-task. First, the ext
 
 **This is not optional polish. Six defects shipped because nothing had ever loaded the built extension** (#379, fixed by #380 and #381): a `.ts` script path that only resolves while Vite serves the source, an inline `<script>` the MV3 CSP refuses outright, LinkedIn missing from the server's extension CORS allowlist, the in-page assistant not registered for `/posts/<slug>-<id>/`, Svelte's runtime dying on LinkedIn's Trusted Types allowlist, and a post reader that returned a screen-reader-only line instead of the post. `tests/extension-packaged-build.test.ts` now builds the extension and asserts on the artifact, which covers the first two classes; the rest only show up on a real page. So drive the built extension in a real profile against preview before calling an extension change done.
 
+**Which bundle is actually installed is a question the manifest could not answer
+until #661, and it cost two round trips on 2026-09-10 alone.** `version` only
+moves on a release commit, so a bundle built at 18:52 and one built after three
+more merges both said `0.17.0`, and a fix merged in between looked broken when
+it simply was not there. Every build now stamps `version_name` with the commit
+(`0.17.0 (a1910bc)`, plus `-dirty` when the tree differed from HEAD), shown in
+`chrome://extensions` and on the side panel's About card;
+`PITCHBOX_BUILD_ID` overrides it for a build with no checkout. Before
+diagnosing a "the fix is not in the build" report, read that string, and when
+it is unavailable grep the emitted content script for a literal the change
+touched, since `dist/` carries the answer and a version number does not.
+
 **Three traps in the side panel's own code, all paid for on 2026-09-08 while building home (#457).** A Svelte file must never declare a variable called `state`: `let state = $derived(...)` turns every `$state` rune in that file into a store subscription (`$` + `state`), and the file stops compiling with errors that name the rune rather than your variable. Second, a component that reads `chrome.storage` for itself is a second reader of the same key and will drift from the first: home said "Not paired" while `PairingList` still rendered the old rows with their Test connection and Disconnect buttons, because that copy refreshed only on mount. One owner reads, the children take props, and a child that mutates calls back up. Third, the panel applies the theme at mount only, so a `extensionSettings.theme` write from another context (a worker, a test, another tab) does not repaint an open panel: reload the page to see dark mode, and do not read that as a bug in what you just changed.
 
 **Mounting a side-panel component in a test needs the root `vitest.config.ts`, not the extension's.** CI runs the root config, and until #457 it had no `$ext`/`$ui` aliases, so a component test that passes under `pnpm -F @pitchbox/extension exec vitest run` fails in CI on an unresolved import - the same split that cost a bisect in #339. Both configs resolve them now. `$lib` is deliberately NOT remapped in the root config: the extension's `ui` primitives resolve `$lib/utils.js` to the web app's own `cn`, which is the same helper, and remapping it would break every web route test.

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -1,11 +1,20 @@
 import { defineManifest } from '@crxjs/vite-plugin';
 import pkg from './package.json' with { type: 'json' };
+import { resolveBuildId, versionLabel } from './vite-plugins/build-id';
+
+// `version` is what Chrome compares between installs, so it stays the plain
+// release number. `version_name` is the human-facing string next to it in
+// `chrome://extensions`, and it carries the commit: without it two bundles
+// built hours and several merges apart are indistinguishable in the only
+// place a person looks (2026-09-10, twice).
+const BUILD_ID = resolveBuildId();
 
 export default defineManifest({
   manifest_version: 3,
   name: 'Pitchbox',
   description: 'Companion extension for the Pitchbox outreach dashboard.',
   version: pkg.version,
+  version_name: versionLabel(pkg.version, BUILD_ID),
   // The side panel (side_panel + chrome.sidePanel) is a Chrome 114+ API. Set a
   // floor so Chrome refuses/warns on install for older builds instead of
   // shipping a toolbar icon that silently does nothing (#208).

--- a/extension/vite-plugins/build-id.ts
+++ b/extension/vite-plugins/build-id.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * The commit a bundle was built from, so a loaded extension can be told apart
+ * from another one carrying the same `version`.
+ *
+ * The manifest version only moves on a release commit, and every build in
+ * between reports it unchanged: an unpacked bundle built at 18:52 and one
+ * built after three more merges both say `0.17.0` in `chrome://extensions`,
+ * with nothing on either surface to tell them apart. That cost a full round
+ * of "the fix is not there" on 2026-09-10, twice, when the installed bundle
+ * simply predated the merge it was being judged on.
+ *
+ * `PITCHBOX_BUILD_ID` wins when set, so a CI or container build with no git
+ * checkout can stamp its own. Otherwise this reads the checkout, and appends
+ * `-dirty` when the tree carries uncommitted changes, since a bundle built
+ * from a dirty tree is not the commit it names.
+ */
+export function resolveBuildId(cwd: string = process.cwd()): string | null {
+  const fromEnv = process.env.PITCHBOX_BUILD_ID?.trim();
+  if (fromEnv) return fromEnv;
+
+  const sha = git(['rev-parse', '--short=7', 'HEAD'], cwd);
+  if (!sha) return null;
+
+  // `--quiet` exits non-zero when the tree differs from HEAD, which `git`
+  // below reports as null. Untracked files are deliberately not counted: a
+  // stray note in the worktree does not change what was compiled.
+  const clean = git(['diff', '--quiet', 'HEAD'], cwd) !== null;
+  return clean ? sha : `${sha}-dirty`;
+}
+
+function git(args: string[], cwd: string): string | null {
+  try {
+    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    // No git, no checkout, or a non-zero exit (which is how `diff --quiet`
+    // reports a dirty tree). Never fatal: a bundle without a build id is
+    // worse to debug, not unbuildable.
+    return null;
+  }
+}
+
+/**
+ * What both the manifest's `version_name` and the side panel's About card
+ * show: the release version, plus the commit when there is one.
+ */
+export function versionLabel(version: string, buildId: string | null): string {
+  return buildId ? `${version} (${buildId})` : version;
+}

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -6,6 +6,7 @@ import tailwindcss from '@tailwindcss/vite';
 import manifest from './manifest.config';
 import { panelContentScripts } from './vite-plugins/panel-content-scripts';
 import pkg from './package.json' with { type: 'json' };
+import { resolveBuildId, versionLabel } from './vite-plugins/build-id';
 
 export default defineConfig({
   plugins: [
@@ -49,7 +50,12 @@ export default defineConfig({
     panelContentScripts(),
   ],
   define: {
-    'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version),
+    // The About card's version line. `versionLabel` rather than the bare
+    // version so the side panel answers "which build is this" on its own,
+    // matching the manifest's `version_name`.
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(
+      versionLabel(pkg.version, resolveBuildId(__dirname)),
+    ),
     // The backend the extension defaults to on a fresh install. Overridable at
     // build time for a self-hosted or preview build; the user can also add
     // other backends at runtime from the side panel. See docs/extension-connection-design.md.

--- a/tests/extension-build-id.test.ts
+++ b/tests/extension-build-id.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { resolveBuildId } from '../extension/vite-plugins/build-id';
+
+/**
+ * The identity a locally built bundle carries. The env path is exercised by
+ * `tests/extension-packaged-build.test.ts` on the real artifact; this covers
+ * the path every hand-built preview bundle actually takes, which is the
+ * checkout.
+ */
+
+const repos: string[] = [];
+
+function repo(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'pitchbox-build-id-'));
+  repos.push(dir);
+  const git = (...args: string[]) =>
+    execFileSync('git', args, {
+      cwd: dir,
+      stdio: 'pipe',
+      env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+    });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+  writeFileSync(path.join(dir, 'a.txt'), 'one\n');
+  git('add', 'a.txt');
+  git('commit', '-qm', 'first');
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of repos) rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  delete process.env.PITCHBOX_BUILD_ID;
+});
+
+describe('resolveBuildId', () => {
+  it('names the commit the bundle was built from', () => {
+    expect(resolveBuildId(repo())).toMatch(/^[0-9a-f]{7}$/);
+  });
+
+  it('marks a bundle built from a modified tree, which is not the commit it names', () => {
+    const dir = repo();
+    writeFileSync(path.join(dir, 'a.txt'), 'two\n');
+    expect(resolveBuildId(dir)).toMatch(/^[0-9a-f]{7}-dirty$/);
+  });
+
+  it('prefers an explicitly supplied id, for a build with no checkout', () => {
+    process.env.PITCHBOX_BUILD_ID = 'ci-1234';
+    expect(resolveBuildId(repo())).toBe('ci-1234');
+  });
+});

--- a/tests/extension-packaged-build.test.ts
+++ b/tests/extension-packaged-build.test.ts
@@ -36,6 +36,9 @@ function walk(dir: string): string[] {
 let files: string[] = [];
 
 const OVERRIDE_BACKEND = 'https://preview-invariant.pitchbox.app';
+// Pinned rather than left to the checkout's own commit, so the assertion
+// below is about the stamping and not about what HEAD happens to be.
+const BUILD_ID = 'test-build-id';
 
 beforeAll(() => {
   // Built with the override set, so the same run proves both that the
@@ -45,7 +48,11 @@ beforeAll(() => {
   execFileSync('pnpm', ['exec', 'vite', 'build'], {
     cwd: EXT_ROOT,
     stdio: 'pipe',
-    env: { ...process.env, VITE_DEFAULT_BACKEND_URL: OVERRIDE_BACKEND },
+    env: {
+      ...process.env,
+      VITE_DEFAULT_BACKEND_URL: OVERRIDE_BACKEND,
+      PITCHBOX_BUILD_ID: BUILD_ID,
+    },
   });
   files = walk(DIST);
 }, 300_000);
@@ -180,5 +187,25 @@ describe('the packaged extension', () => {
       (f) => f.endsWith('.js') && readFileSync(f, 'utf8').includes(OVERRIDE_BACKEND),
     );
     expect(carriers.map((f) => path.relative(DIST, f)).length).toBeGreaterThan(0);
+  });
+
+  it('stamps the build it was made from, so two bundles of one version differ', () => {
+    // The manifest version only moves on a release commit, so every bundle
+    // between two releases reported the same `0.17.0` in chrome://extensions
+    // with nothing else to go on. On 2026-09-10 a bundle built before a fix
+    // merged was judged as if it contained it, twice.
+    const manifest = JSON.parse(readFileSync(path.join(DIST, 'manifest.json'), 'utf8')) as {
+      version: string;
+      version_name?: string;
+    };
+    expect(manifest.version_name).toBe(`${manifest.version} (${BUILD_ID})`);
+
+    // And the side panel says the same thing, so the answer is reachable
+    // without opening chrome://extensions.
+    const carriers = files.filter(
+      (f) =>
+        f.endsWith('.js') && readFileSync(f, 'utf8').includes(`${manifest.version} (${BUILD_ID})`),
+    );
+    expect(carriers.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes LOR-213.

The manifest `version` only moves on a release commit, so every bundle built between two releases reports the same string in `chrome://extensions` and in the side panel's About card. That cost a round trip twice today: I installed "the latest 0.17.0 bundle", the in-page panel was still black, and the theme fix looked broken. It was not, the bundle was built at 18:52 and #658 merged at 20:11. The only way to tell the two apart was grepping the emitted content scripts for a literal that had changed (`pitchbox-panel dark` against the new conditional, `panel-elevation` absent).

`version_name` now carries the commit: `PITCHBOX_BUILD_ID` when a build has no checkout, the short sha otherwise, plus `-dirty` when the tree differs from HEAD. The same label feeds `VITE_APP_VERSION`, so the About card answers the question without opening `chrome://extensions`. `version` itself stays the plain release number, since that is what Chrome compares between installs.

## Verification

* `pnpm exec vitest run tests/extension-packaged-build.test.ts`: 8 green, including the new assertion that the built manifest's `version_name` is `<version> (<build id>)` and that an emitted chunk carries the same string. The build in that file now runs with `PITCHBOX_BUILD_ID` pinned, so the assertion is about the stamping rather than about what HEAD happens to be.
* `pnpm exec vitest run tests/extension-build-id.test.ts`: 3 green, covering the sha, the dirty tree and the explicit override against throwaway git repos. It sits in the root suite rather than `extension/tests/` because the extension's tsconfig carries no node types.
* `pnpm -F @pitchbox/extension check`: 793 files, 0 errors. `preflight` (test-postgres): pass in 550s.
* Built and loaded the real bundle: `chrome://extensions` shows `0.17.0 (a1910bc)`.
