### PR TITLE
feat(cli,playbooks): the campaign drafting turn gets the operator's voice and checks its own style

### DIFF
--- a/bin/pitchbox-assist-mcp
+++ b/bin/pitchbox-assist-mcp
@@ -3,7 +3,9 @@
 # server source (cli/src/mcp/assist-server.ts). Exposes only the seven
 # read-only in-page-assistant tools (shared/src/assist/tools.ts) to the ACP
 # path's agent loop, bound to one organization and one project rather than to
-# a run - the campaign MCP server's 26 tools (bin/pitchbox-mcp) stay a
-# separate plane and are never reachable from here.
+# a run - the campaign MCP server's 29 tools (bin/pitchbox-mcp) stay a
+# separate plane and are never reachable from here. Three of those 29 are
+# read-only reuses of assist tools by name (LOR-224); the isolation this
+# comment is about is write authority, not overlapping tool names.
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
 exec "$REPO_ROOT/node_modules/.bin/tsx" "$REPO_ROOT/cli/src/mcp/assist-index.ts" "$@"

--- a/cli/src/commands/drafts.ts
+++ b/cli/src/commands/drafts.ts
@@ -480,6 +480,38 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
       },
       orgId,
     );
+
+    // LOR-224: this is the measurement of whether the in-run check works.
+    // The playbook is now expected to call the `check_style` MCP tool on
+    // each body before ever calling `drafts_create`, and fix what it finds
+    // while the model is still in the loop - the one place a structural
+    // finding can actually be repaired (see the comment on `styled` above:
+    // this backstop has no live model to send a rewrite back to). A run
+    // event, not just an in-memory count, is what lets that number be
+    // compared across runs after the fact instead of trusted on faith.
+    // Written as an `unknown`-kind event (the client's `EventKind` union
+    // already renders it via `UnknownEvent`) rather than a new kind, so no
+    // client-side type needs to grow for one counter.
+    const findingsAtCreate = styled.reduce(
+      (sum, d) => sum + d.styleFindings.length + (d.variantStyleFindings?.flat().length ?? 0),
+      0,
+    );
+    const [{ maxSeq }] = await db
+      .select({ maxSeq: sql<number>`coalesce(max(${schema.runEvents.seq}), 0)` })
+      .from(schema.runEvents)
+      .where(eq(schema.runEvents.runId, runId));
+    const rawPayload = JSON.stringify({
+      runId,
+      draftCount: styled.length,
+      findingsCount: findingsAtCreate,
+    });
+    await db.insert(schema.runEvents).values({
+      runId,
+      seq: maxSeq + 1,
+      kind: 'unknown',
+      payload: { type: 'unknown', eventType: 'style-findings-at-create', raw: rawPayload },
+      raw: rawPayload,
+    });
   }
 
   return { runId, inserted: inserted.length, skipped, dedupSkipped };

--- a/cli/src/mcp/assist-server.ts
+++ b/cli/src/mcp/assist-server.ts
@@ -5,8 +5,10 @@
 // (docs/design/in-page-agent.md, section 1). A sibling of
 // `cli/src/mcp/server.ts`, the campaign MCP server - deliberately not built
 // on top of it or importing any of its tool registrations, because the two
-// planes carry different privileges (26 tools, most of them writers, bound
-// to a `runs` row, vs seven read-only tools bound to an org).
+// planes carry different privileges (29 tools, most of them writers, bound
+// to a `runs` row, vs seven read-only tools bound to an org - three of the
+// 29 reuse these same handlers by name, LOR-224, but that is a read-only
+// overlap, not a shared write surface).
 // Handing the assistant `drafts_create` or `run_finish` because they happen
 // to share a process would undo the isolation #520 exists for.
 //

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -43,6 +43,8 @@ import {
   projectInsights,
 } from '../commands/project.js';
 import { skillGenerateStart, skillGenerateFinish } from '../commands/skill.js';
+import { ASSIST_TOOLS_BY_NAME, type AssistToolContext } from '@pitchbox/shared/assist/tools';
+import { loadCompanionContext } from '@pitchbox/shared/assist/context';
 
 // The Pitchbox MCP server exposes the data-access surface that playbooks need as
 // MCP tools, reusing the same query logic as the `pitchbox` CLI. It is the single
@@ -138,6 +140,25 @@ export function createPitchboxMcpServer(ctx: PitchboxMcpContext = {}): McpServer
       })();
     }
     return sessionProjectIdPromise;
