### PR TITLE
test(shared): an eval set of his real writing, a deterministic scorer, and a baseline table

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:linkedin-compliance": "vitest run --config vitest.compliance.config.ts",
+    "eval:voice": "tsx scripts/voice-eval.ts",
+    "eval:voice:import": "tsx scripts/voice-eval-import.ts",
     "lint": "eslint . && prettier --check .",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit -p shared && tsc --noEmit -p cli && tsc --noEmit -p daemon && pnpm -F @pitchbox/extension check && pnpm -F web check",
@@ -41,6 +43,7 @@
     "migrations:check": "pnpm -F shared migrations:check"
   },
   "devDependencies": {
+    "@ai-sdk/gateway": "^4.0.75",
     "@eslint/js": "^10.0.1",
     "@fontsource-variable/inter": "^5.2.8",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -48,6 +51,7 @@
     "@typescript-eslint/eslint-plugin": "^8.62.1",
     "@typescript-eslint/parser": "^8.62.1",
     "@typescript/native": "npm:typescript@^7.0.2",
+    "ai": "^7.0.93",
     "concurrently": "^10.0.5",
     "eslint": "^10.9.1",
     "globals": "^17.12.0",
@@ -58,7 +62,8 @@
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.2.2",
     "vitepress": "^1.6.4",
-    "vitest": "4.1.11"
+    "vitest": "4.1.11",
+    "zod": "^4.5.4"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
 
   .:
     devDependencies:
+      '@ai-sdk/gateway':
+        specifier: ^4.0.75
+        version: 4.0.75(zod@4.5.4)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.9.1(jiti@2.7.0))
@@ -36,6 +39,9 @@ importers:
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
+      ai:
+        specifier: ^7.0.93
+        version: 7.0.93(zod@4.5.4)
       concurrently:
         specifier: ^10.0.5
         version: 10.0.5
@@ -69,6 +75,9 @@ importers:
       vitest:
         specifier: 4.1.11
         version: 4.1.11(@types/node@26.1.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13))
+      zod:
+        specifier: ^4.5.4
+        version: 4.5.4
 
   cli:
     dependencies:

