### PR TITLE
feat(shared,cli,web): the quality score measures whether it reads as human, and is not self-graded

### DIFF
--- a/cli/src/commands/drafts.ts
+++ b/cli/src/commands/drafts.ts
@@ -21,8 +21,12 @@ import {
 } from '@pitchbox/shared/comment-target';
 import { notify } from '@pitchbox/shared/notifications';
 import { getProjectOrgId } from '@pitchbox/shared/orgs';
-import { loadQualityRubric } from '@pitchbox/shared/quality-judge';
-import { enforceHouseStyle, type StyleFinding } from '@pitchbox/shared/style-check';
+import {
+  loadQualityRubric,
+  resolveOperatorCorpusProfile,
+  scoreDraftQuality,
+} from '@pitchbox/shared/quality-judge';
+import { checkStyle, enforceHouseStyle, type StyleFinding } from '@pitchbox/shared/style-check';
 import { buildRedditComposeUrl } from '@pitchbox/shared/platforms/reddit';
 import { buildHackernewsComposeUrl } from '@pitchbox/shared/platforms/hackernews';
 import { buildMastodonComposeUrl } from '@pitchbox/shared/platforms/mastodon';
@@ -109,10 +113,14 @@ export const DraftInput = z.object({
   // as the primary (variant A) and `variants` supplies B, C, ... Each entry
   // produces a sibling draft sharing a `variant_group_id`.
   variants: absentOrNull(z.array(z.string().min(1))),
-  // Inline LLM-judge quality score (issue #41), supplied by the creating agent.
-  // Lenient here (clamped at persistence) so one bad score never fails the batch.
-  qualityScore: absentOrNull(z.number()),
-  qualityReason: absentOrNull(z.string()),
+  // `qualityScore`/`qualityReason` used to be accepted here as the drafting
+  // agent's own self-report (issue #41). LOR-229 drops that: the score is
+  // now computed server-side in `createDrafts` (`scoreDraftQuality`,
+  // `@pitchbox/shared/quality-judge`) from the style checker and the
+  // operator's own measured voice, never from what the model that wrote the
+  // draft says about itself. An older payload that still sends these two
+  // keys is silently accepted and ignored - zod strips unrecognized keys by
+  // default - rather than failing the whole batch on a stale playbook.
 });
 
 export const Payload = z.array(DraftInput).min(1).max(200);
@@ -144,6 +152,13 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
   if (orgId == null) {
     throw new Error(`project ${campaign.projectId} has no organization`);
   }
+
+  // Loaded once per batch, not per draft: the rubric and the operator's own
+  // corpus profile are both org-level facts every draft in this run shares
+  // (LOR-229's deterministic quality score reads both - see the `styled`
+  // map below).
+  const qualityRubric = await loadQualityRubric(db);
+  const corpusProfile = await resolveOperatorCorpusProfile(db, orgId);
 
   // Validate that every referenced accountId actually belongs to the
   // campaign's project. The accounts FK only requires the account to exist,
@@ -343,13 +358,42 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
       const variantResults = d.variants
         ? await Promise.all(d.variants.map((v) => enforceHouseStyle(v)))
         : null;
+      const styledTitle = titleResult ? titleResult.text : (d.title ?? null);
+      const styleFindings = [...bodyResult.findings, ...(titleResult?.findings ?? [])];
+      // LOR-229: the deterministic (+ optional judged) score for the
+      // primary body, and independently for each A/B variant - each is a
+      // genuinely different piece of text and gets its own measurement,
+      // never one self-report copied across every sibling the way the old
+      // agent-reported score was.
+      const quality = await scoreDraftQuality(db, {
+        body: bodyResult.text,
+        title: styledTitle,
+        styleFindings,
+        corpus: corpusProfile,
+        rubric: qualityRubric,
+      });
+      const variantQuality = variantResults
+        ? await Promise.all(
+            variantResults.map((r) =>
+              scoreDraftQuality(db, {
+                body: r.text,
+                title: styledTitle,
+                styleFindings: r.findings,
+                corpus: corpusProfile,
+                rubric: qualityRubric,
+              }),
+            ),
+          )
+        : null;
       return {
         ...d,
         styledBody: bodyResult.text,
-        styledTitle: titleResult ? titleResult.text : (d.title ?? null),
-        styleFindings: [...bodyResult.findings, ...(titleResult?.findings ?? [])],
+        styledTitle,
+        styleFindings,
         styledVariants: variantResults ? variantResults.map((r) => r.text) : null,
         variantStyleFindings: variantResults ? variantResults.map((r) => r.findings) : null,
+        quality,
+        variantQuality,
       };
     }),
   );
@@ -382,27 +426,29 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
           }),
           reasoning: d.reasoning ?? null,
           sourceRef: d.sourceRef,
-          metadata:
-            d.styleFindings.length > 0
+          metadata: {
+            ...baseMeta,
+            ...(d.styleFindings.length > 0
               ? {
-                  ...baseMeta,
                   styleFindings: d.styleFindings.map((f: StyleFinding) => ({
                     ruleId: f.ruleId,
                     message: f.message,
                     span: f.span,
                   })),
                 }
-              : baseMeta,
+              : {}),
+            qualityDetail: d.quality.qualityDetail,
+          },
           dedupWarning: d.dedupWarning ?? null,
           variantGroupId: null as string | null,
           variantLabel: null as string | null,
-          qualityScore:
-            d.qualityScore != null ? Math.max(0, Math.min(100, Math.round(d.qualityScore))) : null,
-          qualityReason: d.qualityScore != null ? (d.qualityReason ?? null) : null,
-          qualityModel: d.qualityScore != null ? run.agentRunner : null,
+          qualityScore: d.quality.qualityScore,
+          qualityReason: d.quality.qualityReason,
+          qualityModel: d.quality.qualityModel,
         },
       ];
     }
+    const qualityResults = [d.quality, ...(d.variantQuality ?? [])];
     const seeds = [d.styledBody, ...d.styledVariants].map((body, i) => {
       const findings: StyleFinding[] =
         i === 0 ? d.styleFindings : (d.variantStyleFindings?.[i - 1] ?? []);
@@ -421,7 +467,7 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
       };
     });
     const grouped = groupVariants(seeds);
-    return grouped.rows.map((r) => ({
+    return grouped.rows.map((r, i) => ({
       runId,
       projectId: campaign.projectId,
       platformId: campaign.platformId,
@@ -445,14 +491,17 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
       }),
       reasoning: d.reasoning ?? null,
       sourceRef: d.sourceRef,
-      metadata: { ...baseMeta, ...(r.metadata ?? {}) },
+      metadata: {
+        ...baseMeta,
+        ...(r.metadata ?? {}),
+        qualityDetail: qualityResults[i].qualityDetail,
+      },
       dedupWarning: d.dedupWarning ?? null,
       variantGroupId: r.variantGroupId,
       variantLabel: r.variantLabel,
-      qualityScore:
-        d.qualityScore != null ? Math.max(0, Math.min(100, Math.round(d.qualityScore))) : null,
-      qualityReason: d.qualityScore != null ? (d.qualityReason ?? null) : null,
-      qualityModel: d.qualityScore != null ? run.agentRunner : null,
+      qualityScore: qualityResults[i].qualityScore,
+      qualityReason: qualityResults[i].qualityReason,
+      qualityModel: qualityResults[i].qualityModel,
     }));
   });
 
@@ -598,8 +647,6 @@ export async function draftRegenStart(runId: number) {
     }
   }
 
-  const rubric = await loadQualityRubric(db);
-
   return {
     runId,
     draftId,
@@ -614,17 +661,10 @@ export async function draftRegenStart(runId: number) {
       sourceRef: draft.sourceRef,
     },
     persona,
-    rubricTemplate: rubric.rubric_template,
   };
 }
 