+  };
+
+  // The operator's own persona for this session's organization, loaded once
+  // and reused by every LOR-224 tool below (`operator_voice`,
+  // `my_prior_takes`) - the same one-row-per-org shape `assist/context.ts`'s
+  // `loadCompanionContext` already resolves for the assist plane. A session
+  // with no bound organization has no persona to load either; the tool
+  // itself refuses in that case rather than this loader inventing a value.
+  let operatorPersonaPromise: Promise<AssistToolContext['operator']> | null = null;
+  const sessionOperatorPersona = (): Promise<AssistToolContext['operator']> => {
+    if (!operatorPersonaPromise) {
+      operatorPersonaPromise = (async () => {
+        const orgId = await sessionOrgId();
+        if (orgId == null) return null;
+        const { persona } = await loadCompanionContext(getDb(), { organizationId: orgId });
+        return persona;
+      })();
+    }
+    return operatorPersonaPromise;
   };
 
   /**
@@ -455,6 +476,50 @@ export function createPitchboxMcpServer(ctx: PitchboxMcpContext = {}): McpServer
       }
     },
   );
+
+  // LOR-224: the campaign plane gets the same three read-only reads the
+  // assist plane already has (`shared/src/assist/tools.ts`), reusing their
+  // exact handlers rather than a second implementation - only the context
+  // each handler receives differs (an org resolved from this session's
+  // run/campaign/project, no observed target, since a campaign run has no
+  // single post it is looking at). This is not a regression of #520's
+  // plane isolation: #520 is about *write* authority (the assist plane must
+  // never reach `drafts_create` or `run_finish`), and these three tools
+  // write nothing - they are ordinary org-scoped reads of the operator's
+  // own data, gated by `checkOwnership`'s same `sessionOrgId()` every other
+  // read on this server already uses. A playbook calls `operator_voice` and
+  // `my_prior_takes` before drafting, and `check_style` on the body it is
+  // about to hand to `drafts_create`, so a structural house-style finding
+  // can be repaired while the model is still in the loop - the post-hoc
+  // check inside `createDrafts` has no live model to send a rewrite back
+  // to (see the comment there).
+  const CAMPAIGN_ASSIST_TOOLS = ['operator_voice', 'my_prior_takes', 'check_style'] as const;
+  for (const toolName of CAMPAIGN_ASSIST_TOOLS) {
+    const tool = ASSIST_TOOLS_BY_NAME[toolName];
+    server.registerTool(
+      tool.name,
+      { title: tool.name, description: tool.description, inputSchema: tool.schema },
+      async (args: Record<string, unknown>, extra: { signal?: AbortSignal }) => {
+        const orgId = await sessionOrgId();
+        if (orgId == null) {
+          return errorResult(
+            `${tool.name} needs a session bound to an organization - no run/campaign/project id is set`,
+          );
+        }
+        try {
+          const toolCtx: AssistToolContext = {
+            db: getDb(),
+            orgId,
+            observedTarget: null,
+            operator: await sessionOperatorPersona(),
+          };
+          return jsonResult(await tool.handler(toolCtx, args, extra?.signal));
+        } catch (err) {
+          return errorResult(String(err instanceof Error ? err.message : err));
+        }
+      },
+    );
+  }
 
   server.registerTool(
     'subreddit_snapshot',

--- a/cli/tests/commands/drafts-create.test.ts
+++ b/cli/tests/commands/drafts-create.test.ts
@@ -157,6 +157,91 @@ describe('pitchbox drafts:create', () => {
     expect(metadata.styleFindings).toBeDefined();
     expect(metadata.styleFindings!.map((f) => f.ruleId)).toContain('rhetorical-question-opener');
     expect(metadata.styleFindings!.map((f) => f.ruleId)).not.toContain('em-dash');
+
+    // LOR-224: the finding that survived to this post-hoc backstop is
+    // recorded as a run event too, not just in the draft's own metadata -
+    // that count is the measurement of whether a playbook's own in-run
+    // check_style call is actually catching things before they get here.
+    const events = await db
+      .select()
+      .from(schema.runEvents)
+      .where(eq(schema.runEvents.runId, run.id));
+    const stylePayloads = events.map((e) => e.payload as { eventType?: string });
+    const styleEventIndex = stylePayloads.findIndex(
+      (p) => p.eventType === 'style-findings-at-create',
+    );
+    expect(styleEventIndex).toBeGreaterThanOrEqual(0);
+    const eventPayload = JSON.parse(events[styleEventIndex].raw) as {
+      runId: number;
+      draftCount: number;
+      findingsCount: number;
+    };
+    expect(eventPayload.runId).toBe(run.id);
+    expect(eventPayload.draftCount).toBe(1);
+    expect(eventPayload.findingsCount).toBe(1);
+  });
+
+  it('records a zero-findings run event when the draft is already clean (LOR-224)', async () => {
+    const db = getDb();
+    const [platform] = await db
+      .select()
+      .from(schema.platforms)
+      .where(eq(schema.platforms.slug, 'reddit'));
+    const [org] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(sql`slug = 'default'`);
+    const [project] = await db
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'style-clean-demo', name: 'D' })
+      .returning();
+    const [account] = await db
+      .insert(schema.accounts)
+      .values({ projectId: project.id, platformId: platform.id, handle: 'dana', role: 'personal' })
+      .returning();
+    const [campaign] = await db
+      .insert(schema.campaigns)
+      .values({
+        projectId: project.id,
+        platformId: platform.id,
+        name: 'c',
+        skillSlug: 'reddit-scout',
+        config: {},
+      })
+      .returning();
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ campaignId: campaign.id, trigger: 'manual', status: 'running' })
+      .returning();
+
+    const payload = JSON.stringify([
+      {
+        accountId: account.id,
+        kind: 'dm',
+        subreddit: 'rpg',
+        targetUser: 'erin',
+        body: 'This is a plain, human sentence with nothing to flag.',
+        metadata: {},
+      },
+    ]);
+
+    const out = cli(`drafts:create --run=${run.id}`, payload);
+    const lines = out.trim().split('\n');
+    const res = JSON.parse(lines[lines.length - 1]);
+    expect(res.ok).toBe(true);
+    expect(res.data.inserted).toBe(1);
+
+    const events = await db
+      .select()
+      .from(schema.runEvents)
+      .where(eq(schema.runEvents.runId, run.id));
+    const stylePayloads = events.map((e) => e.payload as { eventType?: string });
+    const styleEventIndex = stylePayloads.findIndex(
+      (p) => p.eventType === 'style-findings-at-create',
+    );
+    expect(styleEventIndex).toBeGreaterThanOrEqual(0);
+    const eventPayload = JSON.parse(events[styleEventIndex].raw) as { findingsCount: number };
+    expect(eventPayload.findingsCount).toBe(0);
   });
 
   it('persists an inline quality score supplied at creation (issue #41)', async () => {

--- a/cli/tests/mcp/assist-server.test.ts
+++ b/cli/tests/mcp/assist-server.test.ts
@@ -58,7 +58,7 @@ function parse(res: CallResult): unknown {
 describe('cli/src/mcp/assist-server', () => {
   beforeEach(reset);
 
-  it('advertises exactly the seven assist tools and none of the campaign server\u2019s', async () => {
+  it('advertises exactly the seven assist tools; the campaign server reuses three by name (LOR-224) and none of the other four', async () => {
     const orgId = await defaultOrgId();
     const assistClient = await connectAssistClient({ organizationId: orgId });
     const { tools } = await assistClient.listTools();
@@ -80,8 +80,27 @@ describe('cli/src/mcp/assist-server', () => {
     await campaignClient.connect(campaignClientT);
     const { tools: campaignTools } = await campaignClient.listTools();
     const campaignNames = new Set(campaignTools.map((t) => t.name));
-    expect(campaignTools.length).toBe(26);
-    for (const name of names) expect(campaignNames.has(name)).toBe(false);
+
+    // LOR-224 deliberately reuses three read-only assist tools on the
+    // campaign server, by name and by handler - this is the one intentional
+    // overlap, and it is read-only (see the comment on their registration
+    // in src/mcp/server.ts). The other four assist tools (observed-target
+    // reads with no meaning on the campaign plane) must never appear there.
+    const reused = ['operator_voice', 'my_prior_takes', 'check_style'];
+    const assistOnly = names.filter((n) => !reused.includes(n));
+    expect(assistOnly).toEqual([
+      'author_history',
+      'look_at_image',
+      'project_knowledge',
+      'read_thread',
+    ]);
+    for (const name of reused) expect(campaignNames.has(name)).toBe(true);
+    for (const name of assistOnly) expect(campaignNames.has(name)).toBe(false);
+
+    // And the reverse never happened either: no campaign write tool leaked
+    // onto the assist server.
+    expect(names).not.toContain('drafts_create');
+    expect(names).not.toContain('run_finish');
   });
 
   it('refuses every tool call when the session has no bound organization', async () => {

--- a/cli/tests/mcp/campaign-assist-tools.test.ts
+++ b/cli/tests/mcp/campaign-assist-tools.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { getDb, getPool, schema } from '@pitchbox/shared/db';
+import { recordVoiceSamples } from '@pitchbox/shared/operator-profile';
+import { refreshVoiceProfile } from '@pitchbox/shared/operator-voice-profile';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createPitchboxMcpServer } from '../../src/mcp/server.js';
+
+// LOR-224: the campaign MCP server exposes three of the assist plane's seven
+// read-only tools (operator_voice, my_prior_takes, check_style), reusing
+// `shared/src/assist/tools.ts`'s own handlers rather than a second copy -
+// see the comment on their registration in `src/mcp/server.ts`. This suite
+// proves the campaign server's own wiring (context construction, org
+// scoping, session binding), not the handlers themselves: `shared/tests/
+// assist-tools.test.ts` already covers what each handler does with a given
+// context, in depth.
+
+type CallResult = { content: { type: string; text?: string }[]; isError?: boolean };
+
+async function reset() {
+  const db = getDb();
+  await db.execute(
+    sql`TRUNCATE drafts, runs, campaigns, accounts, projects, operator_voice_profiles,
+      operator_voice_samples, operator_profiles, messages, contact_history, templates
+      RESTART IDENTITY CASCADE`,
+  );
+  // Org-scoping tests create extra organizations to prove cross-tenant
+  // isolation; drop them between tests (the `default` org must survive).
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function redditPlatformId(): Promise<number> {
+  const [p] = await getDb()
+    .select()
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'reddit'));
+  return p!.id;
+}
+
+async function connectClientWithCtx(ctx: {
+  runId?: number;
+  campaignId?: number;
+  projectId?: number;
+}): Promise<Client> {
+  const server = createPitchboxMcpServer(ctx);
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverT);
+  const client = new Client({ name: 'lor-224-test', version: '0.0.0' });
+  await client.connect(clientT);
+  return client;
+}
+
+async function call(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<CallResult> {
+  return (await client.callTool({ name, arguments: args })) as unknown as CallResult;
+}
+
+function parse(res: CallResult): unknown {
+  return JSON.parse(res.content[0]?.text ?? 'null');
+}
+
+/** Seeds a whole new organization with a project/account/campaign/run chain,
+ * so a test can bind a campaign-server session to it via `runId`. */
+async function seedOrgRun(slug: string) {
+  const db = getDb();
+  const platformId = await redditPlatformId();
+  const [org] = await db.insert(schema.organizations).values({ slug, name: slug }).returning();
+  const [project] = await db
+    .insert(schema.projects)
+    .values({ organizationId: org.id, slug: `${slug}-proj`, name: `${slug} project` })
+    .returning();
+  const [account] = await db
+    .insert(schema.accounts)
+    .values({ projectId: project.id, platformId, handle: `${slug}-acc`, role: 'personal' })
+    .returning();
+  const [campaign] = await db
+    .insert(schema.campaigns)
+    .values({
+      projectId: project.id,
+      platformId,
+      name: 'Commenter',
+      skillSlug: 'reddit-commenter',
+      config: {},
+    })
+    .returning();
+  const [run] = await db
+    .insert(schema.runs)
+    .values({ campaignId: campaign.id, trigger: 'manual', status: 'running' })
+    .returning();
+  return {
+    orgId: org.id,
+    projectId: project.id,
+    accountId: account.id,
+    campaignId: campaign.id,
+    runId: run.id,
+  };
+}
+
+/** Three near-identical voice samples: enough to clear MIN_ITEMS_TO_DERIVE
+ * (3) and to describe a real, non-empty voice profile - the same fixture
+ * shape `shared/tests/operator-voice-profile.test.ts`'s own `seedCorpus`
+ * uses, extended to a third item since that suite only needs two samples
+ * (it adds a message and a draft to reach three; this one keeps everything
+ * in `operator_voice_samples` for simplicity). */
+async function seedMeasuredVoice(orgId: number, tag: string) {
+  const platformId = await redditPlatformId();
+  await recordVoiceSamples(getDb(), orgId, platformId, [
+    {
+      externalId: `${tag}-sample-1`,
+      text: 'Just shipped campaign search today, the team is thrilled with results this week.',
+    },
+    {
+      externalId: `${tag}-sample-2`,
+      text: 'Just shipped the new onboarding flow, our team worked hard to get it right this quarter.',
+    },
+    {
+      externalId: `${tag}-sample-3`,
+      text: 'Just shipped a faster export path, the team is proud of how it turned out this sprint.',
+    },
+  ]);
+  await refreshVoiceProfile(getDb(), orgId);
+}
+
+describe('campaign MCP server - LOR-224 (operator_voice, my_prior_takes, check_style)', () => {
+  beforeEach(reset);
+
+  it('advertises operator_voice, my_prior_takes and check_style alongside the write tools', async () => {
+    const { runId } = await seedOrgRun('lor224-advertise');
+    const client = await connectClientWithCtx({ runId });
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('operator_voice');
+    expect(names).toContain('my_prior_takes');
+    expect(names).toContain('check_style');
+    // Still the same write-capable plane - these three did not remove
+    // drafts_create/run_finish, and did not gain arguments of their own
+    // that could bypass org scoping (their schemas are the assist plane's
+    // own, reused as-is).
+    expect(names).toContain('drafts_create');
+    expect(names).toContain('run_finish');
+  });
+
+  describe('operator_voice', () => {
+    it('answers a measured voice for a run whose organization has one on file', async () => {
+      const { orgId, runId } = await seedOrgRun('lor224-voice-measured');
+      await seedMeasuredVoice(orgId, 'vm');
+      const client = await connectClientWithCtx({ runId });
+      const res = await call(client, 'operator_voice', {});
+      expect(res.isError).toBeFalsy();
+      const data = parse(res) as {
+        ok: boolean;
+        data: { voice: { status: string; summary: string } };
+      };
+      expect(data.ok).toBe(true);
+      expect(data.data.voice.status).toBe('measured');
+      expect(data.data.voice.summary).toContain('Just shipped');
+    });
+
+    it('answers an honest default rather than an invented voice when nothing is on file', async () => {
+      const { runId } = await seedOrgRun('lor224-voice-thin');
+      const client = await connectClientWithCtx({ runId });
+      const res = await call(client, 'operator_voice', {});
+      expect(res.isError).toBeFalsy();
+      const data = parse(res) as {
+        ok: boolean;
+        data: { voice: { status: string; summary: string } };
+      };
+      expect(data.ok).toBe(true);
+      expect(data.data.voice.status).toBe('default');
+      expect(data.data.voice.summary.length).toBeGreaterThan(0);
+    });
+
+    it("never sees another organization's voice profile", async () => {
+      const a = await seedOrgRun('lor224-voice-org-a');
+      const b = await seedOrgRun('lor224-voice-org-b');
+      await seedMeasuredVoice(b.orgId, 'vb');
+      const client = await connectClientWithCtx({ runId: a.runId });
+      const res = await call(client, 'operator_voice', {});
+      const data = parse(res) as { ok: boolean; data: { voice: { status: string } } };
+      expect(data.ok).toBe(true);
+      expect(data.data.voice.status).toBe('default');
+    });
+
+    it('refuses when the session has no bound organization at all', async () => {
+      const server = createPitchboxMcpServer({});
+      const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+      await server.connect(serverT);
+      const client = new Client({ name: 'unbound', version: '0.0.0' });
+      await client.connect(clientT);
+      const res = await call(client, 'operator_voice', {});
+      expect(res.isError).toBe(true);
+      expect(res.content[0]?.text ?? '').toContain('bound to an organization');
+    });
+  });
+
+  describe('my_prior_takes', () => {
+    it('matches a real voice sample against a query naming its subject', async () => {
+      const { orgId, runId } = await seedOrgRun('lor224-takes-match');
+      const platformId = await redditPlatformId();
+      await recordVoiceSamples(getDb(), orgId, platformId, [
+        {
+          externalId: 'takes-1',
+          text: 'We just finished a big database migration this week.',
+        },
+      ]);
+      const client = await connectClientWithCtx({ runId });
+      const res = await call(client, 'my_prior_takes', { query: 'database migration' });
+      expect(res.isError).toBeFalsy();
+      const data = parse(res) as { ok: boolean; data: { matches: Array<{ excerpt: string }> } };
+      expect(data.ok).toBe(true);
+      expect(data.data.matches.length).toBeGreaterThan(0);
+      expect(data.data.matches[0].excerpt).toContain('database migration');
+    });
+
+    it('refuses with an explicit nothing when nothing matches', async () => {
+      const { runId } = await seedOrgRun('lor224-takes-empty');
+      const client = await connectClientWithCtx({ runId });
+      const res = await call(client, 'my_prior_takes', { query: 'quantum photosynthesis' });
+      const data = parse(res) as { ok: boolean; reason?: string };
+      expect(data.ok).toBe(false);
+      expect(data.reason).toBeTruthy();
+    });
+
+    it("never returns another organization's prior writing", async () => {
+      const a = await seedOrgRun('lor224-takes-org-a');
+      const b = await seedOrgRun('lor224-takes-org-b');
+      const platformId = await redditPlatformId();
+      await recordVoiceSamples(getDb(), b.orgId, platformId, [
+        {
+          externalId: 'takes-b-1',
+          text: "Org B's own database migration story, never seen by org A.",
+        },
+      ]);
+      const client = await connectClientWithCtx({ runId: a.runId });
+      const res = await call(client, 'my_prior_takes', { query: 'database migration' });
+      const data = parse(res) as { ok: boolean };
+      expect(data.ok).toBe(false);
+    });
+  });
+
+  describe('check_style', () => {
+    it('never refuses - a clean draft gets an empty findings list', async () => {
+      const { runId } = await seedOrgRun('lor224-style-clean');
+      const client = await connectClientWithCtx({ runId });
+      const res = await call(client, 'check_style', { text: 'A clean, direct sentence.' });
+      expect(res.isError).toBeFalsy();
+      const data = parse(res) as { ok: boolean; data: { findings: unknown[] } };
+      expect(data.ok).toBe(true);
+      expect(data.data.findings).toEqual([]);
+    });
+
+    it('surfaces a real house-style finding for a body carrying a banned tell', async () => {
+      const { runId } = await seedOrgRun('lor224-style-dirty');
+      const client = await connectClientWithCtx({ runId });
+      const res = await call(client, 'check_style', {
+        text: 'Ever wondered why builds are slow\u2014ours got faster this week?',
+      });
+      expect(res.isError).toBeFalsy();
+      const data = parse(res) as {
+        ok: boolean;
+        data: { findings: Array<{ ruleId: string }> };
+      };
+      expect(data.ok).toBe(true);
+      expect(data.data.findings.map((f) => f.ruleId)).toContain('rhetorical-question-opener');
+    });
+  });
+});
+
+afterAll(async () => {
+  await getPool().end();
+});