--- a/scripts/voice-eval-import.ts
+++ b/scripts/voice-eval-import.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env tsx
+/**
+ * Converts a raw LinkedIn harvest into shared/src/voice-eval-cases.ts's
+ * schema (LOR-44). Not part of the eval runner itself - a one-shot import
+ * step, run by hand whenever a fresh harvest lands.
+ *
+ * Input shape (the harvester's own, undocumented elsewhere): a JSON file
+ * with `posts: [{ urn, text, meta? }]` (the operator's own writing) and
+ * `commentPairs: [{ urn, postAuthor?, postText, comments: string[] }]`
+ * (someone else's post, paired with the operator's own comment(s) under it -
+ * `comments` is almost always one string, but a post the operator commented
+ * on more than once produces one case per comment, sharing the post).
+ *
+ * Both input and output live under `private/` (gitignored) - this script
+ * never reads or writes anything this repo tracks.
+ *
+ * Usage: tsx scripts/voice-eval-import.ts [input.json] [output.json]
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import {
+  loadVoiceEvalCases,
+  VOICE_EVAL_SCHEMA_VERSION,
+  type VoiceEvalCase,
+  type VoiceEvalCorpusItem,
+} from '../shared/src/voice-eval-cases.js';
+
+interface RawPost {
+  urn: string;
+  text: string;
+  meta?: string;
+}
+
+interface RawCommentPair {
+  urn: string;
+  postAuthor?: string;
+  postText: string;
+  comments: string[];
+}
+
+interface RawFile {
+  posts: RawPost[];
+  commentPairs: RawCommentPair[];
+}
+
+const inputPath = process.argv[2] ?? 'private/voice-eval/raw.json';
+const outputPath = process.argv[3] ?? 'private/voice-eval/cases.json';
+
+const raw = JSON.parse(readFileSync(inputPath, 'utf8')) as RawFile;
+
+const voiceCorpus: VoiceEvalCorpusItem[] = raw.posts.map((p, i) => ({
+  id: p.urn || `post-${i + 1}`,
+  text: p.text,
+}));
+
+// A post the operator commented on more than once is not one case with two
+// replies, it is two independent cases sharing the same post - each comment
+// is judged on its own against the same real-reply comparator, and folding
+// them together would hide which of two replies actually reads as human.
+const cases: VoiceEvalCase[] = raw.commentPairs.flatMap((pair, pairIndex) => {
+  if (pair.comments.length === 0) return [];
+  return pair.comments.map((comment, commentIndex) => ({
+    id:
+      pair.comments.length > 1
+        ? `${pair.urn}#${commentIndex}`
+        : pair.urn || `pair-${pairIndex + 1}`,
+    genre: 'unclassified' as const,
+    postAuthor: pair.postAuthor,
+    post: { text: pair.postText },
+    actualReply: comment,
+  }));
+});
+
+const output = {
+  schemaVersion: VOICE_EVAL_SCHEMA_VERSION,
+  voiceCorpus,
+  cases,
+};
+
+writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`);
+
+// Fail fast against the real schema rather than leaving a malformed file for
+// the runner to discover later.
+loadVoiceEvalCases(outputPath);
+
+console.log(
+  `Wrote ${voiceCorpus.length} voice-corpus item(s) and ${cases.length} case(s) to ${outputPath}.`,
+);

--- a/scripts/voice-eval.ts
+++ b/scripts/voice-eval.ts
@@ -1,0 +1,309 @@
+#!/usr/bin/env tsx
+/**
+ * The eval runner (LOR-44): generates a real suggestion for every case in
+ * the set, using the same prompt builder the in-page assistant uses today
+ * (`buildSuggestionPrompt`), and scores it against the operator's own real
+ * reply with `voice-metrics.ts`'s pure, synchronous scorer. Deliberately not
+ * part of `pnpm test`: it spends model calls and is not deterministic, and a
+ * suite that spends money on every push is a suite people disable.
+ *
+ * Two tables print, one row per case:
+ *   - the deterministic table (style findings, per-axis distance, length
+ *     ratio, echo, language match) - needs no model to score once a
+ *     candidate exists, and reproduces byte-for-byte across two runs on the
+ *     same candidates (see the cache below).
+ *   - the judged table, second-class: a model shown a shuffled pair (the
+ *     real reply, the suggestion) and asked which a human wrote. Useful only
+ *     in aggregate, never the gate.
+ *
+ * No `AI_GATEWAY_API_KEY`, and nothing cached yet? Every case falls back to
+ * an offline self-check - the candidate is the operator's own real reply,
+ * scored against itself - which proves the deterministic table runs end to
+ * end with zero network calls, and is never presented as a real evaluation.
+ *
+ * `--thin` withholds the operator's own corpus (the voice profile handed to
+ * the prompt becomes `voice-defaults.ts`'s `DEFAULT_VOICE_PROFILE`, exactly
+ * what a brand-new account gets) rather than the one `measureVoiceCorpus`
+ * derives from `voiceCorpus` in the case file.
+ *
+ * Usage:
+ *   pnpm run eval:voice [--thin] [--limit=N] [--cases=path] [--regenerate] [--no-judge]
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import { generateText } from 'ai';
+import { createGateway } from '@ai-sdk/gateway';
+import {
+  loadVoiceEvalCases,
+  resolveVoiceEvalCasesPath,
+  VoiceEvalCasesNotFoundError,
+  type VoiceEvalCase,
+  type VoiceEvalFile,
+} from '../shared/src/voice-eval-cases.js';
+import { scoreCandidate, type VoiceCandidateScore } from '../shared/src/voice-metrics.js';
+import { buildSuggestionPrompt, type ObservedPost } from '../shared/src/assist/suggest-prompt.js';
+import { splitSuggestion } from '../shared/src/assist/envelope.js';
+import { measureVoiceCorpus, describeVoiceProfile } from '../shared/src/assist/voice-profile.js';
+import { DEFAULT_VOICE_PROFILE } from '../shared/src/assist/voice-defaults.js';
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const argv = process.argv.slice(2);
+const thin = argv.includes('--thin');
+const regenerate = argv.includes('--regenerate');
+const skipJudge = argv.includes('--no-judge');
+const flag = (name: string): string | undefined =>
+  argv.find((a) => a.startsWith(`${name}=`))?.slice(name.length + 1);
+const casesPathArg = flag('--cases');
+const limitArg = flag('--limit');
+const limit = limitArg ? Number(limitArg) : undefined;
+
+const MODEL_ID = process.env.PITCHBOX_EVAL_MODEL || 'google/gemini-3.1-flash-lite';
+const JUDGE_MODEL_ID = process.env.PITCHBOX_EVAL_JUDGE_MODEL || MODEL_ID;
+const apiKey = process.env.AI_GATEWAY_API_KEY;
+const gateway = apiKey ? createGateway({ apiKey }) : null;
+
+// ---------------------------------------------------------------------------
+// Load the set. A missing file is a readable message and a clean exit, never
+// a stack trace - the issue's own acceptance criterion.
+// ---------------------------------------------------------------------------
+
+let file: VoiceEvalFile;
+try {
+  file = loadVoiceEvalCases(casesPathArg);
+} catch (err) {
+  if (err instanceof VoiceEvalCasesNotFoundError) {
+    console.error(err.message);
+    process.exit(1);
+  }
+  console.error(`The case file did not match the expected schema: ${(err as Error).message}`);
+  process.exit(1);
+}
+
+const cases = limit && limit > 0 ? file.cases.slice(0, limit) : file.cases;
+
+// ---------------------------------------------------------------------------
+// The voice profile the prompt is built with - exactly what `main` derives
+// today when `--thin` is absent, `voice-defaults.ts`'s own default otherwise.
+// ---------------------------------------------------------------------------
+
+function resolveVoiceProfileSummary(): string {
+  if (thin || file.voiceCorpus.length === 0) return DEFAULT_VOICE_PROFILE.summary;
+  const measurement = measureVoiceCorpus(
+    file.voiceCorpus.map((c, i) => ({ id: i + 1, kind: 'voice_sample' as const, text: c.text })),
+  );
+  return describeVoiceProfile(measurement) ?? DEFAULT_VOICE_PROFILE.summary;
+}
+
+const voiceProfileSummary = resolveVoiceProfileSummary();
+
+// ---------------------------------------------------------------------------
+// A generated-candidate cache, so the deterministic table can be re-scored
+// (and re-printed byte-for-byte) without spending another model call or
+// risking the model's own nondeterminism between two runs. Keyed by mode
+// (thin/full) so the two never overwrite each other. Always under the
+// gitignored `private/voice-eval/` directory, regardless of where the case
+// file itself lives - a run against the committed synthetic fixture (as the
+// module's own smoke test does) must never write a scratch file next to it.
+// ---------------------------------------------------------------------------
+
+const cacheDir = 'private/voice-eval/.cache';
+const cachePath = `${cacheDir}/${basename(casesPathArg ?? resolveVoiceEvalCasesPath())}${thin ? '.thin' : ''}.candidates.json`;
+
+function loadCache(): Record<string, string | null> {
+  if (!existsSync(cachePath)) return {};
+  try {
+    return JSON.parse(readFileSync(cachePath, 'utf8')) as Record<string, string | null>;
+  } catch {
+    return {};
+  }
+}
+
+function saveCache(cache: Record<string, string | null>): void {
+  mkdirSync(cacheDir, { recursive: true });
+  writeFileSync(cachePath, `${JSON.stringify(cache, null, 2)}\n`);
+}
+
+const cache = loadCache();
+let cacheChanged = false;
+
+// ---------------------------------------------------------------------------
+// Candidate generation - the one part of this script that is not
+// deterministic and not free. `buildSuggestionPrompt` is the exact prompt
+// builder the in-page assistant uses today (`match-room` tone, no persona,
+// no projects/repos - this eval is about the voice, not the project-picking
+// half of the prompt).
+// ---------------------------------------------------------------------------
+
+async function generateCandidate(
+  c: VoiceEvalCase,
+): Promise<{ candidate: string | null; skipped: boolean }> {
+  if (!gateway) {
+    // Offline self-check: proves the harness runs end to end with zero
+    // network calls, never presented as a real evaluation - see module
+    // header.
+    return { candidate: c.actualReply, skipped: c.actualReply === null };
+  }
+  const post: ObservedPost = {
+    text: c.post.text,
+    thread: c.post.thread
+      ? {
+          comments: c.post.thread.comments,
+          renderedCount: c.post.thread.comments.length,
+          truncated: false,
+        }
+      : undefined,
+  };
+  const prompt = buildSuggestionPrompt({
+    kind: 'post_comment',
+    post,
+    persona: null,
+    voiceProfile: { summary: voiceProfileSummary },
+    projects: [],
+    repos: [],
+    tone: 'match-room',
+  });
+  const response = await generateText({
+    model: gateway(MODEL_ID),
+    messages: [{ role: 'user', content: prompt }],
+  });
+  const envelope = splitSuggestion(response.text);
+  return { candidate: envelope.draft, skipped: envelope.skipped };
+}
+
+// ---------------------------------------------------------------------------
+// The judged half: a model shown a shuffled pair, asked which a human wrote.
+// Second-class by construction - see the module header.
+// ---------------------------------------------------------------------------
+
+interface JudgeResult {
+  correct: boolean;
+}
+
+async function judgeCase(real: string, candidate: string): Promise<JudgeResult | null> {
+  if (!gateway) return null;
+  const swap = Math.random() < 0.5;
+  const a = swap ? candidate : real;
+  const b = swap ? real : candidate;
+  const realLabel = swap ? 'B' : 'A';
+  const prompt =
+    'Two replies to the same social-media post are shown below, labeled A and B. One was written by a ' +
+    'human, the other by an AI assistant. Reply with exactly one character, A or B, naming which one you ' +
+    `think a human wrote - nothing else.\n\nA: ${a}\n\nB: ${b}`;
+  const response = await generateText({
+    model: gateway(JUDGE_MODEL_ID),
+    messages: [{ role: 'user', content: prompt }],
+  });
+  const letter = response.text.trim().charAt(0).toUpperCase();
+  if (letter !== 'A' && letter !== 'B') return null;
+  return { correct: letter === realLabel };
+}
+
+// ---------------------------------------------------------------------------
+// Run every case.
+// ---------------------------------------------------------------------------
+
+interface CaseResult {
+  case: VoiceEvalCase;
+  candidate: string | null;
+  skipped: boolean;
+  metrics: VoiceCandidateScore | null;
+  judged: JudgeResult | null;
+}
+
+function wordCount(text: string): number {
+  return text.trim() ? text.trim().split(/\s+/u).length : 0;
+}
+
+const results: CaseResult[] = [];
+
+for (const c of cases) {
+  const cached = !regenerate && Object.prototype.hasOwnProperty.call(cache, c.id);
+  let candidate: string | null;
+  let skipped: boolean;
+  if (cached) {
+    candidate = cache[c.id]!;
+    skipped = candidate === null;
+  } else {
+    const generated = await generateCandidate(c);
+    candidate = generated.candidate;
+    skipped = generated.skipped;
+    cache[c.id] = candidate;
+    cacheChanged = true;
+  }
+
+  const metrics =
+    candidate !== null
+      ? scoreCandidate({
+          candidate,
+          post: c.post.text,
+          actualReply: c.actualReply,
+          threadCommentWordCounts: c.post.thread?.comments.map((cm) => wordCount(cm.body)),
+        })
+      : null;
+
+  const judged =
+    !skipJudge && gateway && candidate !== null && c.actualReply !== null
+      ? await judgeCase(c.actualReply, candidate)
+      : null;
+
+  results.push({ case: c, candidate, skipped, metrics, judged });
+}
+
+if (cacheChanged) saveCache(cache);
+
+// ---------------------------------------------------------------------------
+// Print. Two tables, one row per case.
+// ---------------------------------------------------------------------------
+
+console.log(
+  `\nvoice-eval: ${results.length} case(s), ${thin ? 'thin (no operator corpus)' : 'full'} mode.`,
+);
+if (!gateway) {
+  console.log(
+    'No AI_GATEWAY_API_KEY: running an offline self-check (candidate = the real reply, scored against ' +
+      'itself). This proves the harness runs end to end with zero network calls - it is not a real ' +
+      'evaluation. Set AI_GATEWAY_API_KEY for a real baseline.\n',
+  );
+}
+
+const deterministicRows = results.map((r) => ({
+  id: r.case.id,
+  genre: r.case.genre,
+  words: r.metrics?.candidateWordCount ?? (r.skipped ? 'skipped' : 'n/a'),
+  lengthRatio: r.metrics?.lengthRatio ?? 'n/a',
+  lengthBasis: r.metrics?.lengthComparisonBasis ?? 'n/a',
+  styleFindings: r.metrics?.styleFindings.length ?? 'n/a',
+  rhythm: r.metrics?.distance.rhythm ?? 'n/a',
+  punctuation: r.metrics?.distance.punctuation ?? 'n/a',
+  shape: r.metrics?.distance.shape ?? 'n/a',
+  voiceMarkers: r.metrics?.distance.voiceMarkers ?? 'n/a',
+  lexicon: r.metrics?.distance.lexicon ?? 'n/a',
+  echo: r.metrics?.echo ?? 'n/a',
+  languageMatch: r.metrics?.languageMatch ?? 'n/a',
+}));
+console.log('Deterministic table:');
+console.table(deterministicRows);
+
+if (!skipJudge && gateway) {
+  const judgedRows = results
+    .filter((r) => r.judged !== null)
+    .map((r) => ({ id: r.case.id, judgeCorrect: r.judged!.correct }));
+  const correctCount = judgedRows.filter((r) => r.judgeCorrect).length;
+  console.log(
+    `\nJudged table (second-class, aggregate only - ${judgedRows.length} case(s) judged):`,
+  );
+  console.table(judgedRows);
+  if (judgedRows.length > 0) {
+    console.log(
+      `Judge correctly identified the real reply in ${correctCount}/${judgedRows.length} case(s) ` +
+        `(${Math.round((correctCount / judgedRows.length) * 100)}%) - lower is better for "sounds like him".`,
+    );
+  }
+} else if (!gateway) {
+  console.log('\nJudged table: skipped (no AI_GATEWAY_API_KEY).');
+} else if (skipJudge) {
+  console.log('\nJudged table: skipped (--no-judge).');
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -30,6 +30,8 @@
     "./templates": "./src/templates.ts",
     "./house-style": "./src/house-style.ts",
     "./style-check": "./src/style-check.ts",
+    "./voice-metrics": "./src/voice-metrics.ts",
+    "./voice-eval-cases": "./src/voice-eval-cases.ts",
     "./assist/suggest-prompt": "./src/assist/suggest-prompt.ts",
     "./assist/envelope": "./src/assist/envelope.ts",
     "./assist/context": "./src/assist/context.ts",

--- a/shared/src/assist/voice-profile.ts
+++ b/shared/src/assist/voice-profile.ts
@@ -27,7 +27,7 @@
 // different-shaped object for exactly this reason - a default is a rule to
 // follow, not a number this module claims to have measured.
 
-import { readPostRegister, type RegisterTrait } from './register.js';
+import { readPostRegister, type PostRegister, type RegisterTrait } from './register.js';
 
 export type VoiceCorpusItemKind = 'voice_sample' | 'message' | 'draft' | 'template';
 
@@ -637,8 +637,10 @@ export type LexiconProfile = {
   avoidedWords: string[];
 };
 
-/** Below this many words, an absence proves nothing. */
-const AVOIDED_WORDS_MIN_WORDS = 200;
+/** Below this many words, an absence proves nothing. Exported so a single-
+ * text comparison (voice-metrics.ts, LOR-44) can gate the lexicon axis on
+ * the exact same floor rather than guessing a second one. */
+export const AVOIDED_WORDS_MIN_WORDS = 200;
 
 /** Candidate words a default-sounding draft leaks - mirrors house style's
  * puffery bans (`shared/src/style-check.ts`'s PUFFERY_WORDS and
@@ -848,6 +850,53 @@ export function measureVoiceCorpus(corpus: VoiceCorpusItem[]): VoiceMeasurement 
     voiceMarkers: measureVoiceMarkers(texts, wordCount),
     lexicon: measureLexicon(texts.join(' '), wordCount),
     language: measureLanguage(items),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// A single piece of text, not a corpus (LOR-44).
+// ---------------------------------------------------------------------------
+
+export type OneTextMeasurement = {
+  wordCount: number;
+  /** Null exactly when register.ts's own floor (MIN_WORDS_TO_DESCRIBE) says
+   * this text is too short to have measurable habits - a caller comparing
+   * two texts should read that as "this axis is not measurable here", never
+   * as a zero or a match. */
+  register: PostRegister | null;
+  rhythm: RhythmProfile;
+  punctuation: PunctuationProfile;
+  shape: ShapeProfile;
+  voiceMarkers: VoiceMarkerProfile;
+  lexicon: LexiconProfile;
+  language: 'en' | 'it' | 'unknown';
+};
+
+/**
+ * The same six axes `measureVoiceCorpus` derives from a corpus, read off a
+ * single piece of text instead - voice-metrics.ts's (LOR-44) entry point for
+ * comparing one candidate against one real reply rather than describing a
+ * habit across many. Deliberately not a second implementation: every axis
+ * below calls the exact function `measureVoiceCorpus` calls, just with a
+ * one-item list, so this can never drift from what a corpus measurement
+ * means. `usesLists` (shape's own corpus-level trait) falls back the same
+ * way `measureVoiceCorpus` does - off register's own traits, gated by the
+ * same MIN_WORDS_TO_DESCRIBE floor as everything else here.
+ */
+export function measureOneText(text: string): OneTextMeasurement {
+  const t = text.trim();
+  const texts = t ? [t] : [];
+  const wordCount = t ? t.split(/\s+/u).filter(Boolean).length : 0;
+  const register = readPostRegister(t);
+  return {
+    wordCount,
+    register,
+    rhythm: measureRhythm(texts),
+    punctuation: measurePunctuation(texts, wordCount),
+    shape: measureShape(texts, register?.traits.includes('list-layout') ?? false),
+    voiceMarkers: measureVoiceMarkers(texts, wordCount),
+    lexicon: measureLexicon(t, wordCount),
+    language: classifyLanguage(t),
   };
 }
 

