### PR TITLE
fix(shared): name a length target in the task, not the profile alone

### DIFF
--- a/shared/src/assist/context.ts
+++ b/shared/src/assist/context.ts
@@ -87,6 +87,16 @@ export type VoiceProfileSummary = {
    * excluded it in Settings, the same "hide this" control voice samples
    * already have. */
   editSignature: string | null;
+  /** The same comment-genre measurement's own median whole-piece length, in
+   * words (LOR-232's rhythm axis, read per genre - LOR-227's
+   * `medianItemWords` on `VoiceGenreSummary`) - null under the exact same
+   * condition as `commentSummary`, never a number `commentSummary` itself
+   * doesn't also justify. `suggest-prompt.ts` (LOR-233) names this in the
+   * task itself: the prose already says "about 7 words" in passing, and a
+   * task that also demands the comment "add something" outweighs a
+   * sentence buried in a persona description - a number in the task's own
+   * instruction does not. */
+  medianCommentWords: number | null;
 };
 
 export type ProjectBrief = {
@@ -250,6 +260,10 @@ export async function loadCompanionContext(
           editSignature: voiceProfileRow.evidence.editSignatureExcluded
             ? null
             : describeEditSignature(voiceProfileRow.evidence.editSignature),
+          medianCommentWords:
+            voiceProfileRow.evidence.genres.comment.medianItemWords > 0
+              ? voiceProfileRow.evidence.genres.comment.medianItemWords
+              : null,
         }
       : null,
     projects: projectRows.map((p) => ({

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -259,9 +259,17 @@ function clamp(text: string, max: number): string {
   return t.length <= max ? t : `${t.slice(0, max)}\n[truncated]`;
 }
 
+// LOR-233: the old wording ("it has to add something... say so in one
+// sentence instead of padding") made a substantive addition the only
+// legitimate outcome, which is false for most of what the operator
+// actually writes - a plain reaction ("Grande!", a bicep emoji, "che UI!")
+// is not a comment that failed to find an angle, it is the correct comment
+// for a launch, a photo or a win. Naming the short reaction as a real
+// outcome removes the contradiction with the voice profile's own "about 7
+// words" rather than adding a second instruction to fight it.
 const TASK: Record<SuggestionKind, string> = {
   post_comment:
-    'Write one comment to leave on the post below. One paragraph, two at most. It has to add something the author or another reader would not already know: a specific experience, a number, a disagreement worth having. If you have nothing to add, say so in one sentence instead of padding.',
+    "Write one comment to leave on the post below. A short reaction in the operator's own voice - a word, an emoji, one line of real agreement or delight - is a complete answer on its own, not a fallback: a post that is social rather than technical, a launch, a photo, a win, calls for exactly that, and plenty of the operator's own real comments are exactly this short. Write a longer comment, one paragraph, two at most, only when there is something specific to add - an experience, a number, a disagreement worth having. Never pad a short reaction into something that reads as more substantial than it is.",
   post: 'Write one short post for this account, taking the post below as the starting point rather than something to summarise. Say one thing and stop.',
 };
 
@@ -277,7 +285,7 @@ const TASK: Record<SuggestionKind, string> = {
  */
 function taskFor(kind: SuggestionKind, replyToCommentId?: string): string {
   if (kind === 'post_comment' && replyToCommentId) {
-    return `Write one reply to the comment with id "${replyToCommentId}" in the thread below (call read_thread to see who wrote it and what it says) - not a comment on the post itself. One paragraph, two at most. It has to add something that commenter or another reader would not already know: a specific experience, a number, a disagreement worth having. If you have nothing to add, say so in one sentence instead of padding.`;
+    return `Write one reply to the comment with id "${replyToCommentId}" in the thread below (call read_thread to see who wrote it and what it says) - not a comment on the post itself. A short reaction in the operator's own voice is a complete answer on its own, not a fallback, when that is genuinely what the reply calls for. Write a longer reply, one paragraph, two at most, only when there is something specific to add that commenter or another reader would not already know. Never pad a short reaction into something that reads as more substantial than it is.`;
   }
   return TASK[kind];
 }
@@ -323,6 +331,57 @@ const RETUNE_INSTRUCTION: Record<RetuneDirection, string> = {
     'address the author more like a person and let real interest show, without adding exclamation marks.',
   shorter: 'say the same point in noticeably fewer words: keep only what earns its place.',
 };
+
+/** Counts words the same simple way every other length axis in this
+ * codebase does (voice-profile.ts's own `measureRhythm`, voice-metrics.ts's
+ * scorer) - split on whitespace, drop empties - so a target stated here
+ * means the same thing as the numbers it is derived from. */
+function wordCount(text: string): number {
+  const t = text.trim();
+  return t ? t.split(/\s+/u).filter(Boolean).length : 0;
+}
+
+/** Kept local rather than imported from voice-profile.ts or voice-metrics.ts,
+ * which each keep their own copy of this same handful of lines for the same
+ * reason their own module headers give: it is not specific to either of
+ * them, and three modules sharing one three-line function is not worth a
+ * new import surface. */
+function median(nums: number[]): number {
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return Math.round(sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!);
+}
+
+/**
+ * Names a length target in words for a `post_comment` task, derived rather
+ * than fixed (LOR-233) - `null` when neither source below exists, which the
+ * caller renders as no length sentence at all rather than inventing a
+ * default, the same posture `voice-defaults.ts` already takes for a corpus
+ * too thin to measure.
+ *
+ * The room, when the page sent a thread, outranks the operator's own habit:
+ * a person who usually writes seven words still writes thirty under a post
+ * where every other visible comment runs thirty, and the room is the more
+ * specific, more current signal for what fits under *this* post -
+ * `voice-defaults.ts`'s own "fits the room" rule, finally given a number.
+ * The operator's own comment-genre median (LOR-232's rhythm axis, read per
+ * genre - LOR-227's `medianCommentWords`) is the fallback for when no
+ * thread rendered at all, which is always, on the SDUI feed (see this
+ * file's `ObservedThread` doc comment).
+ *
+ * Returns which source won alongside the number: a human reading a
+ * suggestion should be able to tell why it came out the length it did, not
+ * just that it did.
+ */
+function lengthTarget(
+  voiceProfile: VoiceProfileSummary | null,
+  thread: ObservedThread | undefined,
+): { words: number; source: 'room' | "operator's own habit" } | null {
+  const threadWords = (thread?.comments ?? []).map((c) => wordCount(c.body)).filter((n) => n > 0);
+  if (threadWords.length > 0) return { words: median(threadWords), source: 'room' };
+  const own = voiceProfile?.medianCommentWords;
+  return own && own > 0 ? { words: own, source: "operator's own habit" } : null;
+}
 
 /**
  * Builds the single-turn prompt. Pure and synchronous: everything it needs is
@@ -524,6 +583,37 @@ export function buildSuggestionPrompt(args: {
   );
 
   parts.push(`Your task: ${taskFor(kind, post.replyToCommentId)}`);
+
+  // LOR-233: a length target in words, named explicitly rather than left
+  // for the model to reconcile "adds something" against a voice profile
+  // that separately says "about 7 words" - see `lengthTarget`'s own doc
+  // comment for which source wins and why. `post` has no room to read a
+  // target off (no thread, no per-genre comment habit) and keeps its own
+  // brevity instruction in TASK.post above instead.
+  //
+  // Deliberately not a ceiling: a median is the typical case, not every
+  // case, and roughly half of what the operator actually writes runs
+  // longer than it - sometimes much longer, when the post itself is the
+  // kind that earns a real answer. An early version of this sentence said
+  // "going noticeably over that is a defect" outright, and measured
+  // against the eval set it quietly flattened the genuinely long cases
+  // along with the short ones - the same failure this issue exists to
+  // avoid, just moved from "always long" to "always short". The target is
+  // a default to return to once there is nothing left to say, not a limit
+  // on how much there is to say.
+  if (kind === 'post_comment') {
+    const target = lengthTarget(voiceProfile, post.thread);
+    if (target) {
+      const words = `${target.words} word${target.words === 1 ? '' : 's'}`;
+      const clause =
+        target.source === 'room'
+          ? `this thread's own comments run about ${words}`
+          : `the operator's own comments run about ${words}`;
+      parts.push(
+        `Length target: ${clause} - treat that as the length to return to once you have said what is worth saying, not a ceiling on it. Padding a short reaction out to look more substantial is the defect; a longer comment earned by something real to say is not, and the post below sometimes calls for exactly that.`,
+      );
+    }
+  }
 
   // The tone, after the task and before the operator's steer, because that is
   // the precedence: house style outranks the tone, the operator's typed steer

--- a/shared/src/assist/voice-defaults.ts
+++ b/shared/src/assist/voice-defaults.ts
@@ -37,13 +37,13 @@ export type DefaultVoiceProfile = {
 
 export const DEFAULT_VOICE_PROFILE: DefaultVoiceProfile = {
   summary:
-    "No writing on file yet, so this is a default style, not a measurement: a short first sentence with no preamble, one idea anchored to a concrete detail from the post, plain words, and a length that fits the room rather than a paragraph - matched to the post's own language and register rather than a house tone.",
+    "No writing on file yet, so this is a default style, not a measurement: a short first sentence with no preamble, one idea or a plain reaction - never both padded together to look more substantial - anchored to a concrete detail from the post when there is one to add, plain words, and a length that fits the room rather than a paragraph, matched to the post's own language and register rather than a house tone.",
   rules: [
     'Open with a short first sentence: no preamble, no restating the post, no "Great post!".',
     'No tricolons, no "not just X but Y", no rhetorical question as an opener.',
     'No wrap-up closer that summarises what was just said.',
     'Plain words: avoid the candidates in avoidWords.',
-    'One idea per comment, anchored to a concrete detail from the post or thread.',
+    "One idea per comment, or none at all: a short reaction anchored to the post's own tone is a complete comment, not a placeholder for one that says more.",
     "Match the post's own language and register rather than a house tone.",
     'Length that fits the room: about as long as the median visible comment under the post, not a paragraph.',
   ],

--- a/shared/src/assist/voice-profile.ts
+++ b/shared/src/assist/voice-profile.ts
@@ -1019,11 +1019,17 @@ export function describeVoiceProfile(
   // each item to clear register.ts's 12-word floor, which a corpus of
   // one-line comments never does, so before this the description of such a
   // corpus said everything about it except how long it is.
+  //
+  // Measurement only, not an instruction (LOR-233): this used to end "...and
+  // a draft that misses that length is wrong however well it is written",
+  // which reads as an absolute cap sitting in the profile description where
+  // no task-level wording can soften it - it outranked suggest-prompt.ts's
+  // own, more carefully qualified length target and flattened the corpus's
+  // genuinely long items along with the short ones. A description states
+  // what was measured; only the task instructs.
   if (m.rhythm.medianItemWords > 0) {
     const spread = m.rhythm.itemWordsSpread > 0 ? `, give or take ${m.rhythm.itemWordsSpread}` : '';
-    sentences.push(
-      `A typical one runs about ${m.rhythm.medianItemWords} words${spread}, and a draft that misses that length is wrong however well it is written.`,
-    );
+    sentences.push(`A typical one runs about ${m.rhythm.medianItemWords} words${spread}.`);
   }
   if (m.traits.length > 0) {
     const sentenceLength =

--- a/shared/tests/assist-context.test.ts
+++ b/shared/tests/assist-context.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { sql, eq } from 'drizzle-orm';
+import { getDb, schema } from '../src/db/client.js';
+import { loadCompanionContext } from '../src/assist/context.js';
+
+// LOR-233: `buildSuggestionPrompt` needs the operator's own comment-genre
+// median word count as a number, not only as a sentence buried inside
+// `commentSummary`'s prose. This is the wiring test for that one field -
+// `loadCompanionContext` reading `evidence.genres.comment.medianItemWords`
+// (LOR-227's own addition to `VoiceGenreSummary`) off a real row and
+// mapping its `0` (not yet measurable) to `null` rather than forwarding a
+// number nothing actually derived.
+//
+// The pure "which source wins, what the prompt says" behavior lives in
+// `suggest-prompt.test.ts`; this only owns the DB-to-type mapping, which
+// the pure tests cannot exercise since they never touch `loadVoiceProfile`.
+
+async function reset() {
+  await getDb().execute(
+    sql`TRUNCATE operator_voice_profiles, organizations RESTART IDENTITY CASCADE`,
+  );
+  await getDb().execute(sql`DELETE FROM organizations WHERE slug != 'default'`);
+}
+
+async function ensureOrg(slug: string): Promise<number> {
+  const db = getDb();
+  await db.insert(schema.organizations).values({ slug, name: slug }).onConflictDoNothing();
+  const [org] = await db
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.slug, slug));
+  return org!.id;
+}
+
+describe('loadCompanionContext: medianCommentWords (LOR-233)', () => {
+  it("reads the comment genre's own median off evidence, not the pooled rhythm", async () => {
+    await reset();
+    const orgId = await ensureOrg('lor233-median');
+    await getDb()
+      .insert(schema.operatorVoiceProfiles)
+      .values({
+        organizationId: orgId,
+        summary: 'Based on 12 pieces of their own writing (900 words). Often uses hashtags.',
+        evidence: {
+          genres: {
+            comment: {
+              summary:
+                'Based on 27 of their own comments (190 words). A typical one runs about 7 words.',
+              itemCount: 27,
+              measurable: true,
+              medianItemWords: 7,
+              itemWordsSpread: 4,
+            },
+          },
+        },
+      });
+
+    const context = await loadCompanionContext(getDb(), { organizationId: orgId });
+    expect(context.voiceProfile?.commentSummary).toMatch(/about 7 words/);
+    expect(context.voiceProfile?.medianCommentWords).toBe(7);
+  });
+
+  it('reports null, never 0, when the comment genre has not cleared the floor to derive one', async () => {
+    await reset();
+    const orgId = await ensureOrg('lor233-unmeasurable');
+    await getDb()
+      .insert(schema.operatorVoiceProfiles)
+      .values({
+        organizationId: orgId,
+        summary: 'Based on 12 pieces of their own writing (900 words). Often uses hashtags.',
+        evidence: {
+          genres: {
+            comment: {
+              summary: null,
+              itemCount: 1,
+              measurable: false,
+              medianItemWords: 0,
+              itemWordsSpread: 0,
+            },
+          },
+        },
+      });
+
+    const context = await loadCompanionContext(getDb(), { organizationId: orgId });
+    expect(context.voiceProfile?.commentSummary).toBeNull();
+    expect(context.voiceProfile?.medianCommentWords).toBeNull();
+  });
+});

--- a/shared/tests/suggest-prompt.test.ts
+++ b/shared/tests/suggest-prompt.test.ts
@@ -64,6 +64,7 @@ const voiceProfile: VoiceProfileSummary = {
     'Based on 12 pieces of their own writing (640 words). Usually writes with short sentences, close to speech, first person, speaking as themselves, about 11 words per sentence. Often opens with "Shipped the". Reuses these words often: shipped, team, campaign.',
   commentSummary: null,
   editSignature: null,
+  medianCommentWords: null,
 };
 
 const projects: ProjectBrief[] = [
@@ -261,6 +262,7 @@ describe('buildSuggestionPrompt', () => {
         commentSummary:
           'Based on 27 of their own comments (190 words). Usually writes one short sentence.',
         editSignature: null,
+        medianCommentWords: 7,
       };
       const commentPrompt = buildSuggestionPrompt({
         kind: 'post_comment',
@@ -406,7 +408,12 @@ describe('buildSuggestionPrompt', () => {
         kind: 'post_comment',
         post,
         persona: null,
-        voiceProfile: { summary: justOver, commentSummary: null, editSignature: null },
+        voiceProfile: {
+          summary: justOver,
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: null,
+        },
         projects: [],
         repos: [],
       });
@@ -414,7 +421,12 @@ describe('buildSuggestionPrompt', () => {
         kind: 'post_comment',
         post,
         persona: null,
-        voiceProfile: { summary: wayOver, commentSummary: null, editSignature: null },
+        voiceProfile: {
+          summary: wayOver,
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: null,
+        },
         projects: [],
         repos: [],
       });
@@ -450,6 +462,149 @@ describe('buildSuggestionPrompt', () => {
       expect(promptJustOver).not.toContain(marker);
       expect(promptWayOver).not.toContain(marker);
       expect(promptJustOver.length).toBe(promptWayOver.length);
+    });
+  });
+
+  // LOR-233: the old task text made "add something" the only legitimate
+  // outcome for a comment, which contradicted a voice profile that
+  // separately says "about 7 words" - a model given both always resolved
+  // toward the explicit task instruction and wrote a paragraph anyway. The
+  // fix is a task that states a real length target and names a short
+  // reaction as a complete answer, not a second rule bolted on top of the
+  // old one.
+  describe('length target and short reactions (LOR-233)', () => {
+    it('names a short reaction as a complete answer, not only a fallback for having nothing to add', () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        ...noContext,
+      });
+      expect(prompt).toMatch(/short reaction.*is a complete answer/);
+      // The old contradiction: a comment was required to "add something" or
+      // apologise for not doing so. Neither framing survives.
+      expect(prompt).not.toMatch(/has to add something/);
+      expect(prompt).not.toMatch(/say so in one sentence instead of padding/);
+    });
+
+    it('says the same about a reply to one specific comment', () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post: { ...post, replyToCommentId: 'c1' },
+        ...noContext,
+      });
+      expect(prompt).toMatch(/short reaction.*is a complete answer/);
+    });
+
+    it("names the operator's own comment-genre median as the length target when no thread was captured", () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        persona: null,
+        voiceProfile: {
+          summary: 'irrelevant',
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: 7,
+        },
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).toMatch(/Length target: the operator's own comments run about 7 words/);
+      expect(prompt).toMatch(/not a ceiling/);
+      // Deliberately not phrased as a hard cap: a median describes the
+      // typical case, and a comment earned by something real to say is
+      // explicitly not the thing being discouraged.
+      expect(prompt).toMatch(/a longer comment earned by something real to say is not/);
+    });
+
+    it("prefers the room's own median over the operator's habit when the page sent a thread", () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post: {
+          ...post,
+          thread: {
+            comments: [
+              { body: Array(28).fill('word').join(' ') },
+              { body: Array(30).fill('word').join(' ') },
+              { body: Array(32).fill('word').join(' ') },
+            ],
+            renderedCount: 3,
+            truncated: false,
+          },
+        },
+        persona: null,
+        voiceProfile: {
+          summary: 'irrelevant',
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: 7,
+        },
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).toMatch(/Length target: this thread's own comments run about 30 words/);
+      expect(prompt).not.toContain('about 7 words');
+    });
+
+    it("falls back to the operator's own habit when the thread rendered no comments at all", () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post: { ...post, thread: { comments: [], renderedCount: 0, truncated: false } },
+        persona: null,
+        voiceProfile: {
+          summary: 'irrelevant',
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: 12,
+        },
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).toMatch(/Length target: the operator's own comments run about 12 words/);
+    });
+
+    it('says nothing about length when neither the corpus nor the thread has anything to measure - never a fixed number', () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        ...noContext,
+      });
+      expect(prompt).not.toMatch(/Length target/);
+    });
+
+    it('never names a length target for a standalone post, which has no room and no comment-genre habit to read one off', () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post',
+        post,
+        persona: null,
+        voiceProfile: {
+          summary: 'irrelevant',
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: 7,
+        },
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).not.toMatch(/Length target/);
+    });
+
+    it('gets the singular right for a one-word target', () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        persona: null,
+        voiceProfile: {
+          summary: 'irrelevant',
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: 1,
+        },
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).toMatch(/about 1 word\b/);
+      expect(prompt).not.toContain('about 1 words');
     });
   });
 });


### PR DESCRIPTION
Closes LOR-233.

The profile already says my comments run about 7 words. The task separately said a comment has to add something the reader would not already know, or apologize for not adding it, so the model always obeyed the task and wrote a paragraph.

## What changed

`shared/src/assist/suggest-prompt.ts`:
- `TASK.post_comment` and its reply variant now name a short reaction (a word, an emoji, one line of real agreement) as a complete answer on its own, not a fallback for having nothing to add.
- `buildSuggestionPrompt` states a length target in words for a `post_comment` suggestion, derived rather than fixed: the visible thread's own median when the page sent one (the more specific, more current signal for what fits under this exact post), the operator's own comment-genre median otherwise, and nothing at all when neither exists. The sentence names which source it used, so a suggestion's length is legible rather than a mystery.
- No fixed word count anywhere. `medianCommentWords` comes from `VoiceGenreSummary.medianItemWords` (LOR-227, #673); the room number comes from `ObservedThread`'s own visible comments.

`shared/src/assist/context.ts`: `VoiceProfileSummary` gains `medianCommentWords: number | null`, read from `evidence.genres.comment.medianItemWords` in `loadCompanionContext`, null when that genre never cleared the floor to derive one (same condition as `commentSummary`). Rebased onto #676 (edit signature), which added its own `editSignature` field to the same type in the same region - both fields coexist, additive.

`shared/src/assist/voice-defaults.ts`: rule 5 ("one idea per comment, anchored to a concrete detail") stopped requiring an idea when a plain reaction is the honest comment for a brand-new account with no corpus yet.

`shared/src/assist/voice-profile.ts` (one line, Main's call and Main's file - handed to me mid-review, see below): `describeVoiceProfile`'s length sentence used to end "...and a draft that misses that length is wrong however well it is written". That is an absolute cap sitting in the profile description where the task's own, deliberately softened wording cannot reach it, and it outranked the task - which is exactly why the eval's long-tagged cases still collapsed even after the task and length-target changes above. The sentence now ends after the measurement (median plus spread). A description states what was measured; only the task instructs.

I tried a harder version of the length-target sentence in `suggest-prompt.ts` first ("going noticeably over that is a defect") and measured it against the eval set before shipping it: it flattened the long cases too, so I softened it to a default-to-return-to rather than a ceiling. That alone was not enough - the profile's own absolute-cap clause was still there, outranking it - which is what the bucketed measurement below caught and the overall median had hidden.

## Measurement

`pnpm run eval:voice` could not run as-is in my sandbox: `private/voice-eval/cases.json` there is real data in a richer shape (`corpus`/`reference`/`kind`, with a `tags` array per case including `very-short`/`short`/`long`) than `shared/src/voice-eval-cases.ts`'s current schema expects, and `loadVoiceEvalCases` throws on it. No `AI_GATEWAY_API_KEY` was configured either. Both are pre-existing environment facts (detailed under "not fixed" below).

I drove the exact same production functions (`buildSuggestionPrompt`, `scoreCandidate`, `splitSuggestion`, `measureVoiceCorpusByGenre`) against the real 27-case file through a throwaway script (written, used, deleted before every push - never part of the diff), generating real candidates with a model and scoring them with the unmodified deterministic scorer. The operator's own comment corpus for this run is the 27 cases' own real replies, which is what production would have logged as `genre: 'comment'` once accepted.

**Per bucket, not by overall median** - the overall median is what hid the long-tail regression the first time:

|bucket|n|his median|ours|within 5 words|
|---|---|---|---|---|
|very-short|16|3|9.5|8 of 16|
|short|8|18|17|6 of 8|
|long|3|39|13|0 of 3|
|all|27|7|13|14 of 27|

Style-checker findings across the set: 4 total before this PR, 0 after.

**The long cases individually** (39, 39 and 130 real words): before this PR they ran 39, 51 and 39 candidate words (already not tracking their own references well); after the task/length-target change alone they had collapsed to 8, 11 and 7 (the exact regression Main caught, caused by the profile's absolute-cap clause outranking the softened task); after also cutting that clause they run 12, 13 and 17. The long bucket comes back up (median 8 -> 13) rather than swinging past its own reference, and does not close the gap to a genuine 130-word outlier - no case in this set carries a captured `ObservedThread`, so the room signal this PR adds never actually fires here, and the model's own per-post judgment is the only thing deciding whether a specific post earns more than the profile's typical 7 words. That is a real, honest limit of this eval set and of what a length-target sentence can do on its own, not a regression I'm hiding: the short and very-short buckets held close to their own references throughout this last change, and the long bucket moved in the right direction rather than staying flat or reversing.

## Tests

`shared/tests/suggest-prompt.test.ts`: 8 new cases under `length target and short reactions (LOR-233)`. `shared/tests/assist-context.test.ts` (new): `loadCompanionContext` wiring for `medianCommentWords`, including the null-mapping case. `shared/tests/assist-voice-profile.test.ts`'s existing length-sentence test (`/A typical one runs about \d+ words/`) still matches the shortened sentence unchanged.

**Ran on the final tree:** `pnpm -F @pitchbox/shared typecheck` (clean), `pnpm -F web check` (6119 files, 0 errors, 0 warnings), `pnpm exec vitest run shared/tests/assist-voice-profile.test.ts shared/tests/suggest-prompt.test.ts shared/tests/assist-context.test.ts shared/tests/operator-voice-profile.test.ts` (108/108 passed), `npx eslint` and `npx prettier --check` on every changed file (clean).

Full `pnpm test` against my own database (`pitchbox_test_lor233`), run twice back to back before the voice-profile.ts addition: 64 failed / 3226 passed (all 21 failing files under `cli/tests/mcp/`), then 5 failed / 3226 passed (3 different `web/tests/` files, zero overlap with the first run). Confirmed pre-existing and unrelated to this diff: with my changes stashed, `cli/tests/mcp/server.test.ts` passed 43/43 and the whole `cli/` workspace passed 182/182, both in isolation. Both failure sets share the same two signatures (`org.id` undefined off a `seed*` helper, and an SSE stream returning `event: failed` with "Agent runner claude-code is not available in this deployment's edition") - cross-workspace load/ordering flakiness, not a regression from this diff, and a different failure set from the documented LOR-220 flake. Did not re-run the full suite after the one-line `voice-profile.ts` addition since it touches no seeding or SSE path; the targeted tests above cover it directly.

## Not fixed, out of scope

Two real defects found while building the measurement above, named but not touched:
- `shared/src/voice-eval-cases.ts`'s schema (`voiceCorpus`/`actualReply`/`schemaVersion`) does not match the shape of the real `private/voice-eval/cases.json` I was pointed at (`corpus`/`reference`/`schemaVersion` with different nesting and a `tags` array the current schema has no field for) - `pnpm run eval:voice` cannot load that file as-is.
- `scripts/voice-eval.ts`'s own voice-profile construction (`resolveVoiceProfileSummary`) pools every corpus item as one undifferentiated `voice_sample`, never splitting by genre - so even once the schema above is fixed, the official runner would not exercise `commentSummary`/`medianCommentWords` without also learning to tag corpus items by genre or to treat case references as the comment corpus, the way my verification script did.

No migration in this wave - everything above lives in the existing `evidence` jsonb column.
