### PR TITLE
fix(shared,tests): cache the model catalogue per gateway, and contain a test file's env (LOR-216, LOR-217)

### DIFF
--- a/shared/src/agents/sdk/runner.ts
+++ b/shared/src/agents/sdk/runner.ts
@@ -63,27 +63,35 @@ export interface SdkRunnerOptions {
 const DEFAULT_STEP_CEILING = 12;
 
 // Gateway model catalogue (for per-token pricing) is fetched once per
-// process and reused - it changes on the Gateway's own release cadence, not
+// gateway and reused - it changes on the Gateway's own release cadence, not
 // per run, and fetching it per run would add a network round trip to every
 // dispatch for a number a five-minute-old cache answers just as well.
+//
+// Keyed by the gateway that answered it rather than held in one process-wide
+// slot: an entry belongs to the credential and endpoint it came from, so two
+// gateways can never read each other's catalogue. In production there is one
+// gateway per API key and the behaviour is identical; what the old single
+// slot did instead was let whichever run resolved first decide the pricing
+// every later run would see, which is how a cancelled run's empty catalogue
+// could still be in the slot when the next run asked (LOR-216). A WeakMap
+// also means an abandoned gateway's entry goes with it instead of holding a
+// catalogue alive for five minutes.
 const MODEL_CATALOGUE_TTL_MS = 5 * 60 * 1000;
-let modelCatalogueCache: { value: GatewayLanguageModelEntry[]; expiresAt: number } | null = null;
-
-// Test-only escape hatch: the cache above is intentionally process-lifetime
-// in production (see the comment on it), but that means every SdkRunner
-// test in the same file/process shares one cache - a plain-catalogue test
-// that runs first would otherwise poison a later test's custom pricing for
-// up to five minutes. Not used by any production code path.
-export function __resetModelCatalogueCacheForTests(): void {
-  modelCatalogueCache = null;
-}
+const modelCatalogueCache = new WeakMap<
+  GatewayProvider,
+  { value: GatewayLanguageModelEntry[]; expiresAt: number }
+>();
 
 async function loadModelCatalogue(gateway: GatewayProvider): Promise<GatewayLanguageModelEntry[]> {
   const now = Date.now();
-  if (modelCatalogueCache && modelCatalogueCache.expiresAt > now) return modelCatalogueCache.value;
+  const cached = modelCatalogueCache.get(gateway);
+  if (cached && cached.expiresAt > now) return cached.value;
   try {
     const response = await gateway.getAvailableModels();
-    modelCatalogueCache = { value: response.models, expiresAt: now + MODEL_CATALOGUE_TTL_MS };
+    modelCatalogueCache.set(gateway, {
+      value: response.models,
+      expiresAt: now + MODEL_CATALOGUE_TTL_MS,
+    });
     return response.models;
   } catch {
     // Pricing is best-effort: a catalogue hiccup should not fail the run,
@@ -249,8 +257,8 @@ export class SdkRunner implements AgentRunner {
 
       // Resolved before the stream starts, not just at the end as before
       // #419: the mid-stream budget check below needs to price each step's
-      // usage as it accumulates, and `loadModelCatalogue` is cached process-
-      // wide anyway so moving it earlier costs nothing on a warm cache.
+      // usage as it accumulates, and `loadModelCatalogue` is cached per
+      // gateway anyway so moving it earlier costs nothing on a warm cache.
       const catalogueEntries = await loadModelCatalogue(gateway);
       const pricing: SdkModelPricing | undefined = pricingFromCatalogueEntry(
         catalogueEntries.find((m) => m.id === modelId),

--- a/shared/tests/agents/sdk/runner.test.ts
+++ b/shared/tests/agents/sdk/runner.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import type { streamText } from 'ai';
 import type { createGateway } from '@ai-sdk/gateway';
-import { SdkRunner, __resetModelCatalogueCacheForTests } from '../../../src/agents/sdk/runner.js';
+import { SdkRunner } from '../../../src/agents/sdk/runner.js';
 import type { ParsedEvent } from '../../../src/runlog/types.js';
 import type { PitchboxToolSet } from '../../../src/agents/sdk/tools.js';
 
@@ -87,10 +87,6 @@ let logDir: string;
 beforeEach(() => {
   logDir = tmpLogDir();
   process.env.AI_GATEWAY_API_KEY = 'test-key';
-  // Otherwise a plain-catalogue test's cached empty model list (5-minute
-  // TTL, process-lifetime by design) leaks into a later test that supplies
-  // its own pricing via a different fake gateway.
-  __resetModelCatalogueCacheForTests();
 });
 
 afterEach(() => {
@@ -424,6 +420,49 @@ describe('SdkRunner', () => {
     expect(resultEvent?.payload).toMatchObject({ type: 'result', success: false });
     expect(resultEvent?.raw).toMatch(/quota exhausted/);
     expect(resultEvent?.raw).toMatch(/monthly Gateway budget/);
+  });
+
+  it('prices a run from its own gateway catalogue, not from one an earlier gateway answered', async () => {
+    // LOR-216: the catalogue used to live in a single process-wide slot, so
+    // whichever gateway answered first decided the pricing every later run
+    // saw - including a cancelled run's empty catalogue landing in the slot
+    // after the next run had already started. Two runs here, the first on a
+    // gateway with no pricing at all, and the second must still be priced.
+    const unpriced = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGateway(),
+      createToolSetFn: fakeToolSet().fn,
+      streamTextFn: fakeStreamText(() =>
+        gen({
+          type: 'finish',
+          finishReason: 'stop',
+          totalUsage: { inputTokens: 1000, outputTokens: 1000 },
+        }),
+      ),
+    });
+    const unpricedRes = await unpriced.run({ ...baseOpts(), prompt: 'hi', attachMcp: false })
+      .result;
+    expect(unpricedRes.usage?.costUsd).toBeNull();
+
+    const priced = new SdkRunner({
+      config: { model: 'google/gemini-3.1-flash-lite' },
+      logDir,
+      createGatewayFn: fakeGatewayWithPricing('google/gemini-3.1-flash-lite', {
+        input: '0.000002',
+        output: '0.000002',
+      }),
+      createToolSetFn: fakeToolSet().fn,
+      streamTextFn: fakeStreamText(() =>
+        gen({
+          type: 'finish',
+          finishReason: 'stop',
+          totalUsage: { inputTokens: 1000, outputTokens: 1000 },
+        }),
+      ),
+    });
+    const pricedRes = await priced.run({ ...baseOpts(), prompt: 'hi', attachMcp: false }).result;
+    expect(pricedRes.usage?.costUsd).toBeCloseTo(0.004, 4);
   });
 
   it('does not abort a run that stays under its budgetRemainingUsd', async () => {

--- a/tests/setup-env.test.ts
+++ b/tests/setup-env.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { restoreEnv } from './setup-env';
+
+/**
+ * The containment in `tests/setup-env.ts` is what keeps one file's
+ * `PITCHBOX_EDITION` out of the next file's run (LOR-217). Its own behaviour
+ * is asserted against a plain object rather than the real `process.env`, so
+ * this test cannot itself become the leak it exists to prevent.
+ */
+
+describe('restoreEnv', () => {
+  it('removes a key the file added', () => {
+    const env: Record<string, string | undefined> = { KEEP: 'a' };
+    const snapshot = { ...env };
+    env.PITCHBOX_EDITION = 'cloud';
+    restoreEnv(snapshot, env);
+    expect(env).toEqual({ KEEP: 'a' });
+  });
+
+  it('puts back a key the file changed, and one it deleted', () => {
+    const env: Record<string, string | undefined> = { EDITION: 'self-hosted', TOKEN: 'x' };
+    const snapshot = { ...env };
+    env.EDITION = 'cloud';
+    delete env.TOKEN;
+    restoreEnv(snapshot, env);
+    expect(env).toEqual({ EDITION: 'self-hosted', TOKEN: 'x' });
+  });
+
+  it('leaves an untouched environment alone', () => {
+    const env: Record<string, string | undefined> = { A: '1', B: '2' };
+    const snapshot = { ...env };
+    restoreEnv(snapshot, env);
+    expect(env).toEqual({ A: '1', B: '2' });
+  });
+});

--- a/tests/setup-env.ts
+++ b/tests/setup-env.ts
@@ -1,0 +1,46 @@
+import { beforeAll, afterAll } from 'vitest';
+
+/**
+ * Environment containment between test files.
+ *
+ * `fileParallelism` is off and vitest reuses one worker process, so all 355
+ * test files share one `process.env`. Thirty of them set `PITCHBOX_EDITION`
+ * (and a few set other keys) and restore it by hand, which holds only while
+ * nothing throws between the assignment and the restore. When it does not
+ * hold, the file that pays is some unrelated one later in the run: a
+ * suggestion route answering `Agent runner "claude-code" is not available in
+ * this deployment's edition` because a previous file left the deployment on
+ * cloud (LOR-217). That failure names neither the leak nor the leaking file,
+ * which is what makes a red `preflight` unreadable.
+ *
+ * This snapshots the environment when a file starts and puts it back when the
+ * file ends, so a leak cannot outlive the file that caused it. Inside a file,
+ * a test still sees what its own `beforeEach` set, which is what those tests
+ * are for.
+ */
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Undo every difference between `process.env` and `snapshot`: keys added
+ * since are removed, keys changed are put back, keys deleted are restored.
+ */
+export function restoreEnv(snapshot: Env, env: Env = process.env): void {
+  for (const key of Object.keys(env)) {
+    if (!(key in snapshot)) delete env[key];
+    else if (env[key] !== snapshot[key]) env[key] = snapshot[key];
+  }
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (!(key in env) && value !== undefined) env[key] = value;
+  }
+}
+
+let snapshot: Env = {};
+
+beforeAll(() => {
+  snapshot = { ...process.env };
+});
+
+afterAll(() => {
+  restoreEnv(snapshot);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -98,6 +98,12 @@ export default defineConfig({
     // it through the plugin like any workspace source file instead.
     server: { deps: { inline: [/@lucide\/svelte/] } },
     globalSetup: ['./tests/global-setup.ts'],
+    // Runs inside every test file: snapshots `process.env` before the file
+    // and restores it after, so a variable one file sets (and fails to
+    // restore, which a hand-rolled restore does whenever something throws
+    // first) cannot change what a later file sees. See tests/setup-env.ts
+    // for what that failure actually looked like (LOR-217).
+    setupFiles: ['./tests/setup-env.ts'],
     // Point all tests at a dedicated test database so they never truncate the
     // user's real data. AI_GATEWAY_API_KEY is blanked the same way and for the
     // same reason: dotenv (shared/src/db/client.ts) loads the developer's real

--- a/web/tests/extension-suggest-loop.test.ts
+++ b/web/tests/extension-suggest-loop.test.ts
@@ -11,7 +11,6 @@ import type {
 } from '@ai-sdk/provider';
 import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
 import { getDb, schema } from '@pitchbox/shared/db';
-import { __resetModelCatalogueCacheForTests } from '@pitchbox/shared/agents/sdk/runner';
 import type { RunnerConfig } from '@pitchbox/shared/agents/config';
 import type { ObservedPost } from '@pitchbox/shared/assist/suggest-prompt';
 import {
@@ -169,13 +168,11 @@ async function reset() {
   await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
   currentGatewayFn = null;
   process.env.AI_GATEWAY_API_KEY = 'test-key';
-  // The runner's model-catalogue cache is process-wide with a 5-minute TTL
-  // by design (real deployments never re-fetch per run) - in this file's
-  // test process that means an earlier test's plain, empty-catalogue
-  // `useModel()` call would otherwise leak into a later test that supplies
-  // real pricing via a different fake gateway, exactly the trap
-  // `shared/tests/agents/sdk/runner.test.ts` already guards against (#574).
-  __resetModelCatalogueCacheForTests();
+  // The runner's catalogue cache is keyed by the gateway that answered it
+  // (LOR-216), and `useModel` builds a fresh gateway per test, so an
+  // earlier test's empty catalogue cannot be read by a later one that
+  // wires real pricing - including when the earlier run is still finishing
+  // in the background after a cancellation.
 }
 
 async function seedOrgProject(slug: string) {


### PR DESCRIPTION
Two independent hardening changes found while chasing a red `preflight` I could not attribute. **Neither one makes the local full suite green**, and the body below says exactly what is still failing, so nobody reads this as the flake being solved.

**LOR-216, a real defect.** `shared/src/agents/sdk/runner.ts` kept the Gateway model catalogue (the per-token pricing a run is costed with) in one module-level slot with a five-minute TTL. The slot recorded what the catalogue said, not which gateway said it, so the first run to resolve decided the pricing every run in the process saw. In production that is latent - one gateway per deployment today - but a second key or a per-tenant credential would read the wrong catalogue, and an unpriced run silently disables the mid-stream cost ceiling. Keyed by gateway (`WeakMap<GatewayProvider, ...>`) it cannot happen, the test-only reset hook becomes dead and goes with it, and an abandoned gateway's entry is collected instead of pinning a catalogue for five minutes.

The regression test runs an unpriced gateway and a priced one in the same process and asserts the second is priced. Checked both ways: it fails on the old code (`costUsd` null), passes on the new.

**LOR-217, hygiene.** `fileParallelism` is off and vitest reuses one worker, so all 356 files share one `process.env`; thirty of them set `PITCHBOX_EDITION` and restore it by hand, which holds only while nothing throws in between. `tests/setup-env.ts` snapshots the environment before each file and restores it after, so a leak cannot outlive its own file. `restoreEnv` is asserted against a plain object rather than the real environment, so the test cannot become the leak it prevents.

**What is still red locally, and why I am not claiming otherwise.** With both changes in, `preflight` still fails four tests across three files: the two cost-ceiling assertions in `extension-suggest-loop`, and `event: done` in `extension-suggest-plan-limit` and `extension-suggest-payment-required`, the latter two on `Agent runner "claude-code" is not available in this deployment's edition`. Those two files set the cloud edition themselves, on purpose, so the leak hypothesis is disproved for them: what changes between a passing isolated run and a failing full run is the project's resolved runner, which points at configuration state (`app_config` / `runner_configs`) surviving between files rather than at the environment. The set of failing files moved between runs, which is why I am not guessing at a third fix in this PR. Follow-up stays on LOR-217.

CI is green on `main` through all of this; the flake is local-suite only.

Note for review: this touches `vitest.config.ts` (adds `setupFiles`), which is repo-wide.