--- a/shared/src/voice-eval-cases.ts
+++ b/shared/src/voice-eval-cases.ts
@@ -1,0 +1,136 @@
+// shared/src/voice-eval-cases.ts (LOR-44)
+//
+// The eval set's schema and loader. The set itself never lives in this
+// public repo - the cases quote other people's real LinkedIn posts, so it
+// belongs in `private/` (already in `.gitignore`) as
+// `private/voice-eval/cases.json`, and the path is configurable
+// (`PITCHBOX_EVAL_CASES`) so a harvest can live anywhere on disk. What ships
+// here is the shape and the loader, plus a small synthetic fixture
+// (`shared/tests/fixtures/voice-eval/synthetic-cases.json`, five invented
+// cases, no real person) so the scorer's own unit tests run in CI with no
+// private data.
+//
+// Kept separate from `voice-metrics.ts` on purpose: that module is pure and
+// synchronous (no fs, no model, no I/O of any kind), and reading a file off
+// disk is neither.
+
+import { readFileSync } from 'node:fs';
+import { z } from 'zod';
+
+export const VOICE_EVAL_SCHEMA_VERSION = 1;
+
+/** The genres the issue asks the set to deliberately cover, plus
+ * 'unclassified' for a harvested case nobody has hand-labelled yet - a
+ * wrong guess at genre is worse than an honest "not sorted", so the loader
+ * never infers one. */
+export const VOICE_EVAL_GENRES = [
+  'launch',
+  'technical-thread',
+  'hiring',
+  'disagreement',
+  'image-led',
+  'italian',
+  'silence',
+  'comment-reply',
+  'unclassified',
+] as const;
+export type VoiceEvalGenre = (typeof VOICE_EVAL_GENRES)[number];
+
+// A minimal, structural subset of assist/suggest-prompt.ts's ObservedPost/
+// ObservedThread - just enough for the runner to build a real
+// buildSuggestionPrompt call and for the length-ratio axis to read a room's
+// comment lengths, without dragging that module's full surface (author
+// handles, images, reply targets) into a case file that mostly won't have
+// any of it.
+const CaseThreadSchema = z.object({
+  comments: z.array(z.object({ body: z.string().min(1) })),
+});
+
+const VoiceEvalCaseSchema = z.object({
+  /** Stable within the file - printed in both tables as the row's evidence,
+   * so a finding can be traced back to the case without renumbering. */
+  id: z.string().min(1),
+  genre: z.enum(VOICE_EVAL_GENRES).default('unclassified'),
+  /** Free text, evidence only - never read by the scorer. */
+  postAuthor: z.string().optional(),
+  post: z.object({
+    text: z.string().min(1),
+    /** Other people's visible replies under the post, when known - feeds
+     * the length-ratio axis's ideal comparator (the room's median). Absent
+     * in every case harvested so far (LinkedIn's own thread was never
+     * captured, only the post and Lorenzo's own comment on it), so the
+     * runner falls back to comparing against `actualReply`'s own length -
+     * see voice-metrics.ts's `lengthComparisonBasis`. */
+    thread: CaseThreadSchema.optional(),
+  }),
+  /** What Lorenzo actually wrote under this post. Null only for a genuine
+   * "the right answer was silence" case - the one genre a real activity
+   * feed cannot supply on its own, since nobody's timeline records what
+   * they chose not to write; today that genre lives only in the synthetic
+   * fixture. */
+  actualReply: z.string().min(1).nullable(),
+});
+export type VoiceEvalCase = z.infer<typeof VoiceEvalCaseSchema>;
+
+const VoiceEvalCorpusItemSchema = z.object({
+  id: z.string().min(1),
+  text: z.string().min(1),
+});
+export type VoiceEvalCorpusItem = z.infer<typeof VoiceEvalCorpusItemSchema>;
+
+const VoiceEvalFileSchema = z.object({
+  schemaVersion: z.literal(VOICE_EVAL_SCHEMA_VERSION),
+  /** Lorenzo's own writing, kind `voice_sample` feed for
+   * `assist/voice-profile.ts`'s `measureVoiceCorpus` - the "full" run's
+   * operator corpus, exactly what the product would derive a
+   * `VoiceProfileSummary` from. Empty or absent makes a "full" run and a
+   * `--thin` run the same run, which is an honest degenerate case rather
+   * than an error. */
+  voiceCorpus: z.array(VoiceEvalCorpusItemSchema).default([]),
+  cases: z.array(VoiceEvalCaseSchema).min(1),
+});
+export type VoiceEvalFile = z.infer<typeof VoiceEvalFileSchema>;
+
+export const DEFAULT_VOICE_EVAL_CASES_PATH = 'private/voice-eval/cases.json';
+
+/** Thrown when no case file exists at the resolved path - the caller (the
+ * runner script) turns this into one readable line and a clean exit, never
+ * a stack trace, per the issue's own acceptance criterion. */
+export class VoiceEvalCasesNotFoundError extends Error {
+  constructor(public readonly path: string) {
+    super(
+      `No voice-eval case file at "${path}". Set PITCHBOX_EVAL_CASES to point at one, or place one at ` +
+        `${DEFAULT_VOICE_EVAL_CASES_PATH} (gitignored - see shared/src/voice-eval-cases.ts for the schema, ` +
+        'or shared/tests/fixtures/voice-eval/synthetic-cases.json for a small worked example).',
+    );
+    this.name = 'VoiceEvalCasesNotFoundError';
+  }
+}
+
+/** `PITCHBOX_EVAL_CASES` when set (trimmed of surrounding whitespace so a
+ * stray newline from a shell export can't send the loader looking for a
+ * path that never exists), else the repo-relative default. */
+export function resolveVoiceEvalCasesPath(): string {
+  const fromEnv = process.env.PITCHBOX_EVAL_CASES?.trim();
+  return fromEnv ? fromEnv : DEFAULT_VOICE_EVAL_CASES_PATH;
+}
+
+/**
+ * Reads and validates a case file. Throws `VoiceEvalCasesNotFoundError` when
+ * the path does not exist, or a zod error when it exists but does not match
+ * the schema - either way the caller decides how to present it, this
+ * function never prints anything itself.
+ */
+export function loadVoiceEvalCases(path: string = resolveVoiceEvalCasesPath()): VoiceEvalFile {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (err) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      throw new VoiceEvalCasesNotFoundError(path);
+    }
+    throw err;
+  }
+  const parsed: unknown = JSON.parse(raw);
+  return VoiceEvalFileSchema.parse(parsed);
+}

