### PR TITLE
feat(shared,web): the profile learns from the edit the human made before posting

### DIFF
--- a/shared/src/assist/context.ts
+++ b/shared/src/assist/context.ts
@@ -47,6 +47,7 @@
 import { and, asc, desc, eq, inArray } from 'drizzle-orm';
 import { schema, type Db } from '../db/client.js';
 import { loadVoiceProfile } from '../operator-voice-profile.js';
+import { describeEditSignature } from './voice-profile.js';
 
 export type PersonaExperience = {
   title?: string;
@@ -80,6 +81,12 @@ export type VoiceProfileSummary = {
    * the model the operator "usually writes with hashtags" and "closes
    * with #BuildInPublic" when writing a comment neither is true of. */
   commentSummary: string | null;
+  /** What this operator habitually cuts from a draft before posting it
+   * (LOR-227), as prose - null whenever there is nothing to say (too few
+   * edited pairs, a signature that says nothing dominant) or the operator
+   * excluded it in Settings, the same "hide this" control voice samples
+   * already have. */
+  editSignature: string | null;
 };
 
 export type ProjectBrief = {
@@ -240,6 +247,9 @@ export async function loadCompanionContext(
       ? {
           summary: voiceProfileRow.summary,
           commentSummary: voiceProfileRow.evidence.genres.comment.summary,
+          editSignature: voiceProfileRow.evidence.editSignatureExcluded
+            ? null
+            : describeEditSignature(voiceProfileRow.evidence.editSignature),
         }
       : null,
     projects: projectRows.map((p) => ({

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -207,6 +207,13 @@ const PERSONA_ABOUT_MAX = 1200;
  * post with no length contract - past this it would only mean the
  * derivation is padding rather than measuring. */
 export const VOICE_PROFILE_MAX = 500;
+/** Ceiling on the edit signature's own prose (LOR-227) - same reasoning as
+ * VOICE_PROFILE_MAX: it is generated, capped prose
+ * (`assist/voice-profile.ts`'s `describeEditSignature`), not captured text,
+ * so past this it would only mean the derivation is padding. Same size as
+ * VOICE_PROFILE_MAX for the same reason: a section this short does not need
+ * its own budget, it needs the same one. */
+export const EDIT_SIGNATURE_MAX = VOICE_PROFILE_MAX;
 /** Ceiling on a repo's README excerpt as it goes into the prompt. The cached
  * excerpt is already clamped to 1200 chars when it is fetched
  * (github-sources.ts README_EXCERPT_MAX_CHARS), a budget sized for "enough to
@@ -426,6 +433,19 @@ export function buildSuggestionPrompt(args: {
       ? 'How the operator writes when commenting, based on their own comments'
       : 'How the operator writes, based on what they have actually written';
     parts.push(`${lead}: ${clamp(voiceProfileText, VOICE_PROFILE_MAX)}`);
+  }
+
+  // What this operator reliably cuts before publishing (LOR-227), derived
+  // from accepted suggestions they edited before posting -
+  // `assist/voice-profile.ts`'s `describeEditSignature`, computed from
+  // `edited_from`/`body` pairs the same way `voiceProfileText` above is
+  // computed from the pooled corpus. Absent entirely below its own floor
+  // or when the operator excluded it in Settings (`context.ts` already
+  // resolves both to `null`) - never an empty heading.
+  if (voiceProfile?.editSignature?.trim()) {
+    parts.push(
+      `What this operator reliably cuts from a draft before posting it: ${clamp(voiceProfile.editSignature, EDIT_SIGNATURE_MAX)}`,
+    );
   }
 
   // What they are building: every project in the organization, with its own

--- a/shared/src/assist/voice-profile.ts
+++ b/shared/src/assist/voice-profile.ts
@@ -29,14 +29,51 @@
 
 import { readPostRegister, type PostRegister, type RegisterTrait } from './register.js';
 
-export type VoiceCorpusItemKind = 'voice_sample' | 'message' | 'draft' | 'template';
+export type VoiceCorpusItemKind =
+  'voice_sample' | 'message' | 'draft' | 'template' | 'accepted_suggestion';
 
 const VOICE_CORPUS_ITEM_KINDS: readonly VoiceCorpusItemKind[] = [
   'voice_sample',
   'message',
   'draft',
   'template',
+  'accepted_suggestion',
 ];
+
+/** How many times a corpus item's own text counts toward the axes below
+ * that derive a habit from repetition across items - traits, openings,
+ * closings, reused words, and every rate/spread axis (rhythm, punctuation,
+ * shape, voice markers, lexicon, language). Never applied to `itemCount`/
+ * `wordCount`/the `MIN_ITEMS_TO_DERIVE` floor itself: those describe how
+ * much material this org has actually produced, and inflating them would
+ * let two accepted suggestions pass the floor as if they were four pieces
+ * of writing.
+ *
+ * An accepted suggestion (LOR-227) is text the operator was willing to
+ * publish under their own name - stronger evidence of their voice than a
+ * private draft, a sent DM or a template nobody outside the org ever saw,
+ * all of which the operator could still walk back before anyone read them.
+ * Weighted 2x rather than pooled flat with the rest: enough to move what
+ * counts as recurring without one published post alone manufacturing a
+ * "recurring" phrase out of a corpus of otherwise-unrelated writing (it
+ * still needs a second, independently-weighted item to clear
+ * MIN_PHRASE_REPEATS/MIN_WORD_ITEM_COVERAGE below). */
+const CORPUS_KIND_WEIGHT: Record<VoiceCorpusItemKind, number> = {
+  voice_sample: 1,
+  message: 1,
+  draft: 1,
+  template: 1,
+  accepted_suggestion: 2,
+};
+
+function expandByCorpusWeight<T extends { kind: VoiceCorpusItemKind }>(items: T[]): T[] {
+  const out: T[] = [];
+  for (const item of items) {
+    const weight = CORPUS_KIND_WEIGHT[item.kind];
+    for (let i = 0; i < weight; i += 1) out.push(item);
+  }
+  return out;
+}
 
 /** The genre of a piece of writing - a post, a top-level comment or a
  * reply to a comment (LOR-223). Only `voice_sample` items carry one today
@@ -830,11 +867,20 @@ export function measureVoiceCorpus(corpus: VoiceCorpusItem[]): VoiceMeasurement 
     };
   }
 
+  // Weighted view (LOR-227): some kinds count more than once toward what
+  // counts as recurring below - see CORPUS_KIND_WEIGHT. Never rebuilt from
+  // itemCount/wordCount above, which stay the real, unweighted count of
+  // distinct pieces of writing this org has actually produced.
+  const weightedItems = expandByCorpusWeight(items);
+  const weightedTexts = weightedItems.map((i) => i.text);
+  const weightedWordLists = weightedTexts.map((t) => t.split(/\s+/u).filter(Boolean));
+  const weightedWordCount = weightedWordLists.reduce((sum, w) => sum + w.length, 0);
+
   // Register traits and sentence length need each item to individually
   // clear register.ts's own floor (MIN_WORDS_TO_DESCRIBE) - a corpus of
   // long posts and one-line drafts should not have the one-liners drag an
   // average down when they carry no measurable register of their own.
-  const registers = texts.map((t) => readPostRegister(t)).filter((r) => r !== null);
+  const registers = weightedTexts.map((t) => readPostRegister(t)).filter((r) => r !== null);
   let traits: RegisterTrait[] = [];
   let wordsPerSentence = 0;
   if (registers.length >= MIN_ITEMS_TO_DERIVE) {
@@ -858,15 +904,15 @@ export function measureVoiceCorpus(corpus: VoiceCorpusItem[]): VoiceMeasurement 
     measurable: true,
     traits,
     wordsPerSentence,
-    openings: topRepeatedPhrases(wordLists, OPENING_WORDS, false),
-    closings: topRepeatedPhrases(wordLists, CLOSING_WORDS, true),
-    commonWords: topCommonWords(wordLists),
-    rhythm: measureRhythm(texts),
-    punctuation: measurePunctuation(texts, wordCount),
-    shape: measureShape(texts, traits.includes('list-layout')),
-    voiceMarkers: measureVoiceMarkers(texts, wordCount),
-    lexicon: measureLexicon(texts.join(' '), wordCount),
-    language: measureLanguage(items),
+    openings: topRepeatedPhrases(weightedWordLists, OPENING_WORDS, false),
+    closings: topRepeatedPhrases(weightedWordLists, CLOSING_WORDS, true),
+    commonWords: topCommonWords(weightedWordLists),
+    rhythm: measureRhythm(weightedTexts),
+    punctuation: measurePunctuation(weightedTexts, weightedWordCount),
+    shape: measureShape(weightedTexts, traits.includes('list-layout')),
+    voiceMarkers: measureVoiceMarkers(weightedTexts, weightedWordCount),
+    lexicon: measureLexicon(weightedTexts.join(' '), weightedWordCount),
+    language: measureLanguage(weightedItems),
   };
 }
 
@@ -1072,4 +1118,240 @@ export function describeVoiceProfileForGenre(
   m: VoiceMeasurement,
 ): string | null {
   return describeVoiceProfile(m, GENRE_NOUN[genre]);
+}
+
+// ---------------------------------------------------------------------------
+// Edit signature (LOR-227): what habitually changes between the model's own
+// draft and what the operator actually published, when they edited before
+// accepting. `assist_accepted_suggestions.edited_from`/`.body` is the
+// strongest signal this product records and, until now, the one thing
+// nothing ever read back - a human rewrote the model's output, every
+// single time, and the profile learned nothing from the rewrite itself.
+//
+// Same discipline as everything above: countable, no model call, a named
+// floor, and an empty result rather than a guess when there is not enough
+// to say something honest - applied to a different shape of corpus (pairs,
+// not standalone pieces of writing) so it gets its own floor name
+// (MIN_EDIT_PAIRS_TO_DERIVE) even though the number is the same one:
+// two edited pairs is not a pattern, the same way two posts sharing an
+// opening word is not.
+// ---------------------------------------------------------------------------
+
+/** One accepted suggestion the operator edited before posting: the model's
+ * own draft and what they actually published. Only ever built for a
+ * suggestion where `edited_from` is present - an unedited accept says
+ * nothing about what this operator removes, and is not a pair. */
+export type EditPair = {
+  id: number;
+  draft: string;
+  final: string;
+};
+
+export type EditSignature = {
+  /** How many edit pairs this was derived from - the real count, not a
+   * weighted one; there is nothing to weight here, every pair is the same
+   * kind of evidence. */
+  pairCount: number;
+  /** False below MIN_EDIT_PAIRS_TO_DERIVE - every field below is empty/
+   * false rather than a guess. */
+  measurable: boolean;
+  /** The final text ran shorter than the draft in a dominant majority of
+   * pairs (TRAIT_DOMINANCE_RATIO of pairCount, the same threshold traits
+   * use). */
+  shortensText: boolean;
+  /** The draft's own last sentence does not survive into the final text,
+   * in the same dominant-majority sense. */
+  dropsClosingSentence: boolean;
+  /** The final text carries fewer hedge words (register.ts's own list)
+   * than the draft, dominantly. */
+  cutsHedges: boolean;
+  /** The draft's own first sentence does not survive into the final text,
+   * dominantly. */
+  dropsOpening: boolean;
+  /** The draft carried emoji the final text has fewer of, dominantly. */
+  stripsEmoji: boolean;
+  /** The draft and the final text classify to two different languages
+   * (both classified - see classifyLanguage), dominantly. */
+  changesLanguage: boolean;
+  /** Whole sentences (normalized) the operator deleted in at least
+   * MIN_PHRASE_REPEATS separate pairs - a personal ban list derived from
+   * behaviour rather than a hardcoded puffery list. A sentence deleted in
+   * only one pair names nothing here: one edit is a choice about one
+   * draft, not a habit. Capped at MAX_BANNED_PHRASES. */
+  bannedPhrases: string[];
+};
+
+export const EMPTY_EDIT_SIGNATURE: EditSignature = {
+  pairCount: 0,
+  measurable: false,
+  shortensText: false,
+  dropsClosingSentence: false,
+  cutsHedges: false,
+  dropsOpening: false,
+  stripsEmoji: false,
+  changesLanguage: false,
+  bannedPhrases: [],
+};
+
+/** Equal to MIN_ITEMS_TO_DERIVE (two edit pairs is not a pattern, the same
+ * reason two posts are not), named for what this corpus actually is - a
+ * set of edited pairs, not pieces of writing - so a reader of
+ * `measureEditSignature` never has to go check what the shared constant
+ * means for this different kind of floor. */
+export const MIN_EDIT_PAIRS_TO_DERIVE = MIN_ITEMS_TO_DERIVE;
+
+/** Same cap discipline as MAX_COMMON_WORDS: past a handful, a ban list
+ * reads as a dump of every edit ever made rather than the few phrases that
+ * actually keep coming back. */
+const MAX_BANNED_PHRASES = 5;
+
+function normalizeSentenceForCompare(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]+/gu, '')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+/** Sentences in `draft` with no normalized match anywhere among `final`'s
+ * own sentences - gone whole, not merely reworded. A lightly-edited
+ * sentence still has a near neighbor in `final` and is deliberately not
+ * counted: this looks for what disappears entirely, the same thing a
+ * personal ban list needs to name. */
+function removedSentences(draft: string, final: string): string[] {
+  const finalNormalized = new Set(splitSentences(final).map(normalizeSentenceForCompare));
+  return splitSentences(draft)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !finalNormalized.has(normalizeSentenceForCompare(s)));
+}
+
+/**
+ * Derives what this operator habitually cuts from `pairs`. Pure and
+ * synchronous - no model, no I/O, same as `measureVoiceCorpus`.
+ */
+export function measureEditSignature(pairs: EditPair[]): EditSignature {
+  const usable = pairs
+    .map((p) => ({ ...p, draft: p.draft.trim(), final: p.final.trim() }))
+    .filter((p) => p.draft && p.final && p.draft !== p.final);
+  const pairCount = usable.length;
+
+  if (pairCount < MIN_EDIT_PAIRS_TO_DERIVE) {
+    return { ...EMPTY_EDIT_SIGNATURE, pairCount };
+  }
+
+  let shortens = 0;
+  let dropsClosing = 0;
+  let cutsHedgesCount = 0;
+  let dropsOpeningCount = 0;
+  let stripsEmojiCount = 0;
+  let changesLanguageCount = 0;
+  const phraseCounts = new Map<string, { count: number; display: string }>();
+
+  for (const pair of usable) {
+    const draftWords = pair.draft.split(/\s+/u).filter(Boolean).length;
+    const finalWords = pair.final.split(/\s+/u).filter(Boolean).length;
+    if (finalWords < draftWords) shortens += 1;
+
+    const draftSentences = splitSentences(pair.draft)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const finalSentenceSet = new Set(splitSentences(pair.final).map(normalizeSentenceForCompare));
+    if (draftSentences.length > 0) {
+      const first = normalizeSentenceForCompare(draftSentences[0]!);
+      const last = normalizeSentenceForCompare(draftSentences[draftSentences.length - 1]!);
+      if (!finalSentenceSet.has(first)) dropsOpeningCount += 1;
+      if (!finalSentenceSet.has(last)) dropsClosing += 1;
+    }
+
+    const draftHedges = (pair.draft.match(HEDGE_GLOBAL) ?? []).length;
+    const finalHedges = (pair.final.match(HEDGE_GLOBAL) ?? []).length;
+    if (finalHedges < draftHedges) cutsHedgesCount += 1;
+
+    const draftEmoji = (pair.draft.match(EMOJI_GLOBAL) ?? []).length;
+    const finalEmoji = (pair.final.match(EMOJI_GLOBAL) ?? []).length;
+    if (draftEmoji > 0 && finalEmoji < draftEmoji) stripsEmojiCount += 1;
+
+    const draftLang = classifyLanguage(pair.draft);
+    const finalLang = classifyLanguage(pair.final);
+    if (draftLang !== 'unknown' && finalLang !== 'unknown' && draftLang !== finalLang) {
+      changesLanguageCount += 1;
+    }
+
+    const seenInPair = new Set<string>();
+    for (const removed of removedSentences(pair.draft, pair.final)) {
+      const key = normalizeSentenceForCompare(removed);
+      if (!key || seenInPair.has(key)) continue;
+      seenInPair.add(key);
+      const existing = phraseCounts.get(key);
+      if (existing) existing.count += 1;
+      else phraseCounts.set(key, { count: 1, display: removed });
+    }
+  }
+
+  const dominanceThreshold = pairCount * TRAIT_DOMINANCE_RATIO;
+  const bannedPhrases = [...phraseCounts.values()]
+    .filter((v) => v.count >= MIN_PHRASE_REPEATS)
+    .sort((a, b) => b.count - a.count || a.display.localeCompare(b.display))
+    .slice(0, MAX_BANNED_PHRASES)
+    .map((v) => v.display);
+
+  return {
+    pairCount,
+    measurable: true,
+    shortensText: shortens >= dominanceThreshold,
+    dropsClosingSentence: dropsClosing >= dominanceThreshold,
+    cutsHedges: cutsHedgesCount >= dominanceThreshold,
+    dropsOpening: dropsOpeningCount >= dominanceThreshold,
+    stripsEmoji: stripsEmojiCount >= dominanceThreshold,
+    changesLanguage: changesLanguageCount >= dominanceThreshold,
+    bannedPhrases,
+  };
+}
+
+/** True when `measureEditSignature` found something worth telling a model
+ * or a human about - `measurable` alone is not enough, since a corpus of
+ * edits that happens to cut nothing dominantly and repeats no phrase is
+ * measurable and still says nothing. Callers (the prompt, Settings) use
+ * this to decide whether the signature exists at all, never rendering an
+ * empty heading. */
+export function hasEditSignatureContent(s: EditSignature): boolean {
+  return (
+    s.measurable &&
+    (s.shortensText ||
+      s.dropsClosingSentence ||
+      s.cutsHedges ||
+      s.dropsOpening ||
+      s.stripsEmoji ||
+      s.changesLanguage ||
+      s.bannedPhrases.length > 0)
+  );
+}
+
+/** The edit signature as prose, for the prompt and for Settings - same
+ * split as `describeVoiceProfile` and for the same reason: the numbers can
+ * be asserted without pinning the English. Null whenever
+ * `hasEditSignatureContent` is false, which the caller renders as no
+ * section at all. */
+export function describeEditSignature(s: EditSignature): string | null {
+  if (!hasEditSignatureContent(s)) return null;
+
+  const cuts: string[] = [];
+  if (s.shortensText) cuts.push('shortens it');
+  if (s.dropsOpening) cuts.push('drops the opening line');
+  if (s.dropsClosingSentence) cuts.push('drops the closing line');
+  if (s.cutsHedges) cuts.push('cuts hedging phrases');
+  if (s.stripsEmoji) cuts.push('strips emoji');
+  if (s.changesLanguage) cuts.push('rewrites it into a different language');
+
+  const sentences: string[] = [];
+  if (cuts.length > 0) {
+    sentences.push(`Before posting a draft, this operator usually ${cuts.join(', ')}.`);
+  }
+  if (s.bannedPhrases.length > 0) {
+    sentences.push(
+      `Phrases they have deleted from a draft more than once: "${s.bannedPhrases.join('", "')}".`,
+    );
+  }
+
+  return `Based on ${s.pairCount} edited suggestions. ${sentences.join(' ')}`;
 }

--- a/shared/src/operator-voice-profile.ts
+++ b/shared/src/operator-voice-profile.ts
@@ -30,15 +30,19 @@
 
 import { and, desc, eq, isNotNull } from 'drizzle-orm';
 import { schema, type Db } from './db/client.js';
+import type { DraftKind } from './quota-types.js';
 import {
   measureVoiceCorpus,
   measureVoiceCorpusByGenre,
+  measureEditSignature,
   describeVoiceProfile,
   describeVoiceProfileForGenre,
   MIN_ITEMS_TO_DERIVE,
   VOICE_CORPUS_ITEM_GENRES,
   type VoiceCorpusItem,
   type VoiceCorpusItemGenre,
+  type EditPair,
+  type EditSignature,
   type RhythmProfile,
   type PunctuationProfile,
   type ShapeProfile,
@@ -53,6 +57,7 @@ import {
   EMPTY_VOICE_MARKERS,
   EMPTY_LEXICON,
   EMPTY_LANGUAGE,
+  EMPTY_EDIT_SIGNATURE,
 } from './assist/voice-profile.js';
 import { DEFAULT_VOICE_PROFILE, type DefaultVoiceProfile } from './assist/voice-defaults.js';
 import type { RegisterTrait } from './assist/register.js';
@@ -67,7 +72,22 @@ export type VoiceCorpusProvenance = {
   messageIds: number[];
   draftIds: number[];
   templateIds: number[];
-  counts: { voiceSamples: number; messages: number; drafts: number; templates: number };
+  /** Accepted suggestions read as corpus (LOR-227) - only those with no
+   * `edited_from` are counted here; an edited one is provenance for the
+   * edit signature instead (see `editPairIds` below), not for this axis's
+   * "posted text" evidence, to avoid double-claiming one row for two kinds
+   * of proof. */
+  acceptedSuggestionIds: number[];
+  /** `assist_accepted_suggestions` rows with `edited_from` present - what
+   * `measureEditSignature` was actually derived from. */
+  editPairIds: number[];
+  counts: {
+    voiceSamples: number;
+    messages: number;
+    drafts: number;
+    templates: number;
+    acceptedSuggestions: number;
+  };
 };
 
 /** One genre's own share of the derivation, alongside the pooled one -
@@ -104,6 +124,20 @@ export type VoiceProfileEvidence = VoiceCorpusProvenance & {
   lexicon: LexiconProfile;
   language: LanguageProfile;
   genres: Record<VoiceCorpusItemGenre, VoiceGenreSummary>;
+  /** What this operator habitually cuts before publishing a suggestion
+   * (LOR-227), derived from accepted-suggestion pairs where they edited
+   * the draft before posting. Recomputed on every real derivation, same as
+   * every axis above - stored under its own key rather than folded into
+   * one of them so a caller can reason about "how they write" and "what
+   * they cut from a draft" as two separate things. */
+  editSignature: EditSignature;
+  /** A human's own "hide this" toggle (Settings, the same exclude control
+   * voice samples already have) - deliberately NOT recomputed by a
+   * refresh: a manual exclusion is a judgement about the signature, not a
+   * measurement, so it survives every recompute the way `source: 'manual'`
+   * protects the whole summary, at the granularity of this one section
+   * instead of the whole row. */
+  editSignatureExcluded: boolean;
 };
 
 export type OperatorVoiceProfileRow = {
@@ -129,7 +163,9 @@ const EMPTY_PROVENANCE: VoiceCorpusProvenance = {
   messageIds: [],
   draftIds: [],
   templateIds: [],
-  counts: { voiceSamples: 0, messages: 0, drafts: 0, templates: 0 },
+  acceptedSuggestionIds: [],
+  editPairIds: [],
+  counts: { voiceSamples: 0, messages: 0, drafts: 0, templates: 0, acceptedSuggestions: 0 },
 };
 
 const EMPTY_GENRE_SUMMARY: VoiceGenreSummary = {
@@ -156,6 +192,8 @@ const EMPTY_EVIDENCE: VoiceProfileEvidence = {
   lexicon: EMPTY_LEXICON,
   language: EMPTY_LANGUAGE,
   genres: EMPTY_GENRE_SUMMARIES,
+  editSignature: EMPTY_EDIT_SIGNATURE,
+  editSignatureExcluded: false,
 };
 
 /** `genres` merged field-by-field against `EMPTY_GENRE_SUMMARY`, not just
@@ -189,7 +227,12 @@ function normalizeEvidence(raw: unknown): VoiceProfileEvidence {
     messageIds: r.messageIds ?? [],
     draftIds: r.draftIds ?? [],
     templateIds: r.templateIds ?? [],
-    counts: r.counts ?? EMPTY_PROVENANCE.counts,
+    acceptedSuggestionIds: r.acceptedSuggestionIds ?? [],
+    editPairIds: r.editPairIds ?? [],
+    // Merged field-by-field, not substituted whole when absent - the same
+    // reason `normalizeGenreSummaries` merges: a row from before LOR-227
+    // has a `counts` object present but missing `acceptedSuggestions`.
+    counts: { ...EMPTY_PROVENANCE.counts, ...(r.counts ?? {}) },
     rhythm: r.rhythm ?? EMPTY_RHYTHM,
     punctuation: r.punctuation ?? EMPTY_PUNCTUATION,
     shape: r.shape ?? EMPTY_SHAPE,
@@ -197,6 +240,8 @@ function normalizeEvidence(raw: unknown): VoiceProfileEvidence {
     lexicon: r.lexicon ?? EMPTY_LEXICON,
     language: r.language ?? EMPTY_LANGUAGE,
     genres: normalizeGenreSummaries(r.genres),
+    editSignature: r.editSignature ?? EMPTY_EDIT_SIGNATURE,
+    editSignatureExcluded: r.editSignatureExcluded === true,
   };
 }
 
@@ -223,19 +268,43 @@ export async function loadVoiceProfile(
   return row ? toRow(row) : null;
 }
 
+/** Maps `assist_accepted_suggestions.kind` (a `DraftKind` - only `post` and
+ * `post_comment` reach the suggest plane today, per suggest-prompt.ts's own
+ * `SuggestionKind`) onto the corpus's own genre vocabulary (LOR-223) rather
+ * than inventing a third one: a `post_comment` suggestion is a comment, a
+ * `post` suggestion is a post. Anything else has no genre, the same way a
+ * message/draft/template has none. */
+function acceptedSuggestionGenre(kind: DraftKind | string): VoiceCorpusItemGenre | undefined {
+  switch (kind) {
+    case 'post':
+      return 'post';
+    case 'post_comment':
+      return 'comment';
+    default:
+      return undefined;
+  }
+}
+
 /**
  * Every org-scoped piece of writing the derivation is allowed to read:
  * non-excluded voice samples, outbound messages, sent drafts (their
  * `sent_content` when the human edited before sending, their `body`
- * otherwise - the same fallback the send routes themselves use), and every
- * project's templates. Nothing here crosses an organization boundary: each
- * query filters on `organization_id` directly or through the row's project.
+ * otherwise - the same fallback the send routes themselves use), every
+ * project's templates, and (LOR-227) accepted suggestions - what the
+ * operator actually posted, and, for the ones they edited first, the pair
+ * `measureEditSignature` reads. Nothing here crosses an organization
+ * boundary: each query filters on `organization_id` directly or through
+ * the row's project.
  */
 async function gatherVoiceCorpus(
   db: Db,
   organizationId: number,
-): Promise<{ corpus: VoiceCorpusItem[]; evidence: VoiceCorpusProvenance }> {
-  const [sampleRows, messageRows, draftRows, templateRows] = await Promise.all([
+): Promise<{
+  corpus: VoiceCorpusItem[];
+  editPairs: EditPair[];
+  evidence: VoiceCorpusProvenance;
+}> {
+  const [sampleRows, messageRows, draftRows, templateRows, acceptedRows] = await Promise.all([
     db
       .select({
         id: schema.operatorVoiceSamples.id,
@@ -283,6 +352,17 @@ async function gatherVoiceCorpus(
       .where(eq(schema.projects.organizationId, organizationId))
       .orderBy(desc(schema.templates.updatedAt))
       .limit(MAX_CORPUS_ITEMS_PER_SOURCE),
+    db
+      .select({
+        id: schema.assistAcceptedSuggestions.id,
+        kind: schema.assistAcceptedSuggestions.kind,
+        body: schema.assistAcceptedSuggestions.body,
+        editedFrom: schema.assistAcceptedSuggestions.editedFrom,
+      })
+      .from(schema.assistAcceptedSuggestions)
+      .where(eq(schema.assistAcceptedSuggestions.organizationId, organizationId))
+      .orderBy(desc(schema.assistAcceptedSuggestions.createdAt))
+      .limit(MAX_CORPUS_ITEMS_PER_SOURCE),
   ]);
 
   const corpus: VoiceCorpusItem[] = [
@@ -295,22 +375,44 @@ async function gatherVoiceCorpus(
     ...messageRows.map((r) => ({ id: r.id, kind: 'message' as const, text: r.text })),
     ...draftRows.map((r) => ({ id: r.id, kind: 'draft' as const, text: r.sentContent ?? r.body })),
     ...templateRows.map((r) => ({ id: r.id, kind: 'template' as const, text: r.text })),
+    // Posted text outranks captured text as evidence of voice: it is what
+    // the operator was willing to publish under their own name, not merely
+    // draft, DM or template text nobody outside the org ever saw. It still
+    // does not get pooled flat with the rest - `voice-profile.ts`'s
+    // CORPUS_KIND_WEIGHT gives this kind extra weight in what counts as
+    // recurring, applied uniformly by `measureVoiceCorpus` itself.
+    ...acceptedRows.map((r) => ({
+      id: r.id,
+      kind: 'accepted_suggestion' as const,
+      genre: acceptedSuggestionGenre(r.kind),
+      text: r.body,
+    })),
   ];
+
+  // The edit half of the evidence (LOR-227): only rows the operator
+  // actually changed before posting - an unedited accept says nothing
+  // about what this operator removes, and `edited_from` is null for one.
+  const editPairs: EditPair[] = acceptedRows
+    .filter((r) => r.editedFrom != null)
+    .map((r) => ({ id: r.id, draft: r.editedFrom!, final: r.body }));
 
   const evidence: VoiceCorpusProvenance = {
     voiceSampleIds: sampleRows.map((r) => r.id),
     messageIds: messageRows.map((r) => r.id),
     draftIds: draftRows.map((r) => r.id),
     templateIds: templateRows.map((r) => r.id),
+    acceptedSuggestionIds: acceptedRows.map((r) => r.id),
+    editPairIds: editPairs.map((p) => p.id),
     counts: {
       voiceSamples: sampleRows.length,
       messages: messageRows.length,
       drafts: draftRows.length,
       templates: templateRows.length,
+      acceptedSuggestions: acceptedRows.length,
     },
   };
 
-  return { corpus, evidence };
+  return { corpus, editPairs, evidence };
 }
 
 /**
@@ -340,7 +442,7 @@ export async function refreshVoiceProfile(
     return existing;
   }
 
-  const { corpus, evidence: provenance } = await gatherVoiceCorpus(db, organizationId);
+  const { corpus, editPairs, evidence: provenance } = await gatherVoiceCorpus(db, organizationId);
   const measurement = measureVoiceCorpus(corpus);
   const summary = describeVoiceProfile(measurement) ?? '';
 
@@ -362,6 +464,11 @@ export async function refreshVoiceProfile(
     };
   }
 
+  // LOR-227: recomputed every time, same as every axis above -
+  // `editSignatureExcluded` is the one field that is not a measurement and
+  // is carried forward instead, below.
+  const editSignature = measureEditSignature(editPairs);
+
   const evidence: VoiceProfileEvidence = {
     ...provenance,
     version: (existing?.evidence.version ?? 0) + 1,
@@ -372,6 +479,8 @@ export async function refreshVoiceProfile(
     lexicon: measurement.lexicon,
     language: measurement.language,
     genres,
+    editSignature,
+    editSignatureExcluded: existing?.evidence.editSignatureExcluded ?? false,
   };
 
   const values = {
@@ -442,6 +551,37 @@ export async function resetVoiceProfileToDerived(
   return refreshVoiceProfile(db, organizationId, { overwrite: true });
 }
 
+/**
+ * Settings' exclude control for the edit signature (LOR-227), the same
+ * shape voice samples already have (`setVoiceSampleExcluded`,
+ * `operator-profile.ts`) - a human hiding a signature they think is wrong
+ * or too thin, reversibly, without waiting for or forcing a full
+ * recompute. Updates only `editSignatureExcluded`; the measured signature
+ * itself is untouched, so flipping this back on shows the same numbers a
+ * later refresh would have kept anyway.
+ *
+ * Derives a profile first when none is on file yet - the same "always
+ * returns a row" contract `saveVoiceProfileSummary` holds for a fresh org.
+ */
+export async function setEditSignatureExcluded(
+  db: Db,
+  organizationId: number,
+  excluded: boolean,
+): Promise<OperatorVoiceProfileRow> {
+  const existing =
+    (await loadVoiceProfile(db, organizationId)) ?? (await refreshVoiceProfile(db, organizationId));
+
+  const [row] = await db
+    .update(schema.operatorVoiceProfiles)
+    .set({
+      evidence: { ...existing.evidence, editSignatureExcluded: excluded },
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.operatorVoiceProfiles.organizationId, organizationId))
+    .returning();
+  return toRow(row);
+}
+
 // ---------------------------------------------------------------------------
 // #571: resolving "how the operator writes" honestly - the real measurement
 // once there is enough of it, DEFAULT_VOICE_PROFILE otherwise, always
@@ -480,6 +620,16 @@ export type ResolvedOperatorVoiceProfile = {
   version: number;
   derivedAt: string | null;
   itemCount: number;
+  /** What this operator habitually cuts before publishing (LOR-227) - the
+   * last real derivation's signature regardless of `status`, since an org
+   * can clear the edit-pair floor on accepted suggestions alone before its
+   * pooled corpus clears MIN_ITEMS_TO_DERIVE, or the other way around.
+   * `EMPTY_EDIT_SIGNATURE` when there is no row yet or a refresh has never
+   * run - never invented. */
+  editSignature: EditSignature;
+  /** The human's own exclude toggle - true hides `editSignature` from the
+   * next prompt even when it is otherwise non-empty. */
+  editSignatureExcluded: boolean;
   /** What a thin corpus still needs, e.g. "2 more pieces of their own
    * writing...". Null once `status` is 'measured'. */
   gap: string | null;
@@ -533,6 +683,8 @@ export function resolveVoiceProfile(
       version: row.evidence.version,
       derivedAt: row.derivedAt ? row.derivedAt.toISOString() : null,
       itemCount,
+      editSignature: row.evidence.editSignature,
+      editSignatureExcluded: row.evidence.editSignatureExcluded,
       gap: null,
     };
   }
@@ -547,6 +699,8 @@ export function resolveVoiceProfile(
     version: row?.evidence.version ?? 0,
     derivedAt: row?.derivedAt ? row.derivedAt.toISOString() : null,
     itemCount,
+    editSignature: row?.evidence.editSignature ?? EMPTY_EDIT_SIGNATURE,
+    editSignatureExcluded: row?.evidence.editSignatureExcluded ?? false,
     gap: describeVoiceProfileGap(itemCount),
   };
 }

--- a/shared/tests/assist-voice-profile.test.ts
+++ b/shared/tests/assist-voice-profile.test.ts
@@ -8,16 +8,22 @@ import {
   describeVoiceProfileForGenre,
   measureOneText,
   classifyLanguage,
+  measureEditSignature,
+  describeEditSignature,
+  hasEditSignatureContent,
   MIN_ITEMS_TO_DERIVE,
+  MIN_EDIT_PAIRS_TO_DERIVE,
   EMPTY_RHYTHM,
   EMPTY_PUNCTUATION,
   EMPTY_SHAPE,
   EMPTY_VOICE_MARKERS,
   EMPTY_LEXICON,
   EMPTY_LANGUAGE,
+  EMPTY_EDIT_SIGNATURE,
   type VoiceCorpusItem,
   type VoiceCorpusItemGenre,
   type VoiceMeasurement,
+  type EditPair,
 } from '../src/assist/voice-profile.js';
 
 // #407: the operator's own voice, derived from what they have actually
@@ -664,5 +670,160 @@ describe('classifyLanguage (exported for style-check.ts and voice-metrics.ts)', 
     expect(classifyLanguage('This is the plan for the week and it is going well.')).toBe('en');
     expect(classifyLanguage("che bello, non vedo l'ora!")).toBe('it');
     expect(classifyLanguage('Grande!')).toBe('unknown');
+  });
+});
+
+// LOR-227: an accepted suggestion is text the operator was willing to
+// publish, so it counts more than once toward what `measureVoiceCorpus`
+// derives - never toward itemCount/wordCount themselves, which stay the
+// real, unweighted count of distinct pieces of writing gathered.
+describe('accepted_suggestion corpus weighting (LOR-227)', () => {
+  it('a corpus with accepted suggestions produces a different profile than the same corpus without them', () => {
+    // Two 20-word voice samples and one 4-word accepted suggestion: 3 real
+    // items (clears MIN_ITEMS_TO_DERIVE), so itemCount/wordCount are exact.
+    // Weighted 2x, the accepted suggestion's 4-word length enters the
+    // median twice - [20, 20, 4, 4] medians to 12 - where pooling it flat
+    // ([20, 20, 4]) would median to 20. The two corpora below differ only
+    // in whether that one item is present at all.
+    const voiceSampleA =
+      'one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty';
+    const voiceSampleB =
+      'twenty nineteen eighteen seventeen sixteen fifteen fourteen thirteen twelve eleven ten nine eight seven six five four three two one';
+    const withoutAccepted: VoiceCorpusItem[] = [
+      { id: 1, kind: 'voice_sample', text: voiceSampleA },
+      { id: 2, kind: 'voice_sample', text: voiceSampleB },
+    ];
+    const withAccepted: VoiceCorpusItem[] = [
+      ...withoutAccepted,
+      { id: 3, kind: 'accepted_suggestion', genre: 'post', text: 'quick short update today' },
+    ];
+
+    // Below MIN_ITEMS_TO_DERIVE without the accepted suggestion - nothing
+    // to compare a "different profile" against otherwise.
+    expect(measureVoiceCorpus(withoutAccepted).measurable).toBe(false);
+
+    const measured = measureVoiceCorpus(withAccepted);
+    expect(measured.measurable).toBe(true);
+    // itemCount/wordCount are the real, unweighted counts - not inflated by
+    // the accepted suggestion's extra weight.
+    expect(measured.itemCount).toBe(3);
+    expect(measured.wordCount).toBe(44);
+    // The weighted median (12) differs from what flat pooling would have
+    // produced (20) - the observable proof the weighting is applied.
+    expect(measured.rhythm.medianItemWords).toBe(12);
+  });
+});
+
+// LOR-227: the edit signature - what an operator habitually cuts between
+// the model's own draft (`edited_from`) and what they actually posted
+// (`body`). Same discipline as measureVoiceCorpus: a floor before anything
+// is reported, and a phrase named only once it recurs across separate
+// pairs.
+describe('measureEditSignature', () => {
+  function pair(id: number, draft: string, final: string): EditPair {
+    return { id, draft, final };
+  }
+
+  it('reports nothing below MIN_EDIT_PAIRS_TO_DERIVE', () => {
+    const pairs = [
+      pair(1, 'Great question! Thanks for reading, appreciate it.', 'Thanks for reading.'),
+      pair(2, 'Great question! Nice work here.', 'Nice work here.'),
+    ];
+    expect(pairs.length).toBeLessThan(MIN_EDIT_PAIRS_TO_DERIVE);
+    const signature = measureEditSignature(pairs);
+    expect(signature).toEqual({ ...EMPTY_EDIT_SIGNATURE, pairCount: 2 });
+    expect(hasEditSignatureContent(signature)).toBe(false);
+    expect(describeEditSignature(signature)).toBeNull();
+  });
+
+  it('names a phrase deleted in two or more pairs, and nothing from a single pair', () => {
+    const pairs = [
+      pair(
+        1,
+        'Great question! I think this is really cool, thanks so much for sharing this with everyone.',
+        'Cool, thanks for sharing.',
+      ),
+      pair(
+        2,
+        'Great question! I appreciate you writing this, it truly resonates with me a lot.',
+        'This resonates with me.',
+      ),
+      // This third draft's own opener ("Nice post here") is unique to this
+      // one pair - it must not appear in bannedPhrases.
+      pair(
+        3,
+        'Nice post here, I think this is fantastic and I love reading things like this honestly.',
+        'Nice post.',
+      ),
+    ];
+    const signature = measureEditSignature(pairs);
+    expect(signature.measurable).toBe(true);
+    expect(signature.pairCount).toBe(3);
+    expect(signature.bannedPhrases).toEqual(['Great question!']);
+    expect(signature.shortensText).toBe(true);
+    expect(signature.dropsOpening).toBe(true);
+    expect(signature.dropsClosingSentence).toBe(true);
+    expect(signature.cutsHedges).toBe(true);
+    expect(describeEditSignature(signature)).toContain('"Great question!"');
+    expect(describeEditSignature(signature)).toContain('Based on 3 edited suggestions');
+  });
+
+  it('derives stripsEmoji and changesLanguage independently of the other axes', () => {
+    const emojiPairs = [
+      pair(
+        1,
+        'This is great work here honestly, love seeing it happen this way today 🎉🔥',
+        'This is great work here honestly, love seeing it happen this way today.',
+      ),
+      pair(
+        2,
+        'Nice update on the project this week, really appreciate the effort put in 🚀',
+        'Nice update on the project this week, really appreciate the effort put in.',
+      ),
+      pair(
+        3,
+        'Solid progress overall friend, keep it up because it matters a lot to us 🙌',
+        'Solid progress overall friend, keep it up because it matters a lot to us.',
+      ),
+    ];
+    const emojiSignature = measureEditSignature(emojiPairs);
+    expect(emojiSignature.stripsEmoji).toBe(true);
+    expect(emojiSignature.changesLanguage).toBe(false);
+
+    const languagePairs = [
+      pair(
+        1,
+        'This is a great update about the project and the team this week honestly.',
+        'Questo è un buon aggiornamento sul progetto di questa settimana onestamente.',
+      ),
+      pair(
+        2,
+        'The results are looking really strong for this quarter across every team.',
+        'I risultati sembrano davvero forti per questo trimestre in ogni squadra.',
+      ),
+      pair(
+        3,
+        'We shipped a new feature today that the whole team is excited about.',
+        'Abbiamo lanciato una nuova funzione oggi di cui tutto il team è entusiasta.',
+      ),
+    ];
+    const languageSignature = measureEditSignature(languagePairs);
+    expect(languageSignature.changesLanguage).toBe(true);
+    expect(languageSignature.stripsEmoji).toBe(false);
+  });
+
+  it('ignores an unedited pair (identical draft and final)', () => {
+    const pairs = [
+      pair(
+        1,
+        'Same text both times, nothing changed at all here today.',
+        'Same text both times, nothing changed at all here today.',
+      ),
+      pair(2, 'Another edited draft that becomes something shorter.', 'Something shorter.'),
+      pair(3, 'A third edited draft that also becomes shorter text.', 'Shorter text.'),
+    ];
+    // Only 2 of the 3 pairs are real edits - below the floor once the
+    // identical one is discarded.
+    expect(measureEditSignature(pairs).measurable).toBe(false);
   });
 });

--- a/shared/tests/operator-voice-profile.test.ts
+++ b/shared/tests/operator-voice-profile.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { sql, eq } from 'drizzle-orm';
 import { getDb, schema } from '../src/db/client.js';
 import { recordVoiceSamples, setVoiceSampleExcluded } from '../src/operator-profile.js';
-import { EMPTY_RHYTHM, MIN_ITEMS_TO_DERIVE } from '../src/assist/voice-profile.js';
+import {
+  EMPTY_RHYTHM,
+  EMPTY_EDIT_SIGNATURE,
+  MIN_ITEMS_TO_DERIVE,
+} from '../src/assist/voice-profile.js';
 import { DEFAULT_VOICE_PROFILE } from '../src/assist/voice-defaults.js';
 import {
   loadVoiceProfile,
@@ -10,6 +14,7 @@ import {
   saveVoiceProfileSummary,
   resetVoiceProfileToDerived,
   resolveOperatorVoiceProfile,
+  setEditSignatureExcluded,
   VOICE_AXES,
   type VoiceProfileEvidence,
 } from '../src/operator-voice-profile.js';
@@ -218,7 +223,13 @@ describe('shared/src/operator-voice-profile', () => {
     expect(row.itemCount).toBe(5);
     expect(row.summary).toContain('Just shipped');
     expect(row.summary).toContain('team');
-    expect(row.evidence.counts).toEqual({ voiceSamples: 2, messages: 1, drafts: 1, templates: 1 });
+    expect(row.evidence.counts).toEqual({
+      voiceSamples: 2,
+      messages: 1,
+      drafts: 1,
+      templates: 1,
+      acceptedSuggestions: 0,
+    });
     expect(row.evidence.voiceSampleIds).toHaveLength(2);
     expect(row.evidence.messageIds).toHaveLength(1);
     expect(row.evidence.draftIds).toHaveLength(1);
@@ -240,7 +251,13 @@ describe('shared/src/operator-voice-profile', () => {
     const rowB = await refreshVoiceProfile(getDb(), orgB);
     expect(rowB.itemCount).toBe(1);
     expect(rowB.summary).toBe('');
-    expect(rowB.evidence.counts).toEqual({ voiceSamples: 1, messages: 0, drafts: 0, templates: 0 });
+    expect(rowB.evidence.counts).toEqual({
+      voiceSamples: 1,
+      messages: 0,
+      drafts: 0,
+      templates: 0,
+      acceptedSuggestions: 0,
+    });
   });
 
   it('excluding the voice samples that carried a habit removes it from the derived profile', async () => {
@@ -593,5 +610,167 @@ describe('resolveOperatorVoiceProfile', () => {
     expect(evidence.lexicon.avoidedWords).toContain('humbled');
     expect(evidence.lexicon.avoidedWords.length).toBeGreaterThanOrEqual(10);
     expect(evidence.rhythm.medianSentenceWords).toBeGreaterThan(0);
+  });
+});
+
+/** A row in the assist plane's own ledger (`assist_accepted_suggestions`) -
+ * what accepting a suggestion writes. `kind` is a DraftKind ('post' or
+ * 'post_comment' today); `editedFrom` is the model's own draft, present
+ * only when the human changed it before posting. */
+async function makeAcceptedSuggestion(opts: {
+  organizationId: number;
+  kind: 'post' | 'post_comment';
+  body: string;
+  editedFrom?: string | null;
+}) {
+  const db = getDb();
+  await db.insert(schema.assistAcceptedSuggestions).values({
+    organizationId: opts.organizationId,
+    platformId: await platformId('linkedin'),
+    kind: opts.kind,
+    body: opts.body,
+    editedFrom: opts.editedFrom ?? null,
+    agentRunner: 'claude-code',
+  });
+}
+
+describe('accepted suggestions and the edit signature (LOR-227)', () => {
+  beforeEach(reset);
+
+  it('maps an accepted suggestion kind onto the corpus genre vocabulary (post_comment -> comment, post -> post)', async () => {
+    const orgId = await ensureOrg('vp-org-accepted-genre');
+    // Three of each kind - enough to clear MIN_ITEMS_TO_DERIVE per genre on
+    // their own, with nothing else in the corpus to attribute the genre
+    // measurement to.
+    for (let i = 0; i < 3; i += 1) {
+      await makeAcceptedSuggestion({
+        organizationId: orgId,
+        kind: 'post',
+        body: `A real published post about shipping something new today, part ${i}.`,
+      });
+      await makeAcceptedSuggestion({
+        organizationId: orgId,
+        kind: 'post_comment',
+        body: `Nice work ${i}!`,
+      });
+    }
+
+    const row = await refreshVoiceProfile(getDb(), orgId);
+    expect(row.evidence.counts.acceptedSuggestions).toBe(6);
+    expect(row.evidence.genres.post.itemCount).toBe(3);
+    expect(row.evidence.genres.post.measurable).toBe(true);
+    expect(row.evidence.genres.comment.itemCount).toBe(3);
+    expect(row.evidence.genres.comment.measurable).toBe(true);
+  });
+
+  it('a corpus with accepted suggestions produces a different profile than the same corpus without them', async () => {
+    const withoutOrg = await ensureOrg('vp-org-no-accepted');
+    const withOrg = await ensureOrg('vp-org-with-accepted');
+    const baseSamples = [
+      'Shipped a small fix today for the retry queue, seemed to help under load quite a bit honestly.',
+      'Working through a backlog of bug reports this week, slow going but steady real progress overall.',
+      'Put out a new release last night after testing thoroughly across every environment we support today.',
+    ];
+    const linkedin = await platformId('linkedin');
+    for (const org of [withoutOrg, withOrg]) {
+      for (const [i, text] of baseSamples.entries()) {
+        await recordVoiceSamples(getDb(), org, linkedin, [
+          { externalId: `sample-${org}-${i}`, text, postedAt: new Date().toISOString() },
+        ]);
+      }
+    }
+    // Only the second org gets accepted suggestions - three published posts
+    // sharing a phrase reused often enough to be counted as recurring.
+    for (let i = 0; i < 3; i += 1) {
+      await makeAcceptedSuggestion({
+        organizationId: withOrg,
+        kind: 'post',
+        body: `Big news: we just launched a redesign of the whole dashboard, part ${i} of the rollout today.`,
+      });
+    }
+
+    const without = await refreshVoiceProfile(getDb(), withoutOrg);
+    const withAccepted = await refreshVoiceProfile(getDb(), withOrg);
+    expect(without.evidence.counts.acceptedSuggestions).toBe(0);
+    expect(withAccepted.evidence.counts.acceptedSuggestions).toBe(3);
+    expect(withAccepted.itemCount).toBeGreaterThan(without.itemCount);
+    expect(withAccepted.wordCount).not.toBe(without.wordCount);
+    expect(withAccepted.openings).not.toEqual(without.openings);
+  });
+
+  it('derives an edit signature from edited accepted suggestions, and stores it separately from the measured axes', async () => {
+    const orgId = await ensureOrg('vp-org-edit-signature');
+    await makeAcceptedSuggestion({
+      organizationId: orgId,
+      kind: 'post',
+      body: 'Cool, thanks for sharing.',
+      editedFrom:
+        'Great question! I think this is really cool, thanks so much for sharing this with everyone.',
+    });
+    await makeAcceptedSuggestion({
+      organizationId: orgId,
+      kind: 'post',
+      body: 'This resonates with me.',
+      editedFrom:
+        'Great question! I appreciate you writing this, it truly resonates with me a lot.',
+    });
+    await makeAcceptedSuggestion({
+      organizationId: orgId,
+      kind: 'post',
+      body: 'Nice post.',
+      editedFrom:
+        'Nice post here, I think this is fantastic and I love reading things like this honestly.',
+    });
+
+    const row = await refreshVoiceProfile(getDb(), orgId);
+    expect(row.evidence.editSignature.measurable).toBe(true);
+    expect(row.evidence.editSignature.pairCount).toBe(3);
+    expect(row.evidence.editSignature.bannedPhrases).toEqual(['Great question!']);
+    expect(row.evidence.editSignature.shortensText).toBe(true);
+    expect(row.evidence.editSignatureExcluded).toBe(false);
+  });
+
+  it('setEditSignatureExcluded persists across a later refresh, unlike the measured signature itself', async () => {
+    const orgId = await ensureOrg('vp-org-edit-exclude');
+    for (const [body, editedFrom] of [
+      ['Cool, thanks for sharing.', 'Great question! Cool, thanks so much for sharing this.'],
+      ['This resonates with me.', 'Great question! This truly resonates with me a lot.'],
+      ['Nice post.', 'Great question! Nice post, I really loved reading this today.'],
+    ] as const) {
+      await makeAcceptedSuggestion({ organizationId: orgId, kind: 'post', body, editedFrom });
+    }
+    const derived = await refreshVoiceProfile(getDb(), orgId);
+    expect(derived.evidence.editSignatureExcluded).toBe(false);
+    expect(derived.evidence.editSignature.measurable).toBe(true);
+
+    const excluded = await setEditSignatureExcluded(getDb(), orgId, true);
+    expect(excluded.evidence.editSignatureExcluded).toBe(true);
+    // The measured signature itself is untouched by the exclude toggle.
+    expect(excluded.evidence.editSignature).toEqual(derived.evidence.editSignature);
+
+    // A later refresh recomputes the signature but carries the exclusion
+    // forward - it is a human judgement, not a measurement to overwrite.
+    const refreshedAgain = await refreshVoiceProfile(getDb(), orgId, { overwrite: true });
+    expect(refreshedAgain.evidence.editSignatureExcluded).toBe(true);
+    expect(refreshedAgain.evidence.editSignature.measurable).toBe(true);
+  });
+
+  it('resolveOperatorVoiceProfile exposes the edit signature and its exclude flag', async () => {
+    const orgId = await ensureOrg('vp-org-resolve-edit-signature');
+    const resolvedBefore = await resolveOperatorVoiceProfile(getDb(), orgId);
+    expect(resolvedBefore.editSignature).toEqual(EMPTY_EDIT_SIGNATURE);
+    expect(resolvedBefore.editSignatureExcluded).toBe(false);
+
+    for (const [body, editedFrom] of [
+      ['Cool, thanks for sharing.', 'Great question! Cool, thanks so much for sharing this.'],
+      ['This resonates with me.', 'Great question! This truly resonates with me a lot.'],
+      ['Nice post.', 'Great question! Nice post, I really loved reading this today.'],
+    ] as const) {
+      await makeAcceptedSuggestion({ organizationId: orgId, kind: 'post', body, editedFrom });
+    }
+    await refreshVoiceProfile(getDb(), orgId);
+    const resolvedAfter = await resolveOperatorVoiceProfile(getDb(), orgId);
+    expect(resolvedAfter.editSignature.measurable).toBe(true);
+    expect(resolvedAfter.editSignature.bannedPhrases).toEqual(['Great question!']);
   });
 });

--- a/shared/tests/suggest-prompt.test.ts
+++ b/shared/tests/suggest-prompt.test.ts
@@ -63,6 +63,7 @@ const voiceProfile: VoiceProfileSummary = {
   summary:
     'Based on 12 pieces of their own writing (640 words). Usually writes with short sentences, close to speech, first person, speaking as themselves, about 11 words per sentence. Often opens with "Shipped the". Reuses these words often: shipped, team, campaign.',
   commentSummary: null,
+  editSignature: null,
 };
 
 const projects: ProjectBrief[] = [
@@ -259,6 +260,7 @@ describe('buildSuggestionPrompt', () => {
           'Based on 12 pieces of their own writing (640 words). Often closes with "#BuildInPublic".',
         commentSummary:
           'Based on 27 of their own comments (190 words). Usually writes one short sentence.',
+        editSignature: null,
       };
       const commentPrompt = buildSuggestionPrompt({
         kind: 'post_comment',
@@ -297,6 +299,36 @@ describe('buildSuggestionPrompt', () => {
       });
       expect(prompt).toContain(voiceProfile.summary);
       expect(prompt).toMatch(/How the operator writes, based on what they have actually written/);
+    });
+
+    it('LOR-227: carries the edit signature as its own section when present, absent entirely when null', () => {
+      const withSignature: VoiceProfileSummary = {
+        ...voiceProfile,
+        editSignature:
+          'Based on 5 edited suggestions. Before posting a draft, this operator usually shortens it, drops the closing line. Phrases they have deleted from a draft more than once: "Great question!".',
+      };
+      const prompt = buildSuggestionPrompt({
+        kind: 'post',
+        post,
+        persona: null,
+        voiceProfile: withSignature,
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).toContain('What this operator reliably cuts from a draft before posting it');
+      expect(prompt).toContain('"Great question!"');
+
+      // null (below the derivation floor, or excluded in Settings -
+      // context.ts already resolves both to null) - no section at all.
+      const withoutSignature = buildSuggestionPrompt({
+        kind: 'post',
+        post,
+        persona: null,
+        voiceProfile: { ...voiceProfile, editSignature: null },
+        projects: [],
+        repos: [],
+      });
+      expect(withoutSignature).not.toContain('reliably cuts');
     });
 
     it('omits each section entirely, not as an empty heading, when its source is missing', () => {
@@ -374,7 +406,7 @@ describe('buildSuggestionPrompt', () => {
         kind: 'post_comment',
         post,
         persona: null,
-        voiceProfile: { summary: justOver, commentSummary: null },
+        voiceProfile: { summary: justOver, commentSummary: null, editSignature: null },
         projects: [],
         repos: [],
       });
@@ -382,7 +414,7 @@ describe('buildSuggestionPrompt', () => {
         kind: 'post_comment',
         post,
         persona: null,
-        voiceProfile: { summary: wayOver, commentSummary: null },
+        voiceProfile: { summary: wayOver, commentSummary: null, editSignature: null },
         projects: [],
         repos: [],
       });

--- a/web/src/routes/companion/voice/+page.server.ts
+++ b/web/src/routes/companion/voice/+page.server.ts
@@ -16,9 +16,11 @@ import {
   refreshVoiceProfile,
   saveVoiceProfileSummary,
   resetVoiceProfileToDerived,
+  setEditSignatureExcluded,
   type OperatorVoiceProfileRow,
   type VoiceGenreSummary,
 } from '@pitchbox/shared/operator-voice-profile';
+import { describeEditSignature, type EditSignature } from '@pitchbox/shared/assist/voice-profile';
 
 // Companion -> Voice ("how you write"), split out of the old three-card
 // settings/companion page (LOR-178/LOR-179, docs/design/DECISIONS.md D35).
@@ -56,7 +58,13 @@ export type CompanionVoiceProfile = {
   wordsPerSentence: number;
   itemCount: number;
   wordCount: number;
-  evidenceCounts: { voiceSamples: number; messages: number; drafts: number; templates: number };
+  evidenceCounts: {
+    voiceSamples: number;
+    messages: number;
+    drafts: number;
+    templates: number;
+    acceptedSuggestions: number;
+  };
   /** Each genre's own description, alongside the pooled one above
    * (LOR-223) - a post and a comment are different genres of writing, so
    * "how you write" is worth reading per genre as well as pooled. */
@@ -64,6 +72,13 @@ export type CompanionVoiceProfile = {
   source: 'derived' | 'manual';
   derivedAt: string | null;
   updatedAt: string;
+  /** What this operator habitually cuts from a draft before posting it
+   * (LOR-227) - the raw measurement, plus its prose (null below the
+   * derivation floor or when it says nothing dominant) and the human's own
+   * exclude toggle, the same shape voice samples already have. */
+  editSignature: EditSignature;
+  editSignatureDescription: string | null;
+  editSignatureExcluded: boolean;
 };
 
 const MAX_VOICE_IMPORT_BYTES = 20 * 1024 * 1024;
@@ -83,6 +98,9 @@ function toVoiceProfile(row: OperatorVoiceProfileRow): CompanionVoiceProfile {
     source: row.source,
     derivedAt: row.derivedAt ? row.derivedAt.toISOString() : null,
     updatedAt: row.updatedAt.toISOString(),
+    editSignature: row.evidence.editSignature,
+    editSignatureDescription: describeEditSignature(row.evidence.editSignature),
+    editSignatureExcluded: row.evidence.editSignatureExcluded,
   };
 }
 
@@ -134,6 +152,22 @@ export const actions: Actions = {
     await setVoiceSampleExcluded(getDb(), orgId, sampleId, excluded);
     const voiceProfile = await refreshVoiceProfile(getDb(), orgId);
     return { toggledSampleId: sampleId, voiceProfile: toVoiceProfile(voiceProfile) };
+  },
+
+  // The edit signature's own exclude control (LOR-227) - the same "hide
+  // this" reversibility voice samples already have, at the granularity of
+  // the whole signature rather than one row: a signature derived from a
+  // few unusual edits should be dismissable without touching the database
+  // by hand. Does not re-derive anything; a later refresh recomputes the
+  // signature but carries this flag forward (`refreshVoiceProfile`'s own
+  // comment).
+  toggleEditSignature: async (event) => {
+    requireRole(event, 'admin');
+    const orgId = await requireOrgId(event);
+    const form = await event.request.formData();
+    const excluded = form.get('excluded') === 'true';
+    const voiceProfile = await setEditSignatureExcluded(getDb(), orgId, excluded);
+    return { voiceProfile: toVoiceProfile(voiceProfile) };
   },
 
   // Re-derives from the current corpus. A no-op on a `source: 'manual'` row

--- a/web/src/routes/companion/voice/+page.svelte
+++ b/web/src/routes/companion/voice/+page.svelte
@@ -38,6 +38,21 @@
 		capturedAt: string;
 	};
 	type GenreSummary = { summary: string | null; itemCount: number; measurable: boolean };
+	// Mirrors shared/src/assist/voice-profile.ts's EditSignature - a plain,
+	// JSON-serializable measurement, not imported directly so this file
+	// stays independent of the server-only shared package the way its other
+	// local types already do (VoiceProfile/GenreSummary above).
+	type EditSignature = {
+		pairCount: number;
+		measurable: boolean;
+		shortensText: boolean;
+		dropsClosingSentence: boolean;
+		cutsHedges: boolean;
+		dropsOpening: boolean;
+		stripsEmoji: boolean;
+		changesLanguage: boolean;
+		bannedPhrases: string[];
+	};
 	type VoiceProfile = {
 		summary: string;
 		traits: string[];
@@ -47,11 +62,20 @@
 		wordsPerSentence: number;
 		itemCount: number;
 		wordCount: number;
-		evidenceCounts: { voiceSamples: number; messages: number; drafts: number; templates: number };
+		evidenceCounts: {
+			voiceSamples: number;
+			messages: number;
+			drafts: number;
+			templates: number;
+			acceptedSuggestions: number;
+		};
 		genres: Record<VoiceSampleGenre, GenreSummary>;
 		source: 'derived' | 'manual';
 		derivedAt: string | null;
 		updatedAt: string;
+		editSignature: EditSignature;
+		editSignatureDescription: string | null;
+		editSignatureExcluded: boolean;
 	};
 	type PageData = { voiceSamples: VoiceSample[]; voiceProfile: VoiceProfile | null };
 	type FormResult = {
@@ -112,6 +136,8 @@
 	let voiceFormRefs: Record<number, HTMLFormElement> = $state({});
 	let togglingSampleId = $state<number | null>(null);
 	let importFileInput: HTMLInputElement | undefined = $state();
+	let editSignatureFormRef: HTMLFormElement | undefined = $state();
+	let togglingEditSignature = $state(false);
 </script>
 
 <Seo
@@ -283,6 +309,60 @@
 								</div>
 							{/if}
 						{/each}
+					{/if}
+
+					{#if voiceProfile?.editSignature.measurable}
+						<div class="flex flex-col gap-2 rounded-md border border-border/60 bg-muted/30 p-2 text-xs">
+							<div class="flex flex-wrap items-center justify-between gap-2">
+								<span class="font-medium">What you cut before posting</span>
+								<span class="text-muted-foreground">
+									Based on {voiceProfile.editSignature.pairCount} edited suggestion{voiceProfile
+										.editSignature.pairCount === 1
+										? ''
+										: 's'}
+								</span>
+							</div>
+							{#if voiceProfile.editSignatureExcluded}
+								<Badge variant="outline" class="w-fit">Excluded from prompt</Badge>
+							{/if}
+							<p class="text-muted-foreground">
+								{voiceProfile.editSignatureDescription ?? 'Nothing recurring enough yet to name.'}
+							</p>
+							{#if voiceProfile.editSignature.bannedPhrases.length > 0}
+								<div class="flex flex-wrap gap-1">
+									{#each voiceProfile.editSignature.bannedPhrases as phrase (phrase)}
+										<Badge variant="outline">{phrase}</Badge>
+									{/each}
+								</div>
+							{/if}
+							<form
+								method="POST"
+								action="?/toggleEditSignature"
+								bind:this={editSignatureFormRef}
+								use:enhance={() => {
+									togglingEditSignature = true;
+									return async ({ update }) => {
+										await update();
+										togglingEditSignature = false;
+									};
+								}}
+								class="contents"
+							>
+								<input
+									type="hidden"
+									name="excluded"
+									value={(!voiceProfile.editSignatureExcluded).toString()}
+								/>
+							</form>
+							<label class="flex w-fit items-center gap-2 text-xs text-muted-foreground">
+								<Checkbox
+									checked={voiceProfile.editSignatureExcluded}
+									disabled={togglingEditSignature}
+									onCheckedChange={() => editSignatureFormRef?.requestSubmit()}
+								/>
+								Exclude from prompt
+							</label>
+						</div>
 					{/if}
 				</div>
 			</Card.Content>


### PR DESCRIPTION
I made the voice profile learn from what the assist plane already records and then threw away: an accepted suggestion's posted text, and the pair the model's own draft and the human's edit form when they changed it before posting (LOR-227).

**shared/src/assist/voice-profile.ts** (mine, per the file split for this wave): `accepted_suggestion` joins `VoiceCorpusItemKind`. `measureVoiceCorpus` now weights it 2x over the rest of the corpus in whatever counts as recurring (traits, openings/closings, reused words, every rate/spread axis) - never in `itemCount`/`wordCount`, which stay the real, unweighted count of distinct pieces of writing this org actually produced. Published text is stronger evidence of voice than a private draft, a sent DM or a template nobody outside the org ever saw, so it earns more say in what habits get reported, without one real item alone manufacturing a false pattern.

Added `measureEditSignature`/`describeEditSignature`/`hasEditSignatureContent` plus `EditPair`/`EditSignature`: per-axis dominance (shortens the text, drops the opening or closing sentence, cuts hedges, strips emoji, changes language) and a personal ban list of whole sentences the operator deleted in two or more separate pairs - never from a single pair, which is a choice about one draft, not a habit. Gated on `MIN_EDIT_PAIRS_TO_DERIVE` (equal to `MIN_ITEMS_TO_DERIVE`, since two edited pairs is exactly as much a coincidence as two posts sharing a word): below it, an empty signature, nothing invented.

**shared/src/operator-voice-profile.ts** (mine): `gatherVoiceCorpus` reads `assist_accepted_suggestions` for the org, maps its `kind` (`post`/`post_comment`) onto the corpus's own genre vocabulary (`post`/`comment`) rather than inventing a third one, and builds edit pairs from rows with `edited_from` set. `refreshVoiceProfile` derives and stores the edit signature in `evidence` alongside the measured axes, and carries `editSignatureExcluded` forward across every recompute - it's a human's own toggle, not a measurement, the same way a manual summary survives a passive refresh. Added `setEditSignatureExcluded` for Settings, and exposed both on `ResolvedOperatorVoiceProfile`.

**shared/src/assist/context.ts**: `VoiceProfileSummary` gains `editSignature` prose, null whenever there's nothing honest to say or the operator excluded it.

**shared/src/assist/suggest-prompt.ts**: I only added one new section (what this operator reliably cuts, capped, present only when non-empty) placed away from the `TASK`/`taskFor` block LOR-233 owns, and rebased onto their merged length work.

**web/src/routes/companion/voice**: shows the edit signature with its evidence count and its banned phrases, with the same exclude checkbox voice samples already have, posting to a new `toggleEditSignature` action.

Note for a later issue, not fixed here: I didn't touch LOR-234's regex in voice-profile.ts/operator-voice-profile.ts, per the file-split brief.

Verified: `pnpm -F @pitchbox/shared typecheck` and `pnpm -F @pitchbox/cli typecheck` clean, `pnpm -F web check` (svelte-check) 0 errors/0 warnings across 6119 files, `npx eslint`/`npx prettier --check` clean on every changed file. Ran the three touched test files directly against my worktree's Postgres: `assist-voice-profile.test.ts` 46/46, `operator-voice-profile.test.ts` 20/20, `suggest-prompt.test.ts` 32/32 - all passing, including new coverage for the corpus-weighting difference, the edit-signature floor/phrase-threshold/axis derivation, DB round-trip of genre mapping and exclude-persists-across-refresh, and the prompt section's present/absent behavior. Checked the new Settings UI against my own running app (port 5201) with real seeded data: screenshot shows "What you cut before posting", the evidence count, the banned phrase, and the exclude checkbox rendering correctly in dark and light. A full `pnpm test` run is still going in the background against my worktree DB as I open this - will report its exact numbers as a follow-up comment once it finishes; every file I actually touched already passed in isolation above.