### PR TITLE
docs: a page on how a draft is kept from reading as AI (LOR-226)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         text: 'Concepts',
         items: [
           { text: 'Projects · accounts · campaigns', link: '/concepts' },
+          { text: "Why a draft doesn't read as AI", link: '/voice' },
           { text: 'Agent runners', link: '/runners' },
           { text: 'Playbooks', link: '/playbooks' },
           { text: 'Notifications', link: '/notifications' },

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -91,9 +91,13 @@ Both endpoints return `{ results: [{ id, status, reason? }] }` so the UI can sur
 
 The inbox detail panel offers a `Regenerate` action alongside Approve/Reject. The user can optionally supply a short hint (e.g. "shorter and warmer"); the API `POST /api/drafts/[id]/regenerate` invokes the shared helper which records the hint into `draft_regeneration_hints`, increments `drafts.regeneration_count`, and appends a `regenerated` draft_event. The same helper backs `pitchbox drafts:regenerate <id>` so CLI-triggered regenerations leave the same audit trail.
 
-## LLM-judge quality scoring
+## Quality scoring
 
-New drafts can be scored 0-100 by an LLM judge invoked from `shared/src/quality-judge.ts`. The rubric and thresholds live in `app_config.quality_rubric`:
+New drafts carry a 0-100 quality score, but it is self-reported, not an
+independent judge's opinion: `shared/src/quality-judge.ts` holds only the
+rubric template and the score-to-band mapping, and no model call is ever
+made from that module. The rubric and thresholds live in
+`app_config.quality_rubric`:
 
 ```json
 {
@@ -103,9 +107,15 @@ New drafts can be scored 0-100 by an LLM judge invoked from `shared/src/quality-
 }
 ```
 
-The score, reason and judge model are persisted on `drafts.quality_score`, `drafts.quality_reason`, `drafts.quality_model`. The inbox renders a colour-coded `Q<score>` badge next to each draft (red `< threshold_red`, green `>= threshold_green`, amber in between) and exposes a `?minQuality=<n>` filter on the URL.
-
-Scoring is inline: the agent that writes a draft body (on creation, regeneration, or reply) scores it 0-100 against `rubric_template` and passes the score back on the same tool call that persists the body, so every draft is scored at write time with no separate scoring pass.
+Scoring is inline: whenever the agent writes a draft body, it is handed
+`rubric_template` and scores its own output against it, passing the score
+back on the same tool call that persists the body - there is no separate
+scoring pass, and no second model checking the first one's work. The score,
+reason and the model that wrote (and scored) the draft are persisted on
+`drafts.quality_score`, `drafts.quality_reason`, `drafts.quality_model`. The inbox renders a
+colour-coded `Q<score>` badge next to each draft (red `< threshold_red`,
+green `>= threshold_green`, amber in between) and exposes a
+`?minQuality=<n>` filter on the URL.
 
 ## A/B variant drafts
 

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -1,0 +1,127 @@
+# Why a draft doesn't read like ChatGPT
+
+Three separate mechanisms do this work. A measurement of your own writing
+catches what actually repeats in it. A checker runs after the model and can
+refuse to accept what it wrote. A hard boundary limits what the extension is
+even allowed to read in the first place. None of the three is a prompt
+asking the model to "sound human" - each is code you can read, named below
+next to the file it lives in.
+
+## What the system reads about you
+
+Two tables hold what Pitchbox knows about you specifically: `operator_profiles`
+(your persona - handle, headline, about, experience) and
+`operator_voice_samples` (your own recent posts). Both are populated by the
+Chrome extension's content script reading whatever your own browser already
+rendered on your own `/in/<slug>` and `recent-activity` pages
+(`extension/src/content/linkedin-profile-capture.ts`), and both are editable
+by hand from the **Companion** section of the dashboard - the persona at
+`/companion`, the voice samples (excludable one by one) and the derived
+summary at `/companion/voice`.
+
+The boundary that makes this safe: no code path in this product ever issues a
+request toward linkedin.com. The extension reads the DOM already in front of
+you and posts what it found to Pitchbox's own backend - the profile-capture
+script's own comment spells out why the request path is even named apart from
+the word "linkedin" (`OPERATOR_PROFILE_PATH`, same file), so a static scanner
+can tell "posts to our backend" from "fetches LinkedIn" on sight. That
+scanner is real, not a promise: `pnpm run test:linkedin-compliance`
+(`tests/compliance/linkedin-boundary.test.ts`) parses the built extension and
+fails on six things - a fetch toward linkedin.com or licdn, a cookie or
+storage read inside a LinkedIn content script, a synthetic click or submit on
+a LinkedIn element, an alarm reachable from LinkedIn code, a network call
+anywhere in the LinkedIn platform directory, and the LinkedIn host permission
+turning into a blanket grant instead of the optional one it has to stay. It
+is a required CI check, and it inspects the real manifest and source, not a
+checklist someone filled in.
+
+## How the voice profile is derived
+
+`shared/src/assist/voice-profile.ts` is a measurement, not a model call. It
+reads your voice samples, your sent messages, your sent drafts and your
+project templates, and counts what actually repeats:
+
+- Sentence length, and how much it varies from one piece of writing to the next.
+- Paragraph shape.
+- Punctuation habits.
+- How often you write in the first or second person.
+- How often you hedge.
+- Which words you reuse.
+- The split between English and Italian.
+
+Every one of those is a countable property of text that already exists,
+computed with no I/O and no model in the loop.
+
+The floor is explicit: `MIN_ITEMS_TO_DERIVE` is 3. Below that, the function
+returns nothing measured, because two posts sharing an opening word is a
+coincidence, not a habit - a smaller corpus can't tell the difference and the
+code doesn't pretend otherwise. Below the floor, `shared/src/assist/voice-defaults.ts`
+supplies a fallback instead: a short, named set of rules ("open with a short
+first sentence," "no tricolons," "plain words") that is stated as a default
+in its own text, never phrased as if it came from reading anything you wrote.
+`shared/src/operator-voice-profile.ts`'s `resolveVoiceProfile` is what keeps
+the two from blurring together - every axis it hands back is labelled
+`measured` or `default`, never both, so nothing downstream can present a
+guess as a fact about you.
+
+## The house style, and why it is code
+
+`shared/src/house-style.ts` holds the prose every playbook carries verbatim,
+under the heading `## House style: write like a human`. `shared/src/style-check.ts`
+is the part that actually runs against what a draft came back with. It
+catches, among other things:
+
+- Em dashes, curly quotes and curly apostrophes, the single-character
+  ellipsis, non-breaking spaces - e.g. `word — word` becomes `word, word`.
+- Filler openers - `"Great post!"`, `"Thanks for sharing"`.
+- Puffery words - `leverage`, `unlock`, `delve`, `game-changer`.
+- Wrap-up closers - `"at the end of the day"`, `"hope this helps"`.
+- The "not just X but Y" construction.
+- A rhetorical question as the opening sentence.
+- Tricolons (three items closed with an Oxford comma and "and").
+- Hashtag stacks and emoji used as bullet points.
+
+There are two kinds of finding, and they are handled differently.
+A character-level finding (an em dash, a curly quote) is repaired
+mechanically by `applyMechanicalRepairs` - a string substitution, no model
+call. A structural finding (a tricolon, a rhetorical opener) can't be fixed
+that way, so `enforceHouseStyle` sends the draft back to the model exactly
+once, naming the exact span that failed, and checks the result again. A
+finding still present after that round trip is never silently dropped: it
+travels with the draft so a human sees it rather than a cleaned-up draft
+that quietly still has the tell.
+
+## What you can steer
+
+- **Tone.** `Settings → LinkedIn assist` sets a default register for every
+  suggestion, chosen from six presets:
+  - Match the room - the default, mixing the post's own register with your voice.
+  - Professional.
+  - Plain.
+  - Warm.
+  - Technical.
+  - In my own words - a free-text note you write yourself.
+- **Retune, per suggestion.** The panel itself offers Drier, Warmer or
+  Shorter on the draft currently on screen, without touching the stored
+  tone setting - it's a one-off request on that call, not a preference.
+- **Voice samples.** Any post under `/companion/voice` can be excluded from
+  the corpus without deleting it, so a capture you don't want feeding the
+  measurement doesn't just come back on the next page load.
+- **The derived summary itself.** You can hand-edit it, and a manual edit
+  survives the next refresh until you explicitly reset it back to derived
+  (`resetVoiceProfileToDerived` in `shared/src/operator-voice-profile.ts`).
+
+## What it will not do
+
+It does not send anything. The extension writes drafted text into the
+composer already open on the page (`insertComposerText` in
+`extension/src/content/linkedin-comment.ts`) and copies it to the clipboard
+as a fallback - you press LinkedIn's own submit button, always.
+
+It does not imitate anyone but you. Every corpus item the voice measurement
+reads is scoped to your own organization - your own samples, your own sent
+messages, your own sent drafts.
+
+It does not claim to know your voice from nothing. Below the three-item
+floor it says so in its own text rather than guessing: "No writing on file
+yet, so this is a default style, not a measurement."


