### PR TITLE
fix(shared): make style-check enforce its rules on Italian text too

### DIFF
--- a/shared/src/assist/voice-profile.ts
+++ b/shared/src/assist/voice-profile.ts
@@ -693,7 +693,7 @@ export const EMPTY_LANGUAGE: LanguageProfile = {
   byKind: {},
 };
 
-function classifyLanguage(text: string): 'en' | 'it' | 'unknown' {
+export function classifyLanguage(text: string): 'en' | 'it' | 'unknown' {
   const en = (text.match(EN_STOPWORDS_GLOBAL) ?? []).length;
   const it = (text.match(IT_STOPWORDS_GLOBAL) ?? []).length;
   if (en >= LANGUAGE_MARKER_MIN && en > it) return 'en';

--- a/shared/src/style-check.ts
+++ b/shared/src/style-check.ts
@@ -25,11 +25,23 @@
 //     dropped: it travels with the draft so a human sees it (moving-work
 //     -out-of-the-model's "change the evidence, do not weaken the check").
 //
-// Accent and diacritic characters are never touched by any rule below: every
-// pattern targets a specific punctuation code point or an ASCII phrase, never
-// a broad character class that could catch a letter. `shared/tests
-// /style-check.test.ts` asserts this directly against Italian and French text
-// carrying "è", "più", "café" and friends.
+// Accent and diacritic characters are never touched by any rule below in a
+// way that could catch a letter the rule was not written for: every pattern
+// targets a specific punctuation code point, an ASCII phrase, or (for an
+// Italian phrase rule added below) an explicit literal spelled exactly as
+// the language really writes it - never a broad character class. `shared
+// /tests/style-check.test.ts` asserts this directly against Italian and
+// French text carrying "è", "più", "café" and friends.
+//
+// Every phrase-based structural rule below runs a per-language phrase list,
+// chosen by `classifyLanguage` (`shared/src/assist/voice-profile.ts`) on the
+// text being checked - the corpus is bilingual (English/Italian), so a rule
+// that only ever matched English literals was silently not running on half
+// of what the product writes. On `unknown` (too little evidence either way)
+// both lists run: a false positive on a structural finding costs one model
+// round trip, a false negative ships the tell.
+
+import { classifyLanguage } from './assist/voice-profile.js';
 
 export type StyleRuleKind = 'character' | 'structural';
 
@@ -39,7 +51,9 @@ export interface StyleFinding {
   ruleId: string;
   kind: StyleRuleKind;
   /** One sentence, written for the operator who sees the finding, not for a
-   * log. */
+   * log. Always English (developer-facing); a finding matched via a
+   * non-English phrase list names that language in parentheses so a
+   * reviewer is not confused about which list matched. */
   message: string;
   /** The offending text, verbatim, as it appears in the checked string. */
   span: string;
@@ -55,8 +69,10 @@ interface Rule {
   id: string;
   kind: StyleRuleKind;
   message: string;
-  /** Every match in `text`, earliest first, never overlapping. */
-  scan(text: string): Array<{ start: number; end: number; repair?: string }>;
+  /** Every match in `text`, earliest first, never overlapping. A match may
+   * override `message` (used for a non-English phrase list match) instead
+   * of falling back to the rule's own `message`. */
+  scan(text: string): Array<{ start: number; end: number; repair?: string; message?: string }>;
 }
 
 function regexRule(
@@ -87,11 +103,6 @@ function regexRule(
  * text. Each phrase is escaped, so none of them are read as regex syntax. */
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function phraseRule(id: string, kind: StyleRuleKind, message: string, phrases: string[]): Rule {
-  const pattern = new RegExp(`(?:${phrases.map(escapeRegExp).join('|')})`, 'giu');
-  return regexRule(id, kind, message, pattern);
 }
 
 // ---------------------------------------------------------------------------
@@ -188,10 +199,58 @@ CHARACTER_RULES.push(EN_DASH_BETWEEN_WORDS);
 // never touches them.
 // ---------------------------------------------------------------------------
 
-/** house-style.ts's own opener list, checked only at the very start of the
- * text (that is what makes them "openers" rather than ordinary phrases to
- * avoid anywhere). */
-const FILLER_OPENERS = [
+/**
+ * Every phrase-based structural rule below runs the English list when the
+ * checked text classifies as English or `unknown`, and the Italian list
+ * when it classifies as Italian or `unknown` - `unknown` runs both, since a
+ * false positive here costs one model round trip and a false negative
+ * ships the tell. A match picked up from the Italian side tags its
+ * finding's message so a reviewer is not confused about which list
+ * matched.
+ */
+type LangMatch = { start: number; end: number; message?: string };
+
+function scanBilingual(
+  text: string,
+  enPattern: RegExp,
+  itPattern: RegExp,
+  message: string,
+): LangMatch[] {
+  const lang = classifyLanguage(text);
+  const out: LangMatch[] = [];
+  if (lang !== 'it') {
+    for (const m of text.matchAll(enPattern)) {
+      const start = m.index ?? 0;
+      out.push({ start, end: start + m[0].length });
+    }
+  }
+  if (lang !== 'en') {
+    for (const m of text.matchAll(itPattern)) {
+      const start = m.index ?? 0;
+      out.push({ start, end: start + m[0].length, message: `${message} (Italian)` });
+    }
+  }
+  return out.sort((a, b) => a.start - b.start);
+}
+
+function bilingualWordRule(
+  id: string,
+  kind: StyleRuleKind,
+  message: string,
+  enWords: string[],
+  itWords: string[],
+): Rule {
+  const enPattern = new RegExp(`\\b(?:${enWords.map(escapeRegExp).join('|')})\\b`, 'giu');
+  const itPattern = new RegExp(`\\b(?:${itWords.map(escapeRegExp).join('|')})\\b`, 'giu');
+  return { id, kind, message, scan: (text) => scanBilingual(text, enPattern, itPattern, message) };
+}
+
+/** house-style.ts's own opener list, plus its direct Italian counterpart
+ * (a reply praising the post it is answering, "Grande post" / "Ottimo
+ * punto" and friends) - checked only at the very start of the text (that
+ * is what makes them "openers" rather than ordinary phrases to avoid
+ * anywhere), so the phrases' ordinary genericness never matters mid-text. */
+const FILLER_OPENERS_EN = [
   'Great question',
   'Great post',
   'Hope this finds you well',
@@ -199,17 +258,44 @@ const FILLER_OPENERS = [
   "You're absolutely right",
 ];
 
+const FILLER_OPENERS_IT = [
+  'Grande post',
+  'Bel post',
+  'Ottimo punto',
+  'Complimenti per',
+  'Spunto interessante',
+  'Grazie per aver condiviso',
+  "Assolutamente d'accordo",
+  'Concordo pienamente',
+];
+
+const FILLER_OPENER_MESSAGE = 'Filler opener: house style bans starting a draft this way.';
+
 const FILLER_OPENER_RULE: Rule = {
   id: 'filler-opener',
   kind: 'structural',
-  message: 'Filler opener: house style bans starting a draft this way.',
+  message: FILLER_OPENER_MESSAGE,
   scan(text) {
     const leading = text.match(/^\s*/u)?.[0].length ?? 0;
     const rest = text.slice(leading);
     const lower = rest.toLowerCase();
-    for (const phrase of FILLER_OPENERS) {
+    const lang = classifyLanguage(text);
+    const candidates: Array<{ phrase: string; italian: boolean }> = [];
+    if (lang !== 'it') {
+      for (const phrase of FILLER_OPENERS_EN) candidates.push({ phrase, italian: false });
+    }
+    if (lang !== 'en') {
+      for (const phrase of FILLER_OPENERS_IT) candidates.push({ phrase, italian: true });
+    }
+    for (const { phrase, italian } of candidates) {
       if (lower.startsWith(phrase.toLowerCase())) {
-        return [{ start: leading, end: leading + phrase.length }];
+        return [
+          {
+            start: leading,
+            end: leading + phrase.length,
+            message: italian ? `${FILLER_OPENER_MESSAGE} (Italian)` : undefined,
+          },
+        ];
       }
     }
     return [];
@@ -218,8 +304,12 @@ const FILLER_OPENER_RULE: Rule = {
 
 /** house-style.ts's puffery list, minus "in today's fast-paced world" (its
  * own rule below, since it is a phrase rather than a single word and worth
- * naming on its own in a finding). */
-const PUFFERY_WORDS = [
+ * naming on its own in a finding), plus its direct Italian counterparts.
+ * "approfondire" is deliberately not here: it is an ordinary Italian verb
+ * ("to look into further") that shows up constantly in genuine writing,
+ * and only reads as a tell in the stock closing line the wrapup-closer
+ * rule below checks for, never as a bare word anywhere in the draft. */
+const PUFFERY_WORDS_EN = [
   'leverage',
   'seamless',
   'robust',
@@ -230,14 +320,32 @@ const PUFFERY_WORDS = [
   'game-changer',
 ];
 
-const PUFFERY_RULE: Rule = regexRule(
+const PUFFERY_WORDS_IT = [
+  // Both grammatical genders: an Italian adjective agrees with the noun it
+  // describes ("una soluzione innovativa" / "un prodotto innovativo"), so a
+  // masculine-only literal would miss half of ordinary usage.
+  'innovativo',
+  'innovativa',
+  "all'avanguardia",
+  'rivoluzionario',
+  'rivoluzionaria',
+  'sinergia',
+  'valore aggiunto',
+  'sfruttare al meglio',
+  'game changer',
+];
+
+const PUFFERY_MESSAGE = 'Puffery word: house style bans this as a corporate-speak tell.';
+
+const PUFFERY_RULE = bilingualWordRule(
   'puffery',
   'structural',
-  'Puffery word: house style bans this as a corporate-speak tell.',
-  new RegExp(`\\b(?:${PUFFERY_WORDS.map(escapeRegExp).join('|')})\\b`, 'giu'),
+  PUFFERY_MESSAGE,
+  PUFFERY_WORDS_EN,
+  PUFFERY_WORDS_IT,
 );
 
-const WRAPUP_CLOSERS = [
+const WRAPUP_CLOSERS_EN = [
   'hope this helps',
   'at the end of the day',
   'the bottom line is',
@@ -245,21 +353,96 @@ const WRAPUP_CLOSERS = [
   'let me know if you have any questions',
 ];
 
-const WRAPUP_CLOSER_RULE = phraseRule(
-  'wrapup-closer',
-  'structural',
-  'Wrap-up closer: house style bans this as a machine-written tell.',
-  WRAPUP_CLOSERS,
-);
+/** Direct Italian counterparts, kept to the same specificity the English
+ * list has: a bare "fammi sapere" ("let me know") or "in conclusione" ("in
+ * conclusion") is ordinary writing on its own, so only the full closing
+ * formula is banned here, matching how specific every English phrase
+ * above already is. */
+const WRAPUP_CLOSERS_IT = [
+  'spero di essere stato utile',
+  'fammi sapere se hai domande',
+  'resto a disposizione',
+  'alla fine della fiera',
+];
 
-/** house-style.ts's "not just X, but Y" / "it's not X, it's Y" constructions,
- * bounded to one clause so the match cannot cross a sentence. */
-const NOT_X_BUT_Y_RULE = regexRule(
-  'not-x-but-y',
-  'structural',
-  '"Not just X but Y" construction: a listed LinkedIn tell.',
-  /\bnot\s+just\b[^.!?\n]{0,80}?\bbut\b|\bit'?s\s+not\b[^.!?\n]{0,80}?,\s*it'?s\b/giu,
-);
+const WRAPUP_CLOSER_MESSAGE = 'Wrap-up closer: house style bans this as a machine-written tell.';
+
+/**
+ * Two more Italian-only closer tells that fire only in closing position -
+ * the same words earlier in the text are ordinary writing:
+ *   - "cosa ne pensi?" as the literal last sentence (mirrors
+ *     RHETORICAL_OPENER_RULE's opener-only gating, at the other end of the
+ *     text instead of the start).
+ *   - "approfondire" used as the stock "let me know if you'd like to go
+ *     deeper" closing verb, checked only within the closing window rather
+ *     than banned everywhere (see PUFFERY_WORDS_IT's comment on why it is
+ *     not a bare word ban).
+ */
+const CLOSER_WINDOW_CHARS = 100;
+const CLOSING_QUESTION_IT = 'cosa ne pensi?';
+const CLOSER_VERB_IT = /\bapprofondire\b/iu;
+
+function closingWindow(text: string): { window: string; offset: number } {
+  const trimmed = text.replace(/\s+$/u, '');
+  const offset = Math.max(0, trimmed.length - CLOSER_WINDOW_CHARS);
+  return { window: trimmed.slice(offset), offset };
+}
+
+const WRAPUP_CLOSER_RULE: Rule = {
+  id: 'wrapup-closer',
+  kind: 'structural',
+  message: WRAPUP_CLOSER_MESSAGE,
+  scan(text) {
+    const out = scanBilingual(
+      text,
+      new RegExp(`(?:${WRAPUP_CLOSERS_EN.map(escapeRegExp).join('|')})`, 'giu'),
+      new RegExp(`(?:${WRAPUP_CLOSERS_IT.map(escapeRegExp).join('|')})`, 'giu'),
+      WRAPUP_CLOSER_MESSAGE,
+    );
+    if (classifyLanguage(text) !== 'en') {
+      const { window, offset } = closingWindow(text);
+      if (window.toLowerCase().endsWith(CLOSING_QUESTION_IT)) {
+        const start = offset + window.length - CLOSING_QUESTION_IT.length;
+        out.push({
+          start,
+          end: offset + window.length,
+          message: `${WRAPUP_CLOSER_MESSAGE} (Italian)`,
+        });
+      }
+      const verbMatch = CLOSER_VERB_IT.exec(window);
+      if (verbMatch) {
+        const start = offset + verbMatch.index;
+        out.push({
+          start,
+          end: start + verbMatch[0].length,
+          message: `${WRAPUP_CLOSER_MESSAGE} (Italian)`,
+        });
+      }
+    }
+    return out.sort((a, b) => a.start - b.start);
+  },
+};
+
+/** house-style.ts's "not just X, but Y" / "it's not X, it's Y"
+ * constructions, bounded to one clause so the match cannot cross a
+ * sentence, plus the direct Italian counterparts: "non solo X ma Y" and
+ * "non è X, è Y". "è" is not an ASCII word character, so the Italian half
+ * bounds it with a Unicode-letter lookaround instead of `\b` - `\b` never
+ * matches next to an accented letter in a JS regex, `u` flag or not. */
+const NOT_X_BUT_Y_MESSAGE = '"Not just X but Y" construction: a listed LinkedIn tell.';
+
+const NOT_X_BUT_Y_RULE: Rule = {
+  id: 'not-x-but-y',
+  kind: 'structural',
+  message: NOT_X_BUT_Y_MESSAGE,
+  scan: (text) =>
+    scanBilingual(
+      text,
+      /\bnot\s+just\b[^.!?\n]{0,80}?\bbut\b|\bit'?s\s+not\b[^.!?\n]{0,80}?,\s*it'?s\b/giu,
+      /\bnon\s+solo\b[^.!?\n]{0,80}?\bma\b|\bnon\s+è(?![\p{L}\p{N}_])[^.!?\n]{0,80}?,\s*è(?![\p{L}\p{N}_])/giu,
+      NOT_X_BUT_Y_MESSAGE,
+    ),
+};
 
 /** A rhetorical question as the very first sentence ("Ever wondered why...?")
  * - a classic LinkedIn opener. Only the opener is checked: a genuine question
@@ -277,12 +460,24 @@ const RHETORICAL_OPENER_RULE: Rule = {
   },
 };
 
-const FAST_PACED_RULE = regexRule(
-  'fast-paced-cliche',
-  'structural',
-  '"In today\'s fast-paced" cliche: a listed LinkedIn tell.',
-  /\bin\s+today'?s\s+fast-paced\b/giu,
-);
+/** house-style.ts's "in today's fast-paced world" cliche, plus its direct
+ * Italian counterpart "in un mondo sempre più" ("in an ever more ...
+ * world"). No trailing `\b` on the Italian pattern: it ends on "più", and
+ * `\b` never matches next to a non-ASCII letter in a JS regex. */
+const FAST_PACED_MESSAGE = '"In today\'s fast-paced" cliche: a listed LinkedIn tell.';
+
+const FAST_PACED_RULE: Rule = {
+  id: 'fast-paced-cliche',
+  kind: 'structural',
+  message: FAST_PACED_MESSAGE,
+  scan: (text) =>
+    scanBilingual(
+      text,
+      /\bin\s+today'?s\s+fast-paced\b/giu,
+      /\bin\s+un\s+mondo\s+sempre\s+pi\u00f9(?![\p{L}\p{N}_])/giu,
+      FAST_PACED_MESSAGE,
+    ),
+};
 
 /** Three or more hashtags in a row (a "hashtag stack"), separated only by
  * whitespace or commas. */
@@ -303,17 +498,33 @@ const EMOJI_BULLET_RULE = regexRule(
 
 /**
  * A tricolon: three short, comma-separated items closed with an Oxford
- * comma before "and"/"or" ("faster, cheaper, and better"). Bounded to short
- * items (at most four words each) and to one line, so an ordinary sentence
- * that happens to list three things without this shape is not flagged - the
- * counterexample test below is exactly that sentence.
+ * comma before a conjunction ("faster, cheaper, and better" / "più veloce,
+ * più semplice, e più economico"). Bounded to short items (at most four
+ * words each) and to one line, so an ordinary sentence that happens to
+ * list three things without this shape is not flagged - the counterexample
+ * test below is exactly that sentence.
  */
-const TRICOLON_RULE = regexRule(
-  'tricolon',
-  'structural',
-  'Tricolon (rule-of-three list): a listed LinkedIn tell.',
-  /\b(?:\w[\w'-]*(?:\s+\w[\w'-]*){0,3}),\s*(?:\w[\w'-]*(?:\s+\w[\w'-]*){0,3}),\s*(?:and|or)\s+\w[\w'-]*(?:\s+\w[\w'-]*){0,3}\b/giu,
-);
+const TRICOLON_ITEM = `\\w[\\w'-]*(?:\\s+\\w[\\w'-]*){0,3}`;
+const TRICOLON_MESSAGE = 'Tricolon (rule-of-three list): a listed LinkedIn tell.';
+
+const TRICOLON_RULE: Rule = {
+  id: 'tricolon',
+  kind: 'structural',
+  message: TRICOLON_MESSAGE,
+  scan: (text) =>
+    scanBilingual(
+      text,
+      new RegExp(
+        `\\b(?:${TRICOLON_ITEM}),\\s*(?:${TRICOLON_ITEM}),\\s*(?:and|or)\\s+${TRICOLON_ITEM}\\b`,
+        'giu',
+      ),
+      new RegExp(
+        `\\b(?:${TRICOLON_ITEM}),\\s*(?:${TRICOLON_ITEM}),\\s*(?:e|o)\\s+${TRICOLON_ITEM}\\b`,
+        'giu',
+      ),
+      TRICOLON_MESSAGE,
+    ),
+};
 
 const STRUCTURAL_RULES: Rule[] = [
   FILLER_OPENER_RULE,
@@ -337,11 +548,11 @@ const ALL_RULES: Rule[] = [...CHARACTER_RULES, ...STRUCTURAL_RULES];
 export function checkStyle(text: string): StyleFinding[] {
   const findings: StyleFinding[] = [];
   for (const rule of ALL_RULES) {
-    for (const { start, end, repair } of rule.scan(text)) {
+    for (const { start, end, repair, message } of rule.scan(text)) {
       findings.push({
         ruleId: rule.id,
         kind: rule.kind,
-        message: rule.message,
+        message: message ?? rule.message,
         span: text.slice(start, end),
         start,
         end,

--- a/shared/tests/style-check.test.ts
+++ b/shared/tests/style-check.test.ts
@@ -113,6 +113,72 @@ describe('checkStyle: structural rules, one test per rule with a passing counter
   });
 });
 
+describe('checkStyle: Italian counterparts of the structural rules (classifyLanguage picks the list)', () => {
+  const italianCases: Array<{ ruleId: string; fires: string; doesNotFire: string }> = [
+    {
+      ruleId: 'filler-opener',
+      fires: 'Grande post, davvero un ottimo lavoro da parte del team.',
+      doesNotFire: 'Il team ha lavorato bene su questo argomento nelle ultime settimane.',
+    },
+    {
+      ruleId: 'puffery',
+      fires: 'La nostra piattaforma è davvero innovativa e pronta per il mercato.',
+      doesNotFire: 'La nostra piattaforma è pronta per il mercato da qualche settimana.',
+    },
+    {
+      ruleId: 'wrapup-closer',
+      fires: 'Il progetto è terminato in orario. Resto a disposizione per qualsiasi chiarimento.',
+      doesNotFire: 'Il progetto è terminato in orario e il cliente ha già dato un primo riscontro.',
+    },
+    {
+      ruleId: 'not-x-but-y',
+      fires: "Questo non è un problema, è un'opportunità da cogliere subito.",
+      doesNotFire: 'Questo è un problema serio, ma il team lo risolverà entro venerdì.',
+    },
+    {
+      ruleId: 'fast-paced-cliche',
+      fires: 'In un mondo sempre più connesso, la velocità di risposta conta davvero.',
+      doesNotFire: 'Il mondo del lavoro cambia sempre più velocemente di quanto pensassimo.',
+    },
+    {
+      ruleId: 'tricolon',
+      fires: 'Il prodotto è veloce, semplice, e affidabile.',
+      doesNotFire: 'Il prodotto è veloce e affidabile.',
+    },
+  ];
+
+  it.each(italianCases)(
+    '$ruleId fires on the Italian construction, tags the finding, and not on ordinary Italian prose',
+    ({ ruleId, fires, doesNotFire }) => {
+      const found = checkStyle(fires);
+      expect(ruleIds(found)).toContain(ruleId);
+      const hit = found.find((f) => f.ruleId === ruleId);
+      expect(hit?.message).toContain('(Italian)');
+      expect(ruleIds(checkStyle(doesNotFire))).not.toContain(ruleId);
+    },
+  );
+
+  it('flags "cosa ne pensi?" only when it is the closing sentence, not mid-text', () => {
+    const closing = 'Abbiamo appena lanciato la nuova funzione di ricerca. Cosa ne pensi?';
+    expect(ruleIds(checkStyle(closing))).toContain('wrapup-closer');
+    const midText =
+      'Cosa ne pensi? Fammi sapere entro la fine della settimana quando riesci a provarla di persona con il resto del team.';
+    expect(ruleIds(checkStyle(midText))).not.toContain('wrapup-closer');
+  });
+
+  it('flags "approfondire" as a closing verb only near the end of the draft, not as a general word ban', () => {
+    const closing =
+      'Abbiamo condiviso i risultati del test interno. Fammi sapere se vuoi approfondire.';
+    expect(ruleIds(checkStyle(closing))).toContain('wrapup-closer');
+    // "approfondire" is an ordinary Italian verb far from the end of the
+    // draft here - the puffery list deliberately excludes it as a bare
+    // word ban, and the closer check is gated to the closing window.
+    const midText =
+      'Vorrei approfondire questo argomento in un articolo dedicato nelle prossime settimane, perché il team ha raccolto moltissimi dati interessanti durante lo sviluppo del progetto, e sarebbe un peccato non condividerli con calma.';
+    expect(ruleIds(checkStyle(midText))).not.toContain('wrapup-closer');
+  });
+});
+
 describe('checkStyle: the check is not conditional', () => {
   it('runs every rule regardless of draft length', () => {
     // A one-character draft still gets checked; there is no length guard.
@@ -142,6 +208,21 @@ describe('checkStyle: accents and diacritics are never touched', () => {
     expect(repaired).toContain('pi\u00F9');
     expect(repaired).toContain('gi\u00E0');
     expect(repaired).toContain('\u00E8 qui');
+  });
+
+  it('matches an Italian phrase carrying an accent and applyMechanicalRepairs leaves it untouched', () => {
+    const text = 'In un mondo sempre più connesso \u2014 la velocità conta davvero.';
+    const findings = checkStyle(text);
+    const fastPaced = findings.find((f) => f.ruleId === 'fast-paced-cliche');
+    expect(fastPaced?.span).toBe('In un mondo sempre più');
+    expect(fastPaced?.message).toContain('(Italian)');
+    const repaired = applyMechanicalRepairs(text);
+    // The em dash is mechanically repaired; the accented phrase this rule
+    // matched, and every other accented letter in the text, survive
+    // byte-for-byte - only the character-level finding was ever touched.
+    expect(repaired).toBe('In un mondo sempre più connesso, la velocità conta davvero.');
+    expect(repaired).toContain('più');
+    expect(repaired).toContain('velocità');
   });
 });
 


### PR DESCRIPTION
I made the style checker's phrase-based rules actually run on Italian drafts, since half of what the product writes is Italian and the checker was silently only ever checking the English half.

What changed in `shared/src/style-check.ts`: each phrase-based structural rule (filler-opener, puffery, wrapup-closer, not-x-but-y, fast-paced-cliche, tricolon) now carries a direct Italian counterpart list, picked by `classifyLanguage` (the same detector `shared/src/assist/voice-profile.ts` already uses to split the voice corpus) rather than a caller-supplied flag. On an unclassified text both lists run, since a false positive here just costs one model round trip while a false negative ships the tell. A finding that matched via the Italian list tags its message with "(Italian)" so a reviewer knows which list fired.

I trimmed the issue's starting lists where a literal transplant would fire on ordinary Italian prose rather than on a real tell: "approfondire" stays out of the puffery word list entirely (it is a completely ordinary verb) and only counts as a tell when it shows up inside the closing window of the draft; "cosa ne pensi?" only counts when it is literally the last sentence; and I dropped bare two-word closers like "fammi sapere" and "in conclusione" in favor of the fuller closing formula, since the English closer phrases I'm mirroring are all that specific too. The puffery list also carries both genders of the two adjectives it borrows (innovativo/innovativa, rivoluzionario/rivoluzionaria), since Italian agreement means a masculine-only literal misses half of ordinary usage - I found this the hard way when my own first test case for "innovativa" didn't fire.

I exported `classifyLanguage` from `voice-profile.ts` (it was module-private) to reuse it here instead of re-deriving a second language detector. LOR-44 made the same one-line export independently; whichever of us lands first, the other's rebase on that line is a no-op.

On the accent constraint the module's header already commits to: no new rule touches an accent or diacritic. Every new pattern either bounds an ASCII word with `\b`, or, where the literal itself ends on an accented letter ("più") or needs one mid-pattern ("è"), uses a Unicode-letter lookaround instead, because `\b` never matches next to a non-ASCII letter in a JS regex regardless of the `u` flag. The existing accent-safety test is untouched and still green, and I added a new case that proves an Italian phrase carrying an accent is matched and survives `applyMechanicalRepairs` byte-for-byte. Every existing English test case is untouched and still green too: the new bilingual scan only ever adds Italian-side matches next to the same English patterns that were already there, so an English draft's findings do not change.

`shared/tests/style-check.test.ts` went from 37 tests on main to 46: I added a table-driven Italian fire/no-fire case for each bilingual rule, two tests for the position-gated closer checks (the closing question and the closer verb), and the accent-preserving match proof.

Verification: `pnpm test` in my own worktree against my own `pitchbox_test_lor221` database - 356 files, 3120 tests, all passing. `pnpm -F @pitchbox/shared typecheck` clean. `npx eslint` and `npx prettier --check` clean on every file I touched. I did not touch Svelte or the extension, so I skipped `pnpm -F web check` and the LinkedIn compliance suite.

Out of scope, not touched: `shared/src/house-style.ts` and `playbooks/**` (LOR-224's), `shared/src/db/schema.ts` (no schema change needed here).

Closes LOR-221
https://linear.app/fiorelorenzo/issue/LOR-221/fixshared-the-style-checker-only-speaks-english-so-an-italian-draft