-export async function draftRegenFinish(
-  runId: number,
-  body: string,
-  title?: string | null,
-  qualityScore?: number | null,
-  qualityReason?: string | null,
-) {
+export async function draftRegenFinish(runId: number, body: string, title?: string | null) {
   if (!Number.isInteger(runId)) throw new Error('invalid run id');
   if (!body || !body.trim()) throw new Error('body is empty');
   const db = getDb();
@@ -641,14 +681,37 @@ export async function draftRegenFinish(
   if (!draft) throw new Error(`draft ${draftId} not found`);
 
   const newCount = draft.regenerationCount + 1;
-  const qualitySet =
-    qualityScore != null
-      ? {
-          qualityScore: Math.max(0, Math.min(100, Math.round(qualityScore))),
-          qualityReason: qualityReason ?? null,
-          qualityModel: run.agentRunner,
-        }
-      : {};
+  const newTitle = title ?? draft.title;
+  // LOR-229: `draft_regen_finish` still has no live model to send a
+  // targeted style-rewrite instruction back to (the playbook calls
+  // `check_style` itself, mid-turn, for that) - but `checkStyle` is pure
+  // and cheap, so the quality score below measures the rewritten body fresh
+  // rather than trusting the agent already ran the check.
+  const styleFindings = [...checkStyle(body), ...(newTitle ? checkStyle(newTitle) : [])];
+  const orgId = await getProjectOrgId(db, draft.projectId);
+  const [corpusProfile, rubric] = await Promise.all([
+    orgId != null ? resolveOperatorCorpusProfile(db, orgId) : Promise.resolve(null),
+    loadQualityRubric(db),
+  ]);
+  const quality = await scoreDraftQuality(db, {
+    body,
+    title: newTitle,
+    styleFindings,
+    corpus: corpusProfile,
+    rubric,
+  });
+  const priorMeta = (draft.metadata ?? {}) as Record<string, unknown>;
+  const newMeta: Record<string, unknown> = { ...priorMeta, qualityDetail: quality.qualityDetail };
+  if (styleFindings.length > 0) {
+    newMeta.styleFindings = styleFindings.map((f) => ({
+      ruleId: f.ruleId,
+      message: f.message,
+      span: f.span,
+    }));
+  } else {
+    delete newMeta.styleFindings;
+  }
+
   await db.transaction(async (tx) => {
     await tx.insert(schema.draftEvents).values({
       draftId,
@@ -665,11 +728,14 @@ export async function draftRegenFinish(
       .update(schema.drafts)
       .set({
         body,
-        title: title ?? draft.title,
+        title: newTitle,
         version: sql`${schema.drafts.version} + 1`,
         regenerationCount: sql`${schema.drafts.regenerationCount} + 1`,
         regeneratingRunId: null,
-        ...qualitySet,
+        metadata: newMeta,
+        qualityScore: quality.qualityScore,
+        qualityReason: quality.qualityReason,
+        qualityModel: quality.qualityModel,
       })
       .where(eq(schema.drafts.id, draftId));
     await tx
@@ -726,8 +792,6 @@ export async function replyDraftStart(runId: number) {
       .orderBy(schema.messages.createdAtPlatform);
   }
 
-  const rubric = await loadQualityRubric(db);
-
   return {
     runId,
     replyDraftId,
@@ -742,16 +806,10 @@ export async function replyDraftStart(runId: number) {
     parent,
     thread,
     platform: platform?.slug ?? null,
-    rubricTemplate: rubric.rubric_template,
   };
 }
 
-export async function replyDraftFinish(
-  runId: number,
-  body: string,
-  qualityScore?: number | null,
-  qualityReason?: string | null,
-) {
+export async function replyDraftFinish(runId: number, body: string) {
   if (!Number.isInteger(runId)) throw new Error('invalid run id');
   if (!body || !body.trim()) throw new Error('body is empty');
   const db = getDb();
@@ -766,14 +824,32 @@ export async function replyDraftFinish(
   const [draft] = await db.select().from(schema.drafts).where(eq(schema.drafts.id, replyDraftId));
   if (!draft) throw new Error(`reply draft ${replyDraftId} not found`);
 
-  const qualitySet =
-    qualityScore != null
-      ? {
-          qualityScore: Math.max(0, Math.min(100, Math.round(qualityScore))),
-          qualityReason: qualityReason ?? null,
-          qualityModel: run.agentRunner,
-        }
-      : {};
+  // LOR-229: same discipline as `draftRegenFinish` - no live model to send a
+  // rewrite back to here, but the score still measures the real body fresh.
+  const styleFindings = checkStyle(body);
+  const orgId = await getProjectOrgId(db, draft.projectId);
+  const [corpusProfile, rubric] = await Promise.all([
+    orgId != null ? resolveOperatorCorpusProfile(db, orgId) : Promise.resolve(null),
+    loadQualityRubric(db),
+  ]);
+  const quality = await scoreDraftQuality(db, {
+    body,
+    styleFindings,
+    corpus: corpusProfile,
+    rubric,
+  });
+  const priorMeta = (draft.metadata ?? {}) as Record<string, unknown>;
+  const newMeta: Record<string, unknown> = { ...priorMeta, qualityDetail: quality.qualityDetail };
+  if (styleFindings.length > 0) {
+    newMeta.styleFindings = styleFindings.map((f) => ({
+      ruleId: f.ruleId,
+      message: f.message,
+      span: f.span,
+    }));
+  } else {
+    delete newMeta.styleFindings;
+  }
+
   await db.transaction(async (tx) => {
     await tx
       .update(schema.drafts)
@@ -781,7 +857,10 @@ export async function replyDraftFinish(
         body,
         draftingRunId: null,
         version: sql`${schema.drafts.version} + 1`,
-        ...qualitySet,
+        metadata: newMeta,
+        qualityScore: quality.qualityScore,
+        qualityReason: quality.qualityReason,
+        qualityModel: quality.qualityModel,
       })
       .where(eq(schema.drafts.id, replyDraftId));
     await tx.insert(schema.draftEvents).values({
@@ -878,12 +957,7 @@ export function registerDraftCommands(program: Command) {
     .action(async (opts: { run: string }) => {
       const raw = await readStdin();
       if (!raw || !raw.trim()) return fail('empty payload on stdin');
-      let payload: {
-        body?: unknown;
-        title?: unknown;
-        qualityScore?: unknown;
-        qualityReason?: unknown;
-      };
+      let payload: { body?: unknown; title?: unknown };
       try {
         payload = JSON.parse(raw);
       } catch {
@@ -891,12 +965,8 @@ export function registerDraftCommands(program: Command) {
       }
       const body = typeof payload.body === 'string' ? payload.body : '';
       const title = typeof payload.title === 'string' ? payload.title : undefined;
-      const qualityScore =
-        typeof payload.qualityScore === 'number' ? payload.qualityScore : undefined;
-      const qualityReason =
-        typeof payload.qualityReason === 'string' ? payload.qualityReason : undefined;
       try {
-        ok(await draftRegenFinish(Number(opts.run), body, title, qualityScore, qualityReason));
+        ok(await draftRegenFinish(Number(opts.run), body, title));
       } catch (err) {
         fail(String(err instanceof Error ? err.message : err));
       }
@@ -919,19 +989,15 @@ export function registerDraftCommands(program: Command) {
     .action(async (opts: { run: string }) => {
       const raw = await readStdin();
       if (!raw || !raw.trim()) return fail('empty payload on stdin');
-      let payload: { body?: unknown; qualityScore?: unknown; qualityReason?: unknown };
+      let payload: { body?: unknown };
       try {
         payload = JSON.parse(raw);
       } catch {
         return fail('payload is not valid JSON');
       }
       const body = typeof payload.body === 'string' ? payload.body : '';
-      const qualityScore =
-        typeof payload.qualityScore === 'number' ? payload.qualityScore : undefined;
-      const qualityReason =
-        typeof payload.qualityReason === 'string' ? payload.qualityReason : undefined;
       try {
-        ok(await replyDraftFinish(Number(opts.run), body, qualityScore, qualityReason));
+        ok(await replyDraftFinish(Number(opts.run), body));
       } catch (err) {
         fail(String(err instanceof Error ? err.message : err));
       }

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -2,7 +2,6 @@ import { Command } from 'commander';
 import { getDb, schema } from '@pitchbox/shared/db';
 import { getSchema, SCENARIO_META, type ScenarioSlug } from '@pitchbox/shared/campaigns';
 import { loadActiveTemplates, type TemplateKind } from '@pitchbox/shared/templates';
-import { loadQualityRubric } from '@pitchbox/shared/quality-judge';
 import { eq } from 'drizzle-orm';
 import { ok, fail } from '../lib/output.js';
 
@@ -89,8 +88,6 @@ export async function startRun(campaignId: number, runId?: number | null) {
       .returning();
   }
 
-  const rubric = await loadQualityRubric(db);
-
   return {
     runId: run.id,
     campaign: {
@@ -108,7 +105,6 @@ export async function startRun(campaignId: number, runId?: number | null) {
     blocklist: blocks.map((b) => ({ kind: b.kind, value: b.value })),
     contactedRecently: contacted.map((c) => c.target),
     templates: templates.map((t) => ({ id: t.id, kind: t.kind, title: t.title, body: t.body })),
-    rubricTemplate: rubric.rubric_template,
   };
 }
 

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -632,8 +632,6 @@ export function createPitchboxMcpServer(ctx: PitchboxMcpContext = {}): McpServer
       inputSchema: {
         body: z.string().min(1).describe('the rewritten draft body'),
         title: z.string().optional().describe('new title (post drafts only)'),
-        qualityScore: z.number().optional().describe('quality score 0-100 for the rewritten draft'),
-        qualityReason: z.string().optional().describe('one-line reason for the score'),
         runId: z
           .number()
           .int()
@@ -642,13 +640,13 @@ export function createPitchboxMcpServer(ctx: PitchboxMcpContext = {}): McpServer
           .describe('run id (defaults to PITCHBOX_RUN_ID)'),
       },
     },
-    async ({ body, title, qualityScore, qualityReason, runId }) => {
+    async ({ body, title, runId }) => {
       const rid = runId ?? defaultRunId();
       if (rid == null) return errorResult('runId required (or set PITCHBOX_RUN_ID)');
       try {
         const ownershipErr = await checkOwnership('run', rid);
         if (ownershipErr) return errorResult(ownershipErr);
-        return jsonResult(await draftRegenFinish(rid, body, title, qualityScore, qualityReason));
+        return jsonResult(await draftRegenFinish(rid, body, title));
       } catch (err) {
         return errorResult(String(err instanceof Error ? err.message : err));
       }
@@ -691,8 +689,6 @@ export function createPitchboxMcpServer(ctx: PitchboxMcpContext = {}): McpServer
         'Persist the drafted reply body, clear the drafting flag, and mark the run success. Returns { draftId }.',
       inputSchema: {
         body: z.string().min(1).describe('the drafted reply body'),
-        qualityScore: z.number().optional().describe('quality score 0-100 for the drafted reply'),
-        qualityReason: z.string().optional().describe('one-line reason for the score'),
         runId: z
           .number()
           .int()
@@ -701,13 +697,13 @@ export function createPitchboxMcpServer(ctx: PitchboxMcpContext = {}): McpServer
           .describe('run id (defaults to PITCHBOX_RUN_ID)'),
       },
     },
-    async ({ body, qualityScore, qualityReason, runId }) => {
+    async ({ body, runId }) => {
       const rid = runId ?? defaultRunId();
       if (rid == null) return errorResult('runId required (or set PITCHBOX_RUN_ID)');
       try {
         const ownershipErr = await checkOwnership('run', rid);
         if (ownershipErr) return errorResult(ownershipErr);
-        return jsonResult(await replyDraftFinish(rid, body, qualityScore, qualityReason));
+        return jsonResult(await replyDraftFinish(rid, body));
       } catch (err) {
         return errorResult(String(err instanceof Error ? err.message : err));
       }

--- a/cli/tests/commands/draft-regen.test.ts
+++ b/cli/tests/commands/draft-regen.test.ts
@@ -92,21 +92,20 @@ afterAll(async () => {
 });
 
 describe('pitchbox drafts:regen:*', () => {
-  it('start returns the draft, hint, platform, and rubric template', () => {
+  it('start returns the draft, hint, and platform - no rubric template, since scoring is no longer self-reported', () => {
     const parsed = lastJson(cli(`drafts:regen:start --run=${regenRunId}`));
     expect(parsed.ok).toBe(true);
     expect(parsed.data.draftId).toBe(draftId);
     expect(parsed.data.hint).toBe('shorter');
     expect(parsed.data.platform).toBe('reddit');
     expect(parsed.data.draft.body).toBe('old body');
-    expect(typeof parsed.data.rubricTemplate).toBe('string');
-    expect(parsed.data.rubricTemplate.length).toBeGreaterThan(0);
+    expect(parsed.data.rubricTemplate).toBeUndefined();
   });
 
-  it('finish overwrites the body, bumps version + count, clears the flag, ends the run, and re-scores', async () => {
+  it('finish overwrites the body, bumps version + count, clears the flag, ends the run, and recomputes the quality score server-side', async () => {
     const out = cliWithStdin(
       `drafts:regen:finish --run=${regenRunId}`,
-      JSON.stringify({ body: 'new body', qualityScore: 70, qualityReason: 'tightened' }),
+      JSON.stringify({ body: 'new body' }),
     );
     const parsed = lastJson(out);
     expect(parsed.ok).toBe(true);
@@ -118,13 +117,15 @@ describe('pitchbox drafts:regen:*', () => {
     expect(d.version).toBe(1);
     expect(d.regenerationCount).toBe(1);
     expect(d.regeneratingRunId).toBeNull();
-    expect(d.qualityScore).toBe(70);
-    expect(d.qualityReason).toBe('tightened');
+    // No style findings and no operator voice corpus in this fixture - the
+    // deterministic scorer has nothing to measure, so it reports "not
+    // scored" rather than guessing a number.
+    expect(d.qualityScore).toBeNull();
+    expect(d.qualityModel).toBeNull();
 
     const [r] = await db.select().from(schema.runs).where(eq(schema.runs.id, regenRunId));
     expect(r.status).toBe('success');
     expect(r.finishedAt).not.toBeNull();
-    expect(d.qualityModel).toBe(r.agentRunner);
 
     const [evt] = await db
       .select()
@@ -132,6 +133,22 @@ describe('pitchbox drafts:regen:*', () => {
       .where(eq(schema.draftEvents.draftId, draftId));
     expect(evt.event).toBe('regenerated');
     expect((evt.details as { previousBody: string }).previousBody).toBe('old body');
+  });
+
+  it('finish caps the score below green when the rewritten body carries a style finding, never trusting a self-report', async () => {
+    const out = cliWithStdin(
+      `drafts:regen:finish --run=${regenRunId}`,
+      JSON.stringify({
+        body: "In today's fast-paced world, it's worth noting the update shipped.",
+      }),
+    );
+    expect(lastJson(out).ok).toBe(true);
+
+    const db = getDb();
+    const [d] = await db.select().from(schema.drafts).where(eq(schema.drafts.id, draftId));
+    expect(d.qualityModel).toBe('deterministic');
+    expect(d.qualityScore).not.toBeNull();
+    expect(d.qualityScore).toBeLessThan(75);
   });
 
   it('finish rejects an empty body', () => {

--- a/cli/tests/commands/drafts-create.test.ts
+++ b/cli/tests/commands/drafts-create.test.ts
@@ -244,7 +244,7 @@ describe('pitchbox drafts:create', () => {
     expect(eventPayload.findingsCount).toBe(0);
   });
 
-  it('persists an inline quality score supplied at creation (issue #41)', async () => {
+  it('ignores an inline qualityScore/qualityReason in the payload - scoring is computed server-side, never accepted from the caller (LOR-229)', async () => {
     const db = getDb();
     const [platform] = await db
       .select()
@@ -298,9 +298,70 @@ describe('pitchbox drafts:create', () => {
 
     const drafts = await db.select().from(schema.drafts);
     expect(drafts).toHaveLength(1);
-    expect(drafts[0].qualityScore).toBe(82);
-    expect(drafts[0].qualityReason).toBe('specific and personal');
-    expect(drafts[0].qualityModel).toBe(run.agentRunner);
+    // A clean, short body with no operator voice corpus in this fixture has
+    // nothing for the deterministic scorer to measure - it reports "not
+    // scored", never the 82/"specific and personal" the payload asked for.
+    expect(drafts[0].qualityScore).toBeNull();
+    expect(drafts[0].qualityReason).toBeNull();
+    expect(drafts[0].qualityModel).toBeNull();
+  });
+
+  it('computes a deterministic quality score at creation, capped below green when the body carries a style finding (LOR-229)', async () => {
+    const db = getDb();
+    const [platform] = await db
+      .select()
+      .from(schema.platforms)
+      .where(eq(schema.platforms.slug, 'reddit'));
+    const [org] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(sql`slug = 'default'`);
+    const [project] = await db
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'demo3b', name: 'D3b' })
+      .returning();
+    const [account] = await db
+      .insert(schema.accounts)
+      .values({ projectId: project.id, platformId: platform.id, handle: 'erin', role: 'personal' })
+      .returning();
+    const [campaign] = await db
+      .insert(schema.campaigns)
+      .values({
+        projectId: project.id,
+        platformId: platform.id,
+        name: 'c3b',
+        skillSlug: 'reddit-scout',
+        config: {},
+      })
+      .returning();
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ campaignId: campaign.id, trigger: 'manual', status: 'running' })
+      .returning();
+
+    const payload = JSON.stringify([
+      {
+        accountId: account.id,
+        kind: 'dm',
+        targetUser: 'frank',
+        body: "In today's fast-paced world, it's worth noting the update shipped.",
+        sourceRef: {},
+        metadata: {},
+      },
+    ]);
+
+    const out = cli(`drafts:create --run=${run.id}`, payload);
+    const res = JSON.parse(out.trim().split('\n').at(-1)!);
+    expect(res.ok).toBe(true);
+    expect(res.data.inserted).toBe(1);
+
+    const [draft] = await db
+      .select()
+      .from(schema.drafts)
+      .where(eq(schema.drafts.accountId, account.id));
+    expect(draft.qualityModel).toBe('deterministic');
+    expect(draft.qualityScore).not.toBeNull();
+    expect(draft.qualityScore).toBeLessThan(75);
   });
 
   it('skips blocklisted targets and reports them in the response', async () => {

--- a/cli/tests/commands/reply-draft.test.ts
+++ b/cli/tests/commands/reply-draft.test.ts
@@ -131,7 +131,7 @@ afterAll(async () => {
 });
 
 describe('pitchbox drafts:reply:*', () => {
-  it('start returns the placeholder, parent voice, chronological thread, and rubric template', () => {
+  it('start returns the placeholder, parent voice, and chronological thread - no rubric template, since scoring is no longer self-reported', () => {
     const parsed = lastJson(cli(`drafts:reply:start --run=${runId}`));
     expect(parsed.ok).toBe(true);
     expect(parsed.data.replyDraftId).toBe(replyDraftId);
@@ -140,18 +140,13 @@ describe('pitchbox drafts:reply:*', () => {
     expect(parsed.data.thread.length).toBe(1);
     expect(parsed.data.thread[0].body).toBe('tell me more');
     expect(parsed.data.parentMessageId).toBe(inboundId);
-    expect(typeof parsed.data.rubricTemplate).toBe('string');
-    expect(parsed.data.rubricTemplate.length).toBeGreaterThan(0);
+    expect(parsed.data.rubricTemplate).toBeUndefined();
   });
 
-  it('finish sets the body, clears the flag, finalizes the run, and scores the reply', async () => {
+  it('finish sets the body, clears the flag, finalizes the run, and computes the quality score server-side', async () => {
     const out = cliWithStdin(
       `drafts:reply:finish --run=${runId}`,
-      JSON.stringify({
-        body: 'Happy to help - here is more.',
-        qualityScore: 64,
-        qualityReason: 'on tone',
-      }),
+      JSON.stringify({ body: 'Happy to help - here is more.' }),
     );
     expect(lastJson(out).ok).toBe(true);
     const db = getDb();
@@ -159,9 +154,12 @@ describe('pitchbox drafts:reply:*', () => {
     expect(d.body).toBe('Happy to help - here is more.');
     expect(d.draftingRunId).toBeNull();
     expect(d.state).toBe('pending_review');
-    expect(d.qualityScore).toBe(64);
-    expect(d.qualityReason).toBe('on tone');
-    expect(d.qualityModel).toBe('codex');
+    // No style findings and no operator voice corpus in this fixture - the
+    // deterministic scorer has nothing to measure, so it reports "not
+    // scored" rather than guessing a number, and never the drafting run's
+    // own agentRunner the way the old self-report used to.
+    expect(d.qualityScore).toBeNull();
+    expect(d.qualityModel).toBeNull();
     const [r] = await db.select().from(schema.runs).where(eq(schema.runs.id, runId));
     expect(r.status).toBe('success');
     const [evt] = await db
@@ -169,6 +167,21 @@ describe('pitchbox drafts:reply:*', () => {
       .from(schema.draftEvents)
       .where(eq(schema.draftEvents.draftId, replyDraftId));
     expect(evt.event).toBe('reply_drafted');
+  });
+
+  it('finish caps the score below green when the reply carries a style finding, never trusting a self-report', async () => {
+    const out = cliWithStdin(
+      `drafts:reply:finish --run=${runId}`,
+      JSON.stringify({
+        body: "In today's fast-paced world, it's worth noting the update shipped.",
+      }),
+    );
+    expect(lastJson(out).ok).toBe(true);
+    const db = getDb();
+    const [d] = await db.select().from(schema.drafts).where(eq(schema.drafts.id, replyDraftId));
+    expect(d.qualityModel).toBe('deterministic');
+    expect(d.qualityScore).not.toBeNull();
+    expect(d.qualityScore).toBeLessThan(75);
   });
 
   it('finish rejects an empty body', () => {

--- a/cli/tests/commands/run-start.test.ts
+++ b/cli/tests/commands/run-start.test.ts
@@ -76,8 +76,10 @@ describe('pitchbox run:start', () => {
     expect(parsed.data.runId).toBeGreaterThan(0);
     expect(parsed.data.campaign.name).toBe('Scout');
     expect(parsed.data.accounts[0].handle).toBe('alice');
-    expect(typeof parsed.data.rubricTemplate).toBe('string');
-    expect(parsed.data.rubricTemplate.length).toBeGreaterThan(0);
+    // LOR-229: scoring is computed server-side now, never self-reported by
+    // the drafting agent, so run:start no longer hands out a rubric
+    // template for the agent to score itself against.
+    expect(parsed.data.rubricTemplate).toBeUndefined();
   });
 });
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -63,7 +63,7 @@ Pitchbox tracks every successful outreach in `contact_history`. Before creating 
 
 Dedup is per organization (#263). Two organizations reaching the same handle do not warn each other, because doing so would tell one tenant that another had already been in touch. On a single-tenant install everything lives under the `default` organization, so this makes no difference.
 
-A public comment counts as contact with the post's author (#336). A `post_comment` draft therefore carries that author as its `target_user`, and marking it as sent writes a `contact_history` row exactly like a DM: the author enters the dedup window, the blocklist applies before the draft is even created, and a second reply to the same person is warned about or skipped per the policy below. The handle is not left to the playbook to copy across. `drafts:create` derives it from the run's own staged candidates, matching them to the draft by the post identifier the draft already carries (`shared/src/comment-target.ts`). Hacker News stages no candidates, so there the playbook remains the only source, and a comment whose author cannot be named keeps a null target and writes no contact row rather than an invented one.
+A public comment counts as contact with the post's author (#336). A `post_comment` draft therefore carries that author as its `target_user`, and marking it as sent writes a `contact_history` row exactly like a DM: the author enters the dedup window, the blocklist applies before the draft is even created, and a second reply to the same person is warned about or skipped per the policy below. The handle is not left to the playbook to copy across. `drafts:create` derives it from the run's own staged candidates, matching them to the draft by the post identifier the draft already carries (`shared/src/comment-target.ts`). Hacker News stages no candidates, so there the playbook remains the only source, and a comment whose author cannot be named keeps a null target a…
 
 Behaviour is governed by `app_config.dedup_policy`:
 
@@ -93,28 +93,46 @@ The inbox detail panel offers a `Regenerate` action alongside Approve/Reject. Th
 
 ## Quality scoring
 
-New drafts carry a 0-100 quality score, but it is self-reported, not an
-independent judge's opinion: `shared/src/quality-judge.ts` holds only the
-rubric template and the score-to-band mapping, and no model call is ever
-made from that module. The rubric and thresholds live in
-`app_config.quality_rubric`:
+The score is no longer self-reported by the drafting agent. `shared/src/quality-judge.ts` computes a
+deterministic component at persistence time from `shared/src/voice-metrics.ts` and the operator's own
+measured voice profile (`shared/src/operator-voice-profile.ts`): style-checker findings (from
+`shared/src/style-check.ts`), per-axis stylometric distance against the operator's own corpus, and the
+draft's length against the operator's own typical length - no model call, no configuration required. A
+non-zero style-finding count caps the score so it can never read as "green"
+(`app_config.quality_rubric`'s `threshold_green`), regardless of anything else measured.
+
+An axis the module cannot measure (e.g. the operator's voice corpus is too thin, or nothing comparable is
+available) is excluded from the score rather than counted as a match or a miss.
+
+A second, optional component is a real judge call: a real model reads the draft against a rubric
+template and returns its own score and reason, but ONLY when an admin has explicitly configured a model
+for the `quality_judge` function in Settings → Admin → Models (`shared/src/ai/model-functions.ts`) - an
+unconfigured deployment never makes this call, so it costs nothing and never runs by default. When it's
+off, the deterministic score is what's shown; the judge is absent, never a zero that drags the score
+down.
+
+Both live behind the same `app_config.quality_rubric` config shape as before (`rubric_template`,
+`threshold_red`, `threshold_green`) - `rubric_template` now prompts the optional judge (when configured)
+rather than the drafting agent, and an org's existing customized rubric_template is preserved; only the
+literal old default text is upgraded automatically to the new wording:
 
 ```json
 {
-  "rubric_template": "Score the draft 0-100 on clarity, relevance, personalization, tone. Return JSON.",
+  "rubric_template": "Score the draft 0-100 on whether it reads as a real person, not an AI reply.",
   "threshold_red": 40,
   "threshold_green": 75
 }
 ```
 
-Scoring is inline: whenever the agent writes a draft body, it is handed
-`rubric_template` and scores its own output against it, passing the score
-back on the same tool call that persists the body - there is no separate
-scoring pass, and no second model checking the first one's work. The score,
-reason and the model that wrote (and scored) the draft are persisted on
-`drafts.quality_score`, `drafts.quality_reason`, `drafts.quality_model`. The inbox renders a
-colour-coded `Q<score>` badge next to each draft (red `< threshold_red`,
-green `>= threshold_green`, amber in between) and exposes a
+The score, reason and its source are persisted on `drafts.quality_score`, `drafts.quality_reason`,
+`drafts.quality_model` - `quality_model` holds the literal string `"deterministic"` when no judge ran, or
+the judge's real model id when one did, so a caller can always tell which kind of number it's looking at.
+Per-axis detail (which axes were measured, the length ratio, the raw style findings, the judge's own
+output when present) travels in the draft's `metadata.qualityDetail`.
+
+The inbox renders a badge distinguishing the two: a "measured" badge when the score is
+deterministic-only, and a distinctly-styled "judged" badge (naming the model) when a real judge call
+scored it - the two are different claims and never render identically. It still exposes a
 `?minQuality=<n>` filter on the URL.
 
 ## A/B variant drafts

--- a/playbooks/draft-regenerator.md
+++ b/playbooks/draft-regenerator.md
@@ -48,7 +48,7 @@ Write like this instead:
 
 ## Steps
 
-1. **Load context.** Call `draft_regen_start` (no arguments needed). From the result read: `hint`, `platform`, `persona`, `rubricTemplate`, and `draft` (`kind`, `title`, `body`, `targetUser`, `reasoning`, `sourceRef`).
+1. **Load context.** Call `draft_regen_start` (no arguments needed). From the result read: `hint`, `platform`, `persona`, and `draft` (`kind`, `title`, `body`, `targetUser`, `reasoning`, `sourceRef`).
 
 2. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the subject of `draft.body`, for what you have already said about it elsewhere. `persona` already carries the voice this specific draft was written in - these two keep the rewrite consistent with how you actually write in general, not just with that one draft.
 
@@ -64,24 +64,20 @@ Write like this instead:
    - No placeholders, no "TBD", no meta commentary. Output the message text a human would send.
    - Apply the House style section above literally: it outranks every default here and holds even when the campaign voice says nothing about it.
 
-4. **Score the rewritten draft.** Using `rubricTemplate`, score the rewrite 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted drafts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason`.
+4. **Check your own style before persisting.** Call `check_style` with the exact rewritten body (and title, if you changed it) you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `draft_regen_finish` has no live model to send a rewrite back to.
 
-5. **Check your own style before persisting.** Call `check_style` with the exact rewritten body (and title, if you changed it) you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `draft_regen_finish` has no live model to send a rewrite back to.
-
-6. **Submit.** Call `draft_regen_finish` with:
+5. **Submit.** Call `draft_regen_finish` with:
 
    ```json
    {
      "body": "<the rewritten body>",
-     "title": "<only for post drafts, else omit>",
-     "qualityScore": 74,
-     "qualityReason": "tighter and more specific"
+     "title": "<only for post drafts, else omit>"
    }
    ```
 
    The tool overwrites the draft body, bumps its version, records the previous body for undo, and finalizes the run. **If the tool returns an error**, read the message, fix the payload, and try again. **Maximum two retries.**
 
-7. **On failure.** If `draft_regen_start` reports the draft is gone or no longer pending review, or you genuinely cannot improve it, call `run_finish` with `{ "status": "failed", "error": "<short reason>" }` and stop. The draft keeps its current body.
+6. **On failure.** If `draft_regen_start` reports the draft is gone or no longer pending review, or you genuinely cannot improve it, call `run_finish` with `{ "status": "failed", "error": "<short reason>" }` and stop. The draft keeps its current body.
 
 ## What this playbook must never do
 

--- a/playbooks/hn-commenter.md
+++ b/playbooks/hn-commenter.md
@@ -52,7 +52,7 @@ Write like this instead:
 
 1. **Start the run.** Call `run_start` (no arguments needed).
 
-   From the result extract `runId`, `project`, `platform` (should be `hackernews`), `campaign.config` (expects `listing` such as `top` / `new` / `ask` / `show`, optional `topicKeywords`, `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `rubricTemplate`.
+   From the result extract `runId`, `project`, `platform` (should be `hackernews`), `campaign.config` (expects `listing` such as `top` / `new` / `ask` / `show`, optional `topicKeywords`, `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`.
 
 2. **Fetch candidate stories.** Call `hn_search` once per topic keyword (or once with no query) and merge: `{ "listing": "<listing>", "query": "<keyword>", "limit": 30 }`.
 
@@ -79,11 +79,9 @@ Write like this instead:
 
 6. **Pick the account.** Use the first account with `role === 'personal'`. HN accounts only carry a `username` - no secret. Record `accountId`.
 
-7. **Score each draft.** Using `rubricTemplate` from the run context, score the comment 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted comments and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+7. **Check your own style before persisting.** Call `check_style` with the exact comment body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-8. **Check your own style before persisting.** Call `check_style` with the exact comment body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
-
-9. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+8. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft:
 
@@ -96,15 +94,13 @@ Write like this instead:
      "body": "<comment text>",
      "reasoning": "Why this story, what angle, what value you're adding.",
      "sourceRef": { "itemUrl": "https://news.ycombinator.com/item?id=12345", "title": "..." },
-     "metadata": { "itemId": 12345, "listing": "top", "score": 142 },
-     "qualityScore": 78,
-     "qualityReason": "specific reference to their post, clear ask"
+     "metadata": { "itemId": 12345, "listing": "top", "score": 142 }
    }
    ```
 
    `targetUser` is the author of the story you are replying to (`by` on the item you scored). Commenting on someone's story counts as contacting them, so it feeds the blocklist, the dedup window and contact history. Hacker News has no scout staging candidates for the run, so nothing can recover this handle if you omit it: copy it across for every draft.
 
-10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/hn-poster.md
+++ b/playbooks/hn-poster.md
@@ -52,7 +52,7 @@ Write like this instead:
 
 1. **Start the run.** Call `run_start` (no arguments needed).
 
-   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform` (should be `hackernews`), `campaign.config` (`postAngle`, `topicKeywords`, `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`, optional `format` hint such as `show-hn` / `ask-hn` / `text`), `accounts`, `rubricTemplate`.
+   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform` (should be `hackernews`), `campaign.config` (`postAngle`, `topicKeywords`, `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`, optional `format` hint such as `show-hn` / `ask-hn` / `text`), `accounts`.
 
 2. **Study what's currently on HN.** Get a feel for what's resonating right now and the formats that already exist on the front page, so you don't ship something that's about to be flagged as duplicate or off-topic. Call `hn_search` three times:
    - `{ "listing": "top", "limit": 30 }`
@@ -81,13 +81,11 @@ Write like this instead:
    - The post is a thinly disguised pitch with no substantive content (Show HN that's just a landing page summary, Ask HN that's leading toward "would you pay for X").
    - HN already has a near-identical Show HN from the last 30 days for the same product (search step 2).
 
-6. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+6. **Pick the account.** Use the first account with `role === 'personal'`. HN accounts only carry a `username` - no secret. Record `accountId`.
 
-7. **Pick the account.** Use the first account with `role === 'personal'`. HN accounts only carry a `username` - no secret. Record `accountId`.
+7. **Check your own style before persisting.** Call `check_style` with the exact title and body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-8. **Check your own style before persisting.** Call `check_style` with the exact title and body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
-
-9. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+8. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft:
 
@@ -101,13 +99,11 @@ Write like this instead:
      "body": "<plain-text body, including disclosure where applicable>",
      "reasoning": "<one sentence: which format + why this angle now>",
      "sourceRef": { "format": "show-hn | ask-hn | text" },
-     "metadata": { "format": "show-hn", "url": "<productUrl when format=show-hn>" },
-     "qualityScore": 78,
-     "qualityReason": "specific reference to their post, clear ask"
+     "metadata": { "format": "show-hn", "url": "<productUrl when format=show-hn>" }
    }
    ```
 
-10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
+9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
 
 ## Hard rules
 

--- a/playbooks/linkedin-commenter.md
+++ b/playbooks/linkedin-commenter.md
@@ -55,7 +55,7 @@ Write like this instead:
 
 1. **Start the run.** Call `run_start` (no arguments needed; it defaults to this session's campaign).
 
-   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform` (should be `linkedin`), `campaign.config` (`topicKeywords`, optional `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `blocklist`, `contactedRecently`, `rubricTemplate`.
+   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform` (should be `linkedin`), `campaign.config` (`topicKeywords`, optional `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `blocklist`, `contactedRecently`.
 
    Treat `campaign.config.systemInstructions` as additional voice & content guidance - it overrides defaults, but never past the hard constraints below: campaign config can only tighten these rules, never relax them.
 
@@ -93,11 +93,9 @@ Write like this instead:
 
 8. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
 
-9. **Score each draft.** Using `rubricTemplate` from the run context, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, contextual replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+9. **Check your own style before persisting.** Call `check_style` with the exact reply body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-10. **Check your own style before persisting.** Call `check_style` with the exact reply body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
-
-11. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+10. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
 > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
 
@@ -115,15 +113,13 @@ Each draft (the human opens the real post from the Inbox and pastes this in them
     "externalId": "urn:li:activity:1234567890",
     "url": "https://www.linkedin.com/feed/update/urn:li:activity:1234567890/"
   },
-  "metadata": { "authorHandle": "jane-doe" },
-  "qualityScore": 76,
-  "qualityReason": "concrete reference to their post, adds a real point"
+  "metadata": { "authorHandle": "jane-doe" }
 }
 ```
 
 `targetUser` is the author of the post you are replying to, and it is their profile slug (`author.handle`), never their display name: a name cannot be blocklisted or deduped. Commenting on someone's post counts as contacting them, so it feeds the blocklist, the dedup window and contact history, exactly as the in-page assist already does. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.externalId` points at; an observation captured without a slug has no target, and null is the right answer there.
 
-12. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/linkedin-poster.md
+++ b/playbooks/linkedin-poster.md
@@ -55,7 +55,7 @@ Write like this instead:
 
 1. **Start the run.** Call `run_start` (no arguments needed).
 
-   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform` (should be `linkedin`), `campaign.config` (`postAngle`, optional `topicKeywords`, `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `rubricTemplate`.
+   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform` (should be `linkedin`), `campaign.config` (`postAngle`, optional `topicKeywords`, `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`.
 
 2. **Study what's currently active in the network.** Call `linkedin_candidates` with `{ "runId": <runId> }`, then `staging_candidates` with `{ "run": <runId> }`, to see what the human's own browsing has already surfaced. Each candidate is split like the Mastodon candidates are: `author` (`handle`, `name`) and `post` (`externalId`, `url`, `text`, `observedAt`). Read `post.text` for recurring themes, tone, and whether the same angle has already been said recently by someone else. You are not reading these to reply to any of them, and you must never treat one of them as a target - only to calibrate the new post so it doesn't repeat or clash with what's already circulating.
 
@@ -81,13 +81,11 @@ Write like this instead:
    - Step 2's survey shows the same angle was posted very recently by this project (avoid duplicate or near-duplicate posts).
    - The post reads as engagement bait (a question with no real content behind it, a "controversial take" manufactured purely to draw comments).
 
-7. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, well-timed posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+7. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
 
-8. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
+8. **Check your own style before persisting.** Call `check_style` with the exact post body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-9. **Check your own style before persisting.** Call `check_style` with the exact post body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
-
-10. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+9. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
 Each draft (the human reviews it in the Inbox and posts it themselves - there is no auto-post path for LinkedIn):
 
@@ -100,13 +98,11 @@ Each draft (the human reviews it in the Inbox and posts it themselves - there is
   "body": "<plain-text post, including disclosure if the product is named>",
   "reasoning": "<one sentence: which angle + why now>",
   "sourceRef": { "postAngle": "<angle>" },
-  "metadata": { "hashtags": ["buildinpublic"] },
-  "qualityScore": 72,
-  "qualityReason": "genuine lesson-learned angle, not a pitch"
+  "metadata": { "hashtags": ["buildinpublic"] }
 }
 ```
 
-11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
+10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
 
 ## Hard constraints
 

--- a/playbooks/mastodon-commenter.md
+++ b/playbooks/mastodon-commenter.md
@@ -55,7 +55,7 @@ Write like this instead:
 
 1. **Start the run.** Call `run_start` (no arguments needed; it defaults to this session's campaign).
 
-   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform`, `campaign.config` (`targetHashtags`, optional `keywords`, `avoidKeywords`, `perTagLimit`, `maxAgeHours`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `blocklist`, `contactedRecently`, `rubricTemplate`.
+   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform`, `campaign.config` (`targetHashtags`, optional `keywords`, `avoidKeywords`, `perTagLimit`, `maxAgeHours`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `blocklist`, `contactedRecently`.
 
    Treat `campaign.config.systemInstructions` as additional voice & content guidance - it overrides defaults.
 
@@ -92,11 +92,9 @@ Write like this instead:
 
 8. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
 
-9. **Score each draft.** Using `rubricTemplate` from the run context, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, contextual replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+9. **Check your own style before persisting.** Call `check_style` with the exact reply body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-10. **Check your own style before persisting.** Call `check_style` with the exact reply body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
-
-11. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+10. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
 > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
 
@@ -111,15 +109,13 @@ Each draft (sent later as a reply status via `in_reply_to_id`, on human approval
   "body": "<reply text>",
   "reasoning": "2-3 sentences on why this status, what angle, what value you're adding.",
   "sourceRef": { "statusId": "109...", "statusUrl": "https://mastodon.social/@alice/109..." },
-  "metadata": { "matchedHashtag": "selfhosted", "matchedKeyword": "self-hosted" },
-  "qualityScore": 74,
-  "qualityReason": "concrete reference to their status, adds a real point"
+  "metadata": { "matchedHashtag": "selfhosted", "matchedKeyword": "self-hosted" }
 }
 ```
 
 `targetUser` is the author of the status you are replying to, as the fully qualified `author.acct` handle. Replying to someone counts as contacting them, so it feeds the blocklist, the dedup window and contact history. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.statusId` points at.
 
-12. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/mastodon-poster.md
+++ b/playbooks/mastodon-poster.md
@@ -55,7 +55,7 @@ Write like this instead:
 
 1. **Start the run.** Call `run_start` (no arguments needed).
 
-   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform` (should be `mastodon`), `campaign.config` (`targetHashtags`, `postAngle`, optional `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `rubricTemplate`.
+   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform` (should be `mastodon`), `campaign.config` (`targetHashtags`, `postAngle`, optional `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`.
 
 2. **Study what's currently active in the target hashtags.** Call `mastodon_scout` with `{ "runId": <runId> }`, then `staging_candidates` with `{ "run": <runId> }`, to see what people are already posting in `campaign.config.targetHashtags`. Note recurring themes, tone, and whether the same angle has already been said recently - you are not reading these to reply, only to calibrate the new post so it doesn't repeat or clash with what's already there.
 
@@ -76,13 +76,11 @@ Write like this instead:
    - The post is a thinly disguised pitch with no substantive content.
    - Step 2's survey shows the same angle was posted very recently by this project (avoid duplicate/near-duplicate posts).
 
-6. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, well-timed posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+6. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
 
-7. **Pick the account.** Use the first account with `role === 'personal'`. Record `accountId`.
+7. **Check your own style before persisting.** Call `check_style` with the exact status body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-8. **Check your own style before persisting.** Call `check_style` with the exact status body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
-
-9. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+8. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft (sent later as a public status, on human approval):
 
@@ -95,13 +93,11 @@ Write like this instead:
      "body": "<plain-text status, including disclosure and hashtags>",
      "reasoning": "<one sentence: which angle + why now>",
      "sourceRef": { "postAngle": "<angle>" },
-     "metadata": { "hashtags": ["selfhosted", "indiehackers"] },
-     "qualityScore": 74,
-     "qualityReason": "genuine lesson-learned angle, not a pitch"
+     "metadata": { "hashtags": ["selfhosted", "indiehackers"] }
    }
    ```
 
-10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
+9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
 
 ## Hard rules
 

--- a/playbooks/mastodon-scout.md
+++ b/playbooks/mastodon-scout.md
@@ -52,7 +52,7 @@ Write like this instead:
 
 1. **Start the run and load context.** Call `run_start` (no arguments; it defaults to this session's campaign).
 
-   From the result extract: `runId`, `project` (includes `description` - the project's markdown briefing), `platform`, `campaign.config` (`targetHashtags`, optional `keywords`, `perTagLimit`, `maxAgeHours`, `sinceId`, plus `fitScoreThreshold`, `voice`, `offer`, `systemInstructions`), `accounts`, `blocklist`, `contactedRecently`, `rubricTemplate`. Remember `runId` for every later call.
+   From the result extract: `runId`, `project` (includes `description` - the project's markdown briefing), `platform`, `campaign.config` (`targetHashtags`, optional `keywords`, `perTagLimit`, `maxAgeHours`, `sinceId`, plus `fitScoreThreshold`, `voice`, `offer`, `systemInstructions`), `accounts`, `blocklist`, `contactedRecently`. Remember `runId` for every later call.
 
 2. **Fetch raw candidates.** Call `mastodon_scout` with `{ "runId": <runId> }`.
 
@@ -89,33 +89,29 @@ Write like this instead:
 
 8. **Pick the account.** Use the first account from `accounts` whose `role === 'personal'`. Record its `id` as `accountId`.
 
-9. **Score each draft.** Using `rubricTemplate` from the run context, score the DM 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, well-justified mentions and give low scores to anything that reads generic or pitchy. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+9. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`, one draft object per candidate that survived step 6.
 
-10. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`, one draft object per candidate that survived step 6.
+   > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
 
-    > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
+   Each draft object:
 
-    Each draft object:
+   ```json
+   {
+     "accountId": 1,
+     "kind": "dm",
+     "fitScore": 4,
+     "targetUser": "alice@mastodon.social",
+     "body": "@alice@mastodon.social <mention body>",
+     "reasoning": "Why this candidate cleared the outreach gate in step 6, plus the visibility reminder from step 7.",
+     "sourceRef": {
+       "statusUrl": "https://mastodon.social/@alice/109...",
+       "matchedHashtag": "selfhosted"
+     },
+     "metadata": { "matchedHashtag": "selfhosted", "matchedKeyword": "self-hosted" }
+   }
+   ```
 
-    ```json
-    {
-      "accountId": 1,
-      "kind": "dm",
-      "fitScore": 4,
-      "targetUser": "alice@mastodon.social",
-      "body": "@alice@mastodon.social <mention body>",
-      "reasoning": "Why this candidate cleared the outreach gate in step 6, plus the visibility reminder from step 7.",
-      "sourceRef": {
-        "statusUrl": "https://mastodon.social/@alice/109...",
-        "matchedHashtag": "selfhosted"
-      },
-      "metadata": { "matchedHashtag": "selfhosted", "matchedKeyword": "self-hosted" },
-      "qualityScore": 72,
-      "qualityReason": "genuine reply-worthy signal, concrete reference, short and non-pitchy"
-    }
-    ```
-
-11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/reddit-commenter.md
+++ b/playbooks/reddit-commenter.md
@@ -53,7 +53,7 @@ Write like this instead:
 
 1. **Start the run.** Call `run_start` (no arguments needed; it defaults to this session's campaign).
 
-   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform`, `campaign.config` (the strict-validated commenter profile - `targetSubreddits`, `topicKeywords`, `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `blocklist`, `contactedRecently`, `rubricTemplate`.
+   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform`, `campaign.config` (the strict-validated commenter profile - `targetSubreddits`, `topicKeywords`, `avoidKeywords`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `blocklist`, `contactedRecently`.
 
    Treat `campaign.config.systemInstructions` as additional voice & content guidance - it overrides defaults.
 
@@ -90,11 +90,9 @@ Write like this instead:
 
 7. **Pick the account.** Comments almost always use the `personal` account (brand accounts commenting on other people's posts comes off as marketing spam). Use the first account with `role === 'personal'`. Record `accountId`.
 
-8. **Score each draft.** Using `rubricTemplate` from the run context, score the comment 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted comments and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+8. **Check your own style before persisting.** Call `check_style` with the exact comment body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-9. **Check your own style before persisting.** Call `check_style` with the exact comment body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
-
-10. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+9. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
 > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
 
@@ -110,15 +108,13 @@ Each draft:
   "body": "<comment markdown>",
   "reasoning": "2-3 sentences on why this post, what angle, what value you're adding.",
   "sourceRef": { "permalink": "/r/Solo_Roleplaying/comments/abc/.../", "postTitle": "..." },
-  "metadata": { "matchedBy": "search", "postAgeHours": 8 },
-  "qualityScore": 78,
-  "qualityReason": "specific reference to their post, clear ask"
+  "metadata": { "matchedBy": "search", "postAgeHours": 8 }
 }
 ```
 
 `targetUser` is the author of the post you are replying to. Commenting on someone's post counts as contacting them, so it feeds the blocklist, the dedup window and contact history. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.permalink` points at.
 
-11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/reddit-poster.md
+++ b/playbooks/reddit-poster.md
@@ -52,7 +52,7 @@ Write like this instead:
 
 1. **Start the run.** Call `run_start` (no arguments needed).
 
-   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform`, `campaign.config` (`targetSubreddits`, `topicKeywords`, `avoidKeywords`, `postAngle`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `blocklist`, `contactedRecently`, `rubricTemplate`.
+   From the result extract `runId`, `project` (incl. `description` markdown for high-level context), `platform`, `campaign.config` (`targetSubreddits`, `topicKeywords`, `avoidKeywords`, `postAngle`, `voice`, `valuePropositions`, `productUrl`, `systemInstructions`), `accounts`, `blocklist`, `contactedRecently`.
 
 2. **Study each target subreddit.** For every subreddit in `campaign.config.targetSubreddits`, call `subreddit_snapshot` with `{ "subreddit": "<name>" }`.
    - Read the top posts of the week (titles, body excerpts, score, comment counts) from `posts`.
@@ -75,11 +75,9 @@ Write like this instead:
    - The title or body contains any term from `campaign.config.avoidKeywords`.
    - The subreddit's `rules` show explicit "no self-promotion" / "no AI-generated content" rules and the draft can't reasonably claim to be human-authored substantive content.
 
-6. **Score each draft.** Using `rubricTemplate` from the run context, score the post 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted posts and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
+6. **Check your own style before persisting.** Call `check_style` with the exact title and body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
 
-7. **Check your own style before persisting.** Call `check_style` with the exact title and body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `drafts_create` runs after this and can only record what got through.
-
-8. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
+7. **Persist drafts.** Build a JSON array, one row per surviving draft, and call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`.
 
    Each draft:
 
@@ -96,13 +94,11 @@ Write like this instead:
        "subreddit": "<sub>",
        "format": "<launch | lessons | discussion | comparison>"
      },
-     "metadata": { "subreddit": "<sub>" },
-     "qualityScore": 78,
-     "qualityReason": "specific reference to their post, clear ask"
+     "metadata": { "subreddit": "<sub>" }
    }
    ```
 
-9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
+8. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`. If anything failed irrecoverably, call it with `{ "runId": <runId>, "status": "failed", "error": "<reason>" }`.
 
 ## Hard rules
 

--- a/playbooks/reddit-scout.md
+++ b/playbooks/reddit-scout.md
@@ -50,7 +50,7 @@ Write like this instead:
 
 1. **Start the run and load context.** Call `run_start` (no arguments; it defaults to this session's campaign).
 
-   From the result extract: `runId`, `project` (includes `description` - the project's markdown briefing), `platform`, `campaign.config` (the strict-validated structured scout profile), `accounts`, `blocklist`, `contactedRecently`, `rubricTemplate`. Remember `runId` for every later call.
+   From the result extract: `runId`, `project` (includes `description` - the project's markdown briefing), `platform`, `campaign.config` (the strict-validated structured scout profile), `accounts`, `blocklist`, `contactedRecently`. Remember `runId` for every later call.
 
 2. **Fetch raw candidates.** Call `reddit_scout` with `{ "runId": <runId> }`.
 
@@ -84,9 +84,7 @@ Write like this instead:
 
 5. **Pick the account.** Use the first account from `accounts` whose `role === 'personal'`. Record its `id` as `accountId`.
 
-6. **Score each draft.** Using `rubricTemplate` from the run context, score the DM 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted DMs and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason` in the draft object.
-
-7. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`, one draft object per candidate you scored at or above the threshold.
+6. **Write drafts back.** Call `drafts_create` with `{ "runId": <runId>, "drafts": [ ... ] }`, one draft object per candidate you scored at or above the threshold.
 
    > Result: `{ runId, inserted, skipped: [{ targetUser, reason }], dedupSkipped: [...] }` - blocklisted or recently-contacted targets are skipped server-side; log them and do not retry.
 
@@ -102,13 +100,11 @@ Write like this instead:
      "body": "<DM markdown>",
      "reasoning": "2-4 sentences citing specific words from their post.",
      "sourceRef": { "permalink": "/r/rpg/comments/abc/.../" },
-     "metadata": { "matchedBy": "search" },
-     "qualityScore": 78,
-     "qualityReason": "specific reference to their post, clear ask"
+     "metadata": { "matchedBy": "search" }
    }
    ```
 
-8. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
+7. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 
 ## Hard constraints
 

--- a/playbooks/reply-drafter.md
+++ b/playbooks/reply-drafter.md
@@ -48,7 +48,7 @@ Write like this instead:
 
 ## Steps
 
-1. **Load context.** Call `reply_draft_start` (no arguments needed). From the result read: `replyKind` (`reply_dm` / `reply_comment`), `platform`, `parent` (the original outbound draft's `body` and `reasoning`, for voice), `rubricTemplate`, and `thread` (every prior turn in chronological order, `isFromUs` marking ours vs theirs).
+1. **Load context.** Call `reply_draft_start` (no arguments needed). From the result read: `replyKind` (`reply_dm` / `reply_comment`), `platform`, `parent` (the original outbound draft's `body` and `reasoning`, for voice), and `thread` (every prior turn in chronological order, `isFromUs` marking ours vs theirs).
 
 2. **Read how you actually write.** Call `operator_voice` (no arguments) for your persona and derived writing voice, and `my_prior_takes` with a short query naming the subject of this conversation, for what you have already said about it elsewhere. `parent` already anchors the voice for this one thread; these two widen that to how you actually write in general.
 
@@ -62,13 +62,11 @@ Write like this instead:
    - No placeholders, no meta commentary. Output the message text a human would send.
    - Apply the House style section above literally: it outranks every default here and holds even when the campaign voice says nothing about it.
 
-4. **Score the reply.** Using `rubricTemplate`, score the reply 0-100 on the rubric's axes. Be an honest, calibrated critic: most drafts are not 90+; reserve high scores for genuinely specific, personalized, well-targeted replies and give low scores to generic or weak ones. Include `qualityScore` (0-100 integer) and a one-line `qualityReason`.
+4. **Check your own style before persisting.** Call `check_style` with the exact reply body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `reply_draft_finish` has no live model to send a rewrite back to.
 
-5. **Check your own style before persisting.** Call `check_style` with the exact reply body you are about to submit. If it returns findings, rewrite the flagged span yourself and call `check_style` again until it comes back clean. This is the one point in the run where you can still repair a structural tell yourself - `reply_draft_finish` has no live model to send a rewrite back to.
+5. **Submit.** Call `reply_draft_finish` with `{ "body": "<your reply>" }`. It writes the body, clears the drafting flag, and marks the run success. If it returns an error, read the message, fix the payload, and try again. **Maximum two retries.**
 
-6. **Submit.** Call `reply_draft_finish` with `{ "body": "<your reply>", "qualityScore": 68, "qualityReason": "answers their question, on tone" }`. It writes the body, clears the drafting flag, and marks the run success. If it returns an error, read the message, fix the payload, and try again. **Maximum two retries.**
-
-7. **On failure.** If `reply_draft_start` errors or you genuinely cannot draft a reply, call `run_finish` with `{ "status": "failed", "error": "<short reason>" }` and stop. The placeholder stays and the reviewer sees a Retry.
+6. **On failure.** If `reply_draft_start` errors or you genuinely cannot draft a reply, call `run_finish` with `{ "status": "failed", "error": "<short reason>" }` and stop. The placeholder stays and the reviewer sees a Retry.
 
 ## What this playbook must never do
 

--- a/shared/src/ai/model-functions.ts
+++ b/shared/src/ai/model-functions.ts
@@ -10,11 +10,15 @@ import { loadGatewayCatalogue } from './gateway-catalogue.js';
 //
 // The functions are the jobs the product actually runs, not the playbooks:
 // several playbooks draft a message and want the same model, and a job with no
-// model call of its own does not get a knob. Judging quality is the deliberate
-// omission: the rubric is evaluated inside the drafting run rather than by a
-// call of its own (`shared/src/quality-judge.ts` loads a rubric and never
-// reaches a model), so a `quality_judge` entry would be a setting nobody reads.
-// It earns one when it earns a model call.
+// model call of its own does not get a knob. `quality_judge` (LOR-229) is the
+// opposite of the deliberate omission this comment used to describe: judging
+// a draft's quality now DOES earn a model call, but only when an admin has
+// explicitly configured one here - `shared/src/quality-judge.ts` checks
+// `loadModelFunctionConfig` directly (never `resolveFunctionModel`, which
+// would fall back to `defaultModelId` below) so an unconfigured deployment
+// never dials out on a path metered by draft volume. The deterministic part
+// of the score (style findings + the operator's own measured voice profile)
+// still needs no model at all.
 
 export const MODEL_FUNCTIONS = [
   'campaign_draft',
@@ -23,6 +27,7 @@ export const MODEL_FUNCTIONS = [
   'project_extract',
   'project_insights',
   'skill_generate',
+  'quality_judge',
 ] as const;
 
 export type ModelFunction = (typeof MODEL_FUNCTIONS)[number];
@@ -84,6 +89,13 @@ export const MODEL_FUNCTION_META: readonly ModelFunctionMeta[] = [
     label: 'Generating a campaign profile',
     description:
       'Writing a campaign profile from a project and a scenario, which then has to validate against that scenario schema.',
+    defaultModelId: FAST_DEFAULT,
+  },
+  {
+    fn: 'quality_judge',
+    label: 'Judging a draft\u2019s quality',
+    description:
+      'An optional second opinion on a drafted reply: a real model reads it against the quality rubric and returns its own score, alongside (never instead of) the deterministic score every draft already gets from the style checker and the operator\u2019s own measured voice. Off by default - it only runs once a model is set here, since it is a per-draft cost on a path billed by volume.',
     defaultModelId: FAST_DEFAULT,
   },
 ];

--- a/shared/src/quality-judge.ts
+++ b/shared/src/quality-judge.ts
@@ -1,12 +1,66 @@
-// LLM-judge quality scoring for drafts (issue #41).
+// Draft quality scoring (issue #41, reworked by LOR-229).
 //
-// This module owns the rubric config (loaded from app_config.quality_rubric)
-// and the UI band mapping (`scoreBand`). The actual scoring call happens
-// inline at draft creation time, not here; see `createDrafts` for the runner
-// invocation that consumes `loadQualityRubric` and persists the result.
+// Before LOR-229 this module held only a rubric template and a band mapping;
+// the number itself was whatever the drafting agent chose to report about
+// its own output (`cli/src/commands/drafts.ts`'s old `qualityScore` input),
+// with no gate behind it - self-graded homework, on a rubric (clarity,
+// relevance, personalization, tone) that never measured the thing that
+// actually loses the sale: reading as machine-written.
+//
+// The score is now computed here, in two parts that are never confused with
+// each other:
+//
+//   - A deterministic component (`computeDeterministicQuality`), derived from
+//     `shared/src/style-check.ts` and the operator's own measured voice
+//     corpus (`shared/src/operator-voice-profile.ts` / LOR-227). No model
+//     call, no configuration required, and reproducible: the same body
+//     against the same corpus always scores the same. A non-zero style
+//     finding count caps the result outright - it can never read as green,
+//     regardless of anything else measured. An axis the corpus has not
+//     earned an opinion on (too thin, or the candidate itself is too short
+//     to read a register off) is excluded from the average, never treated as
+//     a match or a miss - the same discipline `voice-metrics.ts` (LOR-44)
+//     and `voice-profile.ts` (#571) already apply.
+//   - An optional judged component (`judgeQuality`): a real, separate model
+//     call reading the draft against `rubric_template` and returning its own
+//     score and reason. Off unless an admin has explicitly configured a
+//     model for the `quality_judge` function
+//     (`shared/src/ai/model-functions.ts`) - this checks the raw stored
+//     config, never `resolveFunctionModel`'s coded-default fallback, so an
+//     unconfigured deployment never dials out on a path billed by draft
+//     volume. Absent, not zero, when it does not run: a missing judge must
+//     never drag the score down.
+//
+// `scoreDraftQuality` combines the two into what actually gets persisted:
+// the judged score when one was made, else the deterministic one, always
+// still subject to the style-finding cap. `qualityModel` records which kind
+// of number it is - the literal string `DETERMINISTIC_QUALITY_MODEL` or the
+// judge's real model id - so a caller (the Inbox badge) can always tell.
 import { eq } from 'drizzle-orm';
+import { generateText } from 'ai';
+import { createGateway } from '@ai-sdk/gateway';
+import { z } from 'zod';
 import type { Db } from './db/client.js';
 import { appConfig } from './db/schema.js';
+import { loadModelFunctionConfig } from './ai/model-functions.js';
+import { resolveOperatorVoiceProfile } from './operator-voice-profile.js';
+import {
+  measureOneText,
+  AVOIDED_WORDS_MIN_WORDS,
+  type RhythmProfile,
+  type PunctuationProfile,
+  type ShapeProfile,
+  type VoiceMarkerProfile,
+  type LexiconProfile,
+} from './assist/voice-profile.js';
+import {
+  rhythmDistance,
+  punctuationDistance,
+  shapeDistance,
+  voiceMarkersDistance,
+  lexiconDistance,
+} from './voice-metrics.js';
+import type { StyleFinding } from './style-check.js';
 
 export interface QualityRubric {
   rubric_template: string;
@@ -14,9 +68,15 @@ export interface QualityRubric {
   threshold_green: number;
 }
 
+// The pre-LOR-229 default, kept only so `loadQualityRubric` can recognize a
+// stored row that is really just the old default rather than a genuine
+// customization (see its own comment below) - never used as a live rubric.
+const LEGACY_DEFAULT_RUBRIC_TEMPLATE =
+  'Score the following outreach draft from 0-100 on these axes (clarity, relevance, personalization, tone). Return JSON {"score": number, "reason": string}.';
+
 export const DEFAULT_QUALITY_RUBRIC: QualityRubric = {
   rubric_template:
-    'Score the following outreach draft from 0-100 on these axes (clarity, relevance, personalization, tone). Return JSON {"score": number, "reason": string}.',
+    'Score this draft from 0-100 on whether it reads as something a real person actually wrote and sent, not a generic AI reply. Weigh: would a reader take this for a person rather than a bot; does it say one concrete thing rather than vague encouragement; does it answer this specific post rather than any post on the same subject; and is it roughly the length a real reply in this room runs, not a small essay. Return JSON {"score": number, "reason": string}.',
   threshold_red: 40,
   threshold_green: 75,
 };
@@ -25,11 +85,18 @@ export async function loadQualityRubric(db: Db): Promise<QualityRubric> {
   const [row] = await db.select().from(appConfig).where(eq(appConfig.key, 'quality_rubric'));
   if (!row) return { ...DEFAULT_QUALITY_RUBRIC };
   const v = row.value as Partial<QualityRubric>;
+  const stored = typeof v.rubric_template === 'string' ? v.rubric_template : undefined;
+  // A row already on file carrying the OLD default verbatim is not a real
+  // customization to preserve - it's every deployment that never touched
+  // the setting, migrated forward to the new wording rather than frozen on
+  // a rubric that scored the wrong thing. Anything else stored is a real
+  // choice and survives untouched.
+  const rubric_template =
+    stored && stored !== LEGACY_DEFAULT_RUBRIC_TEMPLATE
+      ? stored
+      : DEFAULT_QUALITY_RUBRIC.rubric_template;
   return {
-    rubric_template:
-      typeof v.rubric_template === 'string'
-        ? v.rubric_template
-        : DEFAULT_QUALITY_RUBRIC.rubric_template,
+    rubric_template,
     threshold_red:
       typeof v.threshold_red === 'number' ? v.threshold_red : DEFAULT_QUALITY_RUBRIC.threshold_red,
     threshold_green:
@@ -48,4 +115,294 @@ export function scoreBand(
   if (score < rubric.threshold_red) return 'red';
   if (score >= rubric.threshold_green) return 'green';
   return 'amber';
+}
+
+// ---------------------------------------------------------------------------
+// The deterministic component.
+// ---------------------------------------------------------------------------
+
+/** The operator's own pooled voice profile, in the shape the per-axis
+ * distance functions need - a subset of `OperatorVoiceProfileRow.evidence`
+ * (`operator-voice-profile.ts`, LOR-227), read-only from here. */
+export interface OperatorCorpusProfile {
+  rhythm: RhythmProfile;
+  punctuation: PunctuationProfile;
+  shape: ShapeProfile;
+  voiceMarkers: VoiceMarkerProfile;
+  lexicon: LexiconProfile;
+}
+
+/** The operator's corpus profile, or `null` when it has not cleared
+ * `MIN_ITEMS_TO_DERIVE` yet (`resolveOperatorVoiceProfile`'s own honest
+ * gate) - never a default profile standing in for a measurement, the same
+ * rule #571 applies everywhere else this data is read. */
+export async function resolveOperatorCorpusProfile(
+  db: Db,
+  organizationId: number,
+): Promise<OperatorCorpusProfile | null> {
+  const resolved = await resolveOperatorVoiceProfile(db, organizationId);
+  if (resolved.status !== 'measured' || !resolved.measured) return null;
+  const { rhythm, punctuation, shape, voiceMarkers, lexicon } = resolved.measured.evidence;
+  return { rhythm, punctuation, shape, voiceMarkers, lexicon };
+}
+
+export type QualityAxisScore = number | null;
+
+export interface DeterministicQualityAxes {
+  rhythm: QualityAxisScore;
+  punctuation: QualityAxisScore;
+  shape: QualityAxisScore;
+  voiceMarkers: QualityAxisScore;
+  lexicon: QualityAxisScore;
+  /** Distance derived from `lengthRatio`: `min(1, abs(ratio - 1))`, the same
+   * capped-at-1 idiom every other numeric axis in `voice-metrics.ts` uses. */
+  length: QualityAxisScore;
+}
+
+export interface DeterministicQualityDetail {
+  /** `null` only when literally nothing was measurable: no style findings
+   * and no axis cleared its own floor (a thin or absent operator corpus).
+   * Never a guessed number standing in for "unmeasured". */
+  score: number | null;
+  styleFindingCount: number;
+  distance: DeterministicQualityAxes;
+  /** Candidate word count divided by the operator's own corpus median item
+   * length (`rhythm.medianItemWords`, LOR-232) - `null` when the corpus is
+   * not measured or has never derived a length. */
+  lengthRatio: number | null;
+  candidateWordCount: number;
+  /** How many of the 6 axes above actually contributed to `score`. */
+  measuredAxisCount: number;
+  corpusMeasured: boolean;
+}
+
+/**
+ * The deterministic half of a draft's quality score: style findings (a hard
+ * cap, never averaged away) plus per-axis stylometric distance and length
+ * against the operator's own measured voice corpus. Pure and synchronous -
+ * no model, no I/O - so it is reproducible across two runs on the same body
+ * and the same corpus, and unit-testable without a database.
+ */
+export function computeDeterministicQuality(args: {
+  body: string;
+  styleFindings: StyleFinding[];
+  corpus: OperatorCorpusProfile | null;
+  rubric: QualityRubric;
+}): DeterministicQualityDetail {
+  const { body, styleFindings, corpus, rubric } = args;
+  const candidateM = measureOneText(body);
+
+  // Rhythm/punctuation/shape/voiceMarkers all need the candidate to
+  // individually clear register.ts's own floor - the same gate
+  // `voice-metrics.ts`'s `distanceAxes` applies to a candidate-vs-reply
+  // comparison, applied here to a candidate-vs-corpus one instead.
+  const structuralMeasurable = corpus !== null && candidateM.register !== null;
+  const lexiconMeasurable = corpus !== null && candidateM.wordCount >= AVOIDED_WORDS_MIN_WORDS;
+
+  const distance: DeterministicQualityAxes = {
+    rhythm: structuralMeasurable ? rhythmDistance(candidateM.rhythm, corpus.rhythm) : null,
+    punctuation: structuralMeasurable
+      ? punctuationDistance(candidateM.punctuation, corpus.punctuation)
+      : null,
+    shape: structuralMeasurable ? shapeDistance(candidateM.shape, corpus.shape) : null,
+    voiceMarkers: structuralMeasurable
+      ? voiceMarkersDistance(candidateM.voiceMarkers, corpus.voiceMarkers)
+      : null,
+    lexicon: lexiconMeasurable ? lexiconDistance(candidateM.lexicon, corpus!.lexicon) : null,
+    length: null,
+  };
+
+  let lengthRatio: number | null = null;
+  if (corpus !== null && corpus.rhythm.medianItemWords > 0) {
+    lengthRatio = Math.round((candidateM.wordCount / corpus.rhythm.medianItemWords) * 100) / 100;
+    distance.length = Math.min(1, Math.abs(lengthRatio - 1));
+  }
+
+  const measured = Object.values(distance).filter((d): d is number => d !== null);
+  const axisScore =
+    measured.length > 0
+      ? 100 * (1 - measured.reduce((sum, v) => sum + v, 0) / measured.length)
+      : null;
+
+  let score = axisScore;
+  if (styleFindings.length > 0) {
+    // "Caps the score outright" (LOR-229): a finding can only ever pull the
+    // score down toward - or below - just-under-green, never leave it
+    // untouched. Applies even when no axis was otherwise measurable, so a
+    // draft with real findings and a thin operator corpus still reports a
+    // real, non-null, non-green number rather than "not measured".
+    const cap = rubric.threshold_green - 1;
+    score = score === null ? cap : Math.min(score, cap);
+  }
+
+  return {
+    score: score === null ? null : Math.round(Math.max(0, Math.min(100, score)) * 100) / 100,
+    styleFindingCount: styleFindings.length,
+    distance,
+    lengthRatio,
+    candidateWordCount: candidateM.wordCount,
+    measuredAxisCount: measured.length,
+    corpusMeasured: corpus !== null,
+  };
+}
+
+function describeDeterministic(d: DeterministicQualityDetail): string | null {
+  if (d.score == null) return null;
+  const parts: string[] = [];
+  if (d.styleFindingCount > 0) {
+    parts.push(
+      `${d.styleFindingCount} style ${d.styleFindingCount === 1 ? 'finding' : 'findings'}`,
+    );
+  }
+  if (d.lengthRatio != null) {
+    parts.push(`${d.lengthRatio}x the operator's typical length`);
+  }
+  if (d.measuredAxisCount > 0) {
+    parts.push(
+      `${d.measuredAxisCount} voice ${d.measuredAxisCount === 1 ? 'axis' : 'axes'} measured against their own writing`,
+    );
+  }
+  return parts.length > 0 ? parts.join('; ') : 'No comparable operator voice profile yet.';
+}
+
+// ---------------------------------------------------------------------------
+// The optional judged component.
+// ---------------------------------------------------------------------------
+
+export interface JudgedQuality {
+  score: number;
+  reason: string;
+  /** The Gateway model id that produced this - what an admin configured for
+   * `quality_judge`, verbatim, so a caller can show whose opinion this is. */
+  model: string;
+}
+
+const JUDGE_PROMPT_MAX_BODY_CHARS = 4000;
+
+function buildJudgePrompt(rubric: QualityRubric, body: string, title?: string | null): string {
+  const parts = [rubric.rubric_template];
+  if (title) parts.push(`Title: ${title}`);
+  parts.push(`Draft:\n${body.slice(0, JUDGE_PROMPT_MAX_BODY_CHARS)}`);
+  return parts.join('\n\n');
+}
+
+const JudgeResponseSchema = z.object({ score: z.number(), reason: z.string() });
+
+function parseJudgeResponse(text: string): { score: number; reason: string } | null {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    return JudgeResponseSchema.parse(JSON.parse(match[0]));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A real, separate model call judging one draft, or `null` when it did not
+ * run - absent, never zero. Gated on the raw `model_functions` config
+ * (`config.quality_judge`) rather than `resolveFunctionModel`'s
+ * coded-default fallback: this must be OFF unless a deployment explicitly
+ * opted in, since it is a per-draft Gateway call on a path billed by draft
+ * volume. Never throws: a bad response, a missing Gateway key, or a
+ * transient provider error all read as "no judge", exactly like a self-
+ * report used to be lenient about a bad score - one judge failure must
+ * never fail the draft batch it is scoring.
+ */
+export async function judgeQuality(
+  db: Db,
+  args: { body: string; title?: string | null; rubric: QualityRubric },
+): Promise<JudgedQuality | null> {
+  const config = await loadModelFunctionConfig(db);
+  const modelId = config.quality_judge;
+  if (!modelId) return null;
+  const apiKey = process.env.AI_GATEWAY_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const gateway = createGateway({ apiKey });
+    const result = await generateText({
+      model: gateway(modelId),
+      messages: [{ role: 'user', content: buildJudgePrompt(args.rubric, args.body, args.title) }],
+    });
+    const parsed = parseJudgeResponse(result.text);
+    if (!parsed || !Number.isFinite(parsed.score)) return null;
+    return {
+      score: Math.max(0, Math.min(100, Math.round(parsed.score))),
+      reason: parsed.reason.slice(0, 300),
+      model: modelId,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Combining the two into what gets persisted.
+// ---------------------------------------------------------------------------
+
+/** `drafts.quality_model`'s sentinel for "computed, not judged" - as real a
+ * value as an actual Gateway model id, never confused with one (no `/` in
+ * it, unlike every Gateway id). */
+export const DETERMINISTIC_QUALITY_MODEL = 'deterministic';
+
+export interface DraftQualityResult {
+  qualityScore: number | null;
+  qualityReason: string | null;
+  qualityModel: string | null;
+  /** Persisted verbatim into the draft's `metadata.qualityDetail` - the
+   * per-axis detail neither `qualityScore` nor `qualityReason` alone carry,
+   * and what lets a caller (or a test) tell a deterministic-only result from
+   * a judged one without re-deriving anything. */
+  qualityDetail: { deterministic: DeterministicQualityDetail; judged: JudgedQuality | null };
+}
+
+/**
+ * Scores one draft body: the deterministic component always, the judged
+ * component when configured. The judged score is what gets shown when
+ * present (a real, separate opinion is worth more than a computed proxy for
+ * it), but the style-finding cap still applies on top of it - "a draft with
+ * style findings can never score green" holds regardless of whether a judge
+ * ran.
+ */
+export async function scoreDraftQuality(
+  db: Db,
+  args: {
+    body: string;
+    title?: string | null;
+    styleFindings: StyleFinding[];
+    corpus: OperatorCorpusProfile | null;
+    rubric: QualityRubric;
+  },
+): Promise<DraftQualityResult> {
+  const deterministic = computeDeterministicQuality({
+    body: args.body,
+    styleFindings: args.styleFindings,
+    corpus: args.corpus,
+    rubric: args.rubric,
+  });
+  const judged = await judgeQuality(db, {
+    body: args.body,
+    title: args.title,
+    rubric: args.rubric,
+  });
+
+  let qualityScore = judged ? judged.score : deterministic.score;
+  if (args.styleFindings.length > 0) {
+    const cap = args.rubric.threshold_green - 1;
+    qualityScore = qualityScore == null ? cap : Math.min(qualityScore, cap);
+  }
+
+  const qualityReason = judged ? judged.reason : describeDeterministic(deterministic);
+  const qualityModel = judged
+    ? judged.model
+    : qualityScore != null
+      ? DETERMINISTIC_QUALITY_MODEL
+      : null;
+
+  return {
+    qualityScore,
+    qualityReason,
+    qualityModel,
+    qualityDetail: { deterministic, judged },
+  };
 }

--- a/shared/src/voice-metrics.ts
+++ b/shared/src/voice-metrics.ts
@@ -163,7 +163,12 @@ function setDistance(a: string[], b: string[]): number {
   return union === 0 ? 0 : round2(1 - intersection / union);
 }
 
-function rhythmDistance(a: RhythmProfile, b: RhythmProfile): number {
+/** Exported (LOR-229) so a caller comparing a candidate against something
+ * other than a single real reply - the operator's own pooled corpus
+ * profile, which shares this exact per-axis shape - can reuse this math
+ * instead of a second copy of it. `distanceAxes` below is still the one
+ * candidate-vs-real-reply entry point `scoreCandidate` uses. */
+export function rhythmDistance(a: RhythmProfile, b: RhythmProfile): number {
   return round2(
     mean([
       numDist(a.medianSentenceWords, b.medianSentenceWords, 20),
@@ -175,7 +180,7 @@ function rhythmDistance(a: RhythmProfile, b: RhythmProfile): number {
   );
 }
 
-function punctuationDistance(a: PunctuationProfile, b: PunctuationProfile): number {
+export function punctuationDistance(a: PunctuationProfile, b: PunctuationProfile): number {
   return round2(
     mean([
       numDist(a.commasPer100Words, b.commasPer100Words, 10),
@@ -191,7 +196,7 @@ function punctuationDistance(a: PunctuationProfile, b: PunctuationProfile): numb
   );
 }
 
-function shapeDistance(a: ShapeProfile, b: ShapeProfile): number {
+export function shapeDistance(a: ShapeProfile, b: ShapeProfile): number {
   // emoji/hashtags are deliberately not compared here: measureOneText always
   // computes them over a one-item list, and voice-profile.ts's own
   // MIN_PHRASE_REPEATS floor (2 separate items) means a single text can
@@ -206,7 +211,7 @@ function shapeDistance(a: ShapeProfile, b: ShapeProfile): number {
   );
 }
 
-function voiceMarkersDistance(a: VoiceMarkerProfile, b: VoiceMarkerProfile): number {
+export function voiceMarkersDistance(a: VoiceMarkerProfile, b: VoiceMarkerProfile): number {
   return round2(
     mean([
       numDist(a.firstPersonPer100Words, b.firstPersonPer100Words, 10),
@@ -218,7 +223,7 @@ function voiceMarkersDistance(a: VoiceMarkerProfile, b: VoiceMarkerProfile): num
   );
 }
 
-function lexiconDistance(a: LexiconProfile, b: LexiconProfile): number {
+export function lexiconDistance(a: LexiconProfile, b: LexiconProfile): number {
   return setDistance(a.avoidedWords, b.avoidedWords);
 }
 

--- a/shared/tests/model-functions.test.ts
+++ b/shared/tests/model-functions.test.ts
@@ -109,4 +109,19 @@ describe('model function configuration', () => {
     // running, so it takes the drafting model rather than failing the run.
     expect(modelFunctionForPlaybook('some-future-playbook')).toBe('campaign_draft');
   });
+
+  it('quality_judge stays unconfigured by default (LOR-229): the raw config, not the resolved default, is what gates the judge call', async () => {
+    const db = getDb();
+    const config = await loadModelFunctionConfig(db);
+    expect(config.quality_judge).toBeNull();
+    // `resolveFunctionModel` still falls back to a coded default like every
+    // other function - `quality-judge.ts` deliberately never calls it for
+    // this one, reading `loadModelFunctionConfig` directly instead, since a
+    // resolved default would make the judge run on every deployment.
+    expect(await resolveFunctionModel(db, 'quality_judge')).toBe(
+      defaultModelForFunction('quality_judge'),
+    );
+    await saveModelFunctionModel(db, 'quality_judge', 'openai/gpt-5-mini');
+    expect((await loadModelFunctionConfig(db)).quality_judge).toBe('openai/gpt-5-mini');
+  });
 });

--- a/shared/tests/quality-judge.test.ts
+++ b/shared/tests/quality-judge.test.ts
@@ -1,11 +1,205 @@
-import { describe, it, expect } from 'vitest';
-import { scoreBand, DEFAULT_QUALITY_RUBRIC } from '../src/quality-judge.js';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getDb } from '../src/db/client.js';
+import { appConfig } from '../src/db/schema.js';
+import {
+  scoreBand,
+  DEFAULT_QUALITY_RUBRIC,
+  loadQualityRubric,
+  computeDeterministicQuality,
+  DETERMINISTIC_QUALITY_MODEL,
+  type OperatorCorpusProfile,
+} from '../src/quality-judge.js';
+import { measureOneText } from '../src/assist/voice-profile.js';
+import { checkStyle } from '../src/style-check.js';
+
+// LOR-229: the measurement that justifies this issue - across 27 real cases,
+// every quality signal the product had passed the defect that actually loses
+// the sale (a suggestion running 17x the real reply's length, and a style
+// checker reporting zero findings on all of them). The tests below defend
+// exactly the two properties that make that impossible now: a style finding
+// always caps the score below green, and an axis the module cannot measure
+// is excluded rather than counted as a match.
+
+async function resetRubric() {
+  await getDb().execute(sql`DELETE FROM app_config WHERE key = 'quality_rubric'`);
+}
+
+// A real, longish piece of writing so `measureOneText` clears every floor
+// (register.ts's own word-count floor, and AVOIDED_WORDS_MIN_WORDS for the
+// lexicon axis) - built from `computeDeterministicQuality`'s own axes, not a
+// second implementation, so the fixture is honest evidence rather than a
+// hand-tuned number.
+const LONG_OPERATOR_SAMPLE = Array.from(
+  { length: 40 },
+  (_, i) =>
+    `This is sentence number ${i} about the project, written the way I actually talk to people who ask questions.`,
+).join(' ');
+
+function corpusFrom(text: string): OperatorCorpusProfile {
+  const m = measureOneText(text);
+  return {
+    rhythm: m.rhythm,
+    punctuation: m.punctuation,
+    shape: m.shape,
+    voiceMarkers: m.voiceMarkers,
+    lexicon: m.lexicon,
+  };
+}
 
 describe('quality-judge', () => {
-  it('maps scores to UI bands using rubric thresholds', () => {
-    expect(scoreBand(null, DEFAULT_QUALITY_RUBRIC)).toBe('none');
-    expect(scoreBand(20, DEFAULT_QUALITY_RUBRIC)).toBe('red');
-    expect(scoreBand(50, DEFAULT_QUALITY_RUBRIC)).toBe('amber');
-    expect(scoreBand(90, DEFAULT_QUALITY_RUBRIC)).toBe('green');
+  describe('scoreBand', () => {
+    it('maps scores to UI bands using rubric thresholds', () => {
+      expect(scoreBand(null, DEFAULT_QUALITY_RUBRIC)).toBe('none');
+      expect(scoreBand(20, DEFAULT_QUALITY_RUBRIC)).toBe('red');
+      expect(scoreBand(50, DEFAULT_QUALITY_RUBRIC)).toBe('amber');
+      expect(scoreBand(90, DEFAULT_QUALITY_RUBRIC)).toBe('green');
+    });
+  });
+
+  describe('loadQualityRubric', () => {
+    beforeEach(resetRubric);
+
+    it('returns the default when nothing is configured', async () => {
+      const rubric = await loadQualityRubric(getDb());
+      expect(rubric).toEqual(DEFAULT_QUALITY_RUBRIC);
+    });
+
+    it('preserves a real customization untouched', async () => {
+      await getDb()
+        .insert(appConfig)
+        .values({
+          key: 'quality_rubric',
+          value: { rubric_template: 'Score for our house voice.' },
+        });
+      const rubric = await loadQualityRubric(getDb());
+      expect(rubric.rubric_template).toBe('Score for our house voice.');
+    });
+
+    it('migrates a stored row carrying the literal old (pre-LOR-229) default to the new wording, rather than freezing it', async () => {
+      const oldDefault =
+        'Score the following outreach draft from 0-100 on these axes (clarity, relevance, personalization, tone). Return JSON {"score": number, "reason": string}.';
+      await getDb()
+        .insert(appConfig)
+        .values({
+          key: 'quality_rubric',
+          value: { rubric_template: oldDefault, threshold_red: 30 },
+        });
+      const rubric = await loadQualityRubric(getDb());
+      expect(rubric.rubric_template).toBe(DEFAULT_QUALITY_RUBRIC.rubric_template);
+      expect(rubric.rubric_template).not.toBe(oldDefault);
+      // A real customization elsewhere in the same row survives.
+      expect(rubric.threshold_red).toBe(30);
+    });
+  });
+
+  describe('computeDeterministicQuality', () => {
+    it('reports null - not a guessed number - when nothing is measurable at all', () => {
+      const result = computeDeterministicQuality({
+        body: 'hey, thanks for sharing this',
+        styleFindings: [],
+        corpus: null,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+      });
+      expect(result.score).toBeNull();
+      expect(result.measuredAxisCount).toBe(0);
+      expect(result.corpusMeasured).toBe(false);
+    });
+
+    it('a non-zero style finding count caps the score below green outright, even with no comparable corpus', () => {
+      const body = "In today's fast-paced world, it's worth noting the update shipped.";
+      const findings = checkStyle(body);
+      expect(findings.length).toBeGreaterThan(0);
+      const result = computeDeterministicQuality({
+        body,
+        styleFindings: findings,
+        corpus: null,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+      });
+      expect(result.score).not.toBeNull();
+      expect(result.score as number).toBeLessThan(DEFAULT_QUALITY_RUBRIC.threshold_green);
+      expect(scoreBand(result.score, DEFAULT_QUALITY_RUBRIC)).not.toBe('green');
+    });
+
+    it('the style-finding cap holds even when the measured axes alone would otherwise read as a perfect match', () => {
+      const corpus = corpusFrom(LONG_OPERATOR_SAMPLE);
+      // The candidate IS the corpus sample, so axis distance is ~0 - the
+      // best possible case for anything other than style findings.
+      const clean = computeDeterministicQuality({
+        body: LONG_OPERATOR_SAMPLE,
+        styleFindings: [],
+        corpus,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+      });
+      expect(clean.score).not.toBeNull();
+      expect(scoreBand(clean.score, DEFAULT_QUALITY_RUBRIC)).toBe('green');
+
+      const withFinding = computeDeterministicQuality({
+        body: LONG_OPERATOR_SAMPLE,
+        styleFindings: checkStyle("in today's fast-paced world"),
+        corpus,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+      });
+      expect(withFinding.score as number).toBeLessThan(DEFAULT_QUALITY_RUBRIC.threshold_green);
+    });
+
+    it('excludes an unmeasured axis from the average rather than counting it as a match', () => {
+      const corpus = corpusFrom(LONG_OPERATOR_SAMPLE);
+      // Too short to clear register.ts's own floor: rhythm/punctuation/shape/
+      // voiceMarkers/lexicon must all read as unmeasured, only length survives
+      // (it only needs a raw word count, not a register).
+      const short = computeDeterministicQuality({
+        body: 'ok thanks',
+        styleFindings: [],
+        corpus,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+      });
+      expect(short.distance.rhythm).toBeNull();
+      expect(short.distance.punctuation).toBeNull();
+      expect(short.distance.shape).toBeNull();
+      expect(short.distance.voiceMarkers).toBeNull();
+      expect(short.distance.lexicon).toBeNull();
+      expect(short.distance.length).not.toBeNull();
+      expect(short.measuredAxisCount).toBe(1);
+    });
+
+    it('measures the full set of axes against a corpus long enough to compare against, and length ratio above 1 means longer than typical', () => {
+      const corpus = corpusFrom(LONG_OPERATOR_SAMPLE);
+      const muchLonger = Array.from(
+        { length: 400 },
+        (_, i) =>
+          `Extra padding word number ${i} that nobody who writes short replies would ever use.`,
+      ).join(' ');
+      const result = computeDeterministicQuality({
+        body: muchLonger,
+        styleFindings: [],
+        corpus,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+      });
+      expect(result.corpusMeasured).toBe(true);
+      expect(result.lengthRatio).not.toBeNull();
+      expect(result.lengthRatio as number).toBeGreaterThan(1);
+      expect(result.measuredAxisCount).toBeGreaterThan(0);
+    });
+
+    it('is reproducible: the same body against the same corpus scores identically on two runs', () => {
+      const corpus = corpusFrom(LONG_OPERATOR_SAMPLE);
+      const args = {
+        body: 'A completely ordinary reply about the same subject, written at a normal length for once.',
+        styleFindings: [],
+        corpus,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+      };
+      const first = computeDeterministicQuality(args);
+      const second = computeDeterministicQuality(args);
+      expect(second).toEqual(first);
+    });
+  });
+
+  describe('DETERMINISTIC_QUALITY_MODEL', () => {
+    it('is a sentinel string, never mistakable for a real Gateway model id', () => {
+      expect(DETERMINISTIC_QUALITY_MODEL).toBe('deterministic');
+      expect(DETERMINISTIC_QUALITY_MODEL).not.toContain('/');
+    });
   });
 });

--- a/web/src/lib/components/DraftDetail.svelte
+++ b/web/src/lib/components/DraftDetail.svelte
@@ -20,6 +20,20 @@
 	import type { UsageByKind, QuotaLimits } from '@pitchbox/shared/quota-types';
 	import { interpretDraftPatchResponse, DraftVersionConflictError } from '$lib/utils/draft-patch-response';
 	import { parseStyleFindings, highlightStyleFindingSpans, STYLE_FINDING_SPAN_CLASS } from '$lib/utils/style-findings';
+	import {
+		scoreBand,
+		DEFAULT_QUALITY_RUBRIC,
+		DETERMINISTIC_QUALITY_MODEL,
+		type QualityRubric,
+	} from '@pitchbox/shared/quality-judge';
+
+	// scoreBand's band names are a shared-package contract (not the design
+	// registry's Tone names) - mirrors DraftListItem's own translation table.
+	const BAND_TONE: Record<'red' | 'amber' | 'green', 'rose' | 'amber' | 'emerald'> = {
+		red: 'rose',
+		amber: 'amber',
+		green: 'emerald',
+	};
 
 	type DraftEvent = {
 		id: number;
@@ -45,6 +59,9 @@
 		sentAt: string | Date | null;
 		sentContent: string | null;
 		undeliverableReason?: string | null;
+		qualityScore?: number | null;
+		qualityReason?: string | null;
+		qualityModel?: string | null;
 		regeneratingRunId?: number | null;
 		regenerationCount?: number;
 		draftingRunId?: number | null;
@@ -57,11 +74,13 @@
 		draft,
 		usage,
 		limits,
+		rubric = DEFAULT_QUALITY_RUBRIC,
 		editRequestId = $bindable(null),
 	}: {
 		draft: Draft | null;
 		usage?: UsageByKind;
 		limits?: QuotaLimits | null;
+		rubric?: QualityRubric;
 		// Set by the parent (the inbox `e` shortcut) to the id of the draft that
 		// should open its inline editor. Consumed and reset to null below.
 		editRequestId?: number | null;
@@ -390,6 +409,13 @@
 			? highlightStyleFindingSpans(draft.body, styleFindings)
 			: (draft?.body ?? ''),
 	);
+	// LOR-229: the quality score's band and provenance - a measured
+	// (deterministic) score and a judged one are different claims and never
+	// render the same way.
+	const qualityBand = $derived(draft ? scoreBand(draft.qualityScore, rubric) : 'none');
+	const isJudged = $derived(
+		!!draft && draft.qualityModel != null && draft.qualityModel !== DETERMINISTIC_QUALITY_MODEL,
+	);
 </script>
 
 {#if draft}
@@ -609,6 +635,36 @@
 							</li>
 						{/each}
 					</ul>
+				</div>
+			{/if}
+
+			<!-- LOR-229: the quality score, always distinguishing measured
+			(deterministic, no model call) from judged (a real, separate model
+			call) - these are different claims about the same draft and must
+			never look the same. -->
+			{#if qualityBand !== 'none'}
+				<div
+					class="rounded-lg border p-3 flex items-start gap-2 text-xs {TONE_BANNER_CLASS[
+						BAND_TONE[qualityBand as 'red' | 'amber' | 'green']
+					]}"
+				>
+					<span
+						class="inline-flex shrink-0 items-center rounded-sm px-1 py-0.5 text-[10px] font-semibold {TONE_CLASS[
+							BAND_TONE[qualityBand as 'red' | 'amber' | 'green']
+						]}"
+					>
+						{isJudged ? 'Judged' : 'Measured'}
+						{draft.qualityScore}
+					</span>
+					<span class="text-foreground/80">
+						{#if isJudged}
+							Scored by {draft.qualityModel}{draft.qualityReason ? `: ${draft.qualityReason}` : '.'}
+						{:else}
+							Computed from the style checker and the operator's own voice - no model call{draft.qualityReason
+								? `: ${draft.qualityReason}`
+								: '.'}
+						{/if}
+					</span>
 				</div>
 			{/if}
 

--- a/web/src/lib/components/DraftListItem.svelte
+++ b/web/src/lib/components/DraftListItem.svelte
@@ -3,7 +3,12 @@
 	import { relativeTime } from '$lib/utils/time';
 	import StatusBadge from '$lib/components/StatusBadge.svelte';
 	import { getPresenter } from '$lib/platforms/presenter';
-	import { scoreBand, DEFAULT_QUALITY_RUBRIC, type QualityRubric } from '@pitchbox/shared/quality-judge';
+	import {
+		scoreBand,
+		DEFAULT_QUALITY_RUBRIC,
+		DETERMINISTIC_QUALITY_MODEL,
+		type QualityRubric,
+	} from '@pitchbox/shared/quality-judge';
 	import { TONE_CLASS, type Tone } from '$lib/config/status-badges';
 	import { parseStyleFindings } from '$lib/utils/style-findings';
 
@@ -30,6 +35,13 @@
 		dedupWarning?: string | null;
 		undeliverableReason?: string | null;
 		qualityScore?: number | null;
+		qualityReason?: string | null;
+		// LOR-229: the literal string `DETERMINISTIC_QUALITY_MODEL` when the
+		// score is computed (no model call), or a real Gateway model id when
+		// a configured judge scored it - `null` when there is no score at
+		// all. Never rendered as the same badge as the other: a measurement
+		// and an opinion are different claims.
+		qualityModel?: string | null;
 		variantGroupId?: string | null;
 		variantLabel?: string | null;
 		scheduledSendAfter?: string | Date | null;
@@ -51,6 +63,14 @@
 
 	const presenter = $derived(getPresenter(draft.platformSlug));
 	const band = $derived(scoreBand(draft.qualityScore, rubric));
+	const isJudged = $derived(
+		draft.qualityModel != null && draft.qualityModel !== DETERMINISTIC_QUALITY_MODEL,
+	);
+	const qualityTitle = $derived(
+		isJudged
+			? `Judged by ${draft.qualityModel}${draft.qualityReason ? `: ${draft.qualityReason}` : ''}`
+			: `Measured (style checker + operator voice, no model call)${draft.qualityReason ? `: ${draft.qualityReason}` : ''}`,
+	);
 	// Mirrors DraftDetail's scheduledUntil: only a future scheduled_send_after
 	// is worth flagging - a past one no longer blocks the send.
 	const scheduledUntil = $derived.by(() => {
@@ -59,7 +79,7 @@
 		return when.getTime() > Date.now() ? when : null;
 	});
 	// D44: same rose as the "red" quality band - a reviewer flags the same
-	// way whether the LLM judge or the mechanical style checker raised it.
+	// way whether the judge or the mechanical style checker raised it.
 	const styleFindingCount = $derived(parseStyleFindings(draft.metadata).length);
 </script>
 
@@ -84,9 +104,9 @@
 			{#if band !== 'none'}
 				<span
 					class="inline-flex items-center rounded-sm px-1 py-0.5 text-[10px] font-medium {TONE_CLASS[BAND_TONE[band as 'red' | 'amber' | 'green']]}"
-					title="Quality score (LLM judge)"
+					title={qualityTitle}
 				>
-					Q{draft.qualityScore}
+					{isJudged ? 'J' : 'M'}{draft.qualityScore}
 				</span>
 			{/if}
 			{#if styleFindingCount > 0}

--- a/web/src/lib/server/inbox-query.ts
+++ b/web/src/lib/server/inbox-query.ts
@@ -245,6 +245,7 @@ export type InboxDraft = {
   scheduledSendAfter: Date | null;
   qualityScore: number | null;
   qualityReason: string | null;
+  qualityModel: string | null;
   variantGroupId: string | null;
   variantLabel: string | null;
   regenerationCount: number;
@@ -334,6 +335,7 @@ export async function queryInboxDraftsPage(
       scheduledSendAfter: schema.drafts.scheduledSendAfter,
       qualityScore: schema.drafts.qualityScore,
       qualityReason: schema.drafts.qualityReason,
+      qualityModel: schema.drafts.qualityModel,
       variantGroupId: schema.drafts.variantGroupId,
       variantLabel: schema.drafts.variantLabel,
       regenerationCount: schema.drafts.regenerationCount,

--- a/web/src/routes/inbox/+page.svelte
+++ b/web/src/routes/inbox/+page.svelte
@@ -43,6 +43,8 @@
 		targetUser: string | null;
 		fitScore: number | null;
 		qualityScore?: number | null;
+		qualityReason?: string | null;
+		qualityModel?: string | null;
 		state: string;
 		body: string;
 		composeUrl: string | null;
@@ -820,6 +822,7 @@
 			draft={selected}
 			usage={selected != null ? itemsUsage[selected.accountId] : undefined}
 			limits={selected ? (itemsQuota[selected.platformId] ?? null) : null}
+			rubric={data.qualityRubric}
 			bind:editRequestId
 		/>
 	</section>


### PR DESCRIPTION
I dropped the self-reported quality score. A drafting agent no longer scores its own output: `shared/src/quality-judge.ts` now computes a deterministic component at persistence time from the style checker (`shared/src/style-check.ts`) and the operator's own measured voice corpus (`shared/src/operator-voice-profile.ts`, LOR-227) - per-axis stylometric distance and the draft's length against the operator's own typical length, reusing `shared/src/voice-metrics.ts`'s per-axis math (LOR-44, newly exported for this). No model call, no configuration required, and reproducible: the same body against the same corpus scores the same every time. A non-zero style-finding count caps the score outright, so a draft with a real tell can never read as green. An axis the module cannot measure (a thin corpus, a candidate too short to read a register off) is excluded from the average, never counted as a match.

A second, optional component is a real judge: `shared/src/ai/model-functions.ts` gets a `quality_judge` function, off by default - it only runs once an admin explicitly configures a model for it in Settings, since it is a per-draft Gateway call on a path billed by draft volume. `quality-judge.ts` gates on the raw stored config, never the coded-default fallback, so an unconfigured deployment never dials out. When it does run, its score is what is shown, still capped by the style-finding rule; when it does not, the draft carries the literal string `deterministic` in `quality_model` rather than a real model id, so nothing downstream can mistake a measurement for an opinion.

`cli/src/commands/drafts.ts` computes this for every draft at creation (`createDrafts`, including each A/B variant separately) and at persistence time for a regenerated or reply draft (`draftRegenFinish`, `replyDraftFinish`), storing the full per-axis detail in `metadata.qualityDetail`. The self-reported `qualityScore`/`qualityReason` fields are gone from `DraftInput` and from every playbook and MCP tool that used to accept them; `cli/src/commands/run.ts` and the regen/reply start endpoints no longer hand a rubric template to the drafting agent, since scoring is no longer its job. `app_config.quality_rubric` keeps its shape; a row already carrying the literal old rubric text is migrated to the new wording in place, and a real customization is left untouched.

The Inbox distinguishes the two: `DraftListItem`'s badge reads `M<score>` for a measured draft and `J<score>` for a judged one, with a tooltip naming the source; `DraftDetail` gets a new quality panel doing the same, with the reason attached. `docs/concepts.md`'s Quality scoring section describes the mechanism as it actually works now.

No migration: everything above lives in existing columns (`drafts.quality_score/quality_reason/quality_model`, already there) or in the existing `metadata`/`app_config` jsonb columns.

Refs LOR-229.