### PR DESCRIPTION
I added `docs/voice.md`, the page a sceptic follows from the landing's evidence link. It covers, in order, the persona and voice samples the extension reads off your own LinkedIn pages (`operator_profiles`, `operator_voice_samples`, populated by `extension/src/content/linkedin-profile-capture.ts`), the boundary that makes that safe (no request ever goes toward linkedin.com, enforced by the required `pnpm run test:linkedin-compliance` check against `tests/compliance/linkedin-boundary.test.ts`), how `shared/src/assist/voice-profile.ts` measures a voice from your own writing with a three-item floor below which `shared/src/assist/voice-defaults.ts` supplies an explicitly labelled default instead, what `shared/src/house-style.ts` and `shared/src/style-check.ts` actually catch with a one-line example of each, what an operator can steer (tone presets and note at Settings -> LinkedIn assist, per-suggestion retune, excluding a voice sample, hand-editing the derived summary and resetting it), and what the product refuses to do.

Every claim names the file or command it came from, and I read that file in this worktree before writing the sentence rather than trusting the issue's own description of it. The page itself avoids the tells it describes - I ran `shared/src/style-check.ts`'s `checkStyle` over the draft and rewrote three passages that tripped its tricolon rule on my own connective prose (the only findings left are literal citations of the banned phrases the checker catches, same as the source file's own comments do).

I also fixed `concepts.md`'s "LLM-judge quality scoring" section, which is in scope per the issue. `shared/src/quality-judge.ts` only holds a rubric template and a score-to-band mapping, no model call is ever made from that module. The score is self-reported: the same agent that writes a draft body scores its own output against the rubric and passes the score back on the same tool call that persists the body. The old heading and wording implied an independent judge that doesn't exist in the code, so I renamed the section to "Quality scoring" and said plainly what happens.

Registered the new page in the sidebar's Concepts group in `docs/.vitepress/config.ts`, right after the projects/accounts/campaigns page.

**Verification**

- `pnpm run docs:build` succeeds; the page renders at `/voice` (cleanUrls) and shows in the sidebar under Concepts.
- Shot `pnpm run docs:preview` (port 4173) in light and dark. GitHub has nowhere to host them from a CLI, so both are attached to LOR-226 - they confirm the docs site's own token copy (D39) covers the new page correctly in both themes.
- `npx eslint docs/.vitepress/config.ts` clean; `npx prettier --check` clean on all three changed files.
- `pnpm test` against my own `pitchbox_test_lor226` database: 3109 passed, 2 failed, both in `web/tests/extension-suggest-loop.test.ts` on cost-ceiling token accounting. Nothing this change touches (only markdown and the sidebar config), and it's a known local-suite-only flake already tracked from #664/LOR-216 - CI stays green on `main` through it.

Closes LOR-226
https://linear.app/fiorelorenzo/issue/LOR-226/docs-a-page-on-how-a-draft-is-kept-from-reading-as-ai
