### PR TITLE
fix(shared,web): the Inbox stopped rendering, the quality badge dragged the AI SDK into the browser

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -55,6 +55,7 @@
     "./draft-send": "./src/draft-send.ts",
     "./draft-regenerate": "./src/draft-regenerate.ts",
     "./quality-judge": "./src/quality-judge.ts",
+    "./quality-bands": "./src/quality-bands.ts",
     "./draft-variants": "./src/draft-variants.ts",
     "./reply-drafter": "./src/reply-drafter.ts",
     "./crypto": "./src/crypto.ts",

--- a/shared/src/quality-bands.ts
+++ b/shared/src/quality-bands.ts
@@ -1,0 +1,58 @@
+// shared/src/quality-bands.ts
+//
+// The client-safe half of quality scoring: the rubric's shape and its
+// thresholds, the sentinel that says a score was computed rather than
+// judged, and the mapping from a number to the band the Inbox paints. All
+// pure, all of it needed by a Svelte component, none of it needing a
+// database or a model.
+//
+// It is a separate module for one concrete reason, found on merged `main`
+// on 2026-09-11 and not on any single branch. `quality-judge.ts` gained a
+// real judged component in LOR-229 and with it top-level imports of `ai`,
+// `@ai-sdk/gateway` and `./operator-voice-profile.js`, which reaches the
+// `pg` client. `DraftListItem.svelte` and `DraftDetail.svelte` import
+// `scoreBand` and `DETERMINISTIC_QUALITY_MODEL` from that same module, so
+// the whole server stack landed in the browser bundle and the Inbox failed
+// to hydrate: the sidebar rendered and the page itself showed "500
+// Internal Error". Server-rendered HTML was correct, which is why nothing
+// caught it short of loading the page.
+//
+// `quality-judge.ts` re-exports everything here, so no server caller
+// changes. Nothing in this file may import anything that is not also pure:
+// `shared/tests/quality-bands.test.ts` asserts that by reading the source,
+// because the failure mode is a transitive import nobody looks at.
+//
+// Same shape and same reason as `quota-types.ts` next to `quota-server.ts`.
+
+/** The rubric the judged component reads, and the two thresholds the band
+ * mapping below uses. Stored in `app_config.quality_rubric`. */
+export interface QualityRubric {
+  rubric_template: string;
+  threshold_red: number;
+  threshold_green: number;
+}
+
+export const DEFAULT_QUALITY_RUBRIC: QualityRubric = {
+  rubric_template:
+    'Score this draft from 0-100 on whether it reads as something a real person actually wrote and sent, not a generic AI reply. Weigh: would a reader take this for a person rather than a bot; does it say one concrete thing rather than vague encouragement; does it answer this specific post rather than any post on the same subject; and is it roughly the length a real reply in this room runs, not a small essay. Return JSON {"score": number, "reason": string}.',
+  threshold_red: 40,
+  threshold_green: 75,
+};
+
+/** `drafts.quality_model`'s sentinel for "computed, not judged" - as real a
+ * value as an actual Gateway model id, never confused with one (no `/` in
+ * it, unlike every Gateway id). */
+export const DETERMINISTIC_QUALITY_MODEL = 'deterministic';
+
+export type QualityBand = 'red' | 'amber' | 'green' | 'none';
+
+/** Maps a score to the band the Inbox paints. `none` is "not measured",
+ * which is a real answer rather than a bad one: an organization with no
+ * voice corpus and a draft with no style findings has nothing to score
+ * against, and the badge says so instead of inventing a number. */
+export function scoreBand(score: number | null | undefined, rubric: QualityRubric): QualityBand {
+  if (score == null) return 'none';
+  if (score < rubric.threshold_red) return 'red';
+  if (score >= rubric.threshold_green) return 'green';
+  return 'amber';
+}

--- a/shared/src/quality-judge.ts
+++ b/shared/src/quality-judge.ts
@@ -62,24 +62,31 @@ import {
 } from './voice-metrics.js';
 import type { StyleFinding } from './style-check.js';
 
