### PR TITLE
fix(shared): the length target's measured range does not clear the bar (LOR-253)

### DIFF
--- a/scripts/voice-eval.ts
+++ b/scripts/voice-eval.ts
@@ -43,8 +43,14 @@ import {
 import { scoreCandidate, type VoiceCandidateScore } from '../shared/src/voice-metrics.js';
 import { buildSuggestionPrompt, type ObservedPost } from '../shared/src/assist/suggest-prompt.js';
 import { splitSuggestion } from '../shared/src/assist/envelope.js';
-import { measureVoiceCorpus, describeVoiceProfile } from '../shared/src/assist/voice-profile.js';
+import {
+  measureVoiceCorpus,
+  describeVoiceProfile,
+  measureVoiceCorpusByGenre,
+  describeVoiceProfileForGenre,
+} from '../shared/src/assist/voice-profile.js';
 import { DEFAULT_VOICE_PROFILE } from '../shared/src/assist/voice-defaults.js';
+import type { VoiceProfileSummary } from '../shared/src/assist/context.js';
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -87,14 +93,56 @@ const cases = limit && limit > 0 ? file.cases.slice(0, limit) : file.cases;
 // ---------------------------------------------------------------------------
 // The voice profile the prompt is built with - exactly what `main` derives
 // today when `--thin` is absent, `voice-defaults.ts`'s own default otherwise.
+//
+// LOR-253: this used to hand `buildSuggestionPrompt` a bare `{ summary }`,
+// which meant `lengthTarget`'s comment-genre path (`medianCommentWords`,
+// `commentWordsSpread`) never fired in this harness at all - every eval run
+// silently skipped the exact section this issue changes. The set's own
+// `actualReply` texts *are* the operator's real comment corpus, so they feed
+// `measureVoiceCorpusByGenre` the same way a real derivation would, tagged
+// 'comment' - computed once over the whole set and applied to every case,
+// the same way a real `operator_voice_profiles` row is derived once from
+// history and then applied prospectively.
 // ---------------------------------------------------------------------------
 
-function resolveVoiceProfileSummary(): string {
-  if (thin || file.voiceCorpus.length === 0) return DEFAULT_VOICE_PROFILE.summary;
-  const measurement = measureVoiceCorpus(
+function resolveVoiceProfileSummary(): VoiceProfileSummary | null {
+  if (thin || file.voiceCorpus.length === 0) {
+    return {
+      summary: DEFAULT_VOICE_PROFILE.summary,
+      commentSummary: null,
+      editSignature: null,
+      medianCommentWords: null,
+      commentWordsSpread: null,
+    };
+  }
+  const pooled = measureVoiceCorpus(
     file.voiceCorpus.map((c, i) => ({ id: i + 1, kind: 'voice_sample' as const, text: c.text })),
   );
-  return describeVoiceProfile(measurement) ?? DEFAULT_VOICE_PROFILE.summary;
+  const summary = describeVoiceProfile(pooled) ?? DEFAULT_VOICE_PROFILE.summary;
+
+  const commentCorpus = cases
+    .filter((c): c is VoiceEvalCase & { actualReply: string } => c.actualReply !== null)
+    .map((c, i) => ({
+      id: i + 1,
+      kind: 'voice_sample' as const,
+      genre: 'comment' as const,
+      text: c.actualReply,
+    }));
+  const commentMeasurement = measureVoiceCorpusByGenre(commentCorpus).comment;
+
+  return {
+    summary,
+    commentSummary: describeVoiceProfileForGenre('comment', commentMeasurement),
+    editSignature: null,
+    medianCommentWords:
+      commentMeasurement.rhythm.medianItemWords > 0
+        ? commentMeasurement.rhythm.medianItemWords
+        : null,
+    commentWordsSpread:
+      commentMeasurement.rhythm.itemWordsSpread > 0
+        ? commentMeasurement.rhythm.itemWordsSpread
+        : null,
+  };
 }
 
 const voiceProfileSummary = resolveVoiceProfileSummary();
@@ -160,7 +208,7 @@ async function generateCandidate(
     kind: 'post_comment',
     post,
     persona: null,
-    voiceProfile: { summary: voiceProfileSummary },
+    voiceProfile: voiceProfileSummary,
     projects: [],
     repos: [],
     tone: 'match-room',

--- a/shared/src/assist/context.ts
+++ b/shared/src/assist/context.ts
@@ -97,6 +97,19 @@ export type VoiceProfileSummary = {
    * sentence buried in a persona description - a number in the task's own
    * instruction does not. */
   medianCommentWords: number | null;
+  /** The same comment-genre measurement's own interquartile range of
+   * whole-piece length, in words (LOR-232's rhythm axis's `itemWordsSpread`,
+   * read per genre same as `medianCommentWords` above) - null under the
+   * exact same condition. LOR-253: `medianCommentWords` alone is a single
+   * point, and a point read as a target gets treated as a ceiling no matter
+   * how the task's prose hedges it - this is the measured range around it,
+   * so `suggest-prompt.ts` can name a real upper end instead of an abstract
+   * "not a ceiling" with nothing concrete behind it. Zero (never negative)
+   * when the corpus is too small to have a spread of its own
+   * (`interquartileRange`'s own floor is four items) - `suggest-prompt.ts`
+   * treats that the same as "no range to add", not a range of zero words.
+   */
+  commentWordsSpread: number | null;
 };
 
 export type ProjectBrief = {
@@ -263,6 +276,10 @@ export async function loadCompanionContext(
           medianCommentWords:
             voiceProfileRow.evidence.genres.comment.medianItemWords > 0
               ? voiceProfileRow.evidence.genres.comment.medianItemWords
+              : null,
+          commentWordsSpread:
+            voiceProfileRow.evidence.genres.comment.itemWordsSpread > 0
+              ? voiceProfileRow.evidence.genres.comment.itemWordsSpread
               : null,
         }
       : null,

--- a/shared/src/assist/suggest-prompt.ts
+++ b/shared/src/assist/suggest-prompt.ts
@@ -273,6 +273,20 @@ const TASK: Record<SuggestionKind, string> = {
   post: 'Write one short post for this account, taking the post below as the starting point rather than something to summarise. Say one thing and stop.',
 };
 
+/** LOR-253: appended to the "only when there is something specific to add"
+ * sentence, never to the standalone "Length target" line below it. Measured
+ * against the eval set, a second number sitting in its own "Length target"
+ * line moved the *whole* distribution up - short, reactive posts drifted
+ * longer along with the genuinely long ones, because the model read it as a
+ * second target to reach for rather than a ceiling that only applies once
+ * the task's own condition ("something specific to add") is already met.
+ * Folding the number into that same conditional sentence keeps the number
+ * behind the condition instead of beside it. */
+function substanceClause(upperWords: number): string {
+  const upper = `${upperWords} word${upperWords === 1 ? '' : 's'}`;
+  return ` This operator has gone as long as about ${upper} when a post genuinely earned it - do not cut a real answer short to stay near the usual case.`;
+}
+
 /**
  * `post_comment`'s own task, sharpened into a reply when the human opened
  * a reply box under one specific comment rather than the post's own
@@ -282,12 +296,19 @@ const TASK: Record<SuggestionKind, string> = {
  * post - the two `post_comment` requests used to be identical past this
  * point. Names the id rather than the words: the thread's own text is
  * `read_thread`'s job, not this prompt's.
+ *
+ * `upperWords` (LOR-253) is `lengthTarget`'s measured stretch, folded into
+ * the task's own conditional sentence rather than into a second standalone
+ * line - see `substanceClause`'s own doc comment for why. Absent (`0`) when
+ * `lengthTarget` found no spread to name, in which case the task reads
+ * exactly as LOR-233 left it.
  */
-function taskFor(kind: SuggestionKind, replyToCommentId?: string): string {
+function taskFor(kind: SuggestionKind, replyToCommentId?: string, upperWords = 0): string {
+  const suffix = upperWords > 0 ? substanceClause(upperWords) : '';
   if (kind === 'post_comment' && replyToCommentId) {
-    return `Write one reply to the comment with id "${replyToCommentId}" in the thread below (call read_thread to see who wrote it and what it says) - not a comment on the post itself. A short reaction in the operator's own voice is a complete answer on its own, not a fallback, when that is genuinely what the reply calls for. Write a longer reply, one paragraph, two at most, only when there is something specific to add that commenter or another reader would not already know. Never pad a short reaction into something that reads as more substantial than it is.`;
+    return `Write one reply to the comment with id "${replyToCommentId}" in the thread below (call read_thread to see who wrote it and what it says) - not a comment on the post itself. A short reaction in the operator's own voice is a complete answer on its own, not a fallback, when that is genuinely what the reply calls for. Write a longer reply, one paragraph, two at most, only when there is something specific to add that commenter or another reader would not already know. Never pad a short reaction into something that reads as more substantial than it is.${suffix}`;
   }
-  return TASK[kind];
+  return `${TASK[kind]}${kind === 'post_comment' ? suffix : ''}`;
 }
 
 /**
@@ -352,6 +373,36 @@ function median(nums: number[]): number {
   return Math.round(sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!);
 }
 
+/** How far past the median `postLooksSubstantive`'s upper end reaches, in
+ * multiples of the measured interquartile range (LOR-253). Not a word count
+ * - a calibration ratio, the same kind of constant `voice-profile.ts`
+ * already uses for its own thresholds (`TRAIT_DOMINANCE_RATIO`,
+ * `PHRASE_COVERAGE_RATIO`). 2 (the standard Tukey boxplot "mild outlier"
+ * fence is Q3 + 1.5 * IQR, which for a right-skewed length distribution
+ * lands close to `median + 2 * IQR`) measurably over-corrected on the eval
+ * set's own "short" bucket once the substance gate below let it fire on the
+ * genuinely medium-length cases too, not only the very long ones - 1.5 is
+ * the smaller value that still moves the "long" bucket's median well past
+ * the old 9-to-12-word floor (LOR-253's own before/after measurement, in
+ * the PR) without pushing "short" past a few words of where it already
+ * was. */
+const LENGTH_SPREAD_MULTIPLIER = 1.5;
+
+/** Same reasoning as `median` above, and the same three-line duplication
+ * `voice-profile.ts`'s own `interquartileRange` already carries - kept local
+ * rather than imported for the same "not worth a new import surface" reason.
+ * Below four items there is nothing honest to call a spread (one outlier in
+ * a corpus of three is the whole corpus, not a distribution), so this
+ * returns 0 the same way `voice-profile.ts`'s copy does. */
+function interquartileRange(nums: number[]): number {
+  if (nums.length < 4) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const half = Math.floor(sorted.length / 2);
+  const q1 = median(sorted.slice(0, half));
+  const q3 = median(sorted.slice(sorted.length - half));
+  return q3 - q1;
+}
+
 /**
  * Names a length target in words for a `post_comment` task, derived rather
  * than fixed (LOR-233) - `null` when neither source below exists, which the
@@ -369,18 +420,65 @@ function median(nums: number[]): number {
  * thread rendered at all, which is always, on the SDUI feed (see this
  * file's `ObservedThread` doc comment).
  *
- * Returns which source won alongside the number: a human reading a
+ * `spread` is LOR-253's addition: the same source's own interquartile range,
+ * 0 when the source is too thin to have one. A single median read as a
+ * target gets treated as a ceiling no matter how the surrounding sentence
+ * hedges it - measured against the eval set, the three cases that called
+ * for a real answer (39, 39 and 130 words) came back at 9 to 12 regardless of
+ * that hedge. The spread gives the model a second, concrete number - how far
+ * this same voice actually stretches - rather than an abstract permission to
+ * ignore the first one.
+ *
+ * Returns which source won alongside the numbers: a human reading a
  * suggestion should be able to tell why it came out the length it did, not
  * just that it did.
  */
 function lengthTarget(
   voiceProfile: VoiceProfileSummary | null,
   thread: ObservedThread | undefined,
-): { words: number; source: 'room' | "operator's own habit" } | null {
+): { words: number; spread: number; source: 'room' | "operator's own habit" } | null {
   const threadWords = (thread?.comments ?? []).map((c) => wordCount(c.body)).filter((n) => n > 0);
-  if (threadWords.length > 0) return { words: median(threadWords), source: 'room' };
+  if (threadWords.length > 0) {
+    return { words: median(threadWords), spread: interquartileRange(threadWords), source: 'room' };
+  }
   const own = voiceProfile?.medianCommentWords;
-  return own && own > 0 ? { words: own, source: "operator's own habit" } : null;
+  if (!own || own <= 0) return null;
+  const ownSpread = voiceProfile?.commentWordsSpread;
+  return {
+    words: own,
+    spread: ownSpread && ownSpread > 0 ? ownSpread : 0,
+    source: "operator's own habit",
+  };
+}
+
+/**
+ * Gates `substanceClause` on the post itself (LOR-253), reusing
+ * `register.ts`'s own measurement rather than a second one. Measured on the
+ * eval set first, per the issue's own instruction not to ship this if it
+ * came back weak: raw word-count correlation between the post and the real
+ * reply is weak (Pearson r = 0.118, r = 0.382 on log-scaled lengths) and it
+ * misses the single longest real reply outright (a 130-word reflection on a
+ * personal post carrying neither trait below) - not strong enough to size
+ * the target itself, which is why `lengthTarget` never reads it.
+ *
+ * It is used here only as a one-way gate, not as the number's source: adding
+ * the substance clause to *every* prompt (the first version of this fix)
+ * measurably pulled the whole distribution up, including plainly reactive
+ * posts - a launch photo drifted from a 12-word reaction toward 18 to 31
+ * words across repeated runs, which is exactly the regression the issue
+ * warns against. `code-or-jargon` and `numbers` are the two traits that
+ * measured longer real replies on average (17.0 vs 14.9, and 16.3 vs 14.8
+ * words) rather than shorter - restricting the clause to posts carrying at
+ * least one of them cuts how often it fires on the eval set's own
+ * very-short bucket from 16 of 16 to 5 of 16, while still firing on 2 of the
+ * 3 genuinely long cases. It will still miss a case like the 130-word one
+ * above; nothing mechanical catches that one, and this does not pretend to.
+ */
+function postLooksSubstantive(text: string): boolean {
+  const register = readPostRegister(text);
+  return (
+    register?.traits.includes('code-or-jargon') || register?.traits.includes('numbers') || false
+  );
 }
 
 /**
@@ -582,15 +680,22 @@ export function buildSuggestionPrompt(args: {
     ].join('\n'),
   );
 
-  parts.push(`Your task: ${taskFor(kind, post.replyToCommentId)}`);
-
   // LOR-233: a length target in words, named explicitly rather than left
   // for the model to reconcile "adds something" against a voice profile
   // that separately says "about 7 words" - see `lengthTarget`'s own doc
   // comment for which source wins and why. `post` has no room to read a
   // target off (no thread, no per-genre comment habit) and keeps its own
-  // brevity instruction in TASK.post above instead.
-  //
+  // brevity instruction in TASK.post above instead. Computed before `Your
+  // task` (LOR-253) so its measured upper end can be folded into the task's
+  // own conditional sentence - see `substanceClause`'s doc comment for why
+  // that upper end no longer lives in this line as a second number.
+  const target = kind === 'post_comment' ? lengthTarget(voiceProfile, post.thread) : null;
+  const upperWords =
+    target && target.spread > 0 && postLooksSubstantive(post.text)
+      ? Math.round(target.words + target.spread * LENGTH_SPREAD_MULTIPLIER)
+      : 0;
+  parts.push(`Your task: ${taskFor(kind, post.replyToCommentId, upperWords)}`);
+
   // Deliberately not a ceiling: a median is the typical case, not every
   // case, and roughly half of what the operator actually writes runs
   // longer than it - sometimes much longer, when the post itself is the
@@ -601,18 +706,15 @@ export function buildSuggestionPrompt(args: {
   // avoid, just moved from "always long" to "always short". The target is
   // a default to return to once there is nothing left to say, not a limit
   // on how much there is to say.
-  if (kind === 'post_comment') {
-    const target = lengthTarget(voiceProfile, post.thread);
-    if (target) {
-      const words = `${target.words} word${target.words === 1 ? '' : 's'}`;
-      const clause =
-        target.source === 'room'
-          ? `this thread's own comments run about ${words}`
-          : `the operator's own comments run about ${words}`;
-      parts.push(
-        `Length target: ${clause} - treat that as the length to return to once you have said what is worth saying, not a ceiling on it. Padding a short reaction out to look more substantial is the defect; a longer comment earned by something real to say is not, and the post below sometimes calls for exactly that.`,
-      );
-    }
+  if (target) {
+    const words = `${target.words} word${target.words === 1 ? '' : 's'}`;
+    const clause =
+      target.source === 'room'
+        ? `this thread's own comments run about ${words}`
+        : `the operator's own comments run about ${words}`;
+    parts.push(
+      `Length target: ${clause} - treat that as the length to return to once you have said what is worth saying, not a ceiling on it. Padding a short reaction out to look more substantial is the defect; a longer comment earned by something real to say is not, and the post below sometimes calls for exactly that.`,
+    );
   }
 
   // The tone, after the task and before the operator's steer, because that is

--- a/shared/tests/assist-context.test.ts
+++ b/shared/tests/assist-context.test.ts
@@ -32,8 +32,8 @@ async function ensureOrg(slug: string): Promise<number> {
   return org!.id;
 }
 
-describe('loadCompanionContext: medianCommentWords (LOR-233)', () => {
-  it("reads the comment genre's own median off evidence, not the pooled rhythm", async () => {
+describe('loadCompanionContext: medianCommentWords (LOR-233), commentWordsSpread (LOR-253)', () => {
+  it("reads the comment genre's own median and spread off evidence, not the pooled rhythm", async () => {
     await reset();
     const orgId = await ensureOrg('lor233-median');
     await getDb()
@@ -58,6 +58,7 @@ describe('loadCompanionContext: medianCommentWords (LOR-233)', () => {
     const context = await loadCompanionContext(getDb(), { organizationId: orgId });
     expect(context.voiceProfile?.commentSummary).toMatch(/about 7 words/);
     expect(context.voiceProfile?.medianCommentWords).toBe(7);
+    expect(context.voiceProfile?.commentWordsSpread).toBe(4);
   });
 
   it('reports null, never 0, when the comment genre has not cleared the floor to derive one', async () => {
@@ -84,5 +85,6 @@ describe('loadCompanionContext: medianCommentWords (LOR-233)', () => {
     const context = await loadCompanionContext(getDb(), { organizationId: orgId });
     expect(context.voiceProfile?.commentSummary).toBeNull();
     expect(context.voiceProfile?.medianCommentWords).toBeNull();
+    expect(context.voiceProfile?.commentWordsSpread).toBeNull();
   });
 });

--- a/shared/tests/suggest-prompt.test.ts
+++ b/shared/tests/suggest-prompt.test.ts
@@ -65,6 +65,7 @@ const voiceProfile: VoiceProfileSummary = {
   commentSummary: null,
   editSignature: null,
   medianCommentWords: null,
+  commentWordsSpread: null,
 };
 
 const projects: ProjectBrief[] = [
@@ -263,6 +264,7 @@ describe('buildSuggestionPrompt', () => {
           'Based on 27 of their own comments (190 words). Usually writes one short sentence.',
         editSignature: null,
         medianCommentWords: 7,
+        commentWordsSpread: null,
       };
       const commentPrompt = buildSuggestionPrompt({
         kind: 'post_comment',
@@ -413,6 +415,7 @@ describe('buildSuggestionPrompt', () => {
           commentSummary: null,
           editSignature: null,
           medianCommentWords: null,
+          commentWordsSpread: null,
         },
         projects: [],
         repos: [],
@@ -426,6 +429,7 @@ describe('buildSuggestionPrompt', () => {
           commentSummary: null,
           editSignature: null,
           medianCommentWords: null,
+          commentWordsSpread: null,
         },
         projects: [],
         repos: [],
@@ -505,6 +509,7 @@ describe('buildSuggestionPrompt', () => {
           commentSummary: null,
           editSignature: null,
           medianCommentWords: 7,
+          commentWordsSpread: null,
         },
         projects: [],
         repos: [],
@@ -538,6 +543,7 @@ describe('buildSuggestionPrompt', () => {
           commentSummary: null,
           editSignature: null,
           medianCommentWords: 7,
+          commentWordsSpread: null,
         },
         projects: [],
         repos: [],
@@ -556,6 +562,7 @@ describe('buildSuggestionPrompt', () => {
           commentSummary: null,
           editSignature: null,
           medianCommentWords: 12,
+          commentWordsSpread: null,
         },
         projects: [],
         repos: [],
@@ -582,6 +589,7 @@ describe('buildSuggestionPrompt', () => {
           commentSummary: null,
           editSignature: null,
           medianCommentWords: 7,
+          commentWordsSpread: null,
         },
         projects: [],
         repos: [],
@@ -599,12 +607,147 @@ describe('buildSuggestionPrompt', () => {
           commentSummary: null,
           editSignature: null,
           medianCommentWords: 1,
+          commentWordsSpread: null,
         },
         projects: [],
         repos: [],
       });
       expect(prompt).toMatch(/about 1 word\b/);
       expect(prompt).not.toContain('about 1 words');
+    });
+
+    // The default `post` fixture ('We cut p99 in half by dropping a cache.')
+    // is nine words - below register.ts's own floor to read anything off, so
+    // `postLooksSubstantive` reads it as not-substantive regardless of
+    // content. These tests use a longer, jargon-and-numbers post instead, so
+    // the gate genuinely fires - see `postLooksSubstantive`'s own doc comment
+    // for why that gate exists and what it is measured against.
+    const substantivePost = {
+      ...post,
+      text: 'We migrated the whole payments pipeline to a new queue this week and cut p99 latency by 40ms, which is the biggest win the team has shipped this quarter.',
+    };
+
+    it('LOR-253: folds a measured upper end into the task itself when the post looks substantive and the comment genre has a real spread', () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post: substantivePost,
+        persona: null,
+        voiceProfile: {
+          summary: 'irrelevant',
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: 7,
+          commentWordsSpread: 15,
+        },
+        projects: [],
+        repos: [],
+      });
+      // The standalone "Length target" line stays exactly as LOR-233 left it -
+      // a single point, no second number - so the short/very-short buckets it
+      // already served well are untouched (see suggest-prompt.ts's own
+      // module-level rationale for why the upper end moved out of this line).
+      expect(prompt).toMatch(
+        /Length target: the operator's own comments run about 7 words - treat/,
+      );
+      expect(prompt).not.toContain('stretching up toward');
+      // The upper end lives inside the task's own conditional sentence
+      // instead, right after "Never pad a short reaction..." - still inside
+      // "Your task:", never inside the standalone "Length target" line.
+      expect(prompt).toMatch(
+        /Never pad a short reaction into something that reads as more substantial than it is\. This operator has gone as long as about 30 words when a post genuinely earned it/,
+      );
+      expect(prompt.indexOf('Your task:')).toBeLessThan(prompt.indexOf('has gone as long as'));
+      expect(prompt.indexOf('has gone as long as')).toBeLessThan(prompt.indexOf('Length target:'));
+    });
+
+    it('says nothing extra in the task when the post itself gives no reason to expect a longer answer, even with a real spread on file', () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post,
+        persona: null,
+        voiceProfile: {
+          summary: 'irrelevant',
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: 7,
+          commentWordsSpread: 15,
+        },
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).not.toContain('has gone as long as');
+    });
+
+    it('says nothing extra in the task when the corpus is too small to have a spread of its own, even on a substantive post', () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post: substantivePost,
+        persona: null,
+        voiceProfile: {
+          summary: 'irrelevant',
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: 7,
+          commentWordsSpread: 0,
+        },
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).toMatch(
+        /Length target: the operator's own comments run about 7 words - treat/,
+      );
+      expect(prompt).not.toContain('has gone as long as');
+    });
+
+    it("folds the thread's own measured spread into the task too, when the page sent enough comments to have one and the post looks substantive", () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post: {
+          ...substantivePost,
+          thread: {
+            comments: [
+              { body: Array(5).fill('word').join(' ') },
+              { body: Array(8).fill('word').join(' ') },
+              { body: Array(10).fill('word').join(' ') },
+              { body: Array(30).fill('word').join(' ') },
+              { body: Array(40).fill('word').join(' ') },
+            ],
+            renderedCount: 5,
+            truncated: false,
+          },
+        },
+        persona: null,
+        voiceProfile: null,
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).toMatch(
+        /Length target: this thread's own comments run about 10 words - treat/,
+      );
+      expect(prompt).toMatch(
+        /This operator has gone as long as about \d+ words when a post genuinely earned it/,
+      );
+    });
+
+    it('folds the upper end into a reply task the same way as the plain comment task', () => {
+      const prompt = buildSuggestionPrompt({
+        kind: 'post_comment',
+        post: { ...substantivePost, replyToCommentId: 'c1' },
+        persona: null,
+        voiceProfile: {
+          summary: 'irrelevant',
+          commentSummary: null,
+          editSignature: null,
+          medianCommentWords: 7,
+          commentWordsSpread: 15,
+        },
+        projects: [],
+        repos: [],
+      });
+      expect(prompt).toMatch(/Write one reply to the comment with id "c1"/);
+      expect(prompt).toMatch(
+        /This operator has gone as long as about 30 words when a post genuinely earned it/,
+      );
     });
   });
 });


### PR DESCRIPTION
Closes LOR-253.

**Update, after Main asked for 5 runs each side rather than 2-3: this does not clear the bar as measured. Recommend against merging as-is; see conclusion at the bottom.**

I re-measured the baseline myself on the same 27 real cases the issue carries, bucketed by how long Lorenzo's own reply actually was, using `scripts/voice-eval.ts` (which I also had to fix: it built `buildSuggestionPrompt` with a bare `{ summary }` voice profile, so `lengthTarget`'s comment-genre path never fired in this harness at all, and every prior eval run through it silently skipped the exact section this issue is about).

## Full run-by-run table (5 runs each side, `google/gemini-3.1-flash-lite`, same 27 cases, same model both sides)

Baseline = current `main` (before this PR's diff to `suggest-prompt.ts`/`context.ts`). After = this PR's code (gate + `median + 1.5 * spread`, folded into the task sentence).

**Long bucket (n=3, his median 39):**

| run | baseline median | baseline within5 | after median | after within5 |
| -- | -- | -- | -- | -- |
| 1 | 17 | 0 of 3 | 18 | 0 of 3 |
| 2 | 14 | 0 of 3 | 15 | 0 of 3 |
| 3 | 16 | 0 of 3 | 17 | 0 of 3 |
| 4 | 16 | 0 of 3 | 21 | 0 of 3 |
| 5 | 15 | 0 of 3 | 16 | 0 of 3 |

Baseline range 14-17, after range 15-21. They overlap (15-17), the after set's own spread (15 to 21) is wider than the gap between the two means (15.6 vs 17.4), and within5 is 0 of 3 in all 10 runs on both sides with no exception. I cannot distinguish this movement from run-to-run noise on this model with n=3 per run.

**Short bucket (n=8, his median 18):**

| run | baseline median | baseline within5 | after median | after within5 |
| -- | -- | -- | -- | -- |
| 1 | 21 | 2 of 8 | 23 | 2 of 8 |
| 2 | 19 | 2 of 8 | 22 | 3 of 8 |
| 3 | 18 | 5 of 8 | 23 | 5 of 8 |
| 4 | 18 | 4 of 8 | 23 | 5 of 8 |
| 5 | 20 | 5 of 8 | 22 | 1 of 8 |

Baseline range 18-21, after range 22-23 - these do **not** overlap across 5 runs each: this bucket moved away from his median (18), by about as much as the long bucket moved toward it, exactly as flagged. The `within5` count does not show a comparable regression (baseline mean 3.6 of 8, after mean 3.2 of 8), but the median shift itself is real and consistent, not noise.

**Very short bucket (n=16, his median 3):**

| run | baseline median | baseline within5 | after median | after within5 |
| -- | -- | -- | -- | -- |
| 1 | 13 | 5 of 16 | 14 | 2 of 16 |
| 2 | 14 | 2 of 16 | 17 | 4 of 16 |
| 3 | 13 | 1 of 16 | 15 | 2 of 16 |
| 4 | 14 | 4 of 16 | 15 | 3 of 16 |
| 5 | 15 | 3 of 16 | 14 | 3 of 16 |

Baseline range 13-15, after range 14-17 - mostly overlapping, a small upward drift.

## Conclusion

The correlation I measured for the gate (`postLooksSubstantive`, `code-or-jargon` or `numbers`) is r = 0.118 raw / r = 0.382 log-scaled between post length and real reply length - weak, and it misses the single longest real reply outright (130 words, a personal reflection with neither trait). That was already stated as a real limit. Read against the fuller 5-run table above, the more important reading of that same weak correlation is that **post length does not reliably predict reply length** on this corpus, which is the premise the whole `postLooksSubstantive`-gated approach rests on. The long bucket's movement is not distinguishable from noise at this sample size, and the short bucket shows a small, consistent regression away from his own median across every run.

I did not tune the multiplier further to chase a cleaner result, per instruction. This PR does not demonstrate that the length-target change fixes the long bucket; I would not merge it as a fix on this evidence, and I think the honest close here is measured-and-rejected rather than shipped-as-improved. Leaving the PR open for that decision rather than closing it myself.

---

<details>
<summary>Original PR description (first 2-3 runs each side)</summary>

**The fix.** `VoiceProfileSummary.medianCommentWords` was a single point, and a point read as a target got treated as a ceiling no matter how the task's prose hedged it. I added `commentWordsSpread` (the same comment-genre `rhythm.itemWordsSpread` LOR-227 already stores on `operator_voice_profiles`, just not threaded through to the prompt - no migration) and used it to name a real upper end: `median + 1.5 * spread`, folded into the task's own "only when there is something specific to add" sentence rather than into the standalone `Length target` line. A first version that put the second number in that line moved the *whole* distribution up, short reactive posts included - exactly the regression the issue warns against.

That upper end is gated on the post itself (`postLooksSubstantive`), reusing `register.ts`'s own measurement, on the theory (now contradicted by the fuller table above) that it would fire selectively on posts that call for more.

**Also touched:**
- `shared/src/assist/context.ts`: `VoiceProfileSummary` gained `commentWordsSpread`, threaded from the existing stored evidence.
- `scripts/voice-eval.ts`: now derives a comment-genre voice profile from the case file's own `actualReply` texts, matching what `loadCompanionContext` actually builds in production (previously it never exercised this code path at all - this part is a real, independent fix to the harness regardless of the outcome above).

</details>

**Verified:**
- `pnpm -F @pitchbox/shared typecheck` - clean.
- `npx eslint` and `npx prettier --check` on every changed file - clean.
- `shared/tests/suggest-prompt.test.ts` (47 tests) and `shared/tests/assist-context.test.ts` (2 tests, DB-backed) - all green.
- `web/tests/extension-suggest-voice.test.ts` (a `buildSuggestionPrompt` caller outside my workspace, to check blast radius) - unchanged, 3 tests green.
- Did not run the full `pnpm test` - see LOR-269 (filed by Main): every worktree's `preflight` shares one Postgres container/port/database, and a sibling's push tears it down mid-run, which is what actually failed my first push attempt, not LOR-220 as I originally guessed.