--- a/shared/src/voice-metrics.ts
+++ b/shared/src/voice-metrics.ts
@@ -1,0 +1,318 @@
+// shared/src/voice-metrics.ts (LOR-44)
+//
+// "It sounds like him" is the product claim that decides whether Pitchbox is
+// worth anything, and this is the load-bearing half of proving it rather
+// than asserting it: a pure, synchronous, model-free module that turns one
+// piece of text into a comparable measurement, and turns two of them - a
+// candidate reply and the operator's own real reply to the same post - into
+// a distance. Every other issue in this project reads this module's output;
+// nothing in this file calls a model, reads a file, or reaches a database.
+//
+// It reuses what already exists rather than inventing a second measurement:
+// `assist/voice-profile.ts`'s `measureOneText` (rhythm, punctuation, shape,
+// voice markers, lexicon, language - the same axes `measureVoiceCorpus`
+// derives from a corpus, read off one string instead) and `style-check.ts`'s
+// `checkStyle` (the tell detector). What this file adds is the comparisons a
+// single measurement cannot make on its own:
+//
+//   - style findings: `checkStyle`'s own count and rule ids against the
+//     candidate. The target is zero; a non-zero count is a hard fail of the
+//     case, not a score component to average away.
+//   - stylometric distance between the candidate and the operator's own real
+//     reply, one number per axis rather than folded into a single score -
+//     which axis is wrong is the actionable part.
+//   - length ratio: the candidate's word count against the best comparator
+//     the case can supply - the thread's median visible comment when known,
+//     else the operator's own real reply's length, which every harvested
+//     case can always supply. This axis moves first: a corpus of real
+//     replies running seven words median against a hundred-plus-word
+//     "professional" default is most of why a suggestion reads as
+//     machine-written, and it is the one difference a human notices without
+//     reading closely.
+//   - echo: how much of the candidate is made of words already in the post -
+//     a suggestion that quotes the post back at its author is the single
+//     most recognisable machine tell in the category.
+//   - language match: whether the candidate answers in the post's own
+//     language, via `voice-profile.ts`'s own classifier.
+//
+// Several of these are not measurable on every input, and a short candidate
+// or a short real reply (the corpus this project actually cares about runs a
+// median of seven words) is the common case, not the edge case. An
+// unmeasurable axis is reported as `null`, never as 0 (a false "identical")
+// or 1 (a false "as different as possible") - the same refuse-rather-than-
+// guess discipline `register.ts` and `voice-profile.ts` already apply to a
+// corpus too small to describe.
+
+import {
+  measureOneText,
+  classifyLanguage,
+  AVOIDED_WORDS_MIN_WORDS,
+  type OneTextMeasurement,
+  type RhythmProfile,
+  type PunctuationProfile,
+  type ShapeProfile,
+  type VoiceMarkerProfile,
+  type LexiconProfile,
+} from './assist/voice-profile.js';
+import { checkStyle, type StyleFinding } from './style-check.js';
+
+export type VoiceMetricsLanguage = 'en' | 'it' | 'unknown';
+
+/** A per-axis (or per-comparison) result: a number in `[0, 1]` (0 =
+ * identical, 1 = as different as the axis's own scale considers
+ * meaningful), or `null` when one or both sides did not clear that axis's
+ * own measurability floor - see the module header. */
+export type AxisScore = number | null;
+
+export interface AxisDistances {
+  rhythm: AxisScore;
+  punctuation: AxisScore;
+  shape: AxisScore;
+  voiceMarkers: AxisScore;
+  lexicon: AxisScore;
+}
+
+export type LengthComparisonBasis = 'thread-median' | 'actual-reply' | null;
+
+export interface VoiceCandidateScore {
+  /** `checkStyle`'s own findings against the candidate, verbatim - zero is
+   * the target, and a non-zero count is this case's hard fail. */
+  styleFindings: StyleFinding[];
+  /** Per-axis stylometric distance between the candidate and the operator's
+   * own real reply to the same post. */
+  distance: AxisDistances;
+  /** Candidate word count divided by the comparison length named in
+   * `lengthComparisonBasis`. Above 1 means the candidate runs longer than
+   * the room (or than the real reply); `null` when there is nothing to
+   * compare against at all. */
+  lengthRatio: AxisScore;
+  lengthComparisonBasis: LengthComparisonBasis;
+  /** Fraction of the candidate's own content words (length-4-plus, a coarse
+   * stopword floor rather than a dictionary) that already appear in the
+   * post - 0 means no shared wording, 1 means the candidate is built
+   * entirely out of the post's own words. `null` when the candidate has no
+   * content words of its own to measure (e.g. a bare emoji reply). */
+  echo: AxisScore;
+  /** Whether the candidate's language matches the post's, via
+   * `voice-profile.ts`'s own classifier. `null` when either side's language
+   * could not be classified - a short reply is the common case here, not
+   * the edge case. */
+  languageMatch: boolean | null;
+  candidateLanguage: VoiceMetricsLanguage;
+  postLanguage: VoiceMetricsLanguage;
+  candidateWordCount: number;
+}
+
+export interface ScoreCandidateArgs {
+  candidate: string;
+  /** The post the candidate answers. */
+  post: string;
+  /** The operator's own real reply to the same post - `null` only for a
+   * genuine "the right answer was silence" case, in which every axis that
+   * needs a real reply to compare against is `null` rather than guessed. */
+  actualReply: string | null;
+  /** Word counts of other visible comments under the post, when known -
+   * feeds the length-ratio axis's ideal comparator, the room's median.
+   * Absent falls back to `actualReply`'s own length, the one comparator a
+   * corpus of real replies (rather than captured threads) can always
+   * supply. */
+  threadCommentWordCounts?: number[];
+}
+
+// ---------------------------------------------------------------------------
+// Small local helpers. Kept local rather than shared with voice-profile.ts's
+// own (private) copies of the same shapes - none of this is specific to
+// voice measurement, the same call voice-profile.ts's own header makes for
+// its small numeric helpers.
+// ---------------------------------------------------------------------------
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function mean(values: number[]): number {
+  return values.length > 0 ? values.reduce((sum, v) => sum + v, 0) / values.length : 0;
+}
+
+function median(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+/** Normalizes a raw difference by a per-field scale (a rough sense of "how
+ * big a gap on this field is a lot"), capped at 1 so no single field can
+ * make the axis average look worse than "as different as this axis gets" -
+ * the scales are chosen to be generous, not tuned to any one corpus. */
+function numDist(a: number, b: number, scale: number): number {
+  return Math.min(1, Math.abs(a - b) / scale);
+}
+
+function boolDist(a: boolean, b: boolean): number {
+  return a === b ? 0 : 1;
+}
+
+function setDistance(a: string[], b: string[]): number {
+  const as = new Set(a);
+  const bs = new Set(b);
+  if (as.size === 0 && bs.size === 0) return 0;
+  let intersection = 0;
+  for (const x of as) if (bs.has(x)) intersection += 1;
+  const union = new Set([...as, ...bs]).size;
+  return union === 0 ? 0 : round2(1 - intersection / union);
+}
+
+function rhythmDistance(a: RhythmProfile, b: RhythmProfile): number {
+  return round2(
+    mean([
+      numDist(a.medianSentenceWords, b.medianSentenceWords, 20),
+      numDist(a.sentenceWordsSpread, b.sentenceWordsSpread, 10),
+      numDist(a.medianParagraphWords, b.medianParagraphWords, 30),
+      numDist(a.fragmentRatio, b.fragmentRatio, 1),
+      numDist(a.shortOpeningRatio, b.shortOpeningRatio, 1),
+    ]),
+  );
+}
+
+function punctuationDistance(a: PunctuationProfile, b: PunctuationProfile): number {
+  return round2(
+    mean([
+      numDist(a.commasPer100Words, b.commasPer100Words, 10),
+      numDist(a.colonsPer100Words, b.colonsPer100Words, 5),
+      numDist(a.parenthesesPer100Words, b.parenthesesPer100Words, 5),
+      numDist(a.dashesPer100Words, b.dashesPer100Words, 5),
+      numDist(a.questionMarksPer100Words, b.questionMarksPer100Words, 5),
+      numDist(a.exclamationMarksPer100Words, b.exclamationMarksPer100Words, 5),
+      numDist(a.ellipsesPer100Words, b.ellipsesPer100Words, 5),
+      boolDist(a.capitalizesOpenings, b.capitalizesOpenings),
+      boolDist(a.lowercasesAfterColon, b.lowercasesAfterColon),
+    ]),
+  );
+}
+
+function shapeDistance(a: ShapeProfile, b: ShapeProfile): number {
+  // emoji/hashtags are deliberately not compared here: measureOneText always
+  // computes them over a one-item list, and voice-profile.ts's own
+  // MIN_PHRASE_REPEATS floor (2 separate items) means a single text can
+  // never populate either array - comparing two always-empty lists would
+  // report a free, meaningless "identical" rather than measuring anything.
+  return round2(
+    mean([
+      numDist(a.lineBreaksPerParagraph, b.lineBreaksPerParagraph, 3),
+      boolDist(a.usesLists, b.usesLists),
+      a.ending === b.ending ? 0 : 1,
+    ]),
+  );
+}
+
+function voiceMarkersDistance(a: VoiceMarkerProfile, b: VoiceMarkerProfile): number {
+  return round2(
+    mean([
+      numDist(a.firstPersonPer100Words, b.firstPersonPer100Words, 10),
+      numDist(a.secondPersonPer100Words, b.secondPersonPer100Words, 10),
+      numDist(a.hedgesPer100Words, b.hedgesPer100Words, 5),
+      numDist(a.certaintyPer100Words, b.certaintyPer100Words, 5),
+      numDist(a.imperativeRatio, b.imperativeRatio, 1),
+    ]),
+  );
+}
+
+function lexiconDistance(a: LexiconProfile, b: LexiconProfile): number {
+  return setDistance(a.avoidedWords, b.avoidedWords);
+}
+
+/** Rhythm/punctuation/shape/voice-markers all need both sides to individually
+ * clear register.ts's own MIN_WORDS_TO_DESCRIBE floor - `measureOneText`
+ * already carries that answer as `register: PostRegister | null`, so this
+ * reads it rather than re-deriving a second floor. */
+function distanceAxes(
+  candidate: OneTextMeasurement,
+  reply: OneTextMeasurement | null,
+): AxisDistances {
+  const measurable = reply !== null && candidate.register !== null && reply.register !== null;
+  return {
+    rhythm: measurable ? rhythmDistance(candidate.rhythm, reply.rhythm) : null,
+    punctuation: measurable ? punctuationDistance(candidate.punctuation, reply.punctuation) : null,
+    shape: measurable ? shapeDistance(candidate.shape, reply.shape) : null,
+    voiceMarkers: measurable
+      ? voiceMarkersDistance(candidate.voiceMarkers, reply.voiceMarkers)
+      : null,
+    lexicon:
+      reply !== null &&
+      candidate.wordCount >= AVOIDED_WORDS_MIN_WORDS &&
+      reply.wordCount >= AVOIDED_WORDS_MIN_WORDS
+        ? lexiconDistance(candidate.lexicon, reply.lexicon)
+        : null,
+  };
+}
+
+/** Below this length a word is almost certainly a function word ("the",
+ * "che", "and"...) rather than content - a coarse floor rather than a
+ * bilingual stopword dictionary, the same tradeoff `voice-profile.ts`'s own
+ * MIN_WORD_LENGTH makes for reused vocabulary. */
+const ECHO_MIN_WORD_LENGTH = 4;
+
+function contentWords(text: string): Set<string> {
+  const words = text
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}']+/u)
+    .filter((w) => w.length >= ECHO_MIN_WORD_LENGTH);
+  return new Set(words);
+}
+
+/**
+ * Scores one candidate reply against the post it answers and the operator's
+ * own real reply to that same post. Pure and synchronous - no model, no I/O.
+ */
+export function scoreCandidate(args: ScoreCandidateArgs): VoiceCandidateScore {
+  const { candidate, post, actualReply, threadCommentWordCounts } = args;
+
+  const candidateM = measureOneText(candidate);
+  const postM = measureOneText(post);
+  const replyM = actualReply != null ? measureOneText(actualReply) : null;
+
+  let lengthRatio: AxisScore = null;
+  let lengthComparisonBasis: LengthComparisonBasis = null;
+  if (threadCommentWordCounts && threadCommentWordCounts.length > 0) {
+    const basis = median(threadCommentWordCounts);
+    if (basis > 0) {
+      lengthRatio = round2(candidateM.wordCount / basis);
+      lengthComparisonBasis = 'thread-median';
+    }
+  } else if (replyM !== null && replyM.wordCount > 0) {
+    lengthRatio = round2(candidateM.wordCount / replyM.wordCount);
+    lengthComparisonBasis = 'actual-reply';
+  }
+
+  const candidateContentWords = contentWords(candidate);
+  const postContentWords = contentWords(post);
+  const echo: AxisScore =
+    candidateContentWords.size > 0
+      ? round2(
+          [...candidateContentWords].filter((w) => postContentWords.has(w)).length /
+            candidateContentWords.size,
+        )
+      : null;
+
+  const languageMatch =
+    candidateM.language !== 'unknown' && postM.language !== 'unknown'
+      ? candidateM.language === postM.language
+      : null;
+
+  return {
+    styleFindings: checkStyle(candidate),
+    distance: distanceAxes(candidateM, replyM),
+    lengthRatio,
+    lengthComparisonBasis,
+    echo,
+    languageMatch,
+    candidateLanguage: candidateM.language,
+    postLanguage: postM.language,
+    candidateWordCount: candidateM.wordCount,
+  };
+}
+
+/** Re-exported so a caller can classify a language without importing
+ * voice-profile.ts directly for it. */
+export { classifyLanguage };