-export interface QualityRubric {
-  rubric_template: string;
-  threshold_red: number;
-  threshold_green: number;
-}
+// The rubric shape, the default, the band mapping and the deterministic
+// sentinel live in `quality-bands.ts` and are re-exported here so no
+// server caller has to know that. They are separate because this module
+// imports `ai`, `@ai-sdk/gateway` and the pg-backed voice profile, and two
+// Svelte components need the band mapping: importing it from here dragged
+// all of that into the browser bundle and broke the Inbox's hydration (see
+// `quality-bands.ts`'s own header for the measurement).
+export {
+  DEFAULT_QUALITY_RUBRIC,
+  DETERMINISTIC_QUALITY_MODEL,
+  scoreBand,
+  type QualityBand,
+  type QualityRubric,
+} from './quality-bands.js';
+import {
+  DEFAULT_QUALITY_RUBRIC,
+  DETERMINISTIC_QUALITY_MODEL,
+  type QualityRubric,
+} from './quality-bands.js';
 
 // The pre-LOR-229 default, kept only so `loadQualityRubric` can recognize a
 // stored row that is really just the old default rather than a genuine
 // customization (see its own comment below) - never used as a live rubric.
 const LEGACY_DEFAULT_RUBRIC_TEMPLATE =
   'Score the following outreach draft from 0-100 on these axes (clarity, relevance, personalization, tone). Return JSON {"score": number, "reason": string}.';
-
-export const DEFAULT_QUALITY_RUBRIC: QualityRubric = {
-  rubric_template:
-    'Score this draft from 0-100 on whether it reads as something a real person actually wrote and sent, not a generic AI reply. Weigh: would a reader take this for a person rather than a bot; does it say one concrete thing rather than vague encouragement; does it answer this specific post rather than any post on the same subject; and is it roughly the length a real reply in this room runs, not a small essay. Return JSON {"score": number, "reason": string}.',
-  threshold_red: 40,
-  threshold_green: 75,
-};
 
 export async function loadQualityRubric(db: Db): Promise<QualityRubric> {
   const [row] = await db.select().from(appConfig).where(eq(appConfig.key, 'quality_rubric'));
@@ -104,17 +111,6 @@ export async function loadQualityRubric(db: Db): Promise<QualityRubric> {
         ? v.threshold_green
         : DEFAULT_QUALITY_RUBRIC.threshold_green,
   };
-}
-
-// Map a numeric score to a UI band given the configured rubric thresholds.
-export function scoreBand(
-  score: number | null | undefined,
-  rubric: QualityRubric,
-): 'red' | 'amber' | 'green' | 'none' {
-  if (score == null) return 'none';
-  if (score < rubric.threshold_red) return 'red';
-  if (score >= rubric.threshold_green) return 'green';
-  return 'amber';
 }
 
 // ---------------------------------------------------------------------------
@@ -343,7 +339,6 @@ export async function judgeQuality(
 /** `drafts.quality_model`'s sentinel for "computed, not judged" - as real a
  * value as an actual Gateway model id, never confused with one (no `/` in
  * it, unlike every Gateway id). */
-export const DETERMINISTIC_QUALITY_MODEL = 'deterministic';
 
 export interface DraftQualityResult {
   qualityScore: number | null;

--- a/shared/tests/quality-bands.test.ts
+++ b/shared/tests/quality-bands.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_QUALITY_RUBRIC,
+  DETERMINISTIC_QUALITY_MODEL,
+  scoreBand,
+} from '../src/quality-bands.js';
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+/** Every module `quality-bands.ts` can reach, following relative imports. */
+function transitiveLocalImports(entry: string): string[] {
+  const seen = new Set<string>();
+  const external: string[] = [];
+  const walk = (file: string) => {
+    if (seen.has(file)) return;
+    seen.add(file);
+    const source = readFileSync(file, 'utf8');
+    for (const match of source.matchAll(/^\s*(?:import|export)[^'"]*from\s+['"]([^'"]+)['"]/gm)) {
+      const spec = match[1]!;
+      if (spec.startsWith('.')) {
+        walk(join(dirname(file), spec.replace(/\.js$/, '.ts')));
+      } else {
+        external.push(spec);
+      }
+    }
+  };
+  walk(entry);
+  return external;
+}
+
+describe('quality-bands is safe to import from a browser bundle', () => {
+  // The regression this pins, found on merged main on 2026-09-11 and on no
+  // single branch: DraftListItem and DraftDetail imported `scoreBand` from
+  // `quality-judge.ts`, which had grown top-level imports of `ai`,
+  // `@ai-sdk/gateway` and the pg-backed voice profile. The server stack
+  // went into the client bundle, the Inbox failed to hydrate, and the page
+  // rendered "500 Internal Error" while its own server-rendered HTML was
+  // correct. Nothing short of loading the page could see it.
+  it('reaches no dependency at all, directly or transitively', () => {
+    expect(transitiveLocalImports(join(SRC, 'quality-bands.ts'))).toEqual([]);
+  });
+
+  it('scoreBand reports an unmeasured draft as none rather than as bad', () => {
+    expect(scoreBand(null, DEFAULT_QUALITY_RUBRIC)).toBe('none');
+    expect(scoreBand(undefined, DEFAULT_QUALITY_RUBRIC)).toBe('none');
+    expect(scoreBand(0, DEFAULT_QUALITY_RUBRIC)).toBe('red');
+  });
+
+  it('bands split on the rubric thresholds, inclusive at green', () => {
+    const r = DEFAULT_QUALITY_RUBRIC;
+    expect(scoreBand(r.threshold_red - 1, r)).toBe('red');
+    expect(scoreBand(r.threshold_red, r)).toBe('amber');
+    expect(scoreBand(r.threshold_green - 1, r)).toBe('amber');
+    expect(scoreBand(r.threshold_green, r)).toBe('green');
+  });
+
+  it('the deterministic sentinel can never collide with a gateway model id', () => {
+    expect(DETERMINISTIC_QUALITY_MODEL).not.toContain('/');
+  });
+});

--- a/web/src/lib/components/DraftDetail.svelte
+++ b/web/src/lib/components/DraftDetail.svelte
@@ -25,7 +25,7 @@
 		DEFAULT_QUALITY_RUBRIC,
 		DETERMINISTIC_QUALITY_MODEL,
 		type QualityRubric,
-	} from '@pitchbox/shared/quality-judge';
+	} from '@pitchbox/shared/quality-bands';
 
 	// scoreBand's band names are a shared-package contract (not the design
 	// registry's Tone names) - mirrors DraftListItem's own translation table.

