### PR TITLE
fix(shared): match accented Italian stopwords in classifyLanguage

### DIFF
--- a/shared/src/assist/voice-profile.ts
+++ b/shared/src/assist/voice-profile.ts
@@ -753,8 +753,16 @@ export type LanguageProfile = LanguageMix & {
 // without claiming to be a general-purpose language detector.
 const EN_STOPWORDS_GLOBAL =
   /\b(?:the|and|of|to|is|that|with|for|this|was|are|it's|i'm|we|you)\b/giu;
-const IT_STOPWORDS_GLOBAL =
-  /\b(?:il|la|di|che|per|con|un|una|è|non|questo|questa|sono|abbiamo|nel|della)\b/giu;
+// `\b` is defined against the ASCII word-character class ([A-Za-z0-9_])
+// regardless of the `u` flag, so it never sees an accented letter like `è`
+// as a word character: the boundary between a space and `è` does not exist
+// as far as the engine is concerned, so `\bè\b` can never match, and that
+// alternative (and any other accented entry) was dead code (LOR-234).
+// Unicode-aware lookaround boundaries fix it, matching the
+// `(?![\p{L}\p{N}_])` convention style-check.ts's own accented rules
+// already use for the same reason.
+export const IT_STOPWORDS_GLOBAL =
+  /(?<![\p{L}\p{N}_])(?:il|la|di|che|per|con|un|una|è|non|questo|questa|sono|abbiamo|nel|della)(?![\p{L}\p{N}_])/giu;
 
 /** Below this many stopword hits, a text has not said enough to classify -
  * one stray "the" in an otherwise Italian post is not evidence. */

--- a/shared/tests/assist-voice-profile.test.ts
+++ b/shared/tests/assist-voice-profile.test.ts
@@ -8,6 +8,7 @@ import {
   describeVoiceProfileForGenre,
   measureOneText,
   classifyLanguage,
+  IT_STOPWORDS_GLOBAL,
   measureEditSignature,
   describeEditSignature,
   hasEditSignatureContent,
@@ -670,6 +671,22 @@ describe('classifyLanguage (exported for style-check.ts and voice-metrics.ts)', 
     expect(classifyLanguage('This is the plan for the week and it is going well.')).toBe('en');
     expect(classifyLanguage("che bello, non vedo l'ora!")).toBe('it');
     expect(classifyLanguage('Grande!')).toBe('unknown');
+  });
+});
+
+// LOR-234: `\b` is defined against the ASCII word-character class, so it
+// never treats an accented letter like `è` as a word character - `\bè\b`
+// could never match, making that stopword (and any other accented entry)
+// dead code. Asserted at the regex itself, not only through
+// classifyLanguage, so a regression here is caught at the level it
+// happened rather than through a downstream classification.
+describe('IT_STOPWORDS_GLOBAL word boundary (LOR-234)', () => {
+  it('matches an accented stopword as a standalone word', () => {
+    expect('questo è tutto'.match(IT_STOPWORDS_GLOBAL)).toEqual(['questo', 'è']);
+  });
+
+  it('does not match an accented stopword inside a longer word', () => {
+    expect('cioè'.match(IT_STOPWORDS_GLOBAL)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What

`IT_STOPWORDS_GLOBAL` wrapped its alternation in `\b(?:...)\b`, and one alternative was `è`. JavaScript's `\b` is defined against the ASCII word-character class (`[A-Za-z0-9_]`) regardless of the `u` flag, so it never treats an accented letter as a word character: the boundary between a space and `è` does not exist as far as the engine is concerned, so `\bè\b` could never match. That alternative was dead code.

I replaced the `\b...\b` wrapper with Unicode-aware lookaround boundaries (`(?<![\p{L}\p{N}_])...(?![\p{L}\p{N}_])`), the same convention `style-check.ts`'s own accented rules already use for this reason. Every existing (ASCII) alternative still matches exactly as before; `è` now matches as a standalone word (`"questo è tutto"`) without matching inside a longer word (`"cioè"`).

I added a test that asserts the regex itself, not just `classifyLanguage`, so a regression is caught at the level it happened rather than through a downstream classification.

## What I measured, plainly

This is a real, demonstrable bug fix, but **it does not deliver the outcome the issue's title implied**. I measured the effect on the actual eval corpus rather than arguing it, and the number is close to zero.

**27-comment eval corpus** (`private/voice-eval/cases.json`, `.reference` text — the exact acceptance criterion), real `classifyLanguage` before (`origin/main`) vs after (this branch):

| | en | it | unknown |
|---|---|---|---|
| before | 1 | 10 | 16 |
| after | 1 | 10 | 16 |

**Zero flips.** No case moved, `en` included. None of the 16 comments this classifier calls `unknown` contain a standalone `è` at all — most are short exclamations, names, or emoji with zero or one Italian stopword hit, not an `è` that the boundary bug was swallowing.

**Independent corroboration on a 5x larger, different-genre corpus** (233 of Lorenzo's own non-draft sent LinkedIn messages, 2016-2026, `FROM == "Lorenzo Fiore"` only — aggregate counts only, message content never left the measurement script):

| | en | it | unknown |
|---|---|---|---|
| before | 26 | 95 | 112 |
| after | 26 | 96 | 111 |

**One flip, `unknown` → `it`.** Zero `en` cases moved. Same story at 5x the sample size: the fix is real (verified directly: `classifyLanguage("Non è possibile")` goes from `unknown` (1 hit) to `it` (2 hits) once `è` counts), but it is not why half of Lorenzo's short-form writing classifies as `unknown`.

**Conclusion:** the accented word-boundary bug is worth fixing on its own (dead code in a regex, now pinned by a test at the level it broke), but it is not the reason LOR-234's "fifteen of 27 unknown" problem exists. That reason is somewhere else — most likely `LANGUAGE_MARKER_MIN = 2` being too high for 3-10 word text, and/or the stopword lists being too thin for short text, since the `unknown` bucket here is dominated by comments with zero or one stopword hit of any kind, not by comments carrying an uncounted `è`. Not fixing that here: it's a different, larger defect than the one this issue named, and outside this issue's scope.

## Verified

- `pnpm exec vitest run shared/tests/assist-voice-profile.test.ts shared/tests/style-check.test.ts` — 94 passed, including the new regex-boundary test and every existing English-classification test (`scanBilingual`'s English literal lists run through the same classifier, unaffected: `EN_STOPWORDS_GLOBAL` untouched).
- `pnpm -F @pitchbox/shared typecheck` — clean.
- `npx eslint` / `npx prettier --check` on both changed files — clean.
- Could not verify: the full `pnpm test` pre-push hook (`preflight`) failed on 30 unrelated tests in 20 files (`skill-generate*` seeding, `org.id` undefined) that have nothing to do with this diff — this is the known LOR-220 flakiness the task constraints call out ("fails a different three files every run on an unchanged tree"), so I pushed with `--no-verify` per those constraints rather than treat it as a signal.
