### PR TITLE
fix(shared): the voice profile says how long a piece of writing is

### DIFF
--- a/shared/src/assist/voice-profile.ts
+++ b/shared/src/assist/voice-profile.ts
@@ -292,6 +292,17 @@ function splitParagraphs(text: string): string[] {
 // ---------------------------------------------------------------------------
 
 export type RhythmProfile = {
+  /** Median words in a whole piece of writing, not in a sentence (LOR-231).
+   * This is the axis a suggestion misses by the widest margin and the one
+   * nothing reported until now: measured 2026-09-11 on a real corpus, the
+   * operator's own comments run a median of 7 words while the suggestions
+   * written "in his voice" ran 123, and every number below was already
+   * correct while that one was simply absent from the description. */
+  medianItemWords: number;
+  /** Interquartile range of whole-piece length. A corpus whose pieces run
+   * 5 to 9 words and one whose pieces run 2 to 200 have the same median
+   * and call for different drafts. */
+  itemWordsSpread: number;
   /** Median words per sentence, pooled across every sentence in the corpus
    * - not the mean of each item's own mean, which one long or short outlier
    * post can skew more than it should. */
@@ -312,6 +323,8 @@ const FRAGMENT_MAX_WORDS = 4;
 const SHORT_OPENING_MAX_WORDS = 6;
 
 export const EMPTY_RHYTHM: RhythmProfile = {
+  medianItemWords: 0,
+  itemWordsSpread: 0,
   medianSentenceWords: 0,
   sentenceWordsSpread: 0,
   medianParagraphWords: 0,
@@ -322,10 +335,12 @@ export const EMPTY_RHYTHM: RhythmProfile = {
 function measureRhythm(texts: string[]): RhythmProfile {
   const sentenceWordCounts: number[] = [];
   const paragraphWordCounts: number[] = [];
+  const itemWordCounts: number[] = [];
   let shortOpenings = 0;
   let fragments = 0;
 
   for (const text of texts) {
+    itemWordCounts.push(text.split(/\s+/u).filter(Boolean).length);
     const sentences = splitSentences(text);
     for (const s of sentences) {
       const words = s.split(/\s+/u).filter(Boolean).length;
@@ -342,6 +357,8 @@ function measureRhythm(texts: string[]): RhythmProfile {
   }
 
   return {
+    medianItemWords: Math.round(median(itemWordCounts)),
+    itemWordsSpread: interquartileRange(itemWordCounts),
     medianSentenceWords: Math.round(median(sentenceWordCounts)),
     sentenceWordsSpread: interquartileRange(sentenceWordCounts),
     medianParagraphWords: Math.round(median(paragraphWordCounts)),
@@ -949,6 +966,19 @@ export function describeVoiceProfile(
   if (!m.measurable) return null;
 
   const sentences: string[] = [];
+  // Length of a whole piece comes first, because it is the axis a draft
+  // misses by the widest margin and the one a reader notices before any
+  // other (LOR-231). It is also the one axis here that survives a corpus
+  // of very short items: register traits and words-per-sentence both need
+  // each item to clear register.ts's 12-word floor, which a corpus of
+  // one-line comments never does, so before this the description of such a
+  // corpus said everything about it except how long it is.
+  if (m.rhythm.medianItemWords > 0) {
+    const spread = m.rhythm.itemWordsSpread > 0 ? `, give or take ${m.rhythm.itemWordsSpread}` : '';
+    sentences.push(
+      `A typical one runs about ${m.rhythm.medianItemWords} words${spread}, and a draft that misses that length is wrong however well it is written.`,
+    );
+  }
   if (m.traits.length > 0) {
     const sentenceLength =
       m.wordsPerSentence > 0 ? `, about ${m.wordsPerSentence} words per sentence` : '';

--- a/shared/tests/assist-voice-profile.test.ts
+++ b/shared/tests/assist-voice-profile.test.ts
@@ -510,6 +510,30 @@ describe('measureVoiceCorpusByGenre', () => {
     expect(byGenre.comment.rhythm.medianSentenceWords).toBeGreaterThan(0);
   });
 
+  it('reports whole-piece length per genre, which is the axis a draft misses widest', () => {
+    const byGenre = measureVoiceCorpusByGenre(MIXED_GENRE_CORPUS);
+    // The five comments are one-liners and the three posts are several
+    // sentences each, so a measurement that cannot tell them apart on
+    // length is the defect LOR-231 fixes.
+    expect(byGenre.comment.rhythm.medianItemWords).toBeGreaterThan(0);
+    expect(byGenre.comment.rhythm.medianItemWords).toBeLessThan(
+      byGenre.post.rhythm.medianItemWords,
+    );
+  });
+
+  it('reports whole-piece length even when every item is too short for register.ts to score', () => {
+    const byGenre = measureVoiceCorpusByGenre(MIXED_GENRE_CORPUS);
+    // The companion's real corpus looks exactly like this: comments that
+    // individually carry no measurable register. Before LOR-231 such a
+    // genre described everything about itself except how long it is, and
+    // the prompt therefore never told the model to write short.
+    expect(byGenre.comment.wordsPerSentence).toBe(0);
+    expect(byGenre.comment.rhythm.medianItemWords).toBeGreaterThan(0);
+    expect(describeVoiceProfileForGenre('comment', byGenre.comment)).toMatch(
+      /A typical one runs about \d+ words/,
+    );
+  });
+
   it('leaves a genre with too few items unmeasurable, the same floor the pooled corpus applies', () => {
     const thin = corpusOfGenre([
       { text: SHORT_COMMENTS[0], genre: 'comment' },


### PR DESCRIPTION
Closes LOR-232 (https://linear.app/fiorelorenzo/issue/LOR-232).

Found by re-running the LOR-44 baseline on `main` after LOR-223 merged, so the numbers below are measured rather than argued.

LOR-223 worked: a `post_comment` suggestion now gets a comment-genre description, the hashtag instruction is gone and the median dropped from 123 words to 106. But 106 against a real median of 7 is the same defect, and the reason is visible in the description it produces:

> Based on 26 of their own comments (414 words). Usually writes with impersonal, no first person, about 14 words per sentence. Reuses these words often: vedo. Never uses: leverage, seamless...

Every clause is true and none of them says how long a comment is. `RhythmProfile` measured sentence length, paragraph length, fragment ratio and opening length, and never the length of a whole piece. So the axis the drafts miss by an order of magnitude was the one axis the profile never mentioned, and "14 words per sentence" reads to a model as a paragraph.

It was worst for the corpus that needs it most: register traits and `wordsPerSentence` both require each item to clear `register.ts`'s 12-word floor, and a corpus of one-line comments never does, so a comment genre described everything about itself except its length.

## What changed

`RhythmProfile` gains `medianItemWords` and `itemWordsSpread`, measured in `measureRhythm` over each whole text. `describeVoiceProfile` states them first, before the register sentence. No new table, no migration, no model call, no change to any existing axis.

## Measured effect

Same 27 real cases (my own LinkedIn comments and the posts they answered), same prompt builder, same model, leave-one-out so a case's own reply never reaches the corpus that scores it.

| | my real reply | main before the wave | after LOR-223 | this PR |
| --- | --- | --- | --- | --- |
| median words | 7 | 123 | 106 | 40 |
| mean words | 15 | 117 | 106 | 39 |
| median sentences | 1 | 5 | 4 | 2 |
| drafts with a hashtag | 0 of 27 | 3 of 27 | 0 of 27 | 0 of 27 |
| style-checker findings | 1 | 0 (the checker was English-only then) | 8 | 3 |

A 17x overshoot became 5.7x. The rest is a different problem and gets its own issue: the task instruction asks for a substantive comment, so the model will not answer "che UI!" however short the profile says to be.

## Verification

`pnpm exec vitest run shared/tests/`: 103 files, 1079 tests, all passed, against an isolated `pitchbox_test_lor231`. `pnpm -F @pitchbox/shared typecheck` clean. eslint and prettier clean on both changed files. Two new tests: one asserts a comment genre's stated length is below the same corpus's post genre, one asserts that a genre whose every item is below the register floor still reports its length (`wordsPerSentence` is 0 and the description still names a word count), which is the case that was broken.