### PR TITLE
fix(web): the dashboard's Docs link points at docs.pitchbox.app (LOR-209)

### DIFF
--- a/tests/docs-url.test.ts
+++ b/tests/docs-url.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * The docs site moved twice (D25 to GitHub Pages, D38 to `docs.pitchbox.app`)
+ * and both times a link in the app kept pointing at the old address, because
+ * the URL was a literal pasted into whichever component needed it. LOR-209
+ * collapsed it into `web/src/lib/config/docs.ts`; this keeps it collapsed and
+ * keeps the retired host out of the shipped code.
+ */
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const SCANNED = ['web/src', 'extension/src', 'daemon/src', 'shared/src', 'cli/src'];
+const RETIRED_HOST = 'fiorelorenzo.github.io';
+const DOCS_HOST = 'docs.pitchbox.app';
+
+/** Every source file under `dir`, repo-relative, with its contents. */
+function sources(dir: string): Array<{ file: string; text: string }> {
+  const out: Array<{ file: string; text: string }> = [];
+  const walk = (abs: string) => {
+    for (const entry of readdirSync(abs, { withFileTypes: true })) {
+      const child = path.join(abs, entry.name);
+      if (entry.isDirectory()) {
+        walk(child);
+        continue;
+      }
+      if (!/\.(ts|js|svelte|css|html|json)$/.test(entry.name)) continue;
+      out.push({ file: path.relative(repoRoot, child), text: readFileSync(child, 'utf8') });
+    }
+  };
+  walk(path.join(repoRoot, dir));
+  return out;
+}
+
+const files = SCANNED.flatMap(sources);
+
+describe('the documentation URL', () => {
+  it('never names the retired GitHub Pages host', () => {
+    const offenders = files.filter((f) => f.text.includes(RETIRED_HOST)).map((f) => f.file);
+    expect(offenders).toEqual([]);
+  });
+
+  it('is defined once, in web/src/lib/config/docs.ts', () => {
+    const holders = files.filter((f) => f.text.includes(DOCS_HOST)).map((f) => f.file);
+    expect(holders).toEqual(['web/src/lib/config/docs.ts']);
+  });
+
+  it('ends both of its URLs in a slash, since callers concatenate a page path', () => {
+    const module = readFileSync(path.join(repoRoot, 'web/src/lib/config/docs.ts'), 'utf8');
+    const urls = [...module.matchAll(/'(https?:\/\/[^']+)'/g)].map((m) => m[1]);
+    expect(urls).toHaveLength(2);
+    for (const url of urls) expect(`${url}auth`).toBe(new URL('auth', url).href);
+  });
+});

--- a/web/src/lib/components/Sidebar.svelte
+++ b/web/src/lib/components/Sidebar.svelte
@@ -19,16 +19,12 @@
 	} from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { dev } from '$app/environment';
 	import { cn } from '$lib/utils';
 	import { toast } from 'svelte-sonner';
 	import SystemStatusCard from '$lib/components/SystemStatusCard.svelte';
 	import OrgSwitcher from '$lib/components/OrgSwitcher.svelte';
 	import { resolveTone, PULSE_DOT_CLASS } from '$lib/config/status-badges';
-
-	// VitePress dev server runs on :5181 with base /pitchbox/. In production
-	// the published Pages site is the source of truth.
-	const DOCS_URL = dev ? 'http://localhost:5181/pitchbox/' : 'https://fiorelorenzo.github.io/pitchbox/';
+	import { DOCS_URL } from '$lib/config/docs';
 
 	// The marketing site (#429): the app moved off the apex to app.pitchbox.app
 	// (#422/#424), so nothing here pointed back at it until now.

--- a/web/src/lib/config/docs.ts
+++ b/web/src/lib/config/docs.ts
@@ -1,0 +1,15 @@
+import { dev } from '$app/environment';
+
+/**
+ * The documentation site, in one place.
+ *
+ * D38 (`docs/design/DECISIONS.md`) moved the site to its own host, so there is
+ * no path prefix any more: production is `https://docs.pitchbox.app/` and the
+ * local VitePress dev/preview server serves the same root base on :5181. Both
+ * halves of the old literal (`.../pitchbox/`) went stale in that move and
+ * nothing noticed, because the value was pasted into two components (LOR-209).
+ *
+ * The trailing slash is part of the value: callers concatenate a page path
+ * onto it (`${DOCS_URL}auth`).
+ */
+export const DOCS_URL = dev ? 'http://localhost:5181/' : 'https://docs.pitchbox.app/';

--- a/web/src/routes/settings/organization/+page.svelte
+++ b/web/src/routes/settings/organization/+page.svelte
@@ -10,7 +10,7 @@
   import { goto, invalidateAll } from '$app/navigation';
   import { UserPlus, Copy, Trash2, MoreHorizontal, Pencil } from '@lucide/svelte';
   import { untrack } from 'svelte';
-  import { dev } from '$app/environment';
+  import { DOCS_URL } from '$lib/config/docs';
   import PageContainer from '$lib/components/PageContainer.svelte';
   import RemoveMemberDialog from '$lib/components/settings/RemoveMemberDialog.svelte';
   import LeaveOrgDialog from '$lib/components/settings/LeaveOrgDialog.svelte';
@@ -50,10 +50,6 @@
     quota: OrgQuota | null;
   };
   let { data }: { data: PageData } = $props();
-
-  // VitePress dev server runs on :5181 with base /pitchbox/. In production
-  // the published Pages site is the source of truth.
-  const DOCS_URL = dev ? 'http://localhost:5181/pitchbox/' : 'https://fiorelorenzo.github.io/pitchbox/';
 
   const ROLE_CAPS = [
     {


### PR DESCRIPTION
Closes LOR-209.

The docs site moved to its own host in #640 (D38), but the dashboard kept the old GitHub Pages address in two hand-copied constants (`Sidebar.svelte`, `settings/organization/+page.svelte`), so every deployment linked at `fiorelorenzo.github.io/pitchbox/` - which answers 200 and then renders unstyled, because the site's base is the domain root now. The dev half was wrong the same way: VitePress serves `/`, not `/pitchbox/`.

One definition, `web/src/lib/config/docs.ts`, and a scan test over `web`, `extension`, `daemon`, `shared` and `cli` that fails if the retired host comes back or if a second copy of the current one appears. The test fails on the pre-fix tree (checked by stashing the source change: `never names the retired GitHub Pages host` goes red) and passes after.

Verified on the production build rather than by reading the source: `web/.svelte-kit/output/server/chunks/docs.js` carries `var DOCS_URL = "https://docs.pitchbox.app/"`, the organization page emits `${DOCS_URL}auth`, and a grep for the old host across the whole build output comes back empty. `pnpm -F web check` is clean (6115 files, 0 errors) and `preflight` passed on this tree.