### PR TITLE
feat(shared): add whole-piece length to per-genre voice evidence

### DIFF
--- a/shared/src/operator-voice-profile.ts
+++ b/shared/src/operator-voice-profile.ts
@@ -80,6 +80,12 @@ export type VoiceGenreSummary = {
   summary: string | null;
   itemCount: number;
   measurable: boolean;
+  /** This genre's own whole-piece median/spread (LOR-232's axis, read per
+   * genre rather than pooled) - 0 while `measurable` is false, never a
+   * guess. `suggest-prompt.ts` needs the number itself, not just the
+   * prose `summary` already carries it in. */
+  medianItemWords: number;
+  itemWordsSpread: number;
 };
 
 /** What a stored row carries about its own derivation: the provenance
@@ -126,7 +132,13 @@ const EMPTY_PROVENANCE: VoiceCorpusProvenance = {
   counts: { voiceSamples: 0, messages: 0, drafts: 0, templates: 0 },
 };
 
-const EMPTY_GENRE_SUMMARY: VoiceGenreSummary = { summary: null, itemCount: 0, measurable: false };
+const EMPTY_GENRE_SUMMARY: VoiceGenreSummary = {
+  summary: null,
+  itemCount: 0,
+  measurable: false,
+  medianItemWords: 0,
+  itemWordsSpread: 0,
+};
 
 const EMPTY_GENRE_SUMMARIES: Record<VoiceCorpusItemGenre, VoiceGenreSummary> = {
   post: EMPTY_GENRE_SUMMARY,
@@ -145,6 +157,23 @@ const EMPTY_EVIDENCE: VoiceProfileEvidence = {
   language: EMPTY_LANGUAGE,
   genres: EMPTY_GENRE_SUMMARIES,
 };
+
+/** `genres` merged field-by-field against `EMPTY_GENRE_SUMMARY`, not just
+ * substituted whole when absent: a row derived before LOR-227 added
+ * `medianItemWords`/`itemWordsSpread` carries a `genres` object whose
+ * per-genre entries lack exactly those two fields, and reading them as
+ * `undefined` would forward that straight into a prompt expecting a
+ * number. */
+function normalizeGenreSummaries(raw: unknown): Record<VoiceCorpusItemGenre, VoiceGenreSummary> {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Partial<
+    Record<VoiceCorpusItemGenre, Partial<VoiceGenreSummary>>
+  >;
+  const out = {} as Record<VoiceCorpusItemGenre, VoiceGenreSummary>;
+  for (const genre of VOICE_CORPUS_ITEM_GENRES) {
+    out[genre] = { ...EMPTY_GENRE_SUMMARY, ...(r[genre] ?? {}) };
+  }
+  return out;
+}
 
 /** Reads a stored `evidence` blob back into the current full shape,
  * whichever version wrote it. A field absent from the stored JSON (a row
@@ -167,7 +196,7 @@ function normalizeEvidence(raw: unknown): VoiceProfileEvidence {
     voiceMarkers: r.voiceMarkers ?? EMPTY_VOICE_MARKERS,
     lexicon: r.lexicon ?? EMPTY_LEXICON,
     language: r.language ?? EMPTY_LANGUAGE,
-    genres: r.genres ?? EMPTY_GENRE_SUMMARIES,
+    genres: normalizeGenreSummaries(r.genres),
   };
 }
 
@@ -328,6 +357,8 @@ export async function refreshVoiceProfile(
       summary: describeVoiceProfileForGenre(genre, genreMeasurement),
       itemCount: genreMeasurement.itemCount,
       measurable: genreMeasurement.measurable,
+      medianItemWords: genreMeasurement.rhythm.medianItemWords,
+      itemWordsSpread: genreMeasurement.rhythm.itemWordsSpread,
     };
   }
 

--- a/shared/tests/operator-voice-profile.test.ts
+++ b/shared/tests/operator-voice-profile.test.ts
@@ -383,6 +383,60 @@ describe('shared/src/operator-voice-profile', () => {
     const refreshed = await refreshVoiceProfile(getDb(), orgId);
     expect(refreshed.evidence.version).toBe(1);
   });
+
+  it('reads a genres object written before LOR-227 added medianItemWords/itemWordsSpread as 0, never undefined', async () => {
+    const orgId = await ensureOrg('vp-org-legacy-genres');
+    // The exact per-genre shape refreshVoiceProfile wrote before LOR-227:
+    // summary/itemCount/measurable only, no medianItemWords/itemWordsSpread,
+    // and `reply` entirely absent (a row derived before every genre had ever
+    // been seen would look like this too).
+    const legacyEvidence = {
+      voiceSampleIds: [],
+      messageIds: [],
+      draftIds: [],
+      templateIds: [],
+      counts: { voiceSamples: 8, messages: 0, drafts: 0, templates: 0 },
+      version: 3,
+      genres: {
+        post: { summary: 'Usually writes long posts.', itemCount: 8, measurable: true },
+        comment: { summary: null, itemCount: 1, measurable: false },
+      },
+    };
+    await getDb().insert(schema.operatorVoiceProfiles).values({
+      organizationId: orgId,
+      summary: 'placeholder',
+      itemCount: 8,
+      wordCount: 100,
+      evidence: legacyEvidence,
+      source: 'derived',
+      derivedAt: new Date(),
+    });
+
+    const row = await loadVoiceProfile(getDb(), orgId);
+    expect(row).not.toBeNull();
+    // Present in the stored blob, missing only the two new fields: read back
+    // as 0, not undefined - the exact bug a `r.genres ?? EMPTY_GENRE_SUMMARIES`
+    // simplification would reintroduce, since that line only guards a wholly
+    // absent `genres`, not a stale per-genre shape inside one that is present.
+    expect(row!.evidence.genres.post).toEqual({
+      summary: 'Usually writes long posts.',
+      itemCount: 8,
+      measurable: true,
+      medianItemWords: 0,
+      itemWordsSpread: 0,
+    });
+    expect(row!.evidence.genres.comment.medianItemWords).toBe(0);
+    expect(row!.evidence.genres.comment.itemWordsSpread).toBe(0);
+    // Absent from the stored blob entirely - still a full, valid empty
+    // summary rather than undefined.
+    expect(row!.evidence.genres.reply).toEqual({
+      summary: null,
+      itemCount: 0,
+      measurable: false,
+      medianItemWords: 0,
+      itemWordsSpread: 0,
+    });
+  });
 });
 
 describe('per-genre derivation (LOR-223)', () => {


### PR DESCRIPTION
I added medianItemWords/itemWordsSpread to VoiceGenreSummary in shared/src/operator-voice-profile.ts, populated in refreshVoiceProfile from measureVoiceCorpusByGenre's own rhythm axis (LOR-232's per-item length measurement, now surfaced per genre instead of only in prose). normalizeEvidence merges each genre against EMPTY_GENRE_SUMMARY so a row derived before this lands still reads 0 for the two new fields instead of undefined.

Splitting this out of LOR-227 as its own small PR because LOR-233's suggest-prompt.ts work needs the number itself (not just the summary sentence) and is blocked on it landing in main first.

Verified: `pnpm -F @pitchbox/shared typecheck` clean. No behavior change to existing fields; additive only.