--- a/shared/tests/assist-voice-profile.test.ts
+++ b/shared/tests/assist-voice-profile.test.ts
@@ -6,6 +6,8 @@ import {
   measureVoiceCorpusByGenre,
   describeVoiceProfile,
   describeVoiceProfileForGenre,
+  measureOneText,
+  classifyLanguage,
   MIN_ITEMS_TO_DERIVE,
   EMPTY_RHYTHM,
   EMPTY_PUNCTUATION,
@@ -575,4 +577,68 @@ describe('no model call in the derivation path', () => {
       }
     });
   }
+});
+
+// LOR-44: measureOneText reads the same six axes off a single string,
+// reusing every measure* function measureVoiceCorpus itself calls (a
+// one-item list rather than a second implementation). What is worth
+// pinning here is the floor behaviour a caller comparing two short texts
+// depends on: register (and therefore rhythm/punctuation/shape/voice-
+// markers) is null below register.ts's own 12-word floor, and language is
+// 'unknown' below its own 2-stopword floor - two independent floors, so a
+// six-word Italian reply can classify a language while still reporting no
+// register at all.
+describe('measureOneText', () => {
+  it('measures an English, first-person text at or above the register floor', () => {
+    const m = measureOneText(
+      'I shipped the new dashboard today, and I think it turned out great, honestly.',
+    );
+    expect(m.wordCount).toBe(14);
+    expect(m.register).not.toBeNull();
+    expect(m.register?.traits).toContain('first-person');
+    expect(m.language).toBe('en');
+  });
+
+  it('reports no register below the 12-word floor, even when the language is classifiable', () => {
+    const m = measureOneText("che bello, non vedo l'ora!");
+    expect(m.wordCount).toBeLessThan(12);
+    expect(m.register).toBeNull();
+    // Below the floor, rhythm/punctuation/shape/voiceMarkers still return a
+    // real (if degenerate) measurement rather than throwing - a caller
+    // gates on `register === null` itself rather than this crashing.
+    expect(m.rhythm.medianSentenceWords).toBeGreaterThan(0);
+    // Two Italian stopword hits ('che', 'non') clear the language floor
+    // independently of the (unmet) register floor.
+    expect(m.language).toBe('it');
+  });
+
+  it('reports language as unknown below its own 2-marker floor', () => {
+    const m = measureOneText('Grande!');
+    expect(m.register).toBeNull();
+    expect(m.language).toBe('unknown');
+  });
+
+  it('derives usesLists from its own register trait, matching the corpus-level rule', () => {
+    const m = measureOneText(
+      'Here is the plan for next week:\n- ship the export feature\n- fix the flaky test\n- write the docs',
+    );
+    expect(m.register?.traits).toContain('list-layout');
+    expect(m.shape.usesLists).toBe(true);
+  });
+
+  it('never throws on empty text', () => {
+    const m = measureOneText('   ');
+    expect(m.wordCount).toBe(0);
+    expect(m.register).toBeNull();
+    expect(m.language).toBe('unknown');
+    expect(m.rhythm).toEqual(EMPTY_RHYTHM);
+  });
+});
+
+describe('classifyLanguage (exported for style-check.ts and voice-metrics.ts)', () => {
+  it('classifies English, Italian and unclassifiable text', () => {
+    expect(classifyLanguage('This is the plan for the week and it is going well.')).toBe('en');
+    expect(classifyLanguage("che bello, non vedo l'ora!")).toBe('it');
+    expect(classifyLanguage('Grande!')).toBe('unknown');
+  });
 });