--- a/web/src/lib/components/DraftListItem.svelte
+++ b/web/src/lib/components/DraftListItem.svelte
@@ -8,7 +8,7 @@
 		DEFAULT_QUALITY_RUBRIC,
 		DETERMINISTIC_QUALITY_MODEL,
 		type QualityRubric,
-	} from '@pitchbox/shared/quality-judge';
+	} from '@pitchbox/shared/quality-bands';
 	import { TONE_CLASS, type Tone } from '$lib/config/status-badges';
 	import { parseStyleFindings } from '$lib/utils/style-findings';
 


### PR DESCRIPTION
Closes LOR-254 (https://linear.app/fiorelorenzo/issue/LOR-254).

Found by rendering merged `main`, which is the one thing no agent in the wave could do: each rendered its own branch, where the other half did not exist yet.

The Inbox showed "500 Internal Error" in place of the page, with the sidebar rendering around it. The server-rendered HTML was correct and contained the drafts, `curl` returned 200, and nothing reached the server log, because SvelteKit catches a client-side failure into its own error boundary. Loading the page in a browser was the only way to see it.

Controlled, same worktree, same database, same browser:

| commit | /inbox |
| --- | --- |
| `740e455` before the wave | renders |
| `63f441d` wave-1 tip, style-findings badge | renders |
| `6ce8cb7` #675, the quality score | 500 |
| `ed5e52f` merged main | 500, empty inbox too |

## Cause

#675 gave `shared/src/quality-judge.ts` a judged component and with it top-level imports of `ai`, `@ai-sdk/gateway` and `./operator-voice-profile.js`, which reaches the `pg` client. `DraftListItem.svelte` and `DraftDetail.svelte` import `scoreBand`, `DEFAULT_QUALITY_RUBRIC` and `DETERMINISTIC_QUALITY_MODEL` from that same module, so importing a band-mapping function pulled the whole server stack into the client bundle and hydration failed.

It is the rule `AGENTS.md` already states for the web workspace, in a shape nobody looks for: the import was a pure three-line function that grew a server dependency underneath it later. Typecheck, `svelte-check` and review all pass with the bug present.

## Fix

`shared/src/quality-bands.ts` holds the rubric shape, the default, the band mapping and the deterministic sentinel, pure and importing nothing. Same shape `quota-types.ts` already has beside `quota-server.ts`. `quality-judge.ts` re-exports it, so no server caller changes, and the two components import the new module.

The test is the part worth keeping: it walks the new module's transitive imports and fails if it ever reaches a dependency again. A human reviewer will not catch that coming back.

## Verified

`/inbox` rendered on this commit in a real browser against a seeded database: a flagged draft shows the measured score and the style-finding count side by side, a clean one shows neither. `pnpm -F web check` 6125 files, 0 errors. shared and cli typecheck clean. eslint and prettier clean. `shared/tests/quality-bands.test.ts` plus `shared/tests/quality-judge.test.ts`: 15 of 15.