### PR TITLE
fix(shared): cloud-runner availability follows the credential, not the first call (LOR-217)

### DIFF
--- a/shared/src/agents/detect.ts
+++ b/shared/src/agents/detect.ts
@@ -60,36 +60,45 @@ async function probe(binary: string): Promise<DetectResult> {
   }
 }
 
+// Only real binary probes are cached: spawning a CLI to read its version is
+// what this exists to avoid paying for twice.
 const cache = new Map<AgentRunnerSlug, Promise<DetectResult>>();
 
 export function detectRunner(slug: AgentRunnerSlug): Promise<DetectResult> {
+  if (slug === 'cloud') {
+    // No local binary: the SDK runner (shared/src/agents/sdk/runner.ts) runs
+    // in-process and is "available" whenever this deployment has a Gateway
+    // credential to reach a model with - no separate service, no runner URL.
+    //
+    // Deliberately not cached. Reading an environment variable costs nothing,
+    // while a cached answer freezes the deployment's capability at whatever
+    // was true the first time anything asked: a process that resolved this
+    // before the credential was in place keeps reporting the cloud runner
+    // unavailable for its whole life, and every project that then resolves a
+    // default runner gets a local slug the cloud edition refuses to dispatch
+    // (LOR-217).
+    const enabled = !!process.env.AI_GATEWAY_API_KEY;
+    return Promise.resolve({
+      available: enabled,
+      version: enabled ? 'managed' : null,
+      path: null,
+      error: enabled ? null : 'Set AI_GATEWAY_API_KEY to enable the cloud runner.',
+      detectedAt: new Date().toISOString(),
+    });
+  }
   let pending = cache.get(slug);
   if (!pending) {
-    if (slug === 'cloud') {
-      // No local binary: the SDK runner (shared/src/agents/sdk/runner.ts) runs
-      // in-process and is "available" whenever this deployment has a Gateway
-      // credential to reach a model with - no separate service, no runner URL.
-      const enabled = !!process.env.AI_GATEWAY_API_KEY;
+    const binary = BINARY_BY_SLUG[slug];
+    if (!binary) {
       pending = Promise.resolve({
-        available: enabled,
-        version: enabled ? 'managed' : null,
+        available: false,
+        version: null,
         path: null,
-        error: enabled ? null : 'Set AI_GATEWAY_API_KEY to enable the cloud runner.',
+        error: 'No local binary - managed by the runtime.',
         detectedAt: new Date().toISOString(),
       });
     } else {
-      const binary = BINARY_BY_SLUG[slug];
-      if (!binary) {
-        pending = Promise.resolve({
-          available: false,
-          version: null,
-          path: null,
-          error: 'No local binary - managed by the runtime.',
-          detectedAt: new Date().toISOString(),
-        });
-      } else {
-        pending = probe(binary);
-      }
+      pending = probe(binary);
     }
     cache.set(slug, pending);
   }

--- a/shared/tests/agents/detect.test.ts
+++ b/shared/tests/agents/detect.test.ts
@@ -32,4 +32,24 @@ describe('runner detection', () => {
     const third = await detectRunner('claude-code');
     expect(third.detectedAt).not.toBe(first.detectedAt);
   });
+
+  it('reports the cloud runner from the credential as it is now, not as it was on the first call', async () => {
+    // LOR-217: this answer used to be cached like a binary probe, so a
+    // process that asked once before AI_GATEWAY_API_KEY was in place kept
+    // reporting the managed runner unavailable for its whole life - and
+    // every project that then resolved a default runner got a local slug the
+    // cloud edition refuses to dispatch.
+    const saved = process.env.AI_GATEWAY_API_KEY;
+    try {
+      delete process.env.AI_GATEWAY_API_KEY;
+      expect((await detectRunner('cloud')).available).toBe(false);
+      process.env.AI_GATEWAY_API_KEY = 'a-key';
+      expect((await detectRunner('cloud')).available).toBe(true);
+      delete process.env.AI_GATEWAY_API_KEY;
+      expect((await detectRunner('cloud')).available).toBe(false);
+    } finally {
+      if (saved === undefined) delete process.env.AI_GATEWAY_API_KEY;
+      else process.env.AI_GATEWAY_API_KEY = saved;
+    }
+  });
 });


### PR DESCRIPTION
Closes LOR-217. This is the actual cause of the unattributable red `preflight` I chased through #664: with it, `preflight` is green on the full suite (exit 0, 3110 tests), where the four runs before it failed one to four tests across three files.

`detectRunner` cached the `cloud` answer in the same map as the real binary probes. But that answer is only `!!process.env.AI_GATEWAY_API_KEY`: free to compute, and not stable for the life of a process. Cached, whichever code path asked first froze the deployment's capability. A process that resolved it before the credential was in place reported the managed runner unavailable forever, every project resolving a default runner after that got a local slug, and the cloud edition then refused to dispatch it - `Agent runner "claude-code" is not available in this deployment's edition`. In the suite that surfaced as suggest-path files failing far from whatever was under test, with a different subset each run depending on which file asked first, which is exactly how it evaded four rounds of diagnosis. In production it is the reason a container started a moment before its secret lands could stay convinced it has no runner.

Binary probes stay cached: spawning a CLI to read its version is what the cache exists for.

The regression test asserts the answer tracks the credential across three flips in one process. Checked both ways: it fails on the old code at the first flip (`expected false to be true`), passes on the new.

What this also retires: the `clearDetectionCache()` calls sprinkled through the runner tests are no longer load-bearing for the cloud slug, though they stay for the binary probes they were also written for.