--- a/playbooks/draft-regenerator.md
+++ b/playbooks/draft-regenerator.md
@@ -16,6 +16,9 @@ The run is bound to this session through the environment, so the tools default t
 ## Tools
 
 - `draft_regen_start` - load the draft, its target, the reviewer hint, and the originating persona.
+- `operator_voice` - your own persona and derived writing voice for this organization.
+- `my_prior_takes` - excerpts of what you have already written, matched against a query.
+- `check_style` - the deterministic house-style checker; run it on a body before persisting it.
 - `draft_regen_finish` - submit the rewritten body (and title, for posts).
 
 ## House style: write like a human
@@ -47,7 +50,11 @@ Write like this instead:
 
 1. **Load context.** Call `draft_regen_start` (no arguments needed). From the result read: `hint`, `platform`, `persona`, `rubricTemplate`, and `draft` (`kind`, `title`, `body`, `targetUser`, `reasoning`, `sourceRef`).
 
-2. **Rewrite the draft.** Produce ONE improved version of the draft body.
+2. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the subject of `draft.body`, for what you have already said about it elsewhere. `persona` already carries the voice this specific draft was written in - these two keep the rewrite consistent with how you actually write in general, not just with that one draft.
+
+   `operator_voice`'s derived summary describes your writing in aggregate (word count, sentence length, closers, hashtag habits), measured mostly from longer posts - it is not a target length for this particular rewrite. Keep whatever length `draft.kind`, `hint` and the platform constraints below call for. Either tool can come back with `{ ok: false, reason }` instead of inventing something when there is nothing on file - keep `persona`'s voice alone when that happens.
+
+3. **Rewrite the draft.** Produce ONE improved version of the draft body.
    - If `hint` is non-empty, treat it as the primary instruction (e.g. "shorter", "less salesy", "reference their last comment"). Satisfy it.
    - Keep the voice and rules from `persona` (the playbook that produced this draft). Do not drift into a different tone.
    - Keep it addressed to the same `targetUser` / thread implied by `sourceRef`. Do not change the target.
@@ -57,9 +64,11 @@ Write like this instead:
    - No placeholders, no "TBD", no meta commentary. Output the message text a human would send.
    - Apply the House style section above literally: it outranks every default here and holds even when the campaign voice says nothing about it.
 
-3. **Score the rewritten draft.** Using `rubricTemplate`, score the rewrite 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted drafts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason`.
+4. **Score the rewritten draft.** Using `rubricTemplate`, score the rewrite 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted drafts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason`.
 
-4. **Submit.** Call `draft_regen_finish` with:
+5. **Check your own style before persisting.** Call `check_style` with the exact rewritten body (and title, if you changed it) you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `draft_regen_finish` has no live model to send a rewrite back to.
+
+6. **Submit.** Call `draft_regen_finish` with:
 
    ```json
    {
@@ -72,7 +81,7 @@ Write like this instead:
 
    The tool overwrites the draft body, bumps its version, records the previous body for undo, and finalizes the run. **If the tool returns an error**, read the message, fix the payload, and try again. **Maximum two retries.**
 
-5. **On failure.** If `draft_regen_start` reports the draft is gone or no longer pending review, or you genuinely cannot improve it, call `run_finish` with `{ "status": "failed", "error": "<short reason>" }` and stop. The draft keeps its current body.
+7. **On failure.** If `draft_regen_start` reports the draft is gone or no longer pending review, or you genuinely cannot improve it, call `run_finish` with `{ "status": "failed", "error": "<short reason>" }` and stop. The draft keeps its current body.
 
 ## What this playbook must never do
 

--- a/playbooks/hn-commenter.md
+++ b/playbooks/hn-commenter.md
@@ -17,6 +17,9 @@ The run is already bound to a campaign and run through the environment, so the t
 
 - `run_start` - create/resume the run and load campaign context.
 - `hn_search` - fetch Hacker News stories from a listing.
+- `operator_voice` - your own persona and derived writing voice for this organization.
+- `my_prior_takes` - excerpts of what you have already written, matched against a query.
+- `check_style` - the deterministic house-style checker; run it on a body before persisting it.
 - `drafts_create` - write the drafts back.
 - `run_finish` - close the run.
 
@@ -63,18 +66,24 @@ Write like this instead:
 
    Drop candidates below 3.
 
-4. **Draft each comment.** Honour `campaign.config.voice` (`tone`, `hardBans`, `dos`, `disclosure`). HN-specific guidance:
+4. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the story's subject (not the whole story) for what you have already said about it. Write the comment in this voice, not a generic house tone.
+
+   `operator_voice`'s derived summary describes your writing in aggregate (word count, sentence length, closers, hashtag habits) - it is measured mostly from longer posts, not comments, so it tells you how you sound, not how long this comment should be. The length and register called for below still win. Either tool can come back with `{ ok: false, reason }` instead of inventing something when there is nothing on file - draft from the campaign voice alone when that happens.
+
+5. **Draft each comment.** Honour `campaign.config.voice` (`tone`, `hardBans`, `dos`, `disclosure`). HN-specific guidance:
    - HN comments use plain text with blank-line paragraphs and `*emphasis*`. No Markdown headings, no bullet syntax beyond `- ` lines.
    - Apply the House style section above literally: it outranks every default here and holds even when the campaign voice says nothing about it.
    - Open with the substantive answer or observation. No "Great post!" or "Thanks for sharing".
    - 60-180 words. Match thread register (terse threads get short replies).
    - Default = no link, no product name. One mention is acceptable only if the OP is asking for tool recommendations and the product is genuinely on-topic.
 
-5. **Pick the account.** Use the first account with `role === 'personal'`. HN accounts only carry a `username` - no secret. Record `accountId`.
+6. **Pick the account.** Use the first account with `role === 'personal'`. HN accounts only carry a `username` - no secret. Record `accountId`.
 
-6. **Score each draft.** Using `rubricTemplate` from the run context, score the comment 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted comments and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+7. **Score each draft.** Using `rubricTemplate` from the run context, score the comment 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted comments and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-7. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+8. **Check your own style before persisting.** Call `check_style` with the exact comment body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
+
+9. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft:
 
@@ -95,7 +104,7 @@ Write like this instead:
 
    `targetUser` is the author of the story you are replying to (`by` on the item you scored). Commenting on someone's story counts as contacting them, so it feeds the blocklist, the dedup window and contact history. Hacker News has no scout staging candidates for the run, so nothing can recover this handle if you omit it: copy it across for every draft.
 
-8. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/hn-poster.md
+++ b/playbooks/hn-poster.md
@@ -17,6 +17,9 @@ The run is already bound to a campaign and run through the environment. Step 1 r
 
 - `run_start` - create/resume the run and load campaign context.
 - `hn_search` - fetch Hacker News stories from a listing.
+- `operator_voice` - your own persona and derived writing voice for this organization.
+- `my_prior_takes` - excerpts of what you have already written, matched against a query.
+- `check_style` - the deterministic house-style checker; run it on a body before persisting it.
 - `drafts_create` - write the drafts back.
 - `run_finish` - close the run.
 
@@ -58,7 +61,9 @@ Write like this instead:
 
    Note recurring themes, opening lines, and how the most-upvoted Show HN / Ask HN posts frame themselves.
 
-3. **Draft 1-3 distinct posts for this run.** For each draft:
+3. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the angle or subject you are about to write about, for what you have already said on it. Draft in this voice rather than a generic house tone - it is measured from your own past posts, so its length and register are a reasonable starting point here. Either tool can come back with `{ ok: false, reason }` instead of inventing something when there is nothing on file yet - draft from the campaign voice alone when that happens.
+
+4. **Draft 1-3 distinct posts for this run.** For each draft:
    - **Pick the format** that best fits `postAngle`:
      - `show-hn` - launching or sharing something you built; title starts with `Show HN: `.
      - `ask-hn` - genuine question for the community; title starts with `Ask HN: `.
@@ -71,16 +76,18 @@ Write like this instead:
    - **Link policy** - Show HN expects a URL field; populate `metadata.url` with `campaign.config.productUrl`. Ask HN and text posts have no URL field on HN; mention the project name at most once in the body if directly relevant.
    - **Disclosure** - include `campaign.config.voice.disclosure` once near the bottom for Show HN and text-with-product-mention. Ask HN posts that don't pitch the product can omit it.
 
-4. **Apply hard skips.** Drop any draft if:
+5. **Apply hard skips.** Drop any draft if:
    - The title or body contains any term from `campaign.config.avoidKeywords`.
    - The post is a thinly disguised pitch with no substantive content (Show HN that's just a landing page summary, Ask HN that's leading toward "would you pay for X").
    - HN already has a near-identical Show HN from the last 30 days for the same product (search step 2).
 
-5. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+6. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-6. **Pick the account.** Use the first account with `role === 'personal'`. HN accounts only carry a `username` - no secret. Record `accountId`.
+7. **Pick the account.** Use the first account with `role === 'personal'`. HN accounts only carry a `username` - no secret. Record `accountId`.
 
-7. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+8. **Check your own style before persisting.** Call `check_style` with the exact title and body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
+
+9. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft:
 
@@ -100,7 +107,7 @@ Write like this instead:
    }
    ```
 
-8. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
+10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
 
 ## Hard rules
 
@@ -113,4 +120,4 @@ Write like this instead:
 ## Failure modes
 
 - If any tool call returns an error result, stop and call `run_finish` with `{ "runId": <runId>, "status": "failed", "error": "<message>" }`.
-- Zero qualifying drafts after step 4 → finish with `success`, zero drafts is valid (means the angle wasn't ripe).
+- Zero qualifying drafts after step 5 → finish with `success`, zero drafts is valid (means the angle wasn't ripe).

--- a/playbooks/linkedin-commenter.md
+++ b/playbooks/linkedin-commenter.md
@@ -20,6 +20,9 @@ The run is already bound to a campaign and run through the environment, so the t
 - `run_start` - create/resume the run and load campaign context.
 - `linkedin_candidates` - drain the browser's observation buffer into staging for this run. This tool fetches nothing over the network: LinkedIn has no discovery API, so the only candidates that exist are posts the human's own browser already rendered while they were signed in and browsing. Applies blocklist and contact-history filters server-side before staging.
 - `staging_candidates` - read the staged candidates.
+- `operator_voice` - your own persona and derived writing voice for this organization.
+- `my_prior_takes` - excerpts of what you have already written, matched against a query.
+- `check_style` - the deterministic house-style checker; run it on a body before persisting it.
 - `drafts_create` - write the drafts back.
 - `run_finish` - close the run.
 
@@ -74,7 +77,11 @@ Write like this instead:
 
    Drop candidates below 4. LinkedIn punishes visible volume more than the other platforms - a handful of genuinely sharp replies beats a comment on every candidate that clears a low bar.
 
-6. **Draft the reply.** The voice rules are in `campaign.config.voice` (`tone`, `hardBans`, `dos`, `disclosure`). LinkedIn-specific guidance:
+6. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the post's subject (not the whole post) for what you have already said about it. Write the reply in this voice, not a generic house tone.
+
+   `operator_voice`'s derived summary describes your writing in aggregate (word count, sentence length, closers, hashtag habits) - it is measured mostly from longer posts, not comments, so it tells you how you sound, not how long this reply should be. The length and register called for below still win. Either tool can come back with `{ ok: false, reason }` instead of inventing something when there is nothing on file - draft from the campaign voice alone when that happens.
+
+7. **Draft the reply.** The voice rules are in `campaign.config.voice` (`tone`, `hardBans`, `dos`, `disclosure`). LinkedIn-specific guidance:
    - Honour every entry in `campaign.config.voice.hardBans` literally - exact substrings to never emit.
    - Apply the House style section above literally: it outranks every default here and holds even when the campaign voice says nothing about it.
    - Plain text, natural paragraph breaks, no markdown headings, no bullet-point lists dressed up as a comment - LinkedIn comments read as a reply to a person, not a slide.
@@ -84,37 +91,39 @@ Write like this instead:
    - **Link policy.** Default = no link. Include `campaign.config.productUrl` only if it is genuinely the answer to what the post is asking - the author is directly asking for a tool, a resource, or a recommendation and the product is a truthful fit. Otherwise the comment stands on its own with nothing to click.
    - **Disclosure.** If you name the product or include its link, also include `campaign.config.voice.disclosure` in the same comment so the relationship is not hidden.
 
-7. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
+8. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
 
-8. **Score each draft.** Using `rubricTemplate` from the run context, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, contextual replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+9. **Score each draft.** Using `rubricTemplate` from the run context, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, contextual replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-9. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+10. **Check your own style before persisting.** Call `check_style` with the exact reply body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-   > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
+11. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
-   Each draft (the human opens the real post from the Inbox and pastes this in themselves - Pitchbox never posts it):
+> Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
 
-   ```json
-   {
-     "accountId": 1,
-     "kind": "post_comment",
-     "fitScore": 4,
-     "targetUser": "<the post author's profile slug, the candidate's author.handle>",
-     "body": "<reply text>",
-     "reasoning": "2-3 sentences on why this post, what angle, what value you're adding.",
-     "sourceRef": {
-       "externalId": "urn:li:activity:1234567890",
-       "url": "https://www.linkedin.com/feed/update/urn:li:activity:1234567890/"
-     },
-     "metadata": { "authorHandle": "jane-doe" },
-     "qualityScore": 76,
-     "qualityReason": "concrete reference to their post, adds a real point"
-   }
-   ```
+Each draft (the human opens the real post from the Inbox and pastes this in themselves - Pitchbox never posts it):
 
-   `targetUser` is the author of the post you are replying to, and it is their profile slug (`author.handle`), never their display name: a name cannot be blocklisted or deduped. Commenting on someone's post counts as contacting them, so it feeds the blocklist, the dedup window and contact history, exactly as the in-page assist already does. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.externalId` points at; an observation captured without a slug has no target, and null is the right answer there.
+```json
+{
+  "accountId": 1,
+  "kind": "post_comment",
+  "fitScore": 4,
+  "targetUser": "<the post author's profile slug, the candidate's author.handle>",
+  "body": "<reply text>",
+  "reasoning": "2-3 sentences on why this post, what angle, what value you're adding.",
+  "sourceRef": {
+    "externalId": "urn:li:activity:1234567890",
+    "url": "https://www.linkedin.com/feed/update/urn:li:activity:1234567890/"
+  },
+  "metadata": { "authorHandle": "jane-doe" },
+  "qualityScore": 76,
+  "qualityReason": "concrete reference to their post, adds a real point"
+}
+```
 
-10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+`targetUser` is the author of the post you are replying to, and it is their profile slug (`author.handle`), never their display name: a name cannot be blocklisted or deduped. Commenting on someone's post counts as contacting them, so it feeds the blocklist, the dedup window and contact history, exactly as the in-page assist already does. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.externalId` points at; an observation captured without a slug has no target, and null is the right answer there.
+
+12. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/linkedin-poster.md
+++ b/playbooks/linkedin-poster.md
@@ -20,6 +20,9 @@ The run is already bound to a campaign and run through the environment. Step 1 r
 - `run_start` - create/resume the run and load campaign context.
 - `linkedin_candidates` - drain the browser's observation buffer into staging, used here for market context (what the network is actually discussing right now), never for targeting - a poster drafts a top-level post, not a reply to anyone.
 - `staging_candidates` - read the staged candidates.
+- `operator_voice` - your own persona and derived writing voice for this organization.
+- `my_prior_takes` - excerpts of what you have already written, matched against a query.
+- `check_style` - the deterministic house-style checker; run it on a body before persisting it.
 - `drafts_create` - write the drafts back.
 - `run_finish` - close the run.
 
@@ -60,46 +63,50 @@ Write like this instead:
 
 3. **Apply the hiring/grieving filter to your context reading, not just to targets.** If a candidate you read for context is a hiring announcement, a bereavement, or another non-commercial personal moment, do not let it shape the angle of your own post - drafting a post that piggybacks off someone else's hiring news or loss, even indirectly, is out of bounds.
 
-4. **Draft at most one or two distinct posts for this run.** For each draft:
+4. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the angle you picked, for what you have already said on it. Draft in this voice rather than a generic house tone - it is measured from your own past posts, so its length and register are a reasonable starting point here. Either tool can come back with `{ ok: false, reason }` instead of inventing something when there is nothing on file yet - draft from the campaign voice alone when that happens.
+
+5. **Draft at most one or two distinct posts for this run.** For each draft:
    - **Pick the angle** from `campaign.config.postAngle` (e.g. a lesson learned, a genuine trade-off write-up, an honest question to the field). Avoid pure announcements with no substance - "Excited to share..." with nothing behind it is the fastest way to get scrolled past and ignored.
    - **Body** - plain text, natural paragraph breaks (blank line between paragraphs), no markdown headings, no emoji bullet lists. Open with substance, not "Excited to announce..." or "Thrilled to share...". 100-300 words usually - LinkedIn's feed truncates aggressively and rewards a post that earns the "see more" click, so the first two lines have to stand alone.
    - **Voice rules** - apply `campaign.config.voice` literally (`hardBans` are substrings to never emit; `dos` are mandatory; `tone` sets register).
    - Apply the House style section above literally: it outranks every default here and holds even when the campaign voice says nothing about it.
    - **Value proposition** - the post must stand on its own as content even if the product were never mentioned. Surface the angle from `campaign.config.valuePropositions` that fits, without turning the body into a bullet list of features.
-   - **Link and product-name policy** - at most one product mention, and only if it is genuinely load-bearing for the post's point. A post that exists only to name-drop the product is a pitch, not content, and gets dropped in step 5.
+   - **Link and product-name policy** - at most one product mention, and only if it is genuinely load-bearing for the post's point. A post that exists only to name-drop the product is a pitch, not content, and gets dropped in step 6.
    - **Disclosure is mandatory whenever the product is named.** If the post names the product, mentions its URL, or is clearly about it, include `campaign.config.voice.disclosure` once, near the bottom, so the relationship is never implicit. If the post never names the product, no disclosure line is needed - there is nothing to disclose.
    - **Hashtags** - LinkedIn hashtags are optional and weaker for discovery than Mastodon's; append at most 2-3 genuinely relevant ones at the end if they fit naturally, never stuffed through the body.
 
-5. **Apply hard skips.** Drop any draft if:
+6. **Apply hard skips.** Drop any draft if:
    - The body or hashtags contain any term from `campaign.config.avoidKeywords`.
    - The post is a thinly disguised pitch with no substantive content.
    - Step 2's survey shows the same angle was posted very recently by this project (avoid duplicate or near-duplicate posts).
    - The post reads as engagement bait (a question with no real content behind it, a "controversial take" manufactured purely to draw comments).
 
-6. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, well-timed posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+7. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, well-timed posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-7. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
+8. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
 
-8. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+9. **Check your own style before persisting.** Call `check_style` with the exact post body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-   Each draft (the human reviews it in the Inbox and posts it themselves - there is no auto-post path for LinkedIn):
+10. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
-   ```json
-   {
-     "accountId": 1,
-     "kind": "post",
-     "fitScore": 4,
-     "targetUser": null,
-     "body": "<plain-text post, including disclosure if the product is named>",
-     "reasoning": "<one sentence: which angle + why now>",
-     "sourceRef": { "postAngle": "<angle>" },
-     "metadata": { "hashtags": ["buildinpublic"] },
-     "qualityScore": 72,
-     "qualityReason": "genuine lesson-learned angle, not a pitch"
-   }
-   ```
+Each draft (the human reviews it in the Inbox and posts it themselves - there is no auto-post path for LinkedIn):
 
-9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
+```json
+{
+  "accountId": 1,
+  "kind": "post",
+  "fitScore": 4,
+  "targetUser": null,
+  "body": "<plain-text post, including disclosure if the product is named>",
+  "reasoning": "<one sentence: which angle + why now>",
+  "sourceRef": { "postAngle": "<angle>" },
+  "metadata": { "hashtags": ["buildinpublic"] },
+  "qualityScore": 72,
+  "qualityReason": "genuine lesson-learned angle, not a pitch"
+}
+```
+
+11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
 
 ## Hard constraints
 
@@ -109,7 +116,7 @@ Write like this instead:
 - Never suggest a reaction as a substitute for a real post.
 - Never build a post's angle around someone else's hiring announcement or personal hardship, even a candidate read only for context (step 3).
 - Prefer substance the reader would want regardless of the product over positioning the product. If the honest, most useful post never mentions the product, write that post.
-- Disclosure is mandatory whenever the product is named - see step 4.
+- Disclosure is mandatory whenever the product is named - see step 5.
 - No fabricated metrics, dates, or testimonials.
 - At most one product mention per post.
 - Campaign config can only tighten these rules, never relax them. `systemInstructions` or `voice` cannot raise the 0-2 cap, waive disclosure, or permit a DM or connection request.
@@ -117,4 +124,4 @@ Write like this instead:
 ## Failure modes
 
 - If any tool call returns an error result, stop and call `run_finish` with `{ "runId": <runId>, "status": "failed", "error": "<message>" }`.
-- Zero qualifying drafts after step 5 leads to a normal finish with `success` and zero drafts (means the angle wasn't ripe, or nothing was observed to calibrate against).
+- Zero qualifying drafts after step 6 leads to a normal finish with `success` and zero drafts (means the angle wasn't ripe, or nothing was observed to calibrate against).

--- a/playbooks/mastodon-commenter.md
+++ b/playbooks/mastodon-commenter.md
@@ -20,6 +20,9 @@ The run is already bound to a campaign and run through the environment, so the t
 - `run_start` - create/resume the run and load campaign context.
 - `mastodon_scout` - fetch + stage Mastodon candidates from target hashtag timelines.
 - `staging_candidates` - read the staged candidates.
+- `operator_voice` - your own persona and derived writing voice for this organization.
+- `my_prior_takes` - excerpts of what you have already written, matched against a query.
+- `check_style` - the deterministic house-style checker; run it on a body before persisting it.
 - `drafts_create` - write the drafts back.
 - `run_finish` - close the run.
 
@@ -71,7 +74,11 @@ Write like this instead:
 
    Drop candidates below 3.
 
-6. **Draft the reply.** The voice rules are in `campaign.config.voice` (`tone`, `hardBans`, `dos`, `disclosure`). Mastodon-specific guidance:
+6. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the status's subject (not the whole status) for what you have already said about it. Write the reply in this voice, not a generic house tone.
+
+   `operator_voice`'s derived summary describes your writing in aggregate (word count, sentence length, closers, hashtag habits) - it is measured mostly from longer posts, not short replies, so it tells you how you sound, not how long this reply should be or whether it carries a hashtag. The length and register called for below still win. Either tool can come back with `{ ok: false, reason }` instead of inventing something when there is nothing on file - draft from the campaign voice alone when that happens.
+
+7. **Draft the reply.** The voice rules are in `campaign.config.voice` (`tone`, `hardBans`, `dos`, `disclosure`). Mastodon-specific guidance:
    - Honour every entry in `campaign.config.voice.hardBans` literally - exact substrings to never emit.
    - Apply the House style section above literally: it outranks every default here and holds even when the campaign voice says nothing about it.
    - Plain text, natural paragraph breaks (blank line between paragraphs), no markdown headings. Hashtags only if they genuinely belong (rarely, in a reply).
@@ -83,34 +90,36 @@ Write like this instead:
 
    **Self-promo constraint.** Default = no link, no product name, no offer. The reply stands on its own. Exception: if the author is directly asking for tool recommendations and `campaign.config.productUrl` is a genuinely appropriate answer, one mention at the end (not the top) is acceptable, together with `campaign.config.voice.disclosure` to flag your relationship with the project.
 
-7. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
+8. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
 
-8. **Score each draft.** Using `rubricTemplate` from the run context, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, contextual replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+9. **Score each draft.** Using `rubricTemplate` from the run context, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, contextual replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-9. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+10. **Check your own style before persisting.** Call `check_style` with the exact reply body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-   > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
+11. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
-   Each draft (sent later as a reply status via `in_reply_to_id`, on human approval):
+> Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
 
-   ```json
-   {
-     "accountId": 1,
-     "kind": "post_comment",
-     "fitScore": 4,
-     "targetUser": "<the status author's fully qualified handle, the candidate's author.acct>",
-     "body": "<reply text>",
-     "reasoning": "2-3 sentences on why this status, what angle, what value you're adding.",
-     "sourceRef": { "statusId": "109...", "statusUrl": "https://mastodon.social/@alice/109..." },
-     "metadata": { "matchedHashtag": "selfhosted", "matchedKeyword": "self-hosted" },
-     "qualityScore": 74,
-     "qualityReason": "concrete reference to their status, adds a real point"
-   }
-   ```
+Each draft (sent later as a reply status via `in_reply_to_id`, on human approval):
 
-   `targetUser` is the author of the status you are replying to, as the fully qualified `author.acct` handle. Replying to someone counts as contacting them, so it feeds the blocklist, the dedup window and contact history. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.statusId` points at.
+```json
+{
+  "accountId": 1,
+  "kind": "post_comment",
+  "fitScore": 4,
+  "targetUser": "<the status author's fully qualified handle, the candidate's author.acct>",
+  "body": "<reply text>",
+  "reasoning": "2-3 sentences on why this status, what angle, what value you're adding.",
+  "sourceRef": { "statusId": "109...", "statusUrl": "https://mastodon.social/@alice/109..." },
+  "metadata": { "matchedHashtag": "selfhosted", "matchedKeyword": "self-hosted" },
+  "qualityScore": 74,
+  "qualityReason": "concrete reference to their status, adds a real point"
+}
+```
 
-10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+`targetUser` is the author of the status you are replying to, as the fully qualified `author.acct` handle. Replying to someone counts as contacting them, so it feeds the blocklist, the dedup window and contact history. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.statusId` points at.
+
+12. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/mastodon-poster.md
+++ b/playbooks/mastodon-poster.md
@@ -20,6 +20,9 @@ The run is already bound to a campaign and run through the environment. Step 1 r
 - `run_start` - create/resume the run and load campaign context.
 - `mastodon_scout` - fetch + stage Mastodon candidates from target hashtag timelines (used here for market context, not for replying).
 - `staging_candidates` - read the staged candidates.
+- `operator_voice` - your own persona and derived writing voice for this organization.
+- `my_prior_takes` - excerpts of what you have already written, matched against a query.
+- `check_style` - the deterministic house-style checker; run it on a body before persisting it.
 - `drafts_create` - write the drafts back.
 - `run_finish` - close the run.
 
@@ -56,7 +59,9 @@ Write like this instead:
 
 2. **Study what's currently active in the target hashtags.** Call `mastodon_scout` with `{ "runId": <runId> }`, then `staging_candidates` with `{ "run": <runId> }`, to see what people are already posting in `campaign.config.targetHashtags`. Note recurring themes, tone, and whether the same angle has already been said recently - you are not reading these to reply, only to calibrate the new post so it doesn't repeat or clash with what's already there.
 
-3. **Draft at most one or two distinct posts for this run.** For each draft:
+3. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the angle you picked, for what you have already said on it. Draft in this voice rather than a generic house tone - it is measured from your own past posts, so its length and register are a reasonable starting point here. Either tool can come back with `{ ok: false, reason }` instead of inventing something when there is nothing on file yet - draft from the campaign voice alone when that happens.
+
+4. **Draft at most one or two distinct posts for this run.** For each draft:
    - **Pick the angle** from `campaign.config.postAngle` (e.g. a launch note, a lesson learned, a genuine question to the community, a short write-up of a trade-off). Avoid pure announcements with no substance.
    - **Body** - plain text, natural paragraph breaks (blank line between paragraphs). Open with substance, not "Excited to announce..." or "Hey fediverse!". 100-350 words usually; most instances cap statuses around 500 characters, so keep the primary post well under that (long posts read as thread spam - if it needs more room, note in `reasoning` that it should be a thread, but only draft the opening status).
    - **Hashtags** - append 2-4 relevant hashtags from `campaign.config.targetHashtags` at the end, not stuffed through the body. Hashtags are how Mastodon discovery works; skipping them entirely makes the post nearly unfindable, but more than a handful reads as spam.
@@ -66,16 +71,18 @@ Write like this instead:
    - **Link policy** - at most one product URL (`campaign.config.productUrl`), mentioned once, not at the very top.
    - **Disclosure** - include `campaign.config.voice.disclosure` once, near the bottom.
 
-4. **Apply hard skips.** Drop any draft if:
+5. **Apply hard skips.** Drop any draft if:
    - The body or hashtags contain any term from `campaign.config.avoidKeywords`.
    - The post is a thinly disguised pitch with no substantive content.
    - Step 2's survey shows the same angle was posted very recently by this project (avoid duplicate/near-duplicate posts).
 
-5. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, well-timed posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+6. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, well-timed posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-6. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
+7. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
 
-7. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+8. **Check your own style before persisting.** Call `check_style` with the exact status body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
+
+9. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft (sent later as a public status, on human approval):
 
@@ -94,7 +101,7 @@ Write like this instead:
    }
    ```
 
-8. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
+10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
 
 ## Hard rules
 
@@ -107,4 +114,4 @@ Write like this instead:
 ## Failure modes
 
 - If any tool call returns an error result, stop and call `run_finish` with `{ "runId": <runId>, "status": "failed", "error": "<message>" }`.
-- Zero qualifying drafts after step 4 → finish with `success`, zero drafts is valid (means the angle wasn't ripe).
+- Zero qualifying drafts after step 5 → finish with `success`, zero drafts is valid (means the angle wasn't ripe).

--- a/playbooks/reddit-commenter.md
+++ b/playbooks/reddit-commenter.md
@@ -18,6 +18,9 @@ The run is already bound to a campaign and run through the environment, so the t
 - `run_start` - create/resume the run and load campaign context.
 - `reddit_scout` - fetch + stage Reddit candidates.
 - `staging_candidates` - read the staged candidates.
+- `operator_voice` - your own persona and derived writing voice for this organization.
+- `my_prior_takes` - excerpts of what you have already written, matched against a query.
+- `check_style` - the deterministic house-style checker; run it on a body before persisting it.
 - `drafts_create` - write the drafts back.
 - `run_finish` - close the run.
 
@@ -68,7 +71,11 @@ Write like this instead:
 
    Drop candidates below 3.
 
-5. **Draft the comment.** The voice rules are in `campaign.config.voice` (`tone`, `hardBans`, `dos`, `disclosure`). Typical hard rules:
+5. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the post's subject (not the whole post) for what you have already said about it. Write the comment in this voice, not a generic house tone.
+
+   `operator_voice`'s derived summary describes your writing in aggregate (word count, sentence length, closers, hashtag habits) - it is measured mostly from longer posts, not comments, so it tells you how you sound, not how long this comment should be. The length and register called for below still win; do not stretch a comment to match the summary's word count. Either tool can come back with `{ ok: false, reason }` instead of inventing something when there is nothing on file - draft from the campaign voice alone when that happens.
+
+6. **Draft the comment.** The voice rules are in `campaign.config.voice` (`tone`, `hardBans`, `dos`, `disclosure`). Typical hard rules:
    - Honour every entry in `campaign.config.voice.hardBans` literally - they are exact substrings to never emit.
    - Apply the House style section above literally: it outranks every default here and holds even when the campaign voice says nothing about it.
    - Capitalization proper. Comments are mid-register (not the DM lowercase opener).
@@ -81,35 +88,37 @@ Write like this instead:
 
    **Self-promo constraint.** Default = no link, no product name, no offer. The comment stands on its own merits. Exception: if the OP is directly asking for recommendations and the product (link in `campaign.config.productUrl`) is a genuinely appropriate answer, one mention at the end (not the top) is acceptable. If you mention it, also follow `campaign.config.voice.disclosure` to flag your relationship with the project.
 
-6. **Pick the account.** Comments almost always use the `personal` account (brand accounts commenting on other people's posts comes off as marketing spam). Use the first account with `role === 'personal'`. Record `accountId`.
+7. **Pick the account.** Comments almost always use the `personal` account (brand accounts commenting on other people's posts comes off as marketing spam). Use the first account with `role === 'personal'`. Record `accountId`.
 
-7. **Score each draft.** Using `rubricTemplate` from the run context, score the comment 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted comments and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+8. **Score each draft.** Using `rubricTemplate` from the run context, score the comment 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted comments and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-8. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+9. **Check your own style before persisting.** Call `check_style` with the exact comment body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-   > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
+10. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
-   Each draft:
+> Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
 
-   ```json
-   {
-     "accountId": 1,
-     "kind": "post_comment",
-     "fitScore": 4,
-     "subreddit": "Solo_Roleplaying",
-     "targetUser": "<the post author's username, from the candidate's user.name>",
-     "body": "<comment markdown>",
-     "reasoning": "2-3 sentences on why this post, what angle, what value you're adding.",
-     "sourceRef": { "permalink": "/r/Solo_Roleplaying/comments/abc/.../", "postTitle": "..." },
-     "metadata": { "matchedBy": "search", "postAgeHours": 8 },
-     "qualityScore": 78,
-     "qualityReason": "specific reference to their post, clear ask"
-   }
-   ```
+Each draft:
 
-   `targetUser` is the author of the post you are replying to. Commenting on someone's post counts as contacting them, so it feeds the blocklist, the dedup window and contact history. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.permalink` points at.
+```json
+{
+  "accountId": 1,
+  "kind": "post_comment",
+  "fitScore": 4,
+  "subreddit": "Solo_Roleplaying",
+  "targetUser": "<the post author's username, from the candidate's user.name>",
+  "body": "<comment markdown>",
+  "reasoning": "2-3 sentences on why this post, what angle, what value you're adding.",
+  "sourceRef": { "permalink": "/r/Solo_Roleplaying/comments/abc/.../", "postTitle": "..." },
+  "metadata": { "matchedBy": "search", "postAgeHours": 8 },
+  "qualityScore": 78,
+  "qualityReason": "specific reference to their post, clear ask"
+}
+```
 
-9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+`targetUser` is the author of the post you are replying to. Commenting on someone's post counts as contacting them, so it feeds the blocklist, the dedup window and contact history. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.permalink` points at.
+
+11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/reddit-poster.md
+++ b/playbooks/reddit-poster.md
@@ -17,6 +17,9 @@ The run is already bound to a campaign and run through the environment. Step 1 r
 
 - `run_start` - create/resume the run and load campaign context.
 - `subreddit_snapshot` - fetch a subreddit's recent top posts + about/rules.
+- `operator_voice` - your own persona and derived writing voice for this organization.
+- `my_prior_takes` - excerpts of what you have already written, matched against a query.
+- `check_style` - the deterministic house-style checker; run it on a body before persisting it.
 - `drafts_create` - write the drafts back.
 - `run_finish` - close the run.
 
@@ -56,7 +59,8 @@ Write like this instead:
    - Note recurring formats (e.g. "Show & tell", weekly threads, AMA cadence).
    - Read `rules` and `about` for moderation / self-promo constraints.
 
-3. **Draft one or more posts per subreddit.** Aim for 1-3 distinct posts per subreddit (not more) for this run. For each draft:
+3. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the angle or subject you are about to write about, for what you have already said on it. Draft in this voice rather than a generic house tone - it is measured from your own past posts, so its length and register are a reasonable starting point here (unlike a short comment reply). Either tool can come back with `{ ok: false, reason }` instead of inventing something when there is nothing on file yet - draft from the campaign voice alone when that happens.
+4. **Draft one or more posts per subreddit.** Aim for 1-3 distinct posts per subreddit (not more) for this run. For each draft:
    - **Pick the format** that fits the subreddit and the `postAngle`. Acceptable formats: launch / show-and-tell, lessons-learned story, question-led discussion, comparison or teardown. Avoid pure announcements without a substantive body.
    - **Title** - concrete, specific, no clickbait. 30-120 chars. Avoid all-caps. Avoid leading `[Show]` / `[Help]` prefixes unless the subreddit conventionally uses them.
    - **Body** - markdown. 200-600 words usually. Open with the hook (not "Hey everyone!"). Mid-section: substance - show your work, share data, explain trade-offs. Close with a concrete question that invites discussion (not "what do you think?").
@@ -66,14 +70,16 @@ Write like this instead:
    - **Link policy** - at most one product URL (`campaign.config.productUrl`), placed in context rather than at the top. Subreddits with strict self-promo rules: skip the link, mention the project name only.
    - **Disclosure** - include `campaign.config.voice.disclosure` once near the bottom, before the closing question.
 
-4. **Apply hard skips.** Drop any draft if:
+5. **Apply hard skips.** Drop any draft if:
    - The subreddit appears in `blocklist` with `kind=subreddit` (global or project scope).
    - The title or body contains any term from `campaign.config.avoidKeywords`.
    - The subreddit's `rules` show explicit "no self-promotion" / "no AI-generated content" rules and the draft can't reasonably claim to be human-authored substantive content.
 
-5. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+6. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
 
-6. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+7. **Check your own style before persisting.** Call `check_style` with the exact title and body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
+
+8. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft:
 
@@ -96,7 +102,7 @@ Write like this instead:
    }
    ```
 
-7. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
+9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
 
 ## Hard rules
 

--- a/playbooks/reply-drafter.md
+++ b/playbooks/reply-drafter.md
@@ -16,6 +16,9 @@ The run is bound to this session through the environment, so the tools default t
 ## Tools
 
 - `reply_draft_start` - load the placeholder reply draft, the parent outbound draft (for voice), and the full conversation thread.
+- `operator_voice` - your own persona and derived writing voice for this organization.
+- `my_prior_takes` - excerpts of what you have already written, matched against a query.
+- `check_style` - the deterministic house-style checker; run it on a body before persisting it.
 - `reply_draft_finish` - write the drafted reply body back.
 
 ## House style: write like a human
@@ -47,7 +50,11 @@ Write like this instead:
 
 1. **Load context.** Call `reply_draft_start` (no arguments needed). From the result read: `replyKind` (`reply_dm` / `reply_comment`), `platform`, `parent` (the original outbound draft's `body` and `reasoning`, for voice), `rubricTemplate`, and `thread` (every prior turn in chronological order, `isFromUs` marking ours vs theirs).
 
-2. **Draft the reply.** Produce ONE continuation:
+2. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the subject of this conversation, for what you have already said about it elsewhere. `parent` already anchors the voice for this one thread; these two widen that to how you actually write in general.
+
+   `operator_voice`'s derived summary describes your writing in aggregate (word count, sentence length, closers, hashtag habits) - it is measured mostly from longer posts, not a short reply like this one, so it tells you how you sound, not how long this reply should be. The length guidance in the next step still wins. Either tool can come back with `{ ok: false, reason }` instead of inventing something when there is nothing on file - match `parent`'s tone alone when that happens.
+
+3. **Draft the reply.** Produce ONE continuation:
    - Answer what the target user actually said in the most recent inbound turn (the last `thread` entry with `isFromUs: false`): address their question or concern, or move the conversation forward.
    - Match the tone and voice of `parent`. Do not be salesy - this is a 1:1 conversation, not a campaign blast.
    - Length: 1-3 short paragraphs for a DM (`reply_dm`); 1-2 sentences for a comment reply (`reply_comment`).
@@ -55,11 +62,13 @@ Write like this instead:
    - No placeholders, no meta commentary. Output the message text a human would send.
    - Apply the House style section above literally: it outranks every default here and holds even when the campaign voice says nothing about it.
 
-3. **Score the reply.** Using `rubricTemplate`, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason`.
+4. **Score the reply.** Using `rubricTemplate`, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason`.
 
-4. **Submit.** Call `reply_draft_finish` with `{ "body": "<your reply>", "qualityScore": 68, "qualityReason": "answers their question, on tone" }`. It writes the body, clears the drafting flag, and marks the run success. If it returns an error, read the message, fix the payload, and try again. **Maximum two retries.**
+5. **Check your own style before persisting.** Call `check_style` with the exact reply body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `reply_draft_finish` has no live model to send a rewrite back to.
 
-5. **On failure.** If `reply_draft_start` errors or you genuinely cannot draft a reply, call `run_finish` with `{ "status": "failed", "error": "<short reason>" }` and stop. The placeholder stays and the reviewer sees a Retry.
+6. **Submit.** Call `reply_draft_finish` with `{ "body": "<your reply>", "qualityScore": 68, "qualityReason": "answers their question, on tone" }`. It writes the body, clears the drafting flag, and marks the run success. If it returns an error, read the message, fix the payload, and try again. **Maximum two retries.**
+
+7. **On failure.** If `reply_draft_start` errors or you genuinely cannot draft a reply, call `run_finish` with `{ "status": "failed", "error": "<short reason>" }` and stop. The placeholder stays and the reviewer sees a Retry.
 
 ## What this playbook must never do
 


### PR DESCRIPTION
I gave the campaign MCP server three of the assist plane's read-only tools: `operator_voice`, `my_prior_takes` and `check_style`. They reuse the exact handlers from `shared/src/assist/tools.ts` rather than a second copy, with a context built from the run's own organization (no observed target, since a campaign run has no single post it is looking at). This is not a regression of the #520 plane isolation: that boundary is about write authority, and none of these three write anything.

All ten playbooks that draft user-visible text (`reddit-commenter`, `reddit-poster`, `hn-commenter`, `hn-poster`, `mastodon-commenter`, `mastodon-poster`, `linkedin-commenter`, `linkedin-poster`, `reply-drafter`, `draft-regenerator`) now call `operator_voice` and `my_prior_takes` before drafting, and `check_style` on the body right before persisting it, fixing whatever it finds while the model is still in the loop. That is the actual point of this issue: `createDrafts`'s own house-style backstop runs after the agent has already exited, so it can only record a structural finding, never repair one. Putting the check inside the run is the only place a repair can happen.

For the eight playbooks whose voice profile summary describes long posts (word count, closers, hashtags), I added a line telling the model the summary is about tone and vocabulary, not a target length for a short comment or reply - after Lorenzo's measurement on LOR-44 showed that same summary, read literally, pushing comment-length drafts toward post length.

`createDrafts` also records a new run event (`kind: unknown`, `eventType: style-findings-at-create`) counting how many structural findings survived to the post-hoc backstop. That count is the only way to tell whether the in-run check is actually working, over time, rather than trusted on faith.

## Acceptance, as specified

- The three tools are listed by the campaign MCP server and answer with real data for a run whose organization has a voice profile; `check_style` never refuses (by design, same as the assist plane); `operator_voice`/`my_prior_takes` answer an honest default/explicit refusal rather than an empty success when nothing is on file. Covered by `cli/tests/mcp/campaign-assist-tools.test.ts` (10 tests) against a real seeded Postgres, including cross-org isolation.
- `shared/tests/playbook-house-style.test.ts` is green (I did not touch the house-style prose, only added steps around it).
- The new run event appears on a real run: proven two ways - a deterministic test (`cli/tests/commands/drafts-create.test.ts`, two new cases: one structural finding survives and is recorded, a clean draft records zero) and a real local ACP run (see below).
- No campaign tool gained write access; no assist tool gained a campaign capability - reused handlers, reused schemas, nothing new.

**The one criterion I can only partially claim: "demonstrated on at least one real run, with the before and after in the PR."** No `AI_GATEWAY_API_KEY` is configured in this environment, so the cloud runner cannot be used. The local ACP path (`claude-code` backend) does authenticate here, and I drove one real end-to-end run through it: `reply-drafter`, with a seeded operator persona, three voice samples, and a real prior DM thread, through the actual local `pitchbox-mcp` server (not a mock). The live model called `reply_draft_start`, `operator_voice` (got the honest default, explained it drove its tone), `my_prior_takes` (explicit refusal, nothing matched), `check_style` on its candidate body (came back clean), then `reply_draft_finish`. The persisted body is independently clean under `checkStyle` when I re-checked it myself outside the run. That proves the wiring and the in-run repair loop are real, not just unit-tested. What I did **not** do is a live run of one of the eight `drafts_create`-backed playbooks to show a literal `metadata.styleFindings` before/after on that exact field, because standing up a second live scenario (campaign config schema, live network dependency) plus a genuine "before" comparison against pre-LOR-224 behavior was more live-model time than I had left in this run. The deterministic test above is the proof for that specific field.

## What I found but did not fix (out of scope for this issue)

- `replyDraftFinish` and `draftRegenFinish` (`cli/src/commands/drafts.ts`) never run the house-style backstop `enforceHouseStyle` at all, unlike `createDrafts`. A structural tell in a reply or a regenerated draft has no backstop today, in-run check or not.
- A wave-wide, cross-cutting bug in `vitest.config.ts`'s `testDatabaseUrl()`: the `DATABASE_URL` suffix regex (`[a-z0-9-]+`) rejected every worktree's actual database name in this wave (`pitchbox_test_lor_<n>`, underscore before the number), silently falling back to the shared `pitchbox_test` for every worktree's `pnpm test`. I flagged this to the whole wave over `hub` immediately; Lorenzo/Main fixed it by renaming the databases rather than patching the regex, so there is nothing left to carry in this diff, but it is worth a real follow-up issue on the config itself.

## Verification

- `pnpm -F @pitchbox/cli typecheck` and `pnpm -F @pitchbox/shared typecheck`: clean.
- `npx eslint` + `npx prettier --check` on every changed file: clean.
- Targeted suites, all green against my own isolated Postgres (`pitchbox_test_lor224`):
  - `cli/tests/mcp/campaign-assist-tools.test.ts` (new): 10/10
  - `cli/tests/commands/drafts-create.test.ts`: 11/11 (includes the two new run-event cases)
  - `cli/tests/mcp/assist-server.test.ts`: 5/5 (updated the isolation test to assert the new intentional 3-tool overlap, and that nothing else crossed)
  - `cli/tests/mcp/server.test.ts`: full file green
  - `shared/tests/playbook-house-style.test.ts`, `cli/tests/commands/playbook-draft-payloads.test.ts`: green
- Full `pnpm test`: started twice in the background; did not return within this run's remaining time budget (each attempt ran past its allotted window without finishing or failing). I could not confirm a clean full-suite result before this PR needed to go up - flagging honestly rather than claiming it.

Closes LOR-224
https://linear.app/fiorelorenzo/issue/LOR-224/featclishared-the-campaign-drafting-turn-gets-the-operators-voice-and