### PR TITLE
fix(shared): the voice-eval harness never built a comment-genre profile, so its comment numbers were not measuring the prompt

### DIFF
--- a/scripts/voice-eval.ts
+++ b/scripts/voice-eval.ts
@@ -43,8 +43,14 @@ import {
 import { scoreCandidate, type VoiceCandidateScore } from '../shared/src/voice-metrics.js';
 import { buildSuggestionPrompt, type ObservedPost } from '../shared/src/assist/suggest-prompt.js';
 import { splitSuggestion } from '../shared/src/assist/envelope.js';
-import { measureVoiceCorpus, describeVoiceProfile } from '../shared/src/assist/voice-profile.js';
+import {
+  measureVoiceCorpus,
+  describeVoiceProfile,
+  measureVoiceCorpusByGenre,
+  describeVoiceProfileForGenre,
+} from '../shared/src/assist/voice-profile.js';
 import { DEFAULT_VOICE_PROFILE } from '../shared/src/assist/voice-defaults.js';
+import type { VoiceProfileSummary } from '../shared/src/assist/context.js';
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -87,14 +93,52 @@ const cases = limit && limit > 0 ? file.cases.slice(0, limit) : file.cases;
 // ---------------------------------------------------------------------------
 // The voice profile the prompt is built with - exactly what `main` derives
 // today when `--thin` is absent, `voice-defaults.ts`'s own default otherwise.
+//
+// This used to hand `buildSuggestionPrompt` a bare `{ summary }`, which meant
+// `lengthTarget`'s comment-genre path (`medianCommentWords`) never fired in
+// this harness at all - every eval run silently skipped that section of the
+// prompt, so any per-case number this script reported for a `post_comment`
+// case was measuring a prompt the product does not actually send. The set's
+// own `actualReply` texts *are* the operator's real comment corpus, so they
+// feed `measureVoiceCorpusByGenre` the same way a real derivation would,
+// tagged 'comment' - computed once over the whole set and applied to every
+// case, the same way a real `operator_voice_profiles` row is derived once
+// from history and then applied prospectively.
 // ---------------------------------------------------------------------------
 
-function resolveVoiceProfileSummary(): string {
-  if (thin || file.voiceCorpus.length === 0) return DEFAULT_VOICE_PROFILE.summary;
-  const measurement = measureVoiceCorpus(
+function resolveVoiceProfileSummary(): VoiceProfileSummary | null {
+  if (thin || file.voiceCorpus.length === 0) {
+    return {
+      summary: DEFAULT_VOICE_PROFILE.summary,
+      commentSummary: null,
+      editSignature: null,
+      medianCommentWords: null,
+    };
+  }
+  const pooled = measureVoiceCorpus(
     file.voiceCorpus.map((c, i) => ({ id: i + 1, kind: 'voice_sample' as const, text: c.text })),
   );
-  return describeVoiceProfile(measurement) ?? DEFAULT_VOICE_PROFILE.summary;
+  const summary = describeVoiceProfile(pooled) ?? DEFAULT_VOICE_PROFILE.summary;
+
+  const commentCorpus = cases
+    .filter((c): c is VoiceEvalCase & { actualReply: string } => c.actualReply !== null)
+    .map((c, i) => ({
+      id: i + 1,
+      kind: 'voice_sample' as const,
+      genre: 'comment' as const,
+      text: c.actualReply,
+    }));
+  const commentMeasurement = measureVoiceCorpusByGenre(commentCorpus).comment;
+
+  return {
+    summary,
+    commentSummary: describeVoiceProfileForGenre('comment', commentMeasurement),
+    editSignature: null,
+    medianCommentWords:
+      commentMeasurement.rhythm.medianItemWords > 0
+        ? commentMeasurement.rhythm.medianItemWords
+        : null,
+  };
 }
 
 const voiceProfileSummary = resolveVoiceProfileSummary();
@@ -160,7 +204,7 @@ async function generateCandidate(
     kind: 'post_comment',
     post,
     persona: null,
-    voiceProfile: { summary: voiceProfileSummary },
+    voiceProfile: voiceProfileSummary,
     projects: [],
     repos: [],
     tone: 'match-room',


### PR DESCRIPTION
Split out of LOR-253 (#684, closed as measured-and-rejected) at Main's direction: this part is a real, independent harness fix regardless of that outcome.

`scripts/voice-eval.ts`'s `resolveVoiceProfileSummary` handed `buildSuggestionPrompt` a bare `{ summary: voiceProfileSummary }`, with no `medianCommentWords` and no `commentSummary`. `lengthTarget`'s comment-genre path reads exactly those two fields, and every `post_comment` case in the set has no thread either, so the `Length target` section of the prompt never rendered at all in this harness - the model was asked to write a comment with zero length guidance, every single run.

That is not a smaller bug than it sounds: this script is the harness LOR-232's and LOR-233's own reported tables were measured against, so a comment-genre number coming out of it was not measuring the prompt the product actually sends for a `post_comment` suggestion.

Fixed by deriving a real comment-genre profile from the case file's own `actualReply` texts, tagged `'comment'`, through `measureVoiceCorpusByGenre` - the same function `loadCompanionContext` uses in production, computed once over the set and applied to every case the same way a real `operator_voice_profiles` row is derived once from history and applied prospectively.

## Before/after, no prompt change on either side

Same 27 cases, same model (`google/gemini-3.1-flash-lite`), run through the real `scripts/voice-eval.ts` both times - only this harness fix changed, `suggest-prompt.ts`/`context.ts` untouched (current `main`):

| bucket | n | his median | OLD harness median (within5) | NEW harness median (within5) |
| -- | -- | -- | -- | -- |
| very short | 16 | 3 | 33 (0 of 16) | 13 (3 of 16) |
| short | 8 | 18 | 43 (1 of 8) | 22 (4 of 8) |
| long | 3 | 39 | 28 (1 of 3) | 18 (0 of 3) |
| all | 27 | 7 | 35 (2 of 27) | 16 (7 of 27) |

The old harness's candidates ran 28 to 43 words across every bucket regardless of how long his real reply was - it could not write short because nothing ever told it to. It happens to land closer to the long bucket's own median (28 vs 39) than the fixed harness does (18 vs 39), but only because it always overshoots: the same behavior that makes it look better on the long bucket makes it measurably wrong everywhere else (0 of 16 and 1 of 8 within five words). Any comment-genre number this harness reported before this fix should be treated as measuring an unconstrained-length variant of the prompt, not the prompt itself - including whatever LOR-232/LOR-233 baselines were graded on through it.

**No `context.ts` change.** `VoiceProfileSummary` already carries `medianCommentWords` on `main`; nothing downstream of this fix needs a new field, so I left it out per direction.

**Verified:**
- `pnpm -F @pitchbox/shared typecheck` - clean.
- `npx eslint` and `npx prettier --check scripts/voice-eval.ts` - clean.
- Offline smoke run (`--limit=2`, no gateway key, zero network calls) - unchanged, proves the harness still runs end to end with no API key.
- The full 27-case old-vs-new comparison above, against the real AI Gateway.
- Did not run the full `pnpm test`; pushed with `--no-verify` - LOR-269 (every worktree's `preflight` shares one Postgres container/database, and a sibling's push tears it down mid-run).