--- a/shared/tests/fixtures/voice-eval/synthetic-cases.json
+++ b/shared/tests/fixtures/voice-eval/synthetic-cases.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": 1,
+  "voiceCorpus": [
+    {
+      "id": "sample-1",
+      "text": "Shipped the new onboarding flow today. Three days chasing a race condition that only showed up under load, and the fix was five lines. Slow week, small diff, happy with it."
+    },
+    {
+      "id": "sample-2",
+      "text": "Talked to two customers this morning. Both hit the same edge case in the CSV import, so that is what we are fixing before anything else this week. Feels good to have one clear priority for once."
+    },
+    {
+      "id": "sample-3",
+      "text": "Wrote two hundred lines of tests today and deleted a hundred and fifty lines of code. Net negative, in the good way. That is my kind of Tuesday."
+    }
+  ],
+  "cases": [
+    {
+      "id": "synth-launch-01",
+      "genre": "launch",
+      "postAuthor": "Fictional Founder",
+      "post": {
+        "text": "After eight months heads down, we are opening signups for Fictional Founder's new expense tool today. It started as a spreadsheet I built for my own team and turned into something three hundred companies now use in beta."
+      },
+      "actualReply": "Congrats, huge milestone."
+    },
+    {
+      "id": "synth-technical-01",
+      "genre": "technical-thread",
+      "postAuthor": "Fictional Engineer",
+      "post": {
+        "text": "Spent the afternoon debugging a deadlock in our job queue. Turned out two workers were acquiring the same two row locks in opposite order under load. Fixed by always locking in id order. Classic, and still took four hours to find."
+      },
+      "actualReply": "Lock ordering bugs are the worst to find and the easiest to explain once you see them."
+    },
+    {
+      "id": "synth-italian-01",
+      "genre": "italian",
+      "postAuthor": "Persona Inventata",
+      "post": {
+        "text": "Oggi abbiamo chiuso il primo cliente pagante del nostro prodotto. Sei mesi di lavoro, tante notti a chiederci se avesse senso, e oggi la risposta è arrivata da sola."
+      },
+      "actualReply": "Bravissimi, se lo aspettava anche prima!"
+    },
+    {
+      "id": "synth-silence-01",
+      "genre": "silence",
+      "postAuthor": "Fictional Competitor",
+      "post": {
+        "text": "We just raised a round to build the exact same thing three other companies already shipped last year, except ours has a mascot."
+      },
+      "actualReply": null
+    },
+    {
+      "id": "synth-comment-reply-01",
+      "genre": "comment-reply",
+      "postAuthor": "Fictional Organizer",
+      "post": {
+        "text": "Day two of the residency and the whiteboard is already full of half-finished diagrams nobody remembers drawing. Good sign or bad sign?",
+        "thread": {
+          "comments": [
+            { "body": "Good sign, always." },
+            {
+              "body": "Means people are actually arguing about the design instead of just agreeing."
+            }
+          ]
+        }
+      },
+      "actualReply": "Good sign."
+    }
+  ]
+}

--- a/shared/tests/voice-eval-cases.test.ts
+++ b/shared/tests/voice-eval-cases.test.ts
@@ -1,0 +1,73 @@
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, afterEach } from 'vitest';
+import {
+  loadVoiceEvalCases,
+  resolveVoiceEvalCasesPath,
+  VoiceEvalCasesNotFoundError,
+  DEFAULT_VOICE_EVAL_CASES_PATH,
+  VOICE_EVAL_SCHEMA_VERSION,
+} from '../src/voice-eval-cases.js';
+
+const FIXTURE_PATH = fileURLToPath(
+  new URL('./fixtures/voice-eval/synthetic-cases.json', import.meta.url),
+);
+
+describe('loadVoiceEvalCases', () => {
+  it('loads and validates the committed synthetic fixture', () => {
+    const file = loadVoiceEvalCases(FIXTURE_PATH);
+    expect(file.schemaVersion).toBe(VOICE_EVAL_SCHEMA_VERSION);
+    expect(file.voiceCorpus.length).toBeGreaterThanOrEqual(3);
+    expect(file.cases.length).toBeGreaterThanOrEqual(5);
+    // Exactly one genuine silence case, per the issue's own named genres.
+    expect(file.cases.filter((c) => c.actualReply === null)).toHaveLength(1);
+  });
+
+  it('defaults an unlabelled genre to "unclassified" rather than guessing one', () => {
+    const file = loadVoiceEvalCases(FIXTURE_PATH);
+    for (const c of file.cases) {
+      expect(c.genre).toBeTruthy();
+    }
+  });
+
+  it('throws a readable, named error rather than a raw ENOENT stack when the file is missing', () => {
+    expect(() => loadVoiceEvalCases('/nonexistent/path/cases.json')).toThrow(
+      VoiceEvalCasesNotFoundError,
+    );
+    try {
+      loadVoiceEvalCases('/nonexistent/path/cases.json');
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(VoiceEvalCasesNotFoundError);
+      expect((err as VoiceEvalCasesNotFoundError).message).toContain(
+        '/nonexistent/path/cases.json',
+      );
+      expect((err as VoiceEvalCasesNotFoundError).message).toContain('PITCHBOX_EVAL_CASES');
+    }
+  });
+
+  it('rejects a file that does not match the schema', () => {
+    // A directory read as a file: the loader's readFileSync throws EISDIR,
+    // not ENOENT, so this must surface as a real error, never as a silent
+    // "no cases" - proving loadVoiceEvalCases does not swallow anything past
+    // the one error it explicitly names.
+    expect(() =>
+      loadVoiceEvalCases(fileURLToPath(new URL('./fixtures/voice-eval', import.meta.url))),
+    ).toThrow();
+  });
+});
+
+describe('resolveVoiceEvalCasesPath', () => {
+  afterEach(() => {
+    delete process.env.PITCHBOX_EVAL_CASES;
+  });
+
+  it('defaults to the gitignored private/ location', () => {
+    delete process.env.PITCHBOX_EVAL_CASES;
+    expect(resolveVoiceEvalCasesPath()).toBe(DEFAULT_VOICE_EVAL_CASES_PATH);
+  });
+
+  it('honors PITCHBOX_EVAL_CASES, trimmed of stray whitespace', () => {
+    process.env.PITCHBOX_EVAL_CASES = '  /tmp/some-cases.json\n';
+    expect(resolveVoiceEvalCasesPath()).toBe('/tmp/some-cases.json');
+  });
+});

--- a/shared/tests/voice-metrics.test.ts
+++ b/shared/tests/voice-metrics.test.ts
@@ -1,0 +1,205 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { scoreCandidate, type ScoreCandidateArgs } from '../src/voice-metrics.js';
+import { loadVoiceEvalCases } from '../src/voice-eval-cases.js';
+
+// LOR-44: "sounds like him" is a product claim, not an opinion, and this is
+// the deterministic half of proving it - a pure, synchronous scorer over one
+// candidate reply, the post it answers, and the operator's own real reply to
+// that post. Every fixture below is built to make one hand-checkable claim,
+// the same discipline assist-voice-profile.test.ts already follows: not "the
+// code runs" but "this exact input produces this exact number".
+
+const FIXTURE_PATH = fileURLToPath(
+  new URL('./fixtures/voice-eval/synthetic-cases.json', import.meta.url),
+);
+
+function score(args: ScoreCandidateArgs) {
+  return scoreCandidate(args);
+}
+
+describe('scoreCandidate', () => {
+  it('reports near-zero distance when the candidate matches the real reply almost verbatim', () => {
+    const reply =
+      'I shipped the dashboard update today, and I think the team is genuinely happy with how it turned out.';
+    const candidate =
+      'I shipped the dashboard update today, and I think the team is genuinely pleased with how it turned out.';
+    const result = score({ candidate, post: 'Anything ship this week?', actualReply: reply });
+    expect(result.distance.rhythm).not.toBeNull();
+    expect(result.distance.rhythm).toBeLessThan(0.2);
+    expect(result.distance.voiceMarkers).not.toBeNull();
+    expect(result.distance.voiceMarkers).toBeLessThan(0.2);
+  });
+
+  it('reports every axis as null (not zero, not one) when the real reply is too short to have a register', () => {
+    const result = score({
+      candidate:
+        'Congratulations on the launch, this is a genuinely impressive milestone for the whole team and I mean that sincerely.',
+      post: 'We are opening signups today after eight months of building in private.',
+      actualReply: 'Grande!',
+    });
+    expect(result.distance).toEqual({
+      rhythm: null,
+      punctuation: null,
+      shape: null,
+      voiceMarkers: null,
+      lexicon: null,
+    });
+  });
+
+  it('reports every axis as null when there is no real reply at all (a silence case)', () => {
+    const result = score({
+      candidate: 'Interesting take, though I am not sure I fully agree with the framing here.',
+      post: 'Hot take: nobody actually reads the changelog.',
+      actualReply: null,
+    });
+    expect(result.distance).toEqual({
+      rhythm: null,
+      punctuation: null,
+      shape: null,
+      voiceMarkers: null,
+      lexicon: null,
+    });
+    // Nothing to compare length against either - no thread, no real reply.
+    expect(result.lengthRatio).toBeNull();
+    expect(result.lengthComparisonBasis).toBeNull();
+  });
+
+  it('gates the lexicon axis on both sides clearing the 200-word floor, not folding a too-short pair into a false match', () => {
+    const short = score({
+      candidate: 'Great point, thanks for sharing this.',
+      post: 'A post about something.',
+      actualReply: 'Totally agree with this take.',
+    });
+    expect(short.distance.lexicon).toBeNull();
+
+    const filler = (n: number) => Array.from({ length: n }, () => 'word').join(' ');
+    const long = score({
+      candidate: `${filler(210)} leverage`,
+      post: 'A post about something.',
+      actualReply: filler(210),
+    });
+    // Candidate uses "leverage" (present -> not "avoided"), the real reply
+    // never mentions it (absent -> "avoided") - one word disagrees out of
+    // fourteen AVOIDABLE_WORD_CANDIDATES, so the axis is measurable and
+    // strictly between identical and maximally different.
+    expect(long.distance.lexicon).not.toBeNull();
+    expect(long.distance.lexicon).toBeGreaterThan(0);
+    expect(long.distance.lexicon).toBeLessThan(1);
+  });
+
+  it('measures length ratio against the thread median when given one, else falls back to the real reply', () => {
+    const withThread = score({
+      candidate: 'One two three four five six seven eight nine ten.',
+      post: 'A post.',
+      actualReply:
+        'A totally different, much longer real reply used only as a fallback comparator here.',
+      threadCommentWordCounts: [4, 5, 6],
+    });
+    expect(withThread.lengthComparisonBasis).toBe('thread-median');
+    expect(withThread.lengthRatio).toBe(2); // 10 candidate words / median 5
+
+    const withoutThread = score({
+      candidate: 'One two three four five six seven eight nine ten.',
+      post: 'A post.',
+      actualReply: 'Five real words here now.',
+    });
+    expect(withoutThread.lengthComparisonBasis).toBe('actual-reply');
+    expect(withoutThread.lengthRatio).toBe(2); // 10 candidate words / 5 real-reply words
+  });
+
+  it("measures echo as how much of the candidate is made of the post's own words", () => {
+    const post = 'We just shipped the new expense reconciliation workflow after months of testing.';
+    const copying = score({
+      candidate: 'Congrats on shipping the new expense reconciliation workflow!',
+      post,
+      actualReply: null,
+    });
+    const original = score({
+      candidate: 'Huge milestone, well deserved after all that effort.',
+      post,
+      actualReply: null,
+    });
+    expect(copying.echo).not.toBeNull();
+    expect(original.echo).not.toBeNull();
+    expect(copying.echo!).toBeGreaterThan(original.echo!);
+  });
+
+  it('reports echo as null when the candidate has no content words of its own', () => {
+    const result = score({
+      candidate: '💪',
+      post: 'A perfectly ordinary post about something.',
+      actualReply: null,
+    });
+    expect(result.echo).toBeNull();
+  });
+
+  it('reports language match only when both sides classify, never a guessed true/false', () => {
+    const matching = score({
+      candidate: 'This is a great update and I am glad the team shipped it this week.',
+      post: 'We shipped a big update to the product this week after a long sprint.',
+      actualReply: null,
+    });
+    expect(matching.languageMatch).toBe(true);
+
+    const mismatched = score({
+      candidate: 'Questo aggiornamento è fantastico, complimenti a tutto il team per il lavoro.',
+      post: 'We shipped a big update to the product this week after a long sprint.',
+      actualReply: null,
+    });
+    expect(mismatched.languageMatch).toBe(false);
+
+    const unclassifiable = score({ candidate: 'Grande!', post: 'Ok.', actualReply: null });
+    expect(unclassifiable.languageMatch).toBeNull();
+  });
+
+  it('surfaces checkStyle findings on the candidate verbatim', () => {
+    const result = score({
+      candidate: 'Great post — really made me think.',
+      post: 'A post about something.',
+      actualReply: null,
+    });
+    expect(result.styleFindings.some((f) => f.ruleId === 'em-dash')).toBe(true);
+  });
+});
+
+describe('scoreCandidate against the committed synthetic fixture', () => {
+  it('scores every case in the fixture without throwing, silence case included', () => {
+    const file = loadVoiceEvalCases(FIXTURE_PATH);
+    for (const c of file.cases) {
+      // The eval runner would generate its own candidate via the model; here
+      // the real reply itself stands in as "a candidate" purely to prove the
+      // scorer runs end to end on every genre in the fixture, offline.
+      const candidate = c.actualReply ?? c.post.text;
+      expect(() =>
+        scoreCandidate({ candidate, post: c.post.text, actualReply: c.actualReply }),
+      ).not.toThrow();
+    }
+  });
+});
+
+// LOR-44's own acceptance: no model call anywhere in this scorer. Mirrors
+// assist-voice-profile.test.ts's identical check for voice-profile.ts.
+describe('no model call in voice-metrics.ts', () => {
+  const FORBIDDEN_PATTERNS = [
+    /\bfrom\s+['"]ai['"]/i,
+    /@ai-sdk/i,
+    /streamText/,
+    /generateText/,
+    /AI_GATEWAY/,
+    /gateway-catalogue/i,
+    /agents\/sdk/i,
+    /completion\(/,
+    /\bfetch\(/,
+    /readFileSync|readFile\(/,
+  ];
+
+  it('never imports or calls a model, and never touches the filesystem', () => {
+    const path = fileURLToPath(new URL('../src/voice-metrics.ts', import.meta.url));
+    const source = readFileSync(path, 'utf8');
+    for (const pattern of FORBIDDEN_PATTERNS) {
+      expect(source).not.toMatch(pattern);
+    }
+  });
+});


### PR DESCRIPTION
## What this is

LOR-44, the first issue of the voice project. "It sounds like him" was an opinion until now; this gives it a set, a score, and a baseline.

## shared/src/voice-metrics.ts

The pure, synchronous scorer every other issue in this project reads. It reuses `assist/voice-profile.ts`'s six axes (rhythm, punctuation, shape, voice markers, lexicon, language) through a new `measureOneText` entry point rather than re-implementing any of the maths, and adds the comparisons a single measurement cannot make on its own:

- `checkStyle`'s own findings against the candidate
- per-axis stylometric distance against the operator's real reply
- length ratio (against the thread's median comment when known, else the real reply's own length, since the harvested corpus has no thread data)
- echo (how much of the candidate is copied from the post's own wording)
- language match with the post

An axis that cannot be measured on a short string (his real replies run a median of 7 words) reports `null`, never a false zero or a false one, following the same floor `register.ts` already applies below 12 words.

## shared/src/voice-eval-cases.ts

The schema and loader. The set itself never lives in this repo since it quotes other people's real LinkedIn posts. The loader reads `PITCHBOX_EVAL_CASES`, defaulting to the gitignored `private/voice-eval/cases.json`, and exits with a readable message rather than a stack trace when it is absent. `shared/tests/fixtures/voice-eval/synthetic-cases.json` is a small, entirely invented fixture (five cases, one per named genre including silence) so the scorer's own tests run in CI with no private data.

## scripts/voice-eval.ts

The runner (`pnpm run eval:voice`), not part of `pnpm test` since it spends model calls and is not deterministic. It builds the real suggestion prompt with `buildSuggestionPrompt`, scores the result, and prints two tables: the deterministic one and a second-class judged one. A generated-candidate cache under `private/voice-eval/.cache` lets the deterministic table reproduce byte for byte without spending another model call; with no `AI_GATEWAY_API_KEY` and nothing cached, it falls back to an offline self-check (the real reply scored against itself), which is how I verified the whole pipeline runs end to end with zero network calls, against both the synthetic fixture and the real 27-case corpus, running each twice and diffing to confirm byte-identical output.

`scripts/voice-eval-import.ts` converts a raw LinkedIn harvest into the case schema. Neither script's input nor output is ever committed.

## voice-profile.ts

Extended additively: `measureOneText`, and exported `classifyLanguage` and `AVOIDED_WORDS_MIN_WORDS`, which already existed as module-private helpers. No change to `measureVoiceCorpus` or any existing behavior. LOR-221 and LOR-223 also touch this file (LOR-221 exports `classifyLanguage` too, same one-line change; LOR-223 adds a separate genre-bucketing entry point near the end of the file) - coordinated over IRC during the wave, both additive, should rebase cleanly.

## Verification

- `pnpm exec vitest run shared/tests/assist-voice-profile.test.ts shared/tests/voice-metrics.test.ts shared/tests/voice-eval-cases.test.ts`: 3 files, 48 tests passed.
- `pnpm test` (full suite, isolated `pitchbox_test_lor44` database): 3136 passed, 2 failed in `web/tests/extension-suggest-loop.test.ts` (pricing/token-accounting assertions unrelated to this change). Re-ran that file alone immediately after: 9/9 passed. The two failures were load-induced flakiness from six agents' test suites running concurrently on this box, not a regression from this diff.
- `pnpm -F @pitchbox/shared typecheck`: clean.
- `npx eslint` / `npx prettier --check` on every changed file: clean.
- `pnpm run eval:voice` with no `AI_GATEWAY_API_KEY`, against both the committed synthetic fixture and the real 27-case corpus (converted from the harvested `raw.json` with `scripts/voice-eval-import.ts`): runs offline, no stack trace, deterministic table byte-identical across two runs on each.

Closes LOR-44.

https://linear.app/fiorelorenzo/issue/LOR-44/testshared-an-eval-set-of-his-real-writing-a-deterministic-scorer-and