### PR TITLE
feat(shared,web,cli): the voice corpus holds comments and replies, and imports a LinkedIn data export

### DIFF
--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -1,0 +1,104 @@
+import { Command } from 'commander';
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import type { Db } from '@pitchbox/shared/db';
+import { findOrgBySlug } from '@pitchbox/shared/orgs';
+import { parseLinkedinExportBuffer } from '@pitchbox/shared/voice-import-archive';
+import { importVoiceSamples } from '@pitchbox/shared/operator-profile';
+import { refreshVoiceProfile } from '@pitchbox/shared/operator-voice-profile';
+import { ok, fail } from '../lib/output.js';
+
+// LOR-223: fills the operator's voice corpus in one step from LinkedIn's own
+// "Get a copy of your data" export, headlessly - the archive carries
+// Shares.csv (posts) and Comments.csv (comments, with the URL of the thing
+// commented on), which is the only way today to get more than a handful of
+// comments into the corpus without weeks of passive browsing. Capturing
+// comments off the page itself is LOR-228, deliberately separate and after
+// this one. `web/src/routes/companion/voice/+page.server.ts`'s
+// `importVoice` action is the same import for an operator without a
+// terminal - both call `parseLinkedinExportBuffer`/`importVoiceSamples` so
+// the two paths cannot drift.
+
+async function linkedinPlatformId(db: Db): Promise<number> {
+  const [row] = await db
+    .select({ id: schema.platforms.id })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.slug, 'linkedin'));
+  if (!row) throw new Error('linkedin platform not found');
+  return row.id;
+}
+
+const NUMERIC_ID = /^\d+$/;
+
+/** `--org` accepts either an organization id or a slug; omitted falls back
+ * to the 'default' organization seeded by seed-core, the same self-host
+ * posture `utility.ts`'s `resolveOrgId` already takes for a CLI command
+ * with no run/project to resolve one from. */
+async function resolveImportOrgId(db: Db, org?: string): Promise<number> {
+  if (org) {
+    const trimmed = org.trim();
+    if (NUMERIC_ID.test(trimmed)) return Number(trimmed);
+    const found = await findOrgBySlug(db, trimmed);
+    if (!found) throw new Error(`Unknown organization "${org}"`);
+    return found.id;
+  }
+  const fallback = await findOrgBySlug(db, 'default');
+  if (!fallback) throw new Error('No default organization on file - pass --org');
+  return fallback.id;
+}
+
+export interface VoiceImportInput {
+  /** Path to a LinkedIn export zip, or a single already-extracted CSV. */
+  path: string;
+  /** Organization id or slug; defaults to the 'default' organization. */
+  org?: string;
+}
+
+export interface VoiceImportResult {
+  organizationId: number;
+  /** Rows the parser produced, before dedup - stable across a re-run of the
+   * same file, which is what proves a second import is a no-op rather than
+   * a parser that silently returns less the second time. */
+  parsed: number;
+  /** New rows actually written. 0 on a re-import of the same export. */
+  inserted: number;
+  byGenre: { post: number; comment: number };
+}
+
+export async function voiceImportRun(input: VoiceImportInput): Promise<VoiceImportResult> {
+  const db = getDb();
+  const organizationId = await resolveImportOrgId(db, input.org);
+  const buffer = await readFile(input.path);
+  const items = parseLinkedinExportBuffer(buffer, basename(input.path));
+  const platformId = await linkedinPlatformId(db);
+  const { inserted, byGenre } = await importVoiceSamples(db, organizationId, platformId, items);
+  // Onboarding in one step: a fresh import is exactly the case where the
+  // corpus just crossed MIN_ITEMS_TO_DERIVE, and the whole point is that
+  // the operator does not have to separately remember to refresh.
+  if (inserted > 0) {
+    await refreshVoiceProfile(db, organizationId);
+  }
+  return { organizationId, parsed: items.length, inserted, byGenre };
+}
+
+export function registerVoiceCommands(program: Command) {
+  program
+    .command('voice:import')
+    .description(
+      'Import voice-corpus samples from a LinkedIn "Get a copy of your data" export (zip or a single Shares.csv/Comments.csv)',
+    )
+    .argument('<path>', 'path to the export zip or CSV')
+    .option(
+      '--org <slugOrId>',
+      'organization to import into (defaults to the default organization)',
+    )
+    .action(async (path: string, opts: { org?: string }) => {
+      try {
+        ok(await voiceImportRun({ path, org: opts.org }));
+      } catch (err) {
+        fail(String(err instanceof Error ? err.message : err));
+      }
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -19,6 +19,7 @@ async function main() {
   const { registerSkillCommands } = await import('./commands/skill.js');
   const { registerSeedCommands } = await import('./commands/seed-owner.js');
   const { registerUserCommands } = await import('./commands/user.js');
+  const { registerVoiceCommands } = await import('./commands/voice.js');
   registerRunCommands(program);
   registerDraftCommands(program);
   registerRedditCommands(program);
@@ -30,6 +31,7 @@ async function main() {
   registerSkillCommands(program);
   registerSeedCommands(program);
   registerUserCommands(program);
+  registerVoiceCommands(program);
   await program.parseAsync(process.argv);
 }
 

--- a/cli/tests/commands/voice-import.test.ts
+++ b/cli/tests/commands/voice-import.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { eq, sql } from 'drizzle-orm';
+import { getDb, schema } from '@pitchbox/shared/db';
+import { parseSharesCsv, parseCommentsCsv } from '@pitchbox/shared/voice-import';
+// `pitchbox voice:import` (LOR-223): fills the voice corpus from a
+// LinkedIn "Get a copy of your data" export headlessly. This exercises the
+// real command function against Postgres - `voice-import.test.ts` in
+// `shared/` already pins the pure parser's own edge cases; what only a real
+// database can prove is dedup on re-import, organization resolution, and
+// that a successful import re-derives the voice profile.
+//
+// FIXTURE NOTE: `SHARES_CSV`/`COMMENTS_CSV` below are byte-identical to the
+// ones in `web/tests/companion-settings.test.ts`'s `importVoice` suite,
+// kept in sync by hand since CLI and web are separate workspaces with no
+// shared test-fixture module between them. Both suites assert their result
+// against `parseSharesCsv`/`parseCommentsCsv` directly (the same functions
+// `voiceImportRun` and the `importVoice` action both call under the hood),
+// which is what actually proves the two paths cannot drift, rather than a
+// literal string comparison across processes.
+export const SHARES_CSV = [
+  'Date,ShareLink,ShareCommentary',
+  '2026-03-01,https://www.linkedin.com/feed/update/urn:li:activity:cli-1,Shipped the new export importer today.',
+  '2026-03-02,https://www.linkedin.com/feed/update/urn:li:activity:cli-2,',
+  '2026-03-03,https://www.linkedin.com/feed/update/urn:li:activity:cli-3,Wrapped up a long week of onboarding fixes.',
+].join('\n');
+
+export const COMMENTS_CSV = [
+  'Date,Link,Message',
+  '2026-03-01,https://www.linkedin.com/feed/update/urn:li:activity:cli-10,Nice work on this.',
+  '2026-03-02,https://www.linkedin.com/feed/update/urn:li:activity:cli-11,Love this.',
+  '2026-03-03,https://www.linkedin.com/feed/update/urn:li:activity:cli-12,So true.',
+].join('\n');
+
+async function reset() {
+  const db = getDb();
+  await db.execute(
+    sql`TRUNCATE operator_voice_samples, operator_voice_profiles RESTART IDENTITY CASCADE`,
+  );
+  await db.execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function ensureOrg(slug: string): Promise<number> {
+  const db = getDb();
+  await db.insert(schema.organizations).values({ slug, name: slug }).onConflictDoNothing();
+  const [org] = await db
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.slug, slug));
+  return org!.id;
+}
+
+beforeEach(reset);
+
+describe('voiceImportRun', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'voice-import-cli-'));
+  });
+
+  it('imports Shares.csv into the default organization when --org is omitted', async () => {
+    const { voiceImportRun } = await import('../../src/commands/voice.js');
+    const path = join(dir, 'Shares.csv');
+    await writeFile(path, SHARES_CSV, 'utf8');
+
+    const result = await voiceImportRun({ path });
+    const expected = parseSharesCsv(SHARES_CSV);
+    expect(result.parsed).toBe(expected.length);
+    expect(result.inserted).toBe(expected.length);
+    expect(result.byGenre).toEqual({ post: expected.length, comment: 0 });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.operatorVoiceSamples)
+      .where(eq(schema.operatorVoiceSamples.organizationId, result.organizationId));
+    expect(rows.map((r) => r.text).sort()).toEqual(expected.map((i) => i.text).sort());
+    expect(rows.every((r) => r.genre === 'post' && r.source === 'import')).toBe(true);
+  });
+
+  it('imports Comments.csv, tagging genre comment and carrying context', async () => {
+    const { voiceImportRun } = await import('../../src/commands/voice.js');
+    const orgId = await ensureOrg('voice-cli-comments');
+    const path = join(dir, 'Comments.csv');
+    await writeFile(path, COMMENTS_CSV, 'utf8');
+
+    const result = await voiceImportRun({ path, org: 'voice-cli-comments' });
+    expect(result.organizationId).toBe(orgId);
+    const expected = parseCommentsCsv(COMMENTS_CSV);
+    expect(result.byGenre).toEqual({ post: 0, comment: expected.length });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.operatorVoiceSamples)
+      .where(eq(schema.operatorVoiceSamples.organizationId, orgId));
+    expect(rows).toHaveLength(expected.length);
+    for (const row of rows) {
+      expect(row.genre).toBe('comment');
+      expect(row.context).not.toBeNull();
+    }
+  });
+
+  it('running the same import twice inserts nothing the second time', async () => {
+    const { voiceImportRun } = await import('../../src/commands/voice.js');
+    const orgId = await ensureOrg('voice-cli-dedup');
+    const path = join(dir, 'Shares.csv');
+    await writeFile(path, SHARES_CSV, 'utf8');
+
+    const first = await voiceImportRun({ path, org: 'voice-cli-dedup' });
+    expect(first.inserted).toBeGreaterThan(0);
+
+    const second = await voiceImportRun({ path, org: 'voice-cli-dedup' });
+    expect(second.parsed).toBe(first.parsed);
+    expect(second.inserted).toBe(0);
+
+    const rows = await getDb()
+      .select()
+      .from(schema.operatorVoiceSamples)
+      .where(eq(schema.operatorVoiceSamples.organizationId, orgId));
+    expect(rows).toHaveLength(first.inserted);
+  });
+
+  it('re-derives the voice profile after a successful import', async () => {
+    const { voiceImportRun } = await import('../../src/commands/voice.js');
+    const orgId = await ensureOrg('voice-cli-refresh');
+    const path = join(dir, 'Shares.csv');
+    await writeFile(path, SHARES_CSV, 'utf8');
+
+    await voiceImportRun({ path, org: 'voice-cli-refresh' });
+
+    const [profile] = await getDb()
+      .select()
+      .from(schema.operatorVoiceProfiles)
+      .where(eq(schema.operatorVoiceProfiles.organizationId, orgId));
+    expect(profile).toBeDefined();
+    expect(profile.source).toBe('derived');
+  });
+
+  it('rejects an unknown --org rather than silently importing into the default organization', async () => {
+    const { voiceImportRun } = await import('../../src/commands/voice.js');
+    const path = join(dir, 'Shares.csv');
+    await writeFile(path, SHARES_CSV, 'utf8');
+    await expect(voiceImportRun({ path, org: 'no-such-org' })).rejects.toThrow(
+      /Unknown organization/,
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       '@ai-sdk/mcp':
         specifier: ^2.0.45
         version: 2.0.45(zod@4.5.4)
+      adm-zip:
+        specifier: ^0.6.0
+        version: 0.6.0
       ai:
         specifier: ^7.0.93
         version: 7.0.93(zod@4.5.4)
@@ -250,6 +253,9 @@ importers:
         specifier: ^4.5.4
         version: 4.5.4
     devDependencies:
+      '@types/adm-zip':
+        specifier: ^0.5.8
+        version: 0.5.8
       '@types/html-to-text':
         specifier: ^9.0.4
         version: 9.0.4
@@ -1616,6 +1622,9 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@types/adm-zip@0.5.8':
+    resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -2067,6 +2076,10 @@ packages:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   ai@7.0.93:
     resolution: {integrity: sha512-CJss6zb9mlltk/mCr8qom20NBnqEQxVawkqwtT62tCwsxilZpXfHNRMRwcS3XRpzdP1kEluVuDBUayYWEEd95g==}
@@ -5407,6 +5420,10 @@ snapshots:
       tailwindcss: 4.3.2
       vite: 8.2.2(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)
 
+  '@types/adm-zip@0.5.8':
+    dependencies:
+      '@types/node': 26.1.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -5846,6 +5863,8 @@ snapshots:
   acorn@8.17.0: {}
 
   acorn@8.18.0: {}
+
+  adm-zip@0.6.0: {}
 
   ai@7.0.93(zod@4.5.4):
     dependencies:

--- a/shared/package.json
+++ b/shared/package.json
@@ -44,6 +44,8 @@
     "./assist/session": "./src/assist/session.ts",
     "./operator-profile": "./src/operator-profile.ts",
     "./operator-voice-profile": "./src/operator-voice-profile.ts",
+    "./voice-import": "./src/voice-import.ts",
+    "./voice-import-archive": "./src/voice-import-archive.ts",
     "./github-sources": "./src/github-sources.ts",
     "./github-app": "./src/github-app.ts",
     "./project-sources": "./src/project-sources.ts",
@@ -115,6 +117,7 @@
     "@agentclientprotocol/sdk": "^1.1.0",
     "@ai-sdk/gateway": "^4.0.75",
     "@ai-sdk/mcp": "^2.0.45",
+    "adm-zip": "^0.6.0",
     "ai": "^7.0.93",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
@@ -129,6 +132,7 @@
     "zod": "^4.5.4"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.8",
     "@types/html-to-text": "^9.0.4",
     "@types/nodemailer": "^8.0.1",
     "@types/pg": "^8.20.0",

--- a/shared/src/assist/context.ts
+++ b/shared/src/assist/context.ts
@@ -71,6 +71,15 @@ export type OperatorPersona = {
  * `operator-voice-profile.ts` for the full row (traits, evidence, source). */
 export type VoiceProfileSummary = {
   summary: string;
+  /** The comment-genre description alone (LOR-223), when the corpus has
+   * enough of the operator's own comments to say something honest about
+   * them specifically - null otherwise, including whenever `summary`
+   * itself is null-equivalent. A `post_comment` suggestion prefers this
+   * over `summary`: the pooled description is dominated by posts (they
+   * outnumber comments in most corpora and run far longer), so it tells
+   * the model the operator "usually writes with hashtags" and "closes
+   * with #BuildInPublic" when writing a comment neither is true of. */
+  commentSummary: string | null;
 };
 
 export type ProjectBrief = {
@@ -227,7 +236,12 @@ export async function loadCompanionContext(
     // A profile that has never derived anything honest (corpus too small,
     // or measurable but with no dominant trait/phrase/word) has an empty
     // summary - treated the same as no row at all.
-    voiceProfile: voiceProfileRow?.summary.trim() ? { summary: voiceProfileRow.summary } : null,
+    voiceProfile: voiceProfileRow?.summary.trim()
+      ? {
+          summary: voiceProfileRow.summary,
+          commentSummary: voiceProfileRow.evidence.genres.comment.summary,
+        }
+      : null,
     projects: projectRows.map((p) => ({
       id: p.id,
       name: p.name,

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -410,10 +410,22 @@ export function buildSuggestionPrompt(args: {
   // them (#407). No "do not reuse the content" guard here, unlike the
   // few-shot examples below - there is no content to reuse, only a
   // description of a pattern.
-  if (voiceProfile?.summary.trim()) {
-    parts.push(
-      `How the operator writes, based on what they have actually written: ${clamp(voiceProfile.summary, VOICE_PROFILE_MAX)}`,
-    );
+  //
+  // A `post_comment` suggestion prefers the comment-genre description over
+  // the pooled one when the corpus has enough comments to have derived one
+  // (LOR-223): the pooled description is dominated by posts, which
+  // outnumber and outrun comments in most corpora, so it tells the model
+  // things true of a post ("usually writes with hashtags", "about 16 words
+  // per sentence") that are false of the one-line comment it is about to
+  // write. Falls back to the pooled summary when the corpus has not
+  // measured comments on their own yet.
+  const commentVoice = kind === 'post_comment' ? voiceProfile?.commentSummary?.trim() : undefined;
+  const voiceProfileText = commentVoice || voiceProfile?.summary.trim();
+  if (voiceProfileText) {
+    const lead = commentVoice
+      ? 'How the operator writes when commenting, based on their own comments'
+      : 'How the operator writes, based on what they have actually written';
+    parts.push(`${lead}: ${clamp(voiceProfileText, VOICE_PROFILE_MAX)}`);
   }
 
   // What they are building: every project in the organization, with its own

--- a/shared/src/assist/voice-profile.ts
+++ b/shared/src/assist/voice-profile.ts
@@ -38,12 +38,33 @@ const VOICE_CORPUS_ITEM_KINDS: readonly VoiceCorpusItemKind[] = [
   'template',
 ];
 
+/** The genre of a piece of writing - a post, a top-level comment or a
+ * reply to a comment (LOR-223). Only `voice_sample` items carry one today
+ * (`operator_voice_samples.genre`): a message, a sent draft or a template
+ * is outreach, not a LinkedIn post or comment, so it has no genre of this
+ * kind and is left out of the per-genre split below, while still counting
+ * toward the pooled corpus `measureVoiceCorpus` already produces. A post
+ * and a comment are not the same voice at a different length - Lorenzo's
+ * own corpus runs a median 122 words per post against a median 7 words per
+ * comment, sixteen of twenty-seven comments under ten words - so pooling
+ * them is what makes a comment suggestion come out as a paragraph. */
+export type VoiceCorpusItemGenre = 'post' | 'comment' | 'reply';
+
+export const VOICE_CORPUS_ITEM_GENRES: readonly VoiceCorpusItemGenre[] = [
+  'post',
+  'comment',
+  'reply',
+];
+
 /** One piece of the operator's own writing, tagged with where it came from
  * and its id, so the caller can turn a measurement back into evidence
- * (which ids it was derived from) without re-deriving it. */
+ * (which ids it was derived from) without re-deriving it. `genre` is
+ * absent for a corpus item with no genre of its own (message, draft,
+ * template) - see `VoiceCorpusItemGenre`'s own comment. */
 export type VoiceCorpusItem = {
   id: number;
   kind: VoiceCorpusItemKind;
+  genre?: VoiceCorpusItemGenre;
   text: string;
 };
 
@@ -865,8 +886,17 @@ const LANGUAGE_PROSE: Record<Exclude<LanguageMix['primary'], null>, string> = {
  * when the corpus said nothing worth reporting - too small, or measurable
  * but with no dominant trait, phrase or reused word - which the prompt
  * renders as no voice-profile section at all rather than an empty one.
+ *
+ * `noun` names what was counted in the leading sentence - "pieces of their
+ * own writing" for the pooled corpus, "of their own posts"/"comments" for
+ * a genre-scoped one (LOR-223's `describeVoiceProfileForGenre`) - so the
+ * same renderer works for both without the caller reaching into the
+ * string afterward.
  */
-export function describeVoiceProfile(m: VoiceMeasurement): string | null {
+export function describeVoiceProfile(
+  m: VoiceMeasurement,
+  noun = 'pieces of their own writing',
+): string | null {
   if (!m.measurable) return null;
 
   const sentences: string[] = [];
@@ -905,5 +935,62 @@ export function describeVoiceProfile(m: VoiceMeasurement): string | null {
   }
 
   if (sentences.length === 0) return null;
-  return `Based on ${m.itemCount} pieces of their own writing (${m.wordCount} words). ${sentences.join(' ')}`;
+  return `Based on ${m.itemCount} ${noun} (${m.wordCount} words). ${sentences.join(' ')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Per-genre measurement (LOR-223): a post and a comment are different
+// genres of writing, not the same voice at a different length, so each gets
+// its own measurement rather than one pooled average diluting both. The
+// pooled `measureVoiceCorpus` above is unchanged and still the right call
+// for "how does this person write, overall" - this is the addition, not a
+// replacement.
+// ---------------------------------------------------------------------------
+
+const GENRE_NOUN: Record<VoiceCorpusItemGenre, string> = {
+  post: 'of their own posts',
+  comment: 'of their own comments',
+  reply: 'of their own replies',
+};
+
+/**
+ * `measureVoiceCorpus`, once per genre, over only the corpus items that
+ * carry one (a message, sent draft or template has no genre and is simply
+ * absent from every bucket - it already counts toward the pooled
+ * measurement). Every genre in `VOICE_CORPUS_ITEM_GENRES` is always a key
+ * in the result, `measurable: false` when that genre's own item count has
+ * not cleared `MIN_ITEMS_TO_DERIVE` - the same "say nothing rather than
+ * guess" discipline the pooled measurement already applies, now per genre
+ * rather than only across the whole corpus.
+ *
+ * A genre whose items are individually short (LinkedIn comments run a
+ * median of a handful of words - well under `register.ts`'s own floor for
+ * a single item to carry a register, and often under the two stopword hits
+ * `measureLanguage` needs to classify one) is not the same thing as a
+ * genre with too few items: `MIN_ITEMS_TO_DERIVE` gates on `itemCount`,
+ * every other floor below it (register's word count, the language
+ * classifier's stopword count, lexicon's 200-word floor) is already
+ * per-item or per-corpus-word-count rather than per-genre, so a comment
+ * corpus large enough in item count still reports rhythm and shape
+ * honestly even when few individual comments clear register.ts's floor -
+ * it just reports an empty `traits`/`wordsPerSentence` rather than one
+ * derived from too little.
+ */
+export function measureVoiceCorpusByGenre(
+  corpus: VoiceCorpusItem[],
+): Record<VoiceCorpusItemGenre, VoiceMeasurement> {
+  const result = {} as Record<VoiceCorpusItemGenre, VoiceMeasurement>;
+  for (const genre of VOICE_CORPUS_ITEM_GENRES) {
+    result[genre] = measureVoiceCorpus(corpus.filter((item) => item.genre === genre));
+  }
+  return result;
+}
+
+/** `describeVoiceProfile`, worded for one genre ("Based on 12 of their own
+ * comments" rather than "12 pieces of their own writing"). */
+export function describeVoiceProfileForGenre(
+  genre: VoiceCorpusItemGenre,
+  m: VoiceMeasurement,
+): string | null {
+  return describeVoiceProfile(m, GENRE_NOUN[genre]);
 }

--- a/shared/src/db/migrations/0035_worried_harrier.sql
+++ b/shared/src/db/migrations/0035_worried_harrier.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "operator_voice_samples" ADD COLUMN "genre" text DEFAULT 'post' NOT NULL;--> statement-breakpoint
+ALTER TABLE "operator_voice_samples" ADD COLUMN "source" text DEFAULT 'capture' NOT NULL;--> statement-breakpoint
+ALTER TABLE "operator_voice_samples" ADD COLUMN "context" text;

--- a/shared/src/db/migrations/meta/0035_snapshot.json
+++ b/shared/src/db/migrations/meta/0035_snapshot.json
@@ -1,0 +1,5426 @@
+{
+  "id": "6e71c637-aa04-4a67-8d2e-eb6ab108e150",
+  "prevId": "c5699563-1869-4e57-b887-88af7899c46e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cookie_session": {
+          "name": "cookie_session",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_url": {
+          "name": "instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_limit": {
+          "name": "weekly_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_project_id_projects_id_fk": {
+          "name": "accounts_project_id_projects_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_platform_id_platforms_id_fk": {
+          "name": "accounts_platform_id_platforms_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assist_accepted_suggestions": {
+      "name": "assist_accepted_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_urn": {
+          "name": "post_urn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_url": {
+          "name": "post_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edited_from": {
+          "name": "edited_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_cost_usd": {
+          "name": "reported_cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_cost_usd": {
+          "name": "recomputed_cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assist_accepted_suggestions_org_created_idx": {
+          "name": "assist_accepted_suggestions_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assist_accepted_suggestions_author_idx": {
+          "name": "assist_accepted_suggestions_author_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assist_accepted_suggestions_organization_id_organizations_id_fk": {
+          "name": "assist_accepted_suggestions_organization_id_organizations_id_fk",
+          "tableFrom": "assist_accepted_suggestions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_accepted_suggestions_project_id_projects_id_fk": {
+          "name": "assist_accepted_suggestions_project_id_projects_id_fk",
+          "tableFrom": "assist_accepted_suggestions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assist_accepted_suggestions_platform_id_platforms_id_fk": {
+          "name": "assist_accepted_suggestions_platform_id_platforms_id_fk",
+          "tableFrom": "assist_accepted_suggestions",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assist_accepted_suggestions_device_id_extension_devices_id_fk": {
+          "name": "assist_accepted_suggestions_device_id_extension_devices_id_fk",
+          "tableFrom": "assist_accepted_suggestions",
+          "tableTo": "extension_devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assist_usage": {
+      "name": "assist_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "assist_usage_org_created_idx": {
+          "name": "assist_usage_org_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "assist_usage_project_created_idx": {
+          "name": "assist_usage_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "assist_usage_organization_id_organizations_id_fk": {
+          "name": "assist_usage_organization_id_organizations_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assist_usage_project_id_projects_id_fk": {
+          "name": "assist_usage_project_id_projects_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assist_usage_device_id_extension_devices_id_fk": {
+          "name": "assist_usage_device_id_extension_devices_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "extension_devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assist_usage_platform_id_platforms_id_fk": {
+          "name": "assist_usage_platform_id_platforms_id_fk",
+          "tableFrom": "assist_usage",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_failures": {
+      "name": "auth_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login_attempt'"
+        }
+      },
+      "indexes": {
+        "auth_failures_identifier_idx": {
+          "name": "auth_failures_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocklist": {
+      "name": "blocklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocklist_platform_id_platforms_id_fk": {
+          "name": "blocklist_platform_id_platforms_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocklist_project_id_projects_id_fk": {
+          "name": "blocklist_project_id_projects_id_fk",
+          "tableFrom": "blocklist",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaign_recommendations": {
+      "name": "campaign_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_slug": {
+          "name": "scenario_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "campaign_recommendations_project_idx": {
+          "name": "campaign_recommendations_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "campaign_recommendations_project_id_projects_id_fk": {
+          "name": "campaign_recommendations_project_id_projects_id_fk",
+          "tableFrom": "campaign_recommendations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.campaigns": {
+      "name": "campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_slug": {
+          "name": "skill_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_attempts": {
+          "name": "failure_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_due_to_failures": {
+          "name": "paused_due_to_failures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_post": {
+          "name": "auto_post",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "campaigns_project_id_projects_id_fk": {
+          "name": "campaigns_project_id_projects_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "campaigns_platform_id_platforms_id_fk": {
+          "name": "campaigns_platform_id_platforms_id_fk",
+          "tableFrom": "campaigns",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_history": {
+      "name": "contact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_handle": {
+          "name": "account_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_checked_at": {
+          "name": "reply_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_room_id": {
+          "name": "chat_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_context_url": {
+          "name": "platform_context_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uncontactable": {
+          "name": "uncontactable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uncontactable_reason": {
+          "name": "uncontactable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_history_target_idx": {
+          "name": "contact_history_target_idx",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_target_idx": {
+          "name": "messages_account_target_idx",
+          "columns": [
+            {
+              "expression": "account_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_history_org_idx": {
+          "name": "contact_history_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_contacted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_history_platform_id_platforms_id_fk": {
+          "name": "contact_history_platform_id_platforms_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contact_history_draft_id_drafts_id_fk": {
+          "name": "contact_history_draft_id_drafts_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_history_organization_id_organizations_id_fk": {
+          "name": "contact_history_organization_id_organizations_id_fk",
+          "tableFrom": "contact_history",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daemon_heartbeats": {
+      "name": "daemon_heartbeats",
+      "schema": "",
+      "columns": {
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tick_at": {
+          "name": "tick_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_events": {
+      "name": "draft_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_events_kind_created_idx": {
+          "name": "draft_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_events_draft_id_drafts_id_fk": {
+          "name": "draft_events_draft_id_drafts_id_fk",
+          "tableFrom": "draft_events",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_regeneration_hints": {
+      "name": "draft_regeneration_hints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint_text": {
+          "name": "hint_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_regeneration_hints_draft_id_drafts_id_fk": {
+          "name": "draft_regeneration_hints_draft_id_drafts_id_fk",
+          "tableFrom": "draft_regeneration_hints",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "fit_score": {
+          "name": "fit_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user": {
+          "name": "target_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_url": {
+          "name": "compose_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_content": {
+          "name": "sent_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_comment_id": {
+          "name": "platform_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dedup_warning": {
+          "name": "dedup_warning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_edited": {
+          "name": "body_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scheduled_send_after": {
+          "name": "scheduled_send_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regeneration_count": {
+          "name": "regeneration_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerating_run_id": {
+          "name": "regenerating_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drafting_run_id": {
+          "name": "drafting_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_reason": {
+          "name": "quality_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_model": {
+          "name": "quality_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_id": {
+          "name": "variant_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_label": {
+          "name": "variant_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undeliverable_reason": {
+          "name": "undeliverable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drafts_state_idx": {
+          "name": "drafts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_project_idx": {
+          "name": "drafts_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_run_idx": {
+          "name": "drafts_state_run_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_state_campaign_created_idx": {
+          "name": "drafts_state_campaign_created_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_variant_group_idx": {
+          "name": "drafts_variant_group_idx",
+          "columns": [
+            {
+              "expression": "variant_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_run_id_runs_id_fk": {
+          "name": "drafts_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_project_id_projects_id_fk": {
+          "name": "drafts_project_id_projects_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_platform_id_platforms_id_fk": {
+          "name": "drafts_platform_id_platforms_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_accounts_id_fk": {
+          "name": "drafts_account_id_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "drafts_regenerating_run_id_runs_id_fk": {
+          "name": "drafts_regenerating_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "regenerating_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drafts_drafting_run_id_runs_id_fk": {
+          "name": "drafts_drafting_run_id_runs_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "drafting_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_verification_tokens_token_hash_unique": {
+          "name": "email_verification_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_verification_tokens_user_idx": {
+          "name": "email_verification_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_devices": {
+      "name": "extension_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unnamed device'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "extension_devices_token_hash_unique": {
+          "name": "extension_devices_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extension_devices_organization_id_organizations_id_fk": {
+          "name": "extension_devices_organization_id_organizations_id_fk",
+          "tableFrom": "extension_devices",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extension_pairings": {
+      "name": "extension_pairings",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extension_pairings_organization_id_organizations_id_fk": {
+          "name": "extension_pairings_organization_id_organizations_id_fk",
+          "tableFrom": "extension_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'User'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selected'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_unique": {
+          "name": "github_installations_installation_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_org_idx": {
+          "name": "github_installations_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_organization_id_organizations_id_fk": {
+          "name": "github_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_sources": {
+      "name": "github_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_language": {
+          "name": "primary_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readme_excerpt": {
+          "name": "readme_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_commits": {
+          "name": "recent_commits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_sources_org_repo_unique": {
+          "name": "github_sources_org_repo_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_sources_organization_id_organizations_id_fk": {
+          "name": "github_sources_organization_id_organizations_id_fk",
+          "tableFrom": "github_sources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_audit_log": {
+      "name": "instance_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "instance_audit_log_created_idx": {
+          "name": "instance_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_watches": {
+      "name": "keyword_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_field": {
+          "name": "match_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_after": {
+          "name": "next_attempt_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "keyword_watches_campaign_idx": {
+          "name": "keyword_watches_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_watches_project_idx": {
+          "name": "keyword_watches_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_watches_project_id_projects_id_fk": {
+          "name": "keyword_watches_project_id_projects_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "keyword_watches_campaign_id_campaigns_id_fk": {
+          "name": "keyword_watches_campaign_id_campaigns_id_fk",
+          "tableFrom": "keyword_watches",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_org_user_unique": {
+          "name": "memberships_org_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_from_us": {
+          "name": "is_from_us",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_platform": {
+          "name": "created_at_platform",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "messages_contact_idx": {
+          "name": "messages_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_platform_message_unique": {
+          "name": "messages_platform_message_unique",
+          "columns": [
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_contact_id_contact_history_id_fk": {
+          "name": "messages_contact_id_contact_history_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "contact_history",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_draft_id_drafts_id_fk": {
+          "name": "messages_draft_id_drafts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_platform_id_platforms_id_fk": {
+          "name": "messages_platform_id_platforms_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_unread_idx": {
+          "name": "notifications_unread_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_idx": {
+          "name": "notifications_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organization_id_organizations_id_fk": {
+          "name": "notifications_organization_id_organizations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observed_targets": {
+      "name": "observed_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consumed_by_run_id": {
+          "name": "consumed_by_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "observed_targets_dedup_idx": {
+          "name": "observed_targets_dedup_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "observed_targets_project_unconsumed_idx": {
+          "name": "observed_targets_project_unconsumed_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_by_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "observed_targets_organization_id_organizations_id_fk": {
+          "name": "observed_targets_organization_id_organizations_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_project_id_projects_id_fk": {
+          "name": "observed_targets_project_id_projects_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "observed_targets_platform_id_platforms_id_fk": {
+          "name": "observed_targets_platform_id_platforms_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observed_targets_consumed_by_run_id_runs_id_fk": {
+          "name": "observed_targets_consumed_by_run_id_runs_id_fk",
+          "tableFrom": "observed_targets",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "consumed_by_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.onboarding_state": {
+      "name": "onboarding_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "onboarding_state_user_org_unique": {
+          "name": "onboarding_state_user_org_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"onboarding_state\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "onboarding_state_org_no_user_unique": {
+          "name": "onboarding_state_org_no_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"onboarding_state\".\"user_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "onboarding_state_user_id_users_id_fk": {
+          "name": "onboarding_state_user_id_users_id_fk",
+          "tableFrom": "onboarding_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "onboarding_state_organization_id_organizations_id_fk": {
+          "name": "onboarding_state_organization_id_organizations_id_fk",
+          "tableFrom": "onboarding_state",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_profiles": {
+      "name": "operator_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "about": {
+          "name": "about",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiences": {
+          "name": "experiences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'linkedin_capture'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_profiles_org_unique": {
+          "name": "operator_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_profiles": {
+      "name": "operator_voice_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "traits": {
+          "name": "traits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "openings": {
+          "name": "openings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "closings": {
+          "name": "closings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "common_words": {
+          "name": "common_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "words_per_sentence": {
+          "name": "words_per_sentence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'derived'"
+        },
+        "derived_at": {
+          "name": "derived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_profiles_org_unique": {
+          "name": "operator_voice_profiles_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_profiles_organization_id_organizations_id_fk": {
+          "name": "operator_voice_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_voice_samples": {
+      "name": "operator_voice_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'capture'"
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "operator_voice_samples_org_external_unique": {
+          "name": "operator_voice_samples_org_external_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operator_voice_samples_org_idx": {
+          "name": "operator_voice_samples_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "excluded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operator_voice_samples_organization_id_organizations_id_fk": {
+          "name": "operator_voice_samples_organization_id_organizations_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "operator_voice_samples_platform_id_platforms_id_fk": {
+          "name": "operator_voice_samples_platform_id_platforms_id_fk",
+          "tableFrom": "operator_voice_samples",
+          "tableTo": "platforms",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invites": {
+      "name": "org_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_invites_org_idx": {
+          "name": "org_invites_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invites_organization_id_organizations_id_fk": {
+          "name": "org_invites_organization_id_organizations_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invites_created_by_user_id_users_id_fk": {
+          "name": "org_invites_created_by_user_id_users_id_fk",
+          "tableFrom": "org_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invites_token_unique": {
+          "name": "org_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_subscriptions": {
+      "name": "org_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_plan_id": {
+          "name": "pending_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_plan_effective_at": {
+          "name": "pending_plan_effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_runs": {
+          "name": "limit_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_suggestions": {
+          "name": "limit_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_projects": {
+          "name": "limit_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_seats": {
+          "name": "limit_seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_devices": {
+          "name": "limit_devices",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrency": {
+          "name": "limit_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_budget_usd": {
+          "name": "limit_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_retention_days": {
+          "name": "limit_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_premium_models": {
+          "name": "limit_premium_models",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_subscriptions_org_unique": {
+          "name": "org_subscriptions_org_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_subscriptions_stripe_subscription_unique": {
+          "name": "org_subscriptions_stripe_subscription_unique",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_subscriptions_organization_id_organizations_id_fk": {
+          "name": "org_subscriptions_organization_id_organizations_id_fk",
+          "tableFrom": "org_subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_run_budget_usd": {
+          "name": "monthly_run_budget_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_source": {
+          "name": "plan_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "plan_updated_at": {
+          "name": "plan_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organizations_stripe_customer_id_unique": {
+          "name": "organizations_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_user_idx": {
+          "name": "password_reset_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platforms": {
+      "name": "platforms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platforms_slug_unique": {
+          "name": "platforms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playbooks": {
+      "name": "playbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playbooks_slug_unique": {
+          "name": "playbooks_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_insights": {
+      "name": "project_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary_md": {
+          "name": "summary_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_insights_project_idx": {
+          "name": "project_insights_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_insights_project_id_projects_id_fk": {
+          "name": "project_insights_project_id_projects_id_fk",
+          "tableFrom": "project_insights",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_sources": {
+      "name": "project_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_error": {
+          "name": "fetch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_runner": {
+          "name": "default_agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "voice_tone": {
+          "name": "voice_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_tone_notes": {
+          "name": "voice_tone_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_org_slug_unique": {
+          "name": "projects_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_events": {
+      "name": "run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_events_run_idx": {
+          "name": "run_events_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_events_kind_created_idx": {
+          "name": "run_events_kind_created_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'campaign'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent_runner": {
+          "name": "agent_runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout_log_path": {
+          "name": "stdout_log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playbook_body": {
+          "name": "playbook_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_project_kind_idx": {
+          "name": "runs_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_campaign_id_campaigns_id_fk": {
+          "name": "runs_campaign_id_campaigns_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_project_id_projects_id_fk": {
+          "name": "runs_project_id_projects_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_scout_candidates": {
+      "name": "staging_scout_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staging_scout_candidates_run_id_runs_id_fk": {
+          "name": "staging_scout_candidates_run_id_runs_id_fk",
+          "tableFrom": "staging_scout_candidates",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_project_kind_idx": {
+          "name": "templates_project_kind_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_project_id_projects_id_fk": {
+          "name": "templates_project_id_projects_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_instance_admin": {
+          "name": "is_instance_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recent_idx": {
+          "name": "webhook_deliveries_recent_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_org_idx": {
+          "name": "webhook_deliveries_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_organization_id_organizations_id_fk": {
+          "name": "webhook_deliveries_organization_id_organizations_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/src/db/migrations/meta/_journal.json
+++ b/shared/src/db/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1789046240689,
       "tag": "0034_ambitious_lady_bullseye",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1789089612285,
+      "tag": "0035_worried_harrier",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/src/db/schema.ts
+++ b/shared/src/db/schema.ts
@@ -1236,6 +1236,26 @@ export const operatorVoiceSamples = pgTable(
     url: text('url'),
     postedAt: timestamp('posted_at', { withTimezone: true }),
     excluded: boolean('excluded').notNull().default(false),
+    /** The writing's genre - `post` (a LinkedIn share), `comment` (a
+     * top-level comment) or `reply` (a reply to a comment). Defaults to
+     * `post` so every row written before this column existed (every
+     * passively captured sample, which was always a post) reads back
+     * correctly without a backfill (LOR-223). A post and a comment are
+     * different genres of writing - different length, different opening,
+     * different relationship to the reader - and pooling them is what
+     * made a comment suggestion come out sounding like a post. */
+    genre: text('genre').notNull().default('post'),
+    /** Where the row came from: `capture` (the extension's passive
+     * recent-activity read), `import` (a LinkedIn data-export upload) or
+     * `manual` (typed by hand). Defaults to `capture`, the only source
+     * that existed before this column (LOR-223). */
+    source: text('source').notNull().default('capture'),
+    /** For a comment, the post it was written under, as far as the export
+     * or capture knows it - the stimulus a comment reacts to, which is
+     * worth keeping alongside the comment itself for the eval set and for
+     * few-shot selection. Null for a post, and for a comment whose
+     * stimulus is unknown (LOR-223). */
+    context: text('context'),
     capturedAt: timestamp('captured_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({

--- a/shared/src/operator-profile.ts
+++ b/shared/src/operator-profile.ts
@@ -10,6 +10,7 @@
 
 import { and, desc, eq } from 'drizzle-orm';
 import { schema, type Db } from './db/client.js';
+import type { ImportedVoiceItem } from './voice-import.js';
 
 export type OperatorProfileSource = 'linkedin_capture' | 'manual';
 
@@ -35,6 +36,15 @@ export type OperatorProfileRow = {
   updatedAt: Date;
 };
 
+/** A voice sample's genre - `post` (a LinkedIn share), `comment` (a
+ * top-level comment) or `reply` (a reply to a comment). See
+ * `schema.ts`'s own comment on `operator_voice_samples.genre` (LOR-223). */
+export type VoiceSampleGenre = 'post' | 'comment' | 'reply';
+
+/** Where a voice sample came from: the extension's passive capture, a
+ * LinkedIn data-export import, or typed by hand. */
+export type VoiceSampleSource = 'capture' | 'import' | 'manual';
+
 export type OperatorVoiceSampleRow = {
   id: number;
   organizationId: number;
@@ -44,6 +54,9 @@ export type OperatorVoiceSampleRow = {
   url: string | null;
   postedAt: Date | null;
   excluded: boolean;
+  genre: VoiceSampleGenre;
+  source: VoiceSampleSource;
+  context: string | null;
   capturedAt: Date;
 };
 
@@ -167,6 +180,13 @@ export type IncomingVoiceSample = {
   text: string;
   url?: string | null;
   postedAt?: string | null;
+  /** Defaults to `post` - every call site before LOR-223 only ever
+   * captured posts, so an omitted genre must keep meaning exactly that. */
+  genre?: VoiceSampleGenre;
+  /** Defaults to `capture` - the extension's passive read is the only
+   * caller that omits this. */
+  source?: VoiceSampleSource;
+  context?: string | null;
 };
 
 /**
@@ -195,6 +215,9 @@ export async function recordVoiceSamples(
         text: s.text,
         url: s.url ?? null,
         postedAt: s.postedAt ? new Date(s.postedAt) : null,
+        genre: s.genre ?? 'post',
+        source: s.source ?? 'capture',
+        context: s.context ?? null,
       })),
     )
     .onConflictDoNothing({
@@ -202,4 +225,54 @@ export async function recordVoiceSamples(
     })
     .returning({ id: schema.operatorVoiceSamples.id });
   return inserted.length;
+}
+
+export type VoiceImportResult = {
+  /** New rows actually written - a re-import of the same export returns 0
+   * here, since `parseLinkedinVoiceExport`'s external ids are deterministic
+   * and the unique index does the rest. */
+  inserted: number;
+  byGenre: { post: number; comment: number };
+};
+
+/**
+ * Persists a parsed LinkedIn export (`voice-import.ts`'s
+ * `ImportedVoiceItem[]`) the same way `recordVoiceSamples` persists a
+ * passive capture - same table, same dedup index - but tagged
+ * `source: 'import'` so the Voice page and the derivation's provenance can
+ * tell the two apart, and carrying each item's genre and, for a comment,
+ * its context (the post it replied to).
+ */
+export async function importVoiceSamples(
+  db: Db,
+  organizationId: number,
+  platformId: number,
+  items: ImportedVoiceItem[],
+): Promise<VoiceImportResult> {
+  if (items.length === 0) return { inserted: 0, byGenre: { post: 0, comment: 0 } };
+  const inserted = await db
+    .insert(schema.operatorVoiceSamples)
+    .values(
+      items.map((item) => ({
+        organizationId,
+        platformId,
+        externalId: item.externalId,
+        text: item.text,
+        url: item.url,
+        postedAt: item.postedAt ? new Date(item.postedAt) : null,
+        genre: item.genre,
+        source: 'import' as const,
+        context: item.context,
+      })),
+    )
+    .onConflictDoNothing({
+      target: [schema.operatorVoiceSamples.organizationId, schema.operatorVoiceSamples.externalId],
+    })
+    .returning({ id: schema.operatorVoiceSamples.id, genre: schema.operatorVoiceSamples.genre });
+
+  const byGenre = { post: 0, comment: 0 };
+  for (const row of inserted) {
+    if (row.genre === 'post' || row.genre === 'comment') byGenre[row.genre] += 1;
+  }
+  return { inserted: inserted.length, byGenre };
 }

--- a/shared/src/operator-voice-profile.ts
+++ b/shared/src/operator-voice-profile.ts
@@ -32,9 +32,13 @@ import { and, desc, eq, isNotNull } from 'drizzle-orm';
 import { schema, type Db } from './db/client.js';
 import {
   measureVoiceCorpus,
+  measureVoiceCorpusByGenre,
   describeVoiceProfile,
+  describeVoiceProfileForGenre,
   MIN_ITEMS_TO_DERIVE,
+  VOICE_CORPUS_ITEM_GENRES,
   type VoiceCorpusItem,
+  type VoiceCorpusItemGenre,
   type RhythmProfile,
   type PunctuationProfile,
   type ShapeProfile,
@@ -66,11 +70,25 @@ export type VoiceCorpusProvenance = {
   counts: { voiceSamples: number; messages: number; drafts: number; templates: number };
 };
 
+/** One genre's own share of the derivation, alongside the pooled one -
+ * "his comments run 2 sentences and open with a concrete noun; his posts
+ * run 5" needs its own prose per genre, not one description averaged
+ * across both (LOR-223). `measurable: false` and `summary: null` mean
+ * exactly what they mean on the pooled `VoiceMeasurement`: this genre has
+ * not cleared `MIN_ITEMS_TO_DERIVE` yet, so nothing here is a guess. */
+export type VoiceGenreSummary = {
+  summary: string | null;
+  itemCount: number;
+  measurable: boolean;
+};
+
 /** What a stored row carries about its own derivation: the provenance
- * above, the format version it was derived with (#570), and the six
- * extended measurement axes - stored here rather than in a new column
- * because `evidence` is already schemaless jsonb and nobody in this wave
- * holds the migration slot. */
+ * above, the format version it was derived with (#570), the six extended
+ * measurement axes, and (LOR-223) each genre's own summary - stored here
+ * rather than in a new column because `evidence` is already schemaless
+ * jsonb and nobody in this wave but LOR-223 holds the migration slot, and
+ * LOR-223's own slot went to the columns the genre itself is read from,
+ * not to a second jsonb shape. */
 export type VoiceProfileEvidence = VoiceCorpusProvenance & {
   version: number;
   rhythm: RhythmProfile;
@@ -79,6 +97,7 @@ export type VoiceProfileEvidence = VoiceCorpusProvenance & {
   voiceMarkers: VoiceMarkerProfile;
   lexicon: LexiconProfile;
   language: LanguageProfile;
+  genres: Record<VoiceCorpusItemGenre, VoiceGenreSummary>;
 };
 
 export type OperatorVoiceProfileRow = {
@@ -107,6 +126,14 @@ const EMPTY_PROVENANCE: VoiceCorpusProvenance = {
   counts: { voiceSamples: 0, messages: 0, drafts: 0, templates: 0 },
 };
 
+const EMPTY_GENRE_SUMMARY: VoiceGenreSummary = { summary: null, itemCount: 0, measurable: false };
+
+const EMPTY_GENRE_SUMMARIES: Record<VoiceCorpusItemGenre, VoiceGenreSummary> = {
+  post: EMPTY_GENRE_SUMMARY,
+  comment: EMPTY_GENRE_SUMMARY,
+  reply: EMPTY_GENRE_SUMMARY,
+};
+
 const EMPTY_EVIDENCE: VoiceProfileEvidence = {
   ...EMPTY_PROVENANCE,
   version: 0,
@@ -116,14 +143,15 @@ const EMPTY_EVIDENCE: VoiceProfileEvidence = {
   voiceMarkers: EMPTY_VOICE_MARKERS,
   lexicon: EMPTY_LEXICON,
   language: EMPTY_LANGUAGE,
+  genres: EMPTY_GENRE_SUMMARIES,
 };
 
 /** Reads a stored `evidence` blob back into the current full shape,
  * whichever version wrote it. A field absent from the stored JSON (a row
- * from before #570, or before #407 for `counts`/the id arrays) reads as
- * this axis's empty value rather than `undefined` - the loader never
- * throws on an older profile, and never invents a measurement for an axis
- * that was never derived. */
+ * from before #570, or before #407 for `counts`/the id arrays, or before
+ * LOR-223 for `genres`) reads as this axis's empty value rather than
+ * `undefined` - the loader never throws on an older profile, and never
+ * invents a measurement for an axis that was never derived. */
 function normalizeEvidence(raw: unknown): VoiceProfileEvidence {
   const r = (raw && typeof raw === 'object' ? raw : {}) as Partial<VoiceProfileEvidence>;
   return {
@@ -139,6 +167,7 @@ function normalizeEvidence(raw: unknown): VoiceProfileEvidence {
     voiceMarkers: r.voiceMarkers ?? EMPTY_VOICE_MARKERS,
     lexicon: r.lexicon ?? EMPTY_LEXICON,
     language: r.language ?? EMPTY_LANGUAGE,
+    genres: r.genres ?? EMPTY_GENRE_SUMMARIES,
   };
 }
 
@@ -179,7 +208,11 @@ async function gatherVoiceCorpus(
 ): Promise<{ corpus: VoiceCorpusItem[]; evidence: VoiceCorpusProvenance }> {
   const [sampleRows, messageRows, draftRows, templateRows] = await Promise.all([
     db
-      .select({ id: schema.operatorVoiceSamples.id, text: schema.operatorVoiceSamples.text })
+      .select({
+        id: schema.operatorVoiceSamples.id,
+        text: schema.operatorVoiceSamples.text,
+        genre: schema.operatorVoiceSamples.genre,
+      })
       .from(schema.operatorVoiceSamples)
       .where(
         and(
@@ -224,7 +257,12 @@ async function gatherVoiceCorpus(
   ]);
 
   const corpus: VoiceCorpusItem[] = [
-    ...sampleRows.map((r) => ({ id: r.id, kind: 'voice_sample' as const, text: r.text })),
+    ...sampleRows.map((r) => ({
+      id: r.id,
+      kind: 'voice_sample' as const,
+      genre: r.genre as VoiceCorpusItemGenre,
+      text: r.text,
+    })),
     ...messageRows.map((r) => ({ id: r.id, kind: 'message' as const, text: r.text })),
     ...draftRows.map((r) => ({ id: r.id, kind: 'draft' as const, text: r.sentContent ?? r.body })),
     ...templateRows.map((r) => ({ id: r.id, kind: 'template' as const, text: r.text })),
@@ -277,6 +315,22 @@ export async function refreshVoiceProfile(
   const measurement = measureVoiceCorpus(corpus);
   const summary = describeVoiceProfile(measurement) ?? '';
 
+  // LOR-223: each genre measured on its own, alongside the pooled corpus
+  // above - "his comments run 2 sentences and open with a concrete noun;
+  // his posts run 5" needs a per-genre description, not the pooled one
+  // repeated. A message/draft/template carries no genre and never enters
+  // any of these three buckets - see VoiceCorpusItemGenre's own comment.
+  const measurementByGenre = measureVoiceCorpusByGenre(corpus);
+  const genres = {} as VoiceProfileEvidence['genres'];
+  for (const genre of VOICE_CORPUS_ITEM_GENRES) {
+    const genreMeasurement = measurementByGenre[genre];
+    genres[genre] = {
+      summary: describeVoiceProfileForGenre(genre, genreMeasurement),
+      itemCount: genreMeasurement.itemCount,
+      measurable: genreMeasurement.measurable,
+    };
+  }
+
   const evidence: VoiceProfileEvidence = {
     ...provenance,
     version: (existing?.evidence.version ?? 0) + 1,
@@ -286,6 +340,7 @@ export async function refreshVoiceProfile(
     voiceMarkers: measurement.voiceMarkers,
     lexicon: measurement.lexicon,
     language: measurement.language,
+    genres,
   };
 
   const values = {

--- a/shared/src/voice-import-archive.ts
+++ b/shared/src/voice-import-archive.ts
@@ -1,0 +1,71 @@
+// The impure half of the LinkedIn export importer (LOR-223): reading a zip
+// or a bare CSV off disk/upload and handing text to the pure parser in
+// voice-import.ts. Kept in its own file so voice-import.ts stays pure and
+// unit-testable without touching a filesystem.
+
+import AdmZip from 'adm-zip';
+import { detectCsvKind, parseLinkedinVoiceExport, type ImportedVoiceItem } from './voice-import.js';
+
+const SHARES_ENTRY = /(?:^|\/)shares\.csv$/iu;
+const COMMENTS_ENTRY = /(?:^|\/)comments\.csv$/iu;
+
+function decodeUtf8(buffer: Buffer): string {
+  let text = buffer.toString('utf8');
+  // Strip a UTF-8 BOM - LinkedIn's own export writes one.
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
+  return text;
+}
+
+/** Reads `Shares.csv`/`Comments.csv` out of a LinkedIn "Get a copy of your
+ * data" zip, wherever they sit inside it (some export versions nest every
+ * CSV under a dated folder). Matches by filename, not by position in the
+ * archive. Throws when the zip carries neither - the same "fail loudly on
+ * a shape this parser does not recognise" posture voice-import.ts's column
+ * resolution takes. */
+export function extractLinkedinExportZip(buffer: Buffer): {
+  sharesCsv: string | null;
+  commentsCsv: string | null;
+} {
+  const zip = new AdmZip(buffer);
+  let sharesCsv: string | null = null;
+  let commentsCsv: string | null = null;
+  for (const entry of zip.getEntries()) {
+    if (entry.isDirectory) continue;
+    if (SHARES_ENTRY.test(entry.entryName)) {
+      sharesCsv = decodeUtf8(entry.getData());
+    } else if (COMMENTS_ENTRY.test(entry.entryName)) {
+      commentsCsv = decodeUtf8(entry.getData());
+    }
+  }
+  if (sharesCsv === null && commentsCsv === null) {
+    throw new Error(
+      'This archive has neither a Shares.csv nor a Comments.csv. Check this is a LinkedIn "Get a copy of your data" export.',
+    );
+  }
+  return { sharesCsv, commentsCsv };
+}
+
+/**
+ * Reads a LinkedIn voice export from a buffer - the zip LinkedIn hands
+ * back directly, or one already-extracted CSV - and parses it into
+ * importable voice-corpus items. The CLI's `voice:import` command and the
+ * companion's `/companion/voice` upload action both call this one
+ * function, so the two paths cannot drift apart.
+ */
+export function parseLinkedinExportBuffer(buffer: Buffer, filename: string): ImportedVoiceItem[] {
+  const lower = filename.toLowerCase();
+  if (lower.endsWith('.zip')) {
+    const { sharesCsv, commentsCsv } = extractLinkedinExportZip(buffer);
+    return parseLinkedinVoiceExport({ sharesCsv, commentsCsv });
+  }
+  if (lower.endsWith('.csv')) {
+    const text = decodeUtf8(buffer);
+    const kind = detectCsvKind(text);
+    if (kind === 'shares') return parseLinkedinVoiceExport({ sharesCsv: text });
+    if (kind === 'comments') return parseLinkedinVoiceExport({ commentsCsv: text });
+    throw new Error(
+      'Could not tell whether this is a Shares.csv or a Comments.csv from its header row.',
+    );
+  }
+  throw new Error(`Unsupported file "${filename}" - expected a .zip export or a .csv file.`);
+}

--- a/shared/src/voice-import.ts
+++ b/shared/src/voice-import.ts
@@ -1,0 +1,304 @@
+// A pure, synchronous parser from LinkedIn "Get a copy of your data" CSV
+// text to importable voice-corpus rows (LOR-223). No I/O, no zip handling -
+// see voice-import-archive.ts for the part of this that has to touch a
+// filesystem or an archive. Kept pure for the same reason
+// assist/voice-profile.ts is: unit-testable against a committed synthetic
+// fixture, deterministic, and reviewable without running anything.
+//
+// The archive carries `Shares.csv` (the operator's own posts, one row each)
+// and `Comments.csv` (their comments, with the URL of the thing they
+// commented on, but no id of their own and no post text). LinkedIn does not
+// publish a stable schema for either file and has changed column names
+// across export versions before, so nothing here trusts a column's
+// position or a name remembered from one archive: every column is resolved
+// by matching a normalized header against a small alias list, and a header
+// row that matches none of the aliases for a column this parser actually
+// needs is a thrown, readable error - never a silently empty column.
+
+import { createHash } from 'node:crypto';
+
+export type ImportedVoiceGenre = 'post' | 'comment';
+
+export type ImportedVoiceItem = {
+  /** Deterministic - the same row parsed twice produces the same id, which
+   * is what lets the DB's `(organization_id, external_id)` unique index
+   * make a re-run a no-op rather than a duplicate. */
+  externalId: string;
+  genre: ImportedVoiceGenre;
+  text: string;
+  /** The post's own URL, for a post. Null for a comment - a comment's own
+   * permalink is not in the export, only the URL of what it replies to
+   * (see `context`). */
+  url: string | null;
+  postedAt: string | null;
+  /** For a comment, the post it was written under, as far as the export
+   * knows it. Null for a post, and for a comment whose export row carried
+   * no link. */
+  context: string | null;
+};
+
+/** One row of a parsed CSV: raw string cells, in file order. */
+type CsvRow = string[];
+
+/**
+ * A minimal RFC 4180 reader: quoted fields may contain commas, newlines
+ * (`\n` or `\r\n`) and an escaped `""` for a literal quote. Handles bare
+ * `\n`, `\r\n` and `\r` line endings outside quotes. Blank lines (including
+ * a trailing one from the file's final newline) are dropped rather than
+ * returned as one-empty-cell rows.
+ */
+function parseCsvRows(csvText: string): CsvRow[] {
+  const rows: CsvRow[] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  const n = csvText.length;
+  let i = 0;
+
+  const endField = () => {
+    row.push(field);
+    field = '';
+  };
+  const endRow = () => {
+    endField();
+    rows.push(row);
+    row = [];
+  };
+
+  while (i < n) {
+    const c = csvText[i]!;
+    if (inQuotes) {
+      if (c === '"') {
+        if (csvText[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i += 1;
+        continue;
+      }
+      field += c;
+      i += 1;
+      continue;
+    }
+    if (c === '"') {
+      inQuotes = true;
+      i += 1;
+      continue;
+    }
+    if (c === ',') {
+      endField();
+      i += 1;
+      continue;
+    }
+    if (c === '\r') {
+      endRow();
+      i += csvText[i + 1] === '\n' ? 2 : 1;
+      continue;
+    }
+    if (c === '\n') {
+      endRow();
+      i += 1;
+      continue;
+    }
+    field += c;
+    i += 1;
+  }
+  if (field.length > 0 || row.length > 0) endRow();
+
+  return rows.filter((r) => !(r.length === 1 && r[0] === ''));
+}
+
+function normalizeHeader(header: string): string {
+  return header
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]/gu, '');
+}
+
+type ColumnSpec = { role: string; aliases: readonly string[]; required: boolean };
+
+/** Matches each `ColumnSpec`'s role to a column index by normalized header
+ * name, never by position - a reordered export parses identically. Throws
+ * a readable error naming the missing role and the headers actually seen
+ * when a required column cannot be found, so a differently-named column in
+ * a newer archive fails loudly instead of importing empty rows. */
+function resolveColumns(header: CsvRow, specs: readonly ColumnSpec[]): Map<string, number> {
+  const normalized = header.map(normalizeHeader);
+  const resolved = new Map<string, number>();
+  for (const spec of specs) {
+    const idx = normalized.findIndex((h) => spec.aliases.includes(h));
+    if (idx === -1) {
+      if (spec.required) {
+        throw new Error(
+          `Could not find a "${spec.role}" column (looked for: ${spec.aliases.join(', ')}) among the headers: ${header.join(', ') || '(empty)'}`,
+        );
+      }
+      continue;
+    }
+    resolved.set(spec.role, idx);
+  }
+  return resolved;
+}
+
+function cell(row: CsvRow, idx: number | undefined): string {
+  return idx == null ? '' : (row[idx]?.trim() ?? '');
+}
+
+function normalizeDate(raw: string): string | null {
+  if (!raw) return null;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+/** Comments.csv carries no id of its own for a comment, and a share's own
+ * link is not guaranteed stable across export versions either, so every
+ * imported id is derived rather than trusted from the row: prefixed with
+ * the import source and genre (so it can never collide with a page-capture
+ * external id, which never carries this prefix) and hashed from the one
+ * thing that is actually stable per row - the URL (the post's own for a
+ * share, the commented-on post's for a comment), falling back to the
+ * posted date when there is no URL - plus the text itself, so two
+ * different rows sharing a URL (two comments under the same post) still
+ * get distinct ids. */
+function deriveExternalId(genre: ImportedVoiceGenre, url: string | null, text: string): string {
+  const hash = createHash('sha256')
+    .update(`${url ?? ''}\u0000${text}`)
+    .digest('hex')
+    .slice(0, 24);
+  return `li-import-${genre}:${hash}`;
+}
+
+const SHARES_COLUMNS: readonly ColumnSpec[] = [
+  { role: 'date', aliases: ['date'], required: false },
+  // A share's own permalink. Real archives have named this "ShareLink"; a
+  // "share"/"post"-qualified link column, not a bare "link" (Comments.csv's
+  // own column means something else entirely and must not match here).
+  {
+    role: 'link',
+    aliases: ['sharelink', 'shareurl', 'sharepermalink', 'postlink', 'permalink'],
+    required: false,
+  },
+  // The written commentary, as opposed to a bare repost. Required: without
+  // it there is nothing to tell a real post apart from a repost with no
+  // commentary, which is exactly the row this parser has to skip.
+  {
+    role: 'text',
+    aliases: ['sharecommentary', 'commentary', 'sharetext', 'shararecommentary'],
+    required: true,
+  },
+];
+
+const COMMENTS_COLUMNS: readonly ColumnSpec[] = [
+  { role: 'date', aliases: ['date'], required: false },
+  // The URL of the post the comment was left under - the only link
+  // Comments.csv carries, and the comment's own stimulus, not its own id.
+  { role: 'link', aliases: ['link', 'posturl', 'permalink', 'sourceurl'], required: false },
+  {
+    role: 'text',
+    aliases: ['message', 'commenttext', 'comment', 'commentbody'],
+    required: true,
+  },
+];
+
+/**
+ * Parses `Shares.csv` into posts. A row whose commentary cell is empty is
+ * skipped rather than imported as an empty post - LinkedIn's export
+ * carries a row for a bare repost (sharing someone else's post with no
+ * added words) the same way it carries a real post, and a repost with
+ * nothing added is not writing.
+ */
+export function parseSharesCsv(csvText: string): ImportedVoiceItem[] {
+  const rows = parseCsvRows(csvText);
+  if (rows.length === 0) return [];
+  const [header, ...body] = rows;
+  const cols = resolveColumns(header!, SHARES_COLUMNS);
+
+  const items: ImportedVoiceItem[] = [];
+  for (const row of body) {
+    const text = cell(row, cols.get('text'));
+    if (!text) continue;
+    const url = cell(row, cols.get('link')) || null;
+    items.push({
+      externalId: deriveExternalId('post', url, text),
+      genre: 'post',
+      text,
+      url,
+      postedAt: normalizeDate(cell(row, cols.get('date'))),
+      context: null,
+    });
+  }
+  return items;
+}
+
+/**
+ * Parses `Comments.csv` into comments. A row whose message cell is empty
+ * is skipped the same way an empty share is - some export rows carry a
+ * reaction with no written text at all.
+ */
+export function parseCommentsCsv(csvText: string): ImportedVoiceItem[] {
+  const rows = parseCsvRows(csvText);
+  if (rows.length === 0) return [];
+  const [header, ...body] = rows;
+  const cols = resolveColumns(header!, COMMENTS_COLUMNS);
+
+  const items: ImportedVoiceItem[] = [];
+  for (const row of body) {
+    const text = cell(row, cols.get('text'));
+    if (!text) continue;
+    const link = cell(row, cols.get('link')) || null;
+    items.push({
+      externalId: deriveExternalId('comment', link, text),
+      genre: 'comment',
+      text,
+      url: null,
+      postedAt: normalizeDate(cell(row, cols.get('date'))),
+      context: link,
+    });
+  }
+  return items;
+}
+
+/** Whether `csvText`'s header row matches Shares.csv's or Comments.csv's
+ * required columns - for a caller that received one bare CSV file (not a
+ * zip) and has to tell which schema it is before it can parse it. Null
+ * when it matches neither. */
+export function detectCsvKind(csvText: string): 'shares' | 'comments' | null {
+  const [header] = parseCsvRows(csvText);
+  if (!header) return null;
+  try {
+    resolveColumns(header, SHARES_COLUMNS);
+    return 'shares';
+  } catch {
+    // fall through
+  }
+  try {
+    resolveColumns(header, COMMENTS_COLUMNS);
+    return 'comments';
+  } catch {
+    return null;
+  }
+}
+
+export type LinkedinExportFiles = {
+  sharesCsv?: string | null;
+  commentsCsv?: string | null;
+};
+
+/**
+ * Parses whichever of the two files an export actually supplied, in one
+ * call - the single entry point the CLI command and the companion's upload
+ * route both call, so the two paths cannot drift from each other.
+ */
+export function parseLinkedinVoiceExport(files: LinkedinExportFiles): ImportedVoiceItem[] {
+  if (!files.sharesCsv && !files.commentsCsv) {
+    throw new Error(
+      'Found neither a Shares.csv nor a Comments.csv to import. Check this is a LinkedIn "Get a copy of your data" export.',
+    );
+  }
+  const items: ImportedVoiceItem[] = [];
+  if (files.sharesCsv) items.push(...parseSharesCsv(files.sharesCsv));
+  if (files.commentsCsv) items.push(...parseCommentsCsv(files.commentsCsv));
+  return items;
+}

--- a/shared/tests/assist-voice-profile.test.ts
+++ b/shared/tests/assist-voice-profile.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   measureVoiceCorpus,
+  measureVoiceCorpusByGenre,
   describeVoiceProfile,
+  describeVoiceProfileForGenre,
   MIN_ITEMS_TO_DERIVE,
   EMPTY_RHYTHM,
   EMPTY_PUNCTUATION,
@@ -12,6 +14,7 @@ import {
   EMPTY_LEXICON,
   EMPTY_LANGUAGE,
   type VoiceCorpusItem,
+  type VoiceCorpusItemGenre,
   type VoiceMeasurement,
 } from '../src/assist/voice-profile.js';
 
@@ -438,6 +441,105 @@ describe('describeVoiceProfile', () => {
       commonWords: [],
     };
     expect(describeVoiceProfile(tooSmall)).toBeNull();
+  });
+});
+
+// LOR-223: a post and a comment are different genres of writing, not the
+// same voice at a different length - real evidence from Lorenzo's own
+// LinkedIn activity put his posts at a median 122 words against a median 7
+// words for his comments, sixteen of twenty-seven comments under ten
+// words. The fixtures below invent a corpus at the same order of
+// magnitude: three long posts (SHORT_FIRST_PERSON, ~17 words each) and
+// five one-to-three-word comments, well under register.ts's own
+// MIN_WORDS_TO_DESCRIBE floor for a single item to carry a register.
+function corpusOfGenre(
+  items: Array<{ text: string; genre: VoiceCorpusItemGenre }>,
+): VoiceCorpusItem[] {
+  return items.map((item, i) => ({
+    id: i + 1,
+    kind: 'voice_sample' as const,
+    genre: item.genre,
+    text: item.text,
+  }));
+}
+
+const SHORT_COMMENTS = ['🔥', 'Love this!', 'So true', 'Nice work', 'Well said'];
+
+const MIXED_GENRE_CORPUS = corpusOfGenre([
+  ...SHORT_FIRST_PERSON.map((text) => ({ text, genre: 'post' as const })),
+  ...SHORT_COMMENTS.map((text) => ({ text, genre: 'comment' as const })),
+]);
+
+describe('measureVoiceCorpusByGenre', () => {
+  it('always returns every genre as a key, even one entirely absent from the corpus', () => {
+    const byGenre = measureVoiceCorpusByGenre(MIXED_GENRE_CORPUS);
+    expect(Object.keys(byGenre).sort()).toEqual(['comment', 'post', 'reply']);
+    expect(byGenre.reply.measurable).toBe(false);
+    expect(byGenre.reply.itemCount).toBe(0);
+  });
+
+  it('measures a genre honestly once its own item count clears MIN_ITEMS_TO_DERIVE, independent of the other genre', () => {
+    const byGenre = measureVoiceCorpusByGenre(MIXED_GENRE_CORPUS);
+    expect(byGenre.post.measurable).toBe(true);
+    expect(byGenre.post.itemCount).toBe(SHORT_FIRST_PERSON.length);
+    expect(byGenre.comment.measurable).toBe(true);
+    expect(byGenre.comment.itemCount).toBe(SHORT_COMMENTS.length);
+  });
+
+  it('reports comments as far shorter than posts on the same corpus - the whole reason to split them', () => {
+    const byGenre = measureVoiceCorpusByGenre(MIXED_GENRE_CORPUS);
+    expect(byGenre.comment.rhythm.medianSentenceWords).toBeLessThan(
+      byGenre.post.rhythm.medianSentenceWords,
+    );
+    expect(byGenre.comment.rhythm.medianSentenceWords).toBeLessThanOrEqual(3);
+    expect(byGenre.post.rhythm.medianSentenceWords).toBeGreaterThanOrEqual(5);
+  });
+
+  it('measures rhythm/shape for a genre whose items are individually too short for register.ts to score, rather than reporting nothing', () => {
+    const byGenre = measureVoiceCorpusByGenre(MIXED_GENRE_CORPUS);
+    // None of the five comments clears register.ts's 12-word floor, so no
+    // register-derived trait or per-item sentence length is available -
+    // traits/wordsPerSentence say nothing, honestly - but the corpus as a
+    // whole (5 items) clears MIN_ITEMS_TO_DERIVE, so rhythm still measures
+    // real sentence-length numbers off the raw text.
+    expect(byGenre.comment.traits).toEqual([]);
+    expect(byGenre.comment.wordsPerSentence).toBe(0);
+    expect(byGenre.comment.measurable).toBe(true);
+    expect(byGenre.comment.rhythm.medianSentenceWords).toBeGreaterThan(0);
+  });
+
+  it('leaves a genre with too few items unmeasurable, the same floor the pooled corpus applies', () => {
+    const thin = corpusOfGenre([
+      { text: SHORT_COMMENTS[0], genre: 'comment' },
+      { text: SHORT_COMMENTS[1], genre: 'comment' },
+    ]);
+    const byGenre = measureVoiceCorpusByGenre(thin);
+    expect(byGenre.comment.measurable).toBe(false);
+    expect(byGenre.comment.itemCount).toBe(2);
+  });
+});
+
+describe('describeVoiceProfileForGenre', () => {
+  it('words the leading sentence per genre rather than reusing the pooled noun', () => {
+    const byGenre = measureVoiceCorpusByGenre(MIXED_GENRE_CORPUS);
+    const postDescription = describeVoiceProfileForGenre('post', byGenre.post);
+    const commentDescription = describeVoiceProfileForGenre('comment', byGenre.comment);
+    expect(postDescription).toMatch(/^Based on 3 of their own posts /);
+    expect(commentDescription).toMatch(/^Based on 5 of their own comments /);
+  });
+
+  it('a post and a comment description genuinely differ when the two genres differ', () => {
+    const byGenre = measureVoiceCorpusByGenre(MIXED_GENRE_CORPUS);
+    const postDescription = describeVoiceProfileForGenre('post', byGenre.post);
+    const commentDescription = describeVoiceProfileForGenre('comment', byGenre.comment);
+    expect(postDescription).not.toBeNull();
+    expect(commentDescription).not.toBeNull();
+    expect(postDescription).not.toBe(commentDescription);
+  });
+
+  it('returns null for a genre with nothing measurable, same as the pooled describeVoiceProfile', () => {
+    const byGenre = measureVoiceCorpusByGenre(MIXED_GENRE_CORPUS);
+    expect(describeVoiceProfileForGenre('reply', byGenre.reply)).toBeNull();
   });
 });
 

--- a/shared/tests/operator-profile.test.ts
+++ b/shared/tests/operator-profile.test.ts
@@ -7,6 +7,7 @@ import {
   listVoiceSamples,
   setVoiceSampleExcluded,
   recordVoiceSamples,
+  importVoiceSamples,
 } from '../src/operator-profile.js';
 
 async function platformId(slug: string): Promise<number> {
@@ -149,6 +150,89 @@ describe('shared/src/operator-profile', () => {
 
       const stillB = await listVoiceSamples(getDb(), orgBId);
       expect(stillB[0].excluded).toBe(false);
+    });
+  });
+
+  describe('genre/source (LOR-223)', () => {
+    it('recordVoiceSamples defaults to genre post and source capture when neither is given', async () => {
+      await recordVoiceSamples(getDb(), orgAId, linkedinId, [
+        { externalId: 'urn:li:activity:default-genre', text: 'A plain captured post.' },
+      ]);
+      const [sample] = await listVoiceSamples(getDb(), orgAId);
+      expect(sample.genre).toBe('post');
+      expect(sample.source).toBe('capture');
+      expect(sample.context).toBeNull();
+    });
+
+    it('recordVoiceSamples honors an explicit genre, source and context', async () => {
+      await recordVoiceSamples(getDb(), orgAId, linkedinId, [
+        {
+          externalId: 'urn:li:activity:explicit',
+          text: 'Nice work',
+          genre: 'comment',
+          source: 'manual',
+          context: 'https://www.linkedin.com/feed/update/urn:li:activity:stimulus',
+        },
+      ]);
+      const [sample] = await listVoiceSamples(getDb(), orgAId);
+      expect(sample.genre).toBe('comment');
+      expect(sample.source).toBe('manual');
+      expect(sample.context).toBe('https://www.linkedin.com/feed/update/urn:li:activity:stimulus');
+    });
+  });
+
+  describe('importVoiceSamples', () => {
+    it('inserts every item tagged source import, and reports how many landed per genre', async () => {
+      const result = await importVoiceSamples(getDb(), orgAId, linkedinId, [
+        {
+          externalId: 'li-import-post:1',
+          genre: 'post',
+          text: 'Shipped the importer today.',
+          url: 'https://www.linkedin.com/feed/update/urn:li:activity:import-1',
+          postedAt: null,
+          context: null,
+        },
+        {
+          externalId: 'li-import-comment:1',
+          genre: 'comment',
+          text: 'Nice work',
+          url: null,
+          postedAt: null,
+          context: 'https://www.linkedin.com/feed/update/urn:li:activity:import-1',
+        },
+      ]);
+      expect(result).toEqual({ inserted: 2, byGenre: { post: 1, comment: 1 } });
+
+      const samples = await listVoiceSamples(getDb(), orgAId);
+      expect(samples).toHaveLength(2);
+      expect(samples.every((s) => s.source === 'import')).toBe(true);
+      const comment = samples.find((s) => s.genre === 'comment');
+      expect(comment?.context).toBe(
+        'https://www.linkedin.com/feed/update/urn:li:activity:import-1',
+      );
+    });
+
+    it('dedupes on (organization_id, external_id) the same way recordVoiceSamples does - a re-import is a no-op', async () => {
+      const item = {
+        externalId: 'li-import-post:dup',
+        genre: 'post' as const,
+        text: 'Shipped the importer today.',
+        url: null,
+        postedAt: null,
+        context: null,
+      };
+      const first = await importVoiceSamples(getDb(), orgAId, linkedinId, [item]);
+      expect(first.inserted).toBe(1);
+      const second = await importVoiceSamples(getDb(), orgAId, linkedinId, [item]);
+      expect(second.inserted).toBe(0);
+
+      const samples = await listVoiceSamples(getDb(), orgAId);
+      expect(samples).toHaveLength(1);
+    });
+
+    it('returns zero for an empty batch without touching the database', async () => {
+      const result = await importVoiceSamples(getDb(), orgAId, linkedinId, []);
+      expect(result).toEqual({ inserted: 0, byGenre: { post: 0, comment: 0 } });
     });
   });
 

--- a/shared/tests/operator-voice-profile.test.ts
+++ b/shared/tests/operator-voice-profile.test.ts
@@ -385,6 +385,106 @@ describe('shared/src/operator-voice-profile', () => {
   });
 });
 
+describe('per-genre derivation (LOR-223)', () => {
+  beforeEach(reset);
+
+  it('derives a comment-genre description that differs from the post-genre one, on a corpus containing both', async () => {
+    const orgId = await ensureOrg('vp-org-genres');
+    const linkedin = await platformId('linkedin');
+    await recordVoiceSamples(getDb(), orgId, linkedin, [
+      {
+        externalId: 'g-post-1',
+        text: 'Shipped a brand new onboarding flow this week after months of customer interviews and design review.',
+        genre: 'post',
+      },
+      {
+        externalId: 'g-post-2',
+        text: 'Just wrapped up a long migration project and the whole team is relieved it finally landed cleanly.',
+        genre: 'post',
+      },
+      {
+        externalId: 'g-post-3',
+        text: 'Spent the week debugging a nasty race condition in the scheduler and finally found the root cause today.',
+        genre: 'post',
+      },
+      {
+        externalId: 'g-comment-1',
+        text: 'Nice work',
+        genre: 'comment',
+        context: 'https://www.linkedin.com/feed/update/urn:li:activity:1',
+      },
+      {
+        externalId: 'g-comment-2',
+        text: 'Love this',
+        genre: 'comment',
+        context: 'https://www.linkedin.com/feed/update/urn:li:activity:2',
+      },
+      {
+        externalId: 'g-comment-3',
+        text: 'So true',
+        genre: 'comment',
+        context: 'https://www.linkedin.com/feed/update/urn:li:activity:3',
+      },
+    ]);
+
+    const row = await refreshVoiceProfile(getDb(), orgId);
+    expect(row.evidence.genres.post.measurable).toBe(true);
+    expect(row.evidence.genres.comment.measurable).toBe(true);
+    expect(row.evidence.genres.post.summary).not.toBeNull();
+    expect(row.evidence.genres.comment.summary).not.toBeNull();
+    expect(row.evidence.genres.post.summary).not.toBe(row.evidence.genres.comment.summary);
+    expect(row.evidence.genres.post.summary).toMatch(/^Based on 3 of their own posts /);
+    expect(row.evidence.genres.comment.summary).toMatch(/^Based on 3 of their own comments /);
+    expect(row.evidence.genres.reply.measurable).toBe(false);
+  });
+
+  it('a genre with too few items stays unmeasurable even when the pooled corpus is measurable', async () => {
+    const orgId = await ensureOrg('vp-org-genre-thin');
+    const linkedin = await platformId('linkedin');
+    await recordVoiceSamples(getDb(), orgId, linkedin, [
+      {
+        externalId: 'thin-post-1',
+        text: 'Shipped a brand new onboarding flow this week after months of customer interviews and design review.',
+        genre: 'post',
+      },
+      {
+        externalId: 'thin-post-2',
+        text: 'Just wrapped up a long migration project and the whole team is relieved it finally landed cleanly.',
+        genre: 'post',
+      },
+      {
+        externalId: 'thin-post-3',
+        text: 'Spent the week debugging a nasty race condition in the scheduler and finally found the root cause today.',
+        genre: 'post',
+      },
+      { externalId: 'thin-comment-1', text: 'Nice work', genre: 'comment' },
+    ]);
+
+    const row = await refreshVoiceProfile(getDb(), orgId);
+    expect(row.itemCount).toBe(4);
+    expect(row.evidence.genres.post.measurable).toBe(true);
+    expect(row.evidence.genres.comment.measurable).toBe(false);
+    expect(row.evidence.genres.comment.summary).toBeNull();
+    expect(row.evidence.genres.comment.itemCount).toBe(1);
+  });
+
+  it('a passive capture with no genre specified defaults to post/capture with no context', async () => {
+    const orgId = await ensureOrg('vp-org-genre-defaults');
+    const linkedin = await platformId('linkedin');
+    await recordVoiceSamples(getDb(), orgId, linkedin, [
+      { externalId: 'default-1', text: 'A plain captured post with no genre specified at all.' },
+    ]);
+    const rows = await getDb()
+      .select()
+      .from(schema.operatorVoiceSamples)
+      .where(eq(schema.operatorVoiceSamples.organizationId, orgId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].genre).toBe('post');
+    expect(rows[0].source).toBe('capture');
+    expect(rows[0].context).toBeNull();
+  });
+});
+
 describe('resolveOperatorVoiceProfile', () => {
   beforeEach(reset);
 

--- a/shared/tests/suggest-prompt.test.ts
+++ b/shared/tests/suggest-prompt.test.ts
@@ -62,6 +62,7 @@ const persona: OperatorPersona = {
 const voiceProfile: VoiceProfileSummary = {
   summary:
     'Based on 12 pieces of their own writing (640 words). Usually writes with short sentences, close to speech, first person, speaking as themselves, about 11 words per sentence. Often opens with "Shipped the". Reuses these words often: shipped, team, campaign.',
+  commentSummary: null,
 };
 
 const projects: ProjectBrief[] = [
@@ -252,6 +253,52 @@ describe('buildSuggestionPrompt', () => {
       expect(prompt).toContain('Fix ranking for multi-word queries');
     });
 
+    it('LOR-223: a post_comment suggestion prefers the comment-genre voice summary over the pooled one', () => {
+      const genreVoiceProfile: VoiceProfileSummary = {
+        summary:
+          'Based on 12 pieces of their own writing (640 words). Often closes with "#BuildInPublic".',
+        commentSummary:
+          'Based on 27 of their own comments (190 words). Usually writes one short sentence.',
+      };
+      const commentPrompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        persona: null,
+        voiceProfile: genreVoiceProfile,
+        projects: [],
+        repos: [],
+      });
+      expect(commentPrompt).toContain('Usually writes one short sentence.');
+      expect(commentPrompt).not.toContain('#BuildInPublic');
+      expect(commentPrompt).toMatch(/How the operator writes when commenting/);
+
+      // A `post` suggestion has no comment to write - it keeps the pooled
+      // summary regardless of whether a comment-genre one exists.
+      const postPrompt = buildSuggestionPrompt({
+        kind: 'post',
+        post,
+        persona: null,
+        voiceProfile: genreVoiceProfile,
+        projects: [],
+        repos: [],
+      });
+      expect(postPrompt).toContain('#BuildInPublic');
+      expect(postPrompt).not.toContain('Usually writes one short sentence.');
+    });
+
+    it('LOR-223: a post_comment suggestion falls back to the pooled summary when no comment-genre one was derived', () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        persona: null,
+        voiceProfile,
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).toContain(voiceProfile.summary);
+      expect(prompt).toMatch(/How the operator writes, based on what they have actually written/);
+    });
+
     it('omits each section entirely, not as an empty heading, when its source is missing', () => {
       const prompt = buildSuggestionPrompt({
         kind: 'post_comment',
@@ -327,7 +374,7 @@ describe('buildSuggestionPrompt', () => {
         kind: 'post_comment',
         post,
         persona: null,
-        voiceProfile: { summary: justOver },
+        voiceProfile: { summary: justOver, commentSummary: null },
         projects: [],
         repos: [],
       });
@@ -335,7 +382,7 @@ describe('buildSuggestionPrompt', () => {
         kind: 'post_comment',
         post,
         persona: null,
-        voiceProfile: { summary: wayOver },
+        voiceProfile: { summary: wayOver, commentSummary: null },
         projects: [],
         repos: [],
       });

--- a/shared/tests/voice-import-archive.test.ts
+++ b/shared/tests/voice-import-archive.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import AdmZip from 'adm-zip';
+import {
+  extractLinkedinExportZip,
+  parseLinkedinExportBuffer,
+} from '../src/voice-import-archive.js';
+
+// LOR-223: the impure half of the importer - reading Shares.csv/Comments.csv
+// out of a real zip archive (LinkedIn's own export shape) and off a bare
+// CSV, and handing the text to the pure parser (voice-import.test.ts covers
+// the parser itself in full). Builds real zip buffers with the same
+// library the extractor uses, which is the correct end-to-end proof for
+// this file since the archive format itself, not this library's own
+// round-trip, is what a differently-shaped LinkedIn export could break.
+
+const SHARES_CSV = [
+  'Date,ShareLink,ShareCommentary',
+  '2026-04-01,https://www.linkedin.com/feed/update/urn:li:activity:zip-1,Shipped the archive importer today.',
+].join('\n');
+
+const COMMENTS_CSV = [
+  'Date,Link,Message',
+  '2026-04-01,https://www.linkedin.com/feed/update/urn:li:activity:zip-10,Great read.',
+].join('\n');
+
+function zipOf(entries: Record<string, string>): Buffer {
+  const zip = new AdmZip();
+  for (const [name, content] of Object.entries(entries)) {
+    zip.addFile(name, Buffer.from(content, 'utf8'));
+  }
+  return zip.toBuffer();
+}
+
+describe('extractLinkedinExportZip', () => {
+  it('finds both files at the top level of the archive', () => {
+    const buffer = zipOf({ 'Shares.csv': SHARES_CSV, 'Comments.csv': COMMENTS_CSV });
+    const { sharesCsv, commentsCsv } = extractLinkedinExportZip(buffer);
+    expect(sharesCsv).toBe(SHARES_CSV);
+    expect(commentsCsv).toBe(COMMENTS_CSV);
+  });
+
+  it('finds both files nested under a folder, matching by filename not path', () => {
+    const buffer = zipOf({
+      'Basic_LinkedInDataExport_2026-04-01/Shares.csv': SHARES_CSV,
+      'Basic_LinkedInDataExport_2026-04-01/Comments.csv': COMMENTS_CSV,
+    });
+    const { sharesCsv, commentsCsv } = extractLinkedinExportZip(buffer);
+    expect(sharesCsv).toBe(SHARES_CSV);
+    expect(commentsCsv).toBe(COMMENTS_CSV);
+  });
+
+  it('is fine with only one of the two files present', () => {
+    const buffer = zipOf({ 'Shares.csv': SHARES_CSV });
+    const { sharesCsv, commentsCsv } = extractLinkedinExportZip(buffer);
+    expect(sharesCsv).toBe(SHARES_CSV);
+    expect(commentsCsv).toBeNull();
+  });
+
+  it('throws a readable error when neither file is present', () => {
+    const buffer = zipOf({ 'Profile.csv': 'Name\nSomeone' });
+    expect(() => extractLinkedinExportZip(buffer)).toThrow(
+      /neither a Shares\.csv nor a Comments\.csv/,
+    );
+  });
+});
+
+describe('parseLinkedinExportBuffer', () => {
+  it('parses a zip end to end into both genres', () => {
+    const buffer = zipOf({ 'Shares.csv': SHARES_CSV, 'Comments.csv': COMMENTS_CSV });
+    const items = parseLinkedinExportBuffer(buffer, 'export.zip');
+    expect(items.filter((i) => i.genre === 'post')).toHaveLength(1);
+    expect(items.filter((i) => i.genre === 'comment')).toHaveLength(1);
+  });
+
+  it('parses a bare Shares.csv, sniffing its kind from the header', () => {
+    const items = parseLinkedinExportBuffer(Buffer.from(SHARES_CSV, 'utf8'), 'Shares.csv');
+    expect(items).toHaveLength(1);
+    expect(items[0].genre).toBe('post');
+  });
+
+  it('parses a bare Comments.csv the same way', () => {
+    const items = parseLinkedinExportBuffer(Buffer.from(COMMENTS_CSV, 'utf8'), 'Comments.csv');
+    expect(items).toHaveLength(1);
+    expect(items[0].genre).toBe('comment');
+  });
+
+  it('rejects a file extension it does not recognise', () => {
+    expect(() => parseLinkedinExportBuffer(Buffer.from('hello'), 'export.txt')).toThrow(
+      /Unsupported file/,
+    );
+  });
+
+  it('rejects a CSV whose header matches neither known shape', () => {
+    expect(() => parseLinkedinExportBuffer(Buffer.from('Foo,Bar\n1,2'), 'mystery.csv')).toThrow(
+      /Could not tell whether/,
+    );
+  });
+});

--- a/shared/tests/voice-import.test.ts
+++ b/shared/tests/voice-import.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseSharesCsv,
+  parseCommentsCsv,
+  parseLinkedinVoiceExport,
+  detectCsvKind,
+} from '../src/voice-import.js';
+
+// LOR-223: the pure LinkedIn-export parser. Every case here is a shape the
+// real export can carry that a naive split(',')/split('\n') would get
+// wrong: a quoted field spanning multiple lines, a row with nothing
+// written in it, a repost that is not writing, and a header whose columns
+// arrived in a different order than expected - all four are the acceptance
+// list for this file. Fixtures are entirely invented (no real LinkedIn
+// content).
+
+const SHARES_CSV = [
+  'Date,ShareLink,ShareCommentary',
+  '2026-01-05,https://www.linkedin.com/feed/update/urn:li:activity:1,"Shipped a new caching layer today.\nCut p99 latency in half."',
+  '2026-01-06,https://www.linkedin.com/feed/update/urn:li:activity:2,',
+  '2026-01-07,https://www.linkedin.com/feed/update/urn:li:activity:3,"Comma, quote ""test"", and more"',
+].join('\r\n');
+
+const COMMENTS_CSV = [
+  'Date,Link,Message',
+  '2026-01-05,https://www.linkedin.com/feed/update/urn:li:activity:10,Nice work on this!',
+  '2026-01-06,https://www.linkedin.com/feed/update/urn:li:activity:11,',
+].join('\n');
+
+describe('parseSharesCsv', () => {
+  it('parses a real post, preserving a quoted embedded newline', () => {
+    const items = parseSharesCsv(SHARES_CSV);
+    const first = items.find((i) => i.url?.endsWith('activity:1'));
+    expect(first?.text).toBe('Shipped a new caching layer today.\nCut p99 latency in half.');
+    expect(first?.genre).toBe('post');
+    expect(first?.postedAt).toBe(new Date('2026-01-05').toISOString());
+    expect(first?.context).toBeNull();
+  });
+
+  it('unescapes a doubled quote and keeps a literal comma inside a quoted field', () => {
+    const items = parseSharesCsv(SHARES_CSV);
+    const third = items.find((i) => i.url?.endsWith('activity:3'));
+    expect(third?.text).toBe('Comma, quote "test", and more');
+  });
+
+  it('skips a repost with no commentary rather than importing an empty post', () => {
+    const items = parseSharesCsv(SHARES_CSV);
+    expect(items.some((i) => i.url?.endsWith('activity:2'))).toBe(false);
+    expect(items).toHaveLength(2);
+  });
+
+  it('resolves columns by name, not position - a reordered header parses identically', () => {
+    const reordered = [
+      'ShareCommentary,ShareLink,Date',
+      '"Reordered but still readable",https://www.linkedin.com/feed/update/urn:li:activity:99,2026-02-01',
+    ].join('\n');
+    const items = parseSharesCsv(reordered);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      text: 'Reordered but still readable',
+      url: 'https://www.linkedin.com/feed/update/urn:li:activity:99',
+      genre: 'post',
+    });
+  });
+
+  it('throws a readable error naming the missing column when the header matches nothing known', () => {
+    const unrecognized = ['Timestamp,Body', '2026-01-01,hello'].join('\n');
+    expect(() => parseSharesCsv(unrecognized)).toThrow(/text/i);
+  });
+
+  it('derives the same external id for the same row parsed twice - a re-import is a no-op', () => {
+    const first = parseSharesCsv(SHARES_CSV);
+    const second = parseSharesCsv(SHARES_CSV);
+    expect(first.map((i) => i.externalId)).toEqual(second.map((i) => i.externalId));
+  });
+
+  it('gives two different rows two different external ids', () => {
+    const items = parseSharesCsv(SHARES_CSV);
+    const ids = new Set(items.map((i) => i.externalId));
+    expect(ids.size).toBe(items.length);
+  });
+});
+
+describe('parseCommentsCsv', () => {
+  it('parses a comment, carrying the commented-on post as context rather than url', () => {
+    const items = parseCommentsCsv(COMMENTS_CSV);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      genre: 'comment',
+      text: 'Nice work on this!',
+      url: null,
+      context: 'https://www.linkedin.com/feed/update/urn:li:activity:10',
+    });
+  });
+
+  it('skips a row with an empty message cell', () => {
+    const items = parseCommentsCsv(COMMENTS_CSV);
+    expect(items.some((i) => i.context?.endsWith('activity:11'))).toBe(false);
+  });
+
+  it('derives distinct ids for two different comments left under the same post', () => {
+    const csv = [
+      'Date,Link,Message',
+      '2026-01-01,https://www.linkedin.com/feed/update/urn:li:activity:same,First comment',
+      '2026-01-01,https://www.linkedin.com/feed/update/urn:li:activity:same,Second comment',
+    ].join('\n');
+    const items = parseCommentsCsv(csv);
+    expect(items).toHaveLength(2);
+    expect(items[0].externalId).not.toBe(items[1].externalId);
+  });
+});
+
+describe('detectCsvKind', () => {
+  it('recognises Shares.csv and Comments.csv headers', () => {
+    expect(detectCsvKind(SHARES_CSV)).toBe('shares');
+    expect(detectCsvKind(COMMENTS_CSV)).toBe('comments');
+  });
+
+  it('returns null for a header matching neither known shape', () => {
+    expect(detectCsvKind('Foo,Bar\n1,2')).toBeNull();
+  });
+});
+
+describe('parseLinkedinVoiceExport', () => {
+  it('combines both files when both are present', () => {
+    const items = parseLinkedinVoiceExport({ sharesCsv: SHARES_CSV, commentsCsv: COMMENTS_CSV });
+    expect(items.filter((i) => i.genre === 'post')).toHaveLength(2);
+    expect(items.filter((i) => i.genre === 'comment')).toHaveLength(1);
+  });
+
+  it('throws when neither file is present', () => {
+    expect(() => parseLinkedinVoiceExport({})).toThrow();
+  });
+});

--- a/web/src/routes/companion/voice/+page.server.ts
+++ b/web/src/routes/companion/voice/+page.server.ts
@@ -1,14 +1,23 @@
 import type { Actions, PageServerLoad } from './$types';
 import { fail } from '@sveltejs/kit';
-import { getDb } from '$lib/server/db.js';
+import { eq } from 'drizzle-orm';
+import { getDb, schema } from '$lib/server/db.js';
 import { requireOrgId, requireRole } from '$lib/server/auth.js';
-import { listVoiceSamples, setVoiceSampleExcluded } from '@pitchbox/shared/operator-profile';
+import {
+  listVoiceSamples,
+  setVoiceSampleExcluded,
+  importVoiceSamples,
+  type VoiceSampleGenre,
+  type VoiceSampleSource,
+} from '@pitchbox/shared/operator-profile';
+import { parseLinkedinExportBuffer } from '@pitchbox/shared/voice-import-archive';
 import {
   loadVoiceProfile,
   refreshVoiceProfile,
   saveVoiceProfileSummary,
   resetVoiceProfileToDerived,
   type OperatorVoiceProfileRow,
+  type VoiceGenreSummary,
 } from '@pitchbox/shared/operator-voice-profile';
 
 // Companion -> Voice ("how you write"), split out of the old three-card
@@ -18,12 +27,23 @@ import {
 // every suggestion's prompt too - and the same reasoning for repeating
 // requireRole('admin') here rather than inheriting one: see that file's
 // comment.
+//
+// LOR-223: the `importVoice` action is the onboarding path this page was
+// missing - a LinkedIn export upload that fills the corpus with posts and,
+// for the first time, comments, in one step instead of weeks of passive
+// browsing. It calls the exact same `parseLinkedinExportBuffer` and
+// `importVoiceSamples` the `pitchbox voice:import` CLI command calls, so
+// the two paths cannot drift and a fixture run through both produces the
+// same rows.
 export type CompanionVoiceSample = {
   id: number;
   text: string;
   url: string | null;
   postedAt: string | null;
   excluded: boolean;
+  genre: VoiceSampleGenre;
+  source: VoiceSampleSource;
+  context: string | null;
   capturedAt: string;
 };
 
@@ -37,10 +57,16 @@ export type CompanionVoiceProfile = {
   itemCount: number;
   wordCount: number;
   evidenceCounts: { voiceSamples: number; messages: number; drafts: number; templates: number };
+  /** Each genre's own description, alongside the pooled one above
+   * (LOR-223) - a post and a comment are different genres of writing, so
+   * "how you write" is worth reading per genre as well as pooled. */
+  genres: Record<VoiceSampleGenre, VoiceGenreSummary>;
   source: 'derived' | 'manual';
   derivedAt: string | null;
   updatedAt: string;
 };
+
+const MAX_VOICE_IMPORT_BYTES = 20 * 1024 * 1024;
 
 function toVoiceProfile(row: OperatorVoiceProfileRow): CompanionVoiceProfile {
   return {
@@ -53,6 +79,7 @@ function toVoiceProfile(row: OperatorVoiceProfileRow): CompanionVoiceProfile {
     itemCount: row.itemCount,
     wordCount: row.wordCount,
     evidenceCounts: row.evidence.counts,
+    genres: row.evidence.genres,
     source: row.source,
     derivedAt: row.derivedAt ? row.derivedAt.toISOString() : null,
     updatedAt: row.updatedAt.toISOString(),
@@ -74,6 +101,9 @@ export const load: PageServerLoad = async (event) => {
       url: s.url,
       postedAt: s.postedAt ? s.postedAt.toISOString() : null,
       excluded: s.excluded,
+      genre: s.genre,
+      source: s.source,
+      context: s.context,
       capturedAt: s.capturedAt.toISOString(),
     })),
     voiceProfile: voiceProfile ? toVoiceProfile(voiceProfile) : null,
@@ -136,5 +166,56 @@ export const actions: Actions = {
     const orgId = await requireOrgId(event);
     const voiceProfile = await resetVoiceProfileToDerived(getDb(), orgId);
     return { voiceProfile: toVoiceProfile(voiceProfile) };
+  },
+
+  // LOR-223: fills the corpus from a LinkedIn "Get a copy of your data"
+  // export in one step - the onboarding path this page was missing,
+  // especially for comments, which passive capture barely reaches. Calls
+  // the same `parseLinkedinExportBuffer`/`importVoiceSamples` the
+  // `pitchbox voice:import` CLI command calls, so an upload and a CLI run
+  // against the same file produce the same rows. Refuses anything that is
+  // not a recognisable export with a readable message rather than a stack
+  // trace, and caps the upload size the same way other upload routes in
+  // this app cap theirs.
+  importVoice: async (event) => {
+    requireRole(event, 'admin');
+    const orgId = await requireOrgId(event);
+    const form = await event.request.formData();
+    const file = form.get('file');
+    if (!(file instanceof File) || file.size === 0) {
+      return fail(400, {
+        importError: 'Choose a LinkedIn export file (.zip) or a Shares.csv/Comments.csv first.',
+      });
+    }
+    if (file.size > MAX_VOICE_IMPORT_BYTES) {
+      return fail(413, {
+        importError: `File exceeds the ${Math.floor(MAX_VOICE_IMPORT_BYTES / (1024 * 1024))}MB limit.`,
+      });
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    let items;
+    try {
+      items = parseLinkedinExportBuffer(buffer, file.name);
+    } catch (err) {
+      return fail(400, {
+        importError: err instanceof Error ? err.message : 'Could not read that file.',
+      });
+    }
+
+    const db = getDb();
+    const [platform] = await db
+      .select({ id: schema.platforms.id })
+      .from(schema.platforms)
+      .where(eq(schema.platforms.slug, 'linkedin'))
+      .limit(1);
+    if (!platform) return fail(500, { importError: 'LinkedIn platform is not configured.' });
+
+    const { inserted, byGenre } = await importVoiceSamples(db, orgId, platform.id, items);
+    const voiceProfile = await refreshVoiceProfile(db, orgId);
+    return {
+      imported: { inserted, byGenre },
+      voiceProfile: toVoiceProfile(voiceProfile),
+    };
   },
 };

--- a/web/src/routes/companion/voice/+page.svelte
+++ b/web/src/routes/companion/voice/+page.svelte
@@ -4,7 +4,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Checkbox } from '$lib/components/ui/checkbox';
-	import { Mic, RefreshCw, RotateCcw } from '@lucide/svelte';
+	import { Mic, RefreshCw, RotateCcw, Upload } from '@lucide/svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import Seo from '$lib/components/Seo.svelte';
 	import PageContainer from '$lib/components/PageContainer.svelte';
@@ -16,6 +16,15 @@
 
 	// Companion -> Voice (LOR-178/LOR-179, docs/design/DECISIONS.md D35),
 	// split out of the old three-card settings/companion page.
+	//
+	// LOR-223: a voice sample now carries a genre (post/comment/reply) and a
+	// source (captured passively, imported from a LinkedIn export, or typed
+	// by hand), and the derived profile carries a description per genre
+	// alongside the pooled one - a post and a comment are different genres
+	// of writing, not the same voice at a different length.
+
+	type VoiceSampleGenre = 'post' | 'comment' | 'reply';
+	type VoiceSampleSource = 'capture' | 'import' | 'manual';
 
 	type VoiceSample = {
 		id: number;
@@ -23,8 +32,12 @@
 		url: string | null;
 		postedAt: string | null;
 		excluded: boolean;
+		genre: VoiceSampleGenre;
+		source: VoiceSampleSource;
+		context: string | null;
 		capturedAt: string;
 	};
+	type GenreSummary = { summary: string | null; itemCount: number; measurable: boolean };
 	type VoiceProfile = {
 		summary: string;
 		traits: string[];
@@ -35,6 +48,7 @@
 		itemCount: number;
 		wordCount: number;
 		evidenceCounts: { voiceSamples: number; messages: number; drafts: number; templates: number };
+		genres: Record<VoiceSampleGenre, GenreSummary>;
 		source: 'derived' | 'manual';
 		derivedAt: string | null;
 		updatedAt: string;
@@ -43,7 +57,9 @@
 	type FormResult = {
 		toggledSampleId?: number;
 		voiceProfile?: VoiceProfile;
+		imported?: { inserted: number; byGenre: { post: number; comment: number } };
 		error?: string;
+		importError?: string;
 	} | null;
 
 	let { data, form }: { data: PageData; form: FormResult } = $props();
@@ -53,10 +69,23 @@
 	let savingVoiceProfile = $state(false);
 	let refreshingVoiceProfile = $state(false);
 	let resettingVoiceProfile = $state(false);
+	let importingVoice = $state(false);
 	const includedSampleCount = $derived(data.voiceSamples.filter((s) => !s.excluded).length);
 
+	const GENRE_LABEL: Record<VoiceSampleGenre, string> = {
+		post: 'Post',
+		comment: 'Comment',
+		reply: 'Reply',
+	};
+	const SOURCE_LABEL: Record<VoiceSampleSource, string> = {
+		capture: 'Captured',
+		import: 'Imported',
+		manual: 'Manual',
+	};
+	const GENRE_ORDER: VoiceSampleGenre[] = ['post', 'comment', 'reply'];
+
 	$effect(() => {
-		if (form?.voiceProfile) {
+		if (form?.voiceProfile && !form?.imported) {
 			voiceProfileSummary = form.voiceProfile.summary;
 			toast.success(
 				form.voiceProfile.source === 'manual' ? 'Voice description saved' : 'Voice profile refreshed',
@@ -64,8 +93,25 @@
 		}
 	});
 
+	$effect(() => {
+		if (form?.imported) {
+			voiceProfileSummary = form.voiceProfile?.summary ?? voiceProfileSummary;
+			const { inserted, byGenre } = form.imported;
+			toast.success(
+				inserted === 0
+					? 'Nothing new in that export - already imported'
+					: `Imported ${inserted} sample${inserted === 1 ? '' : 's'} (${byGenre.post} post${byGenre.post === 1 ? '' : 's'}, ${byGenre.comment} comment${byGenre.comment === 1 ? '' : 's'})`,
+			);
+		}
+	});
+
+	$effect(() => {
+		if (form?.importError) toast.error(form.importError);
+	});
+
 	let voiceFormRefs: Record<number, HTMLFormElement> = $state({});
 	let togglingSampleId = $state<number | null>(null);
+	let importFileInput: HTMLInputElement | undefined = $state();
 </script>
 
 <Seo
@@ -78,6 +124,46 @@
 		title="Voice"
 		description="How you write, derived from what you have actually written - your voice samples, outbound messages, sent drafts and project templates - rather than a raw list of posts."
 	/>
+
+	<Card.Root>
+		<Card.Header>
+			<Card.Title class="flex items-center gap-2"><Upload class="size-4" /> Import from LinkedIn</Card.Title>
+			<Card.Description>
+				Upload the "Shares.csv"/"Comments.csv" from LinkedIn's own "Get a copy of your data"
+				export (the zip works too) to fill the corpus with your posts and comments in one step,
+				instead of waiting on passive capture. Re-uploading the same export changes nothing - it
+				only ever adds what is not already on file.
+			</Card.Description>
+		</Card.Header>
+		<Card.Content>
+			<form
+				method="POST"
+				action="?/importVoice"
+				enctype="multipart/form-data"
+				use:enhance={() => {
+					importingVoice = true;
+					return async ({ update }) => {
+						await update();
+						importingVoice = false;
+						if (importFileInput) importFileInput.value = '';
+					};
+				}}
+				class="flex flex-wrap items-center gap-2"
+			>
+				<input
+					bind:this={importFileInput}
+					type="file"
+					name="file"
+					accept=".zip,.csv"
+					required
+					class="text-sm file:mr-3 file:rounded-md file:border-0 file:bg-secondary file:px-3 file:py-1.5 file:text-sm file:font-medium"
+				/>
+				<Button type="submit" size="sm" disabled={importingVoice}>
+					<Upload class="size-4" /> {importingVoice ? 'Importing...' : 'Import'}
+				</Button>
+			</form>
+		</Card.Content>
+	</Card.Root>
 
 	<div class="grid items-start gap-4 xl:grid-cols-2">
 		<Card.Root>
@@ -186,6 +272,18 @@
 							{/if}
 						</p>
 					{/if}
+
+					{#if voiceProfile}
+						{#each GENRE_ORDER as genre (genre)}
+							{@const g = voiceProfile.genres[genre]}
+							{#if g.summary}
+								<div class="rounded-md border border-border/60 bg-muted/30 p-2 text-xs">
+									<span class="font-medium">{GENRE_LABEL[genre]}s:</span>
+									<span class="text-muted-foreground">{g.summary}</span>
+								</div>
+							{/if}
+						{/each}
+					{/if}
 				</div>
 			</Card.Content>
 		</Card.Root>
@@ -194,9 +292,10 @@
 			<Card.Header>
 				<Card.Title>Voice samples</Card.Title>
 				<Card.Description>
-					Your own recent posts, captured passively. {includedSampleCount} of {data.voiceSamples
-						.length} feed the derived voice beside this - excluding a sample keeps it here, it just
-					stops contributing, because a delete would come back on the next capture.
+					Your own posts and comments, captured passively or imported from a LinkedIn export.
+					{includedSampleCount} of {data.voiceSamples.length} feed the derived voice beside this -
+					excluding a sample keeps it here, it just stops contributing, because a delete would come
+					back on the next capture or import.
 				</Card.Description>
 			</Card.Header>
 			<Card.Content class="flex flex-col gap-4">
@@ -204,16 +303,23 @@
 					<EmptyState
 						icon={Mic}
 						title="No voice samples yet"
-						description="Captured passively when you browse your own recent activity on LinkedIn with the extension installed."
+						description="Captured passively when you browse your own recent activity on LinkedIn with the extension installed, or filled in one step above from a LinkedIn data export."
 					/>
 				{:else}
 					<div class="flex flex-col divide-y divide-border">
 						{#each data.voiceSamples as sample (sample.id)}
 							<div class="flex items-start justify-between gap-3 py-3">
 								<div class="min-w-0 flex-1">
+									{#if sample.genre === 'comment' && sample.context}
+										<p class="mb-1 truncate text-xs text-muted-foreground">
+											Replying to <a href={sample.context} target="_blank" rel="noreferrer" class="underline">{sample.context}</a>
+										</p>
+									{/if}
 									<p class="text-sm whitespace-pre-wrap">{sample.text}</p>
 									<div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
 										<span>{relativeTime(sample.postedAt ?? sample.capturedAt)}</span>
+										<Badge variant="outline">{GENRE_LABEL[sample.genre]}</Badge>
+										<Badge variant="outline">{SOURCE_LABEL[sample.source]}</Badge>
 										{#if sample.excluded}
 											<Badge variant="outline">Excluded</Badge>
 										{:else}

--- a/web/tests/companion-settings.test.ts
+++ b/web/tests/companion-settings.test.ts
@@ -375,6 +375,92 @@ describe('companion/voice actions', () => {
       ),
     ).toBe(403);
   });
+
+  // FIXTURE NOTE: byte-identical to `cli/tests/commands/voice-import.test.ts`'s
+  // `SHARES_CSV` - kept in sync by hand since CLI and web are separate
+  // workspaces. Both suites assert their result against
+  // `parseSharesCsv`/`parseCommentsCsv` directly (the same functions
+  // `voiceImportRun` and this route's `importVoice` action both call
+  // under the hood), which is what actually proves the two paths cannot
+  // drift, rather than a literal string comparison across processes.
+  const IMPORT_SHARES_CSV = [
+    'Date,ShareLink,ShareCommentary',
+    '2026-03-01,https://www.linkedin.com/feed/update/urn:li:activity:cli-1,Shipped the new export importer today.',
+    '2026-03-02,https://www.linkedin.com/feed/update/urn:li:activity:cli-2,',
+    '2026-03-03,https://www.linkedin.com/feed/update/urn:li:activity:cli-3,Wrapped up a long week of onboarding fixes.',
+  ].join('\n');
+
+  function csvFile(text: string, name: string): File {
+    return new File([text], name, { type: 'text/csv' });
+  }
+
+  it('importVoice: a member is forbidden (403)', async () => {
+    const orgId = await seedOrg('comp-import-member');
+    const form = new FormData();
+    form.set('file', csvFile(IMPORT_SHARES_CSV, 'Shares.csv'));
+    expect(
+      await statusOf(() =>
+        voiceActions.importVoice(
+          actionEvent<VoiceActionEvent>(orgId, 'member', '/companion/voice', form),
+        ),
+      ),
+    ).toBe(403);
+  });
+
+  it('importVoice: refuses to run without a file, with a readable message rather than a stack trace', async () => {
+    const orgId = await seedOrg('comp-import-nofile');
+    const result = (await voiceActions.importVoice(
+      actionEvent<VoiceActionEvent>(orgId, 'admin', '/companion/voice', new FormData()),
+    )) as { status: number; data: { importError: string } };
+    expect(result.status).toBe(400);
+    expect(result.data.importError).toMatch(/choose a linkedin export/i);
+  });
+
+  it('importVoice: refuses a file whose header matches neither known export shape', async () => {
+    const orgId = await seedOrg('comp-import-badheader');
+    const form = new FormData();
+    form.set('file', csvFile('Foo,Bar\n1,2', 'export.csv'));
+    const result = (await voiceActions.importVoice(
+      actionEvent<VoiceActionEvent>(orgId, 'admin', '/companion/voice', form),
+    )) as { status: number; data: { importError: string } };
+    expect(result.status).toBe(400);
+    expect(result.data.importError).toBeTruthy();
+  });
+
+  it('importVoice: parses Shares.csv the same way the CLI does, dedups on re-upload, and re-derives the voice profile', async () => {
+    const orgId = await seedOrg('comp-import-shares');
+    const { parseSharesCsv } = await import('@pitchbox/shared/voice-import');
+    const expected = parseSharesCsv(IMPORT_SHARES_CSV);
+
+    const form = new FormData();
+    form.set('file', csvFile(IMPORT_SHARES_CSV, 'Shares.csv'));
+    const first = (await voiceActions.importVoice(
+      actionEvent<VoiceActionEvent>(orgId, 'admin', '/companion/voice', form),
+    )) as { imported: { inserted: number; byGenre: { post: number; comment: number } } };
+    expect(first.imported.inserted).toBe(expected.length);
+    expect(first.imported.byGenre).toEqual({ post: expected.length, comment: 0 });
+
+    const rows = await getDb()
+      .select()
+      .from(schema.operatorVoiceSamples)
+      .where(eq(schema.operatorVoiceSamples.organizationId, orgId));
+    expect(rows.map((r) => r.text).sort()).toEqual(expected.map((i) => i.text).sort());
+    expect(rows.every((r) => r.genre === 'post' && r.source === 'import')).toBe(true);
+
+    const [profile] = await getDb()
+      .select()
+      .from(schema.operatorVoiceProfiles)
+      .where(eq(schema.operatorVoiceProfiles.organizationId, orgId));
+    expect(profile.source).toBe('derived');
+
+    // Re-uploading the same export is a no-op, the same dedup the CLI relies on.
+    const secondForm = new FormData();
+    secondForm.set('file', csvFile(IMPORT_SHARES_CSV, 'Shares.csv'));
+    const second = (await voiceActions.importVoice(
+      actionEvent<VoiceActionEvent>(orgId, 'admin', '/companion/voice', secondForm),
+    )) as { imported: { inserted: number } };
+    expect(second.imported.inserted).toBe(0);
+  });
 });
 
 describe('companion/work load', () => {


### PR DESCRIPTION
The companion writes mostly comments and replies, but the corpus it learned from was posts only, pooled into one measurement. Main measured this tonight against 27 real cases and shared the numbers with me while I was on this: his real replies run a median 7 words, one sentence, 16 of 27 under ten words, zero hashtags. Today's suggestions run a median 123 words, five sentences, three with hashtags. The cause is `describeVoiceProfile` telling the model, right before it writes a one-line comment, that the operator "usually writes with hashtags" and "runs about 16 words per sentence" - true of his posts, false of his comments. `checkStyle` reported zero findings across all 27 of those drafts, so a clean style check means far less than it looks like. This PR is the fix for that gap.

## Schema

Added to `operator_voice_samples`: `genre` (`post`/`comment`/`reply`, default `post`), `source` (`capture`/`import`/`manual`, default `capture`) and `context` (the post a comment replied to, nullable). One migration (`0035_worried_harrier.sql`), generated by drizzle, never hand-edited. Verified against a freshly migrated database:

```
migrations applied (35 in journal, all present)
```

## Per-genre derivation

`measureVoiceCorpus` (`shared/src/assist/voice-profile.ts`) gets a genre-scoped sibling, `measureVoiceCorpusByGenre`, alongside the pooled measurement, which I keep exactly as is. A genre with too few items says nothing (`measurable: false`), the same floor the pooled corpus already applies. A genre whose items are individually too short for `register.ts`'s own 12-word floor - which is most one-line comments - still gets a real rhythm and shape measurement off the corpus as a whole; it just reports no trait or per-item sentence length rather than guessing one from too little. `operator-voice-profile.ts` stores each genre's own summary in `evidence.genres` (schemaless jsonb, no second migration needed), and `suggest-prompt.ts` now prefers the comment-genre description for a `post_comment` suggestion when the corpus has derived one, falling back to the pooled summary otherwise.

## The importer

`shared/src/voice-import.ts` (pure, synchronous) and `shared/src/voice-import-archive.ts` (the zip/CSV I/O) read LinkedIn's own "Get a copy of your data" export: `Shares.csv` (posts) and `Comments.csv` (comments, with the URL of the thing commented on). Columns are resolved by normalized header name, never position, so a reordered or differently-named column degrades to a readable error instead of silently importing empty rows. A repost with no commentary and a row with an empty text cell are both skipped - they are not writing. A comment has no stable id in the export, so its external id is derived deterministically from the stimulus URL plus a hash of the text, which is what makes a re-import a no-op (proven in both the CLI and web test suites, run twice).

Two entry points, both calling the same `parseLinkedinExportBuffer`/`importVoiceSamples` so they cannot drift: `pitchbox voice:import <path-to-zip-or-csv>` on the CLI, and a file upload on the companion's Voice page, which now also shows each sample's genre and source, and, for a comment, the post it replied to.

Out of scope on purpose: capturing comments off the LinkedIn page itself (LOR-228, needs this column to exist first) and feeding accepted suggestions back into the corpus (separate issue).

## Verification

- `pnpm test` against my own isolated database (`pitchbox_test_lor223`): 359 files, 3164 tests, all passing.
- `pnpm -F @pitchbox/shared typecheck` and `pnpm -F cli typecheck`: clean.
- `pnpm -F web check`: 0 errors, 0 warnings.
- `npx eslint`/`npx prettier --check` on every changed file: clean (the one `.svelte` file I touched cannot be checked by prettier in this repo at all - no `prettier-plugin-svelte` dependency exists anywhere in the repo, confirmed against an untouched existing `.svelte` file too, so this is a pre-existing gap and not something this PR introduces or can fix in scope).
- New unit tests cover the parser's required edge cases: a quoted embedded newline, an empty text cell, a repost with no commentary, and a reordered header.
- New DB-backed tests prove a post-genre description and a comment-genre description genuinely differ on a mixed corpus, and that a thin genre stays unmeasurable even when the pooled corpus is not.

Closes LOR-223
https://linear.app/fiorelorenzo/issue/LOR-223/featsharedwebcli-the-voice-corpus-holds-comments-and-replies-and