### PR TITLE
fix(cli,shared,playbooks): a draft is persisted without the text it was answering, so half the quality axes can never be computed

### DIFF
--- a/cli/src/commands/drafts.ts
+++ b/cli/src/commands/drafts.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { z } from 'zod';
-import { getDb, schema } from '@pitchbox/shared/db';
+import { getDb, schema, type Db } from '@pitchbox/shared/db';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import {
   isBlocklisted,
@@ -31,6 +31,12 @@ import { buildRedditComposeUrl } from '@pitchbox/shared/platforms/reddit';
 import { buildHackernewsComposeUrl } from '@pitchbox/shared/platforms/hackernews';
 import { buildMastodonComposeUrl } from '@pitchbox/shared/platforms/mastodon';
 import type { DraftKind } from '@pitchbox/shared/quota-types';
+import {
+  MAX_POST_CHARS,
+  MAX_THREAD_COMMENTS,
+  MAX_COMMENT_CHARS,
+  MAX_THREAD_CHARS,
+} from '@pitchbox/shared/assist/suggest-prompt';
 import { ok, fail } from '../lib/output.js';
 
 // The compose URL is built here, server-side, from fields the caller already
@@ -75,6 +81,78 @@ function extractOfferSubject(config: unknown): string | null {
   if (offer == null || typeof offer !== 'object') return null;
   const subject = (offer as Record<string, unknown>).subject;
   return typeof subject === 'string' && subject.trim() !== '' ? subject : null;
+}
+
+/** Word count the same simple way every other length axis in this codebase
+ * does (voice-metrics.ts's own scorer, suggest-prompt.ts's `wordCount`) -
+ * split on whitespace, drop empties. Reused below for both a draft's own
+ * clamped source comments and a reply thread's messages. */
+function wordCount(text: string): number {
+  const trimmed = text.trim();
+  return trimmed === '' ? 0 : trimmed.split(/\s+/).length;
+}
+
+/**
+ * `sourceRef.sourceText` (the post/story/status this draft answers) and
+ * `sourceRef.sourceComments` (its visible comments, where a playbook has
+ * them) are what LOR-251 adds so `voice-metrics.ts`'s echo, language-match
+ * and thread-length axes stop being structurally dead on a real campaign
+ * draft - `sourceRef` never carried the actual text before this, only
+ * identifiers and a title. Clamped here, server-side, to the assist plane's
+ * own ceilings (`assist/suggest-prompt.ts`'s
+ * MAX_POST_CHARS/MAX_THREAD_COMMENTS/MAX_COMMENT_CHARS/MAX_THREAD_CHARS)
+ * regardless of what a playbook actually sent - the same "enforced where
+ * the effect happens" rule AGENTS.md already states for the LinkedIn assist
+ * switch and every plan limit, applied here to a draft row's storage
+ * footprint rather than to a model call. Returns the clamped `sourceRef`
+ * (what actually gets persisted, so the jsonb column stays bounded no
+ * matter how large a playbook's raw candidate was) alongside the two
+ * values the quality computation needs, ready to pass straight through.
+ * A draft with neither key (a proactive post, or one drafted before this
+ * shipped) comes back with `sourceText: null` - honestly not-measurable,
+ * never a guessed empty string.
+ */
+function clampSourceContext(sourceRef: Record<string, unknown>): {
+  sourceRef: Record<string, unknown>;
+  sourceText: string | null;
+  threadCommentWordCounts: number[] | undefined;
+} {
+  const clamped: Record<string, unknown> = { ...sourceRef };
+
+  const rawText = sourceRef.sourceText;
+  let sourceText: string | null = null;
+  if (typeof rawText === 'string' && rawText.trim() !== '') {
+    sourceText = rawText.length > MAX_POST_CHARS ? rawText.slice(0, MAX_POST_CHARS) : rawText;
+    clamped.sourceText = sourceText;
+  } else {
+    delete clamped.sourceText;
+  }
+
+  const rawComments = sourceRef.sourceComments;
+  let threadCommentWordCounts: number[] | undefined;
+  if (Array.isArray(rawComments)) {
+    const capped = rawComments
+      .filter((c): c is string => typeof c === 'string' && c.trim() !== '')
+      .slice(0, MAX_THREAD_COMMENTS);
+    const clampedComments: string[] = [];
+    let usedChars = 0;
+    for (const c of capped) {
+      const body = c.length > MAX_COMMENT_CHARS ? c.slice(0, MAX_COMMENT_CHARS) : c;
+      if (usedChars + body.length > MAX_THREAD_CHARS) break;
+      usedChars += body.length;
+      clampedComments.push(body);
+    }
+    if (clampedComments.length > 0) {
+      clamped.sourceComments = clampedComments;
+      threadCommentWordCounts = clampedComments.map(wordCount);
+    } else {
+      delete clamped.sourceComments;
+    }
+  } else {
+    delete clamped.sourceComments;
+  }
+
+  return { sourceRef: clamped, sourceText, threadCommentWordCounts };
 }
 
 // Playbooks document their `drafts_create` payloads with an explicit `null`
@@ -360,6 +438,12 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
         : null;
       const styledTitle = titleResult ? titleResult.text : (d.title ?? null);
       const styleFindings = [...bodyResult.findings, ...(titleResult?.findings ?? [])];
+      // LOR-251: the source post (and, where the playbook supplied them,
+      // its visible comments) this draft answers, clamped and persisted in
+      // place of the raw sourceRef so the echo/language-match/thread-length
+      // axes below - and a later regeneration, which reads this same
+      // sourceRef back - see the same bounded text.
+      const { sourceRef, sourceText, threadCommentWordCounts } = clampSourceContext(d.sourceRef);
       // LOR-229: the deterministic (+ optional judged) score for the
       // primary body, and independently for each A/B variant - each is a
       // genuinely different piece of text and gets its own measurement,
@@ -371,6 +455,8 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
         styleFindings,
         corpus: corpusProfile,
         rubric: qualityRubric,
+        post: sourceText,
+        threadCommentWordCounts,
       });
       const variantQuality = variantResults
         ? await Promise.all(
@@ -381,12 +467,15 @@ export async function createDrafts(runId: number, draftsInput: z.infer<typeof Pa
                 styleFindings: r.findings,
                 corpus: corpusProfile,
                 rubric: qualityRubric,
+                post: sourceText,
+                threadCommentWordCounts,
               }),
             ),
           )
         : null;
       return {
         ...d,
+        sourceRef,
         styledBody: bodyResult.text,
         styledTitle,
         styleFindings,
@@ -693,12 +782,22 @@ export async function draftRegenFinish(runId: number, body: string, title?: stri
     orgId != null ? resolveOperatorCorpusProfile(db, orgId) : Promise.resolve(null),
     loadQualityRubric(db),
   ]);
+  // LOR-251: re-reads whatever source text/comments the original draft was
+  // created with (already clamped by `clampSourceContext` at creation time,
+  // re-clamped here anyway for defense in depth - a draft predating this
+  // feature simply has no `sourceText` key and comes back `null`, which is
+  // the correct, honest answer, not a guess).
+  const { sourceText, threadCommentWordCounts } = clampSourceContext(
+    (draft.sourceRef ?? {}) as Record<string, unknown>,
+  );
   const quality = await scoreDraftQuality(db, {
     body,
     title: newTitle,
     styleFindings,
     corpus: corpusProfile,
     rubric,
+    post: sourceText,
+    threadCommentWordCounts,
   });
   const priorMeta = (draft.metadata ?? {}) as Record<string, unknown>;
   const newMeta: Record<string, unknown> = { ...priorMeta, qualityDetail: quality.qualityDetail };
@@ -747,25 +846,25 @@ export async function draftRegenFinish(runId: number, body: string, title?: stri
   return { draftId, version: draft.version + 1, regenerationCount: newCount };
 }
 
-export async function replyDraftStart(runId: number) {
-  if (!Number.isInteger(runId)) throw new Error('invalid run id');
-  const db = getDb();
-  const [run] = await db.select().from(schema.runs).where(eq(schema.runs.id, runId));
-  if (!run) throw new Error(`run ${runId} not found`);
-  if (run.kind !== 'reply_drafting') throw new Error(`run ${runId} is not a reply_drafting run`);
-  const params = (run.params ?? {}) as { replyDraftId?: number; parentMessageId?: number };
-  const replyDraftId = params.replyDraftId;
-  if (!replyDraftId) throw new Error(`run ${runId} has no replyDraftId in params`);
-
-  const [draft] = await db.select().from(schema.drafts).where(eq(schema.drafts.id, replyDraftId));
-  if (!draft) throw new Error(`reply draft ${replyDraftId} not found`);
-
-  const [platform] = await db
-    .select({ slug: schema.platforms.slug })
-    .from(schema.platforms)
-    .where(eq(schema.platforms.id, draft.platformId));
-
-  const sourceRef = (draft.sourceRef ?? {}) as { parentDraftId?: number };
+/** Thread context for a `reply_drafting` run: the parent outbound draft (for
+ * voice) and the full conversation, both attached to the parent draft, not
+ * the reply-placeholder draft itself. Shared by `replyDraftStart` (shown to
+ * the drafting agent) and `replyDraftFinish` (LOR-251: read again there to
+ * feed the quality computation's source-dependent axes) so the two never
+ * disagree about what the conversation actually was. */
+async function loadReplyThread(
+  db: Db,
+  sourceRefValue: unknown,
+): Promise<{
+  parent: { body: string; reasoning: string | null } | null;
+  thread: Array<{
+    id: number;
+    isFromUs: boolean;
+    body: string | null;
+    createdAtPlatform: Date | null;
+  }>;
+}> {
+  const sourceRef = (sourceRefValue ?? {}) as { parentDraftId?: number };
   let parent: { body: string; reasoning: string | null } | null = null;
   let thread: Array<{
     id: number;
@@ -791,6 +890,28 @@ export async function replyDraftStart(runId: number) {
       .where(eq(schema.messages.draftId, sourceRef.parentDraftId))
       .orderBy(schema.messages.createdAtPlatform);
   }
+  return { parent, thread };
+}
+
+export async function replyDraftStart(runId: number) {
+  if (!Number.isInteger(runId)) throw new Error('invalid run id');
+  const db = getDb();
+  const [run] = await db.select().from(schema.runs).where(eq(schema.runs.id, runId));
+  if (!run) throw new Error(`run ${runId} not found`);
+  if (run.kind !== 'reply_drafting') throw new Error(`run ${runId} is not a reply_drafting run`);
+  const params = (run.params ?? {}) as { replyDraftId?: number; parentMessageId?: number };
+  const replyDraftId = params.replyDraftId;
+  if (!replyDraftId) throw new Error(`run ${runId} has no replyDraftId in params`);
+
+  const [draft] = await db.select().from(schema.drafts).where(eq(schema.drafts.id, replyDraftId));
+  if (!draft) throw new Error(`reply draft ${replyDraftId} not found`);
+
+  const [platform] = await db
+    .select({ slug: schema.platforms.slug })
+    .from(schema.platforms)
+    .where(eq(schema.platforms.id, draft.platformId));
+
+  const { parent, thread } = await loadReplyThread(db, draft.sourceRef);
 
   return {
     runId,
@@ -828,15 +949,28 @@ export async function replyDraftFinish(runId: number, body: string) {
   // rewrite back to here, but the score still measures the real body fresh.
   const styleFindings = checkStyle(body);
   const orgId = await getProjectOrgId(db, draft.projectId);
-  const [corpusProfile, rubric] = await Promise.all([
+  const [corpusProfile, rubric, replyContext] = await Promise.all([
     orgId != null ? resolveOperatorCorpusProfile(db, orgId) : Promise.resolve(null),
     loadQualityRubric(db),
+    loadReplyThread(db, draft.sourceRef),
   ]);
+  // LOR-251: the message this reply actually answers is the most recent
+  // inbound turn, not the parent draft (which is OUR earlier outbound
+  // message, kept only for voice) - that feeds echo/language-match. The
+  // rest of the visible conversation feeds the length-vs-room axis, the
+  // same role a post's visible comment thread plays for a campaign draft.
+  const lastInbound = [...replyContext.thread].reverse().find((m) => !m.isFromUs);
+  const sourceText = lastInbound?.body ?? null;
+  const threadCommentWordCounts = replyContext.thread
+    .filter((m): m is (typeof replyContext.thread)[number] & { body: string } => m.body != null)
+    .map((m) => wordCount(m.body));
   const quality = await scoreDraftQuality(db, {
     body,
     styleFindings,
     corpus: corpusProfile,
     rubric,
+    post: sourceText,
+    threadCommentWordCounts,
   });
   const priorMeta = (draft.metadata ?? {}) as Record<string, unknown>;
   const newMeta: Record<string, unknown> = { ...priorMeta, qualityDetail: quality.qualityDetail };

--- a/cli/tests/commands/draft-regen.test.ts
+++ b/cli/tests/commands/draft-regen.test.ts
@@ -151,6 +151,41 @@ describe('pitchbox drafts:regen:*', () => {
     expect(d.qualityScore).toBeLessThan(75);
   });
 
+  it('finish measures echo and language match against the source text the original draft carried, when present (LOR-251)', async () => {
+    const db = getDb();
+    const postText =
+      'We just shipped the new expense reconciliation workflow after months of testing and everyone on the team is relieved it finally works end to end.';
+    await db
+      .update(schema.drafts)
+      .set({ sourceRef: { permalink: '/r/x/1', sourceText: postText } })
+      .where(eq(schema.drafts.id, draftId));
+
+    // The "in today's fast-paced world" clause is a known style finding,
+    // which caps the score at an integer regardless of the axis average -
+    // this test is about the echo/language-match axes, not about
+    // exercising every score value the deterministic scorer can reach.
+    const out = cliWithStdin(
+      `drafts:regen:finish --run=${regenRunId}`,
+      JSON.stringify({
+        body: "In today's fast-paced world, congrats on shipping the new expense reconciliation workflow for the whole team.",
+      }),
+    );
+    expect(lastJson(out).ok).toBe(true);
+
+    const [d] = await db.select().from(schema.drafts).where(eq(schema.drafts.id, draftId));
+    const detail = (d.metadata as Record<string, unknown>).qualityDetail as {
+      deterministic: {
+        sourceMeasured: boolean;
+        languageMatch: boolean | null;
+        distance: { echo: number | null };
+      };
+    };
+    expect(detail.deterministic.sourceMeasured).toBe(true);
+    expect(detail.deterministic.distance.echo).not.toBeNull();
+    expect(detail.deterministic.distance.echo as number).toBeGreaterThan(0);
+    expect(detail.deterministic.languageMatch).toBe(true);
+  });
+
   it('finish rejects an empty body', () => {
     expect(() =>
       cliWithStdin(`drafts:regen:finish --run=${regenRunId}`, JSON.stringify({ body: '  ' })),

--- a/cli/tests/commands/drafts-create.test.ts
+++ b/cli/tests/commands/drafts-create.test.ts
@@ -364,6 +364,152 @@ describe('pitchbox drafts:create', () => {
     expect(draft.qualityScore).toBeLessThan(75);
   });
 
+  it('carries sourceRef.sourceText through to persistence and populates the echo/language-match axes a source-less draft leaves null (LOR-251)', async () => {
+    const db = getDb();
+    const [platform] = await db
+      .select()
+      .from(schema.platforms)
+      .where(eq(schema.platforms.slug, 'reddit'));
+    const [org] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(sql`slug = 'default'`);
+    const [project] = await db
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'demo-lor251a', name: 'D251a' })
+      .returning();
+    const [account] = await db
+      .insert(schema.accounts)
+      .values({ projectId: project.id, platformId: platform.id, handle: 'grace', role: 'personal' })
+      .returning();
+    const [campaign] = await db
+      .insert(schema.campaigns)
+      .values({
+        projectId: project.id,
+        platformId: platform.id,
+        name: 'c251a',
+        skillSlug: 'reddit-scout',
+        config: {},
+      })
+      .returning();
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ campaignId: campaign.id, trigger: 'manual', status: 'running' })
+      .returning();
+
+    const postText =
+      'We just shipped the new expense reconciliation workflow after months of testing and everyone on the team is relieved it finally works end to end.';
+    const payload = JSON.stringify([
+      {
+        accountId: account.id,
+        kind: 'post_comment',
+        subreddit: 'smallbusiness',
+        targetUser: 'opuser',
+        // The "in today's fast-paced world" clause is a known style
+        // finding, which caps the score at an integer regardless of the
+        // axis average - this test is about the echo axis, not about
+        // exercising every score value the deterministic scorer can reach.
+        body: "In today's fast-paced world, congrats on shipping the new expense reconciliation workflow for the whole team.",
+        sourceRef: { permalink: '/r/smallbusiness/comments/abc/x/', sourceText: postText },
+        metadata: {},
+      },
+    ]);
+
+    const out = cli(`drafts:create --run=${run.id}`, payload);
+    const res = JSON.parse(out.trim().split('\n').at(-1)!);
+    expect(res.ok).toBe(true);
+    expect(res.data.inserted).toBe(1);
+
+    const [draft] = await db
+      .select()
+      .from(schema.drafts)
+      .where(eq(schema.drafts.accountId, account.id));
+    expect((draft.sourceRef as Record<string, unknown>).sourceText).toBe(postText);
+    const detail = (draft.metadata as Record<string, unknown>).qualityDetail as {
+      deterministic: {
+        sourceMeasured: boolean;
+        languageMatch: boolean | null;
+        distance: { echo: number | null; languageMatch: number | null };
+      };
+    };
+    expect(detail.deterministic.sourceMeasured).toBe(true);
+    expect(detail.deterministic.distance.echo).not.toBeNull();
+    expect(detail.deterministic.distance.echo as number).toBeGreaterThan(0);
+    expect(detail.deterministic.languageMatch).toBe(true);
+    expect(detail.deterministic.distance.languageMatch).toBe(0);
+  });
+
+  it('reports the echo and language-match axes as not measurable, never a guessed zero, on a proactive post with no source (LOR-251)', async () => {
+    const db = getDb();
+    const [platform] = await db
+      .select()
+      .from(schema.platforms)
+      .where(eq(schema.platforms.slug, 'reddit'));
+    const [org] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(sql`slug = 'default'`);
+    const [project] = await db
+      .insert(schema.projects)
+      .values({ organizationId: org.id, slug: 'demo-lor251b', name: 'D251b' })
+      .returning();
+    const [account] = await db
+      .insert(schema.accounts)
+      .values({ projectId: project.id, platformId: platform.id, handle: 'henry', role: 'personal' })
+      .returning();
+    const [campaign] = await db
+      .insert(schema.campaigns)
+      .values({
+        projectId: project.id,
+        platformId: platform.id,
+        name: 'c251b',
+        skillSlug: 'reddit-scout',
+        config: {},
+      })
+      .returning();
+    const [run] = await db
+      .insert(schema.runs)
+      .values({ campaignId: campaign.id, trigger: 'manual', status: 'running' })
+      .returning();
+
+    const payload = JSON.stringify([
+      {
+        accountId: account.id,
+        kind: 'post',
+        subreddit: 'smallbusiness',
+        title: 'Launch day',
+        // A known style finding ("in today's fast-paced world") so the score
+        // is guaranteed non-null via the style cap regardless of corpus
+        // state - the point of this test is the source axes, not the cap.
+        body: "In today's fast-paced world, it's worth noting the update shipped.",
+        sourceRef: { postAngle: 'launch' },
+        metadata: {},
+      },
+    ]);
+
+    const out = cli(`drafts:create --run=${run.id}`, payload);
+    const res = JSON.parse(out.trim().split('\n').at(-1)!);
+    expect(res.ok).toBe(true);
+    expect(res.data.inserted).toBe(1);
+
+    const [draft] = await db
+      .select()
+      .from(schema.drafts)
+      .where(eq(schema.drafts.accountId, account.id));
+    expect(draft.qualityScore).not.toBeNull();
+    const detail = (draft.metadata as Record<string, unknown>).qualityDetail as {
+      deterministic: {
+        sourceMeasured: boolean;
+        languageMatch: boolean | null;
+        distance: { echo: number | null; languageMatch: number | null };
+      };
+    };
+    expect(detail.deterministic.sourceMeasured).toBe(false);
+    expect(detail.deterministic.distance.echo).toBeNull();
+    expect(detail.deterministic.languageMatch).toBeNull();
+    expect(detail.deterministic.distance.languageMatch).toBeNull();
+  });
+
   it('skips blocklisted targets and reports them in the response', async () => {
     const db = getDb();
     const [platform] = await db

--- a/cli/tests/commands/reply-draft.test.ts
+++ b/cli/tests/commands/reply-draft.test.ts
@@ -154,12 +154,14 @@ describe('pitchbox drafts:reply:*', () => {
     expect(d.body).toBe('Happy to help - here is more.');
     expect(d.draftingRunId).toBeNull();
     expect(d.state).toBe('pending_review');
-    // No style findings and no operator voice corpus in this fixture - the
-    // deterministic scorer has nothing to measure, so it reports "not
-    // scored" rather than guessing a number, and never the drafting run's
-    // own agentRunner the way the old self-report used to.
-    expect(d.qualityScore).toBeNull();
-    expect(d.qualityModel).toBeNull();
+    // No operator voice corpus in this fixture, but the reply thread
+    // always supplies a source (the inbound message "tell me more") for
+    // the echo/length-vs-thread axes (LOR-251), so the deterministic
+    // scorer now has something to measure even with no corpus - unlike
+    // before LOR-251, this no longer reports "not scored", and still never
+    // the drafting run's own agentRunner the way the old self-report used to.
+    expect(d.qualityScore).not.toBeNull();
+    expect(d.qualityModel).toBe('deterministic');
     const [r] = await db.select().from(schema.runs).where(eq(schema.runs.id, runId));
     expect(r.status).toBe('success');
     const [evt] = await db
@@ -182,6 +184,23 @@ describe('pitchbox drafts:reply:*', () => {
     expect(d.qualityModel).toBe('deterministic');
     expect(d.qualityScore).not.toBeNull();
     expect(d.qualityScore).toBeLessThan(75);
+  });
+
+  it('finish measures echo against the most recent inbound thread message, not the parent draft (LOR-251)', async () => {
+    // The "in today's fast-paced world" clause is a known style finding,
+    // which caps the score at an integer regardless of the axis average.
+    const out = cliWithStdin(
+      `drafts:reply:finish --run=${runId}`,
+      JSON.stringify({ body: "In today's fast-paced world, happy to tell you more about that." }),
+    );
+    expect(lastJson(out).ok).toBe(true);
+    const db = getDb();
+    const [d] = await db.select().from(schema.drafts).where(eq(schema.drafts.id, replyDraftId));
+    const detail = (d.metadata as Record<string, unknown>).qualityDetail as {
+      deterministic: { sourceMeasured: boolean; distance: { echo: number | null } };
+    };
+    expect(detail.deterministic.sourceMeasured).toBe(true);
+    expect(detail.deterministic.distance.echo).not.toBeNull();
   });
 
   it('finish rejects an empty body', () => {

--- a/playbooks/hn-commenter.md
+++ b/playbooks/hn-commenter.md
@@ -93,12 +93,18 @@ Write like this instead:
      "targetUser": "<the story's author, the candidate's `by` field>",
      "body": "<comment text>",
      "reasoning": "Why this story, what angle, what value you're adding.",
-     "sourceRef": { "itemUrl": "https://news.ycombinator.com/item?id=12345", "title": "..." },
+     "sourceRef": {
+       "itemUrl": "https://news.ycombinator.com/item?id=12345",
+       "title": "...",
+       "sourceText": "<the story's title and self-post text (item.text), verbatim - title alone for a link post>"
+     },
      "metadata": { "itemId": 12345, "listing": "top", "score": 142 }
    }
    ```
 
    `targetUser` is the author of the story you are replying to (`by` on the item you scored). Commenting on someone's story counts as contacting them, so it feeds the blocklist, the dedup window and contact history. Hacker News has no scout staging candidates for the run, so nothing can recover this handle if you omit it: copy it across for every draft.
+
+   `sourceRef.sourceText` is the story you are actually answering - copy the candidate's real `title`/`text`, never a paraphrase. The server measures how much of your comment echoes the story's own wording and whether you answered in its language, and both checks need the real text; it also clamps the length, so send it in full.
 
 9. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 

--- a/playbooks/linkedin-commenter.md
+++ b/playbooks/linkedin-commenter.md
@@ -111,13 +111,16 @@ Each draft (the human opens the real post from the Inbox and pastes this in them
   "reasoning": "2-3 sentences on why this post, what angle, what value you're adding.",
   "sourceRef": {
     "externalId": "urn:li:activity:1234567890",
-    "url": "https://www.linkedin.com/feed/update/urn:li:activity:1234567890/"
+    "url": "https://www.linkedin.com/feed/update/urn:li:activity:1234567890/",
+    "sourceText": "<the candidate's text - the post exactly as the browser rendered it>"
   },
   "metadata": { "authorHandle": "jane-doe" }
 }
 ```
 
 `targetUser` is the author of the post you are replying to, and it is their profile slug (`author.handle`), never their display name: a name cannot be blocklisted or deduped. Commenting on someone's post counts as contacting them, so it feeds the blocklist, the dedup window and contact history, exactly as the in-page assist already does. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.externalId` points at; an observation captured without a slug has no target, and null is the right answer there.
+
+`sourceRef.sourceText` is the post you are actually answering - copy the candidate's real `text`, never a paraphrase. The server measures how much of your reply echoes the post's own wording and whether you answered in its language, and both checks need the real text; it also clamps the length, so send it in full.
 
 11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 

--- a/playbooks/mastodon-commenter.md
+++ b/playbooks/mastodon-commenter.md
@@ -108,12 +108,18 @@ Each draft (sent later as a reply status via `in_reply_to_id`, on human approval
   "targetUser": "<the status author's fully qualified handle, the candidate's author.acct>",
   "body": "<reply text>",
   "reasoning": "2-3 sentences on why this status, what angle, what value you're adding.",
-  "sourceRef": { "statusId": "109...", "statusUrl": "https://mastodon.social/@alice/109..." },
+  "sourceRef": {
+    "statusId": "109...",
+    "statusUrl": "https://mastodon.social/@alice/109...",
+    "sourceText": "<status.content with the HTML tags stripped out, plain text only>"
+  },
   "metadata": { "matchedHashtag": "selfhosted", "matchedKeyword": "self-hosted" }
 }
 ```
 
 `targetUser` is the author of the status you are replying to, as the fully qualified `author.acct` handle. Replying to someone counts as contacting them, so it feeds the blocklist, the dedup window and contact history. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.statusId` points at.
+
+`sourceRef.sourceText` is the status you are actually answering - strip `status.content`'s HTML tags yourself and send the plain text, never a paraphrase. The server measures how much of your reply echoes the status's own wording and whether you answered in its language, and both checks need the real text; it also clamps the length, so send it in full.
 
 11. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 

--- a/playbooks/reddit-commenter.md
+++ b/playbooks/reddit-commenter.md
@@ -107,12 +107,18 @@ Each draft:
   "targetUser": "<the post author's username, from the candidate's user.name>",
   "body": "<comment markdown>",
   "reasoning": "2-3 sentences on why this post, what angle, what value you're adding.",
-  "sourceRef": { "permalink": "/r/Solo_Roleplaying/comments/abc/.../", "postTitle": "..." },
+  "sourceRef": {
+    "permalink": "/r/Solo_Roleplaying/comments/abc/.../",
+    "postTitle": "...",
+    "sourceText": "<the post's title and selftext, verbatim - the title alone when selftext is empty>"
+  },
   "metadata": { "matchedBy": "search", "postAgeHours": 8 }
 }
 ```
 
 `targetUser` is the author of the post you are replying to. Commenting on someone's post counts as contacting them, so it feeds the blocklist, the dedup window and contact history. If you leave it out, the server fills it in from the staged candidate the draft's `sourceRef.permalink` points at.
+
+`sourceRef.sourceText` is the post you are actually answering - copy the candidate's real `title`/`selftext`, never a paraphrase or your own summary of it. The server measures how much of your comment echoes the post's own wording and whether you answered in its language, and both checks need the real text to mean anything; the server also clamps it to a fixed length, so send it in full rather than trimming it yourself.
 
 10. **Finish the run.** Call `run_finish` with `{ "runId": <runId>, "status": "success" }`.
 

--- a/shared/src/quality-judge.ts
+++ b/shared/src/quality-judge.ts
@@ -36,6 +36,22 @@
 // still subject to the style-finding cap. `qualityModel` records which kind
 // of number it is - the literal string `DETERMINISTIC_QUALITY_MODEL` or the
 // judge's real model id - so a caller (the Inbox badge) can always tell.
+//
+// 2026-09-11 (LOR-251): the deterministic component gained two more axes,
+// echo and language match, measured against the post the draft answers
+// rather than the operator's own corpus. A campaign draft never carried
+// that text at all before this, so both axes were structurally dead outside
+// the offline voice-eval harness - `createDrafts`
+// (cli/src/commands/drafts.ts) now reads it off
+// `sourceRef.sourceText`/`sourceRef.sourceComments`, clamped to the same
+// MAX_POST_CHARS/MAX_THREAD_COMMENTS/MAX_COMMENT_CHARS/MAX_THREAD_CHARS
+// ceilings the assist plane already enforces (`assist/suggest-prompt.ts`).
+// The length axis now prefers the visible thread's median over the
+// operator's own corpus median when a playbook supplied one - the same
+// preference order `voice-metrics.ts`'s own header documents for
+// `scoreCandidate`. Absent source text (a proactive post) leaves
+// echo/languageMatch/thread-length `null`, the same refuse-rather-than-
+// guess discipline the rest of this file already applies.
 import { eq } from 'drizzle-orm';
 import { generateText } from 'ai';
 import { createGateway } from '@ai-sdk/gateway';
@@ -59,6 +75,8 @@ import {
   shapeDistance,
   voiceMarkersDistance,
   lexiconDistance,
+  echoScore,
+  type VoiceMetricsLanguage,
 } from './voice-metrics.js';
 import type { StyleFinding } from './style-check.js';
 
@@ -153,40 +171,88 @@ export interface DeterministicQualityAxes {
   /** Distance derived from `lengthRatio`: `min(1, abs(ratio - 1))`, the same
    * capped-at-1 idiom every other numeric axis in `voice-metrics.ts` uses. */
   length: QualityAxisScore;
+  /** `voice-metrics.ts`'s `echoScore`, against the post this draft answers
+   * (LOR-251) - `null` when there is no source post to compare against, or
+   * the candidate has no content words of its own to measure. */
+  echo: QualityAxisScore;
+  /** `0` when the candidate answers in the source post's own language, `1`
+   * when it does not, `null` when there is no source post or either side's
+   * language could not be classified. Distance-shaped (0 = good) so it
+   * folds into the same average as every other axis here; `languageMatch`
+   * on `DeterministicQualityDetail` below carries the raw boolean. */
+  languageMatch: QualityAxisScore;
 }
 
 export interface DeterministicQualityDetail {
   /** `null` only when literally nothing was measurable: no style findings
-   * and no axis cleared its own floor (a thin or absent operator corpus).
-   * Never a guessed number standing in for "unmeasured". */
+   * and no axis cleared its own floor (a thin or absent operator corpus,
+   * and no source post to answer). Never a guessed number standing in for
+   * "unmeasured". */
   score: number | null;
   styleFindingCount: number;
   distance: DeterministicQualityAxes;
-  /** Candidate word count divided by the operator's own corpus median item
-   * length (`rhythm.medianItemWords`, LOR-232) - `null` when the corpus is
-   * not measured or has never derived a length. */
+  /** Candidate word count divided by the comparator named in
+   * `lengthComparisonBasis` - `null` when neither comparator is available. */
   lengthRatio: number | null;
+  /** Which comparator `lengthRatio` used: the visible thread's median word
+   * count when a playbook supplied one (LOR-251, preferred - it is the
+   * room the reply is actually read in), else the operator's own corpus
+   * median item length, else `null` when neither is available. */
+  lengthComparisonBasis: 'thread-median' | 'operator-corpus' | null;
   candidateWordCount: number;
-  /** How many of the 6 axes above actually contributed to `score`. */
+  /** How many of the 8 axes above actually contributed to `score`. */
   measuredAxisCount: number;
   corpusMeasured: boolean;
+  /** Whether a source post was supplied at all (LOR-251) - distinct from
+   * `corpusMeasured`, since a proactive post has no source to answer and
+   * that is a normal, honest outcome, not a thin corpus. */
+  sourceMeasured: boolean;
+  /** Raw form of `distance.languageMatch` - `null` when `sourceMeasured` is
+   * false or either side's language could not be classified. */
+  languageMatch: boolean | null;
+  candidateLanguage: VoiceMetricsLanguage;
+  /** `null` when `sourceMeasured` is false. */
+  postLanguage: VoiceMetricsLanguage | null;
+}
+
+/** 3-line copy of `voice-metrics.ts`'s own private `median`, on purpose -
+ * the same call that file's header already makes for its small numeric
+ * helpers: not specific to either module, and not worth a new import
+ * surface for three lines. */
+function median(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
 }
 
 /**
  * The deterministic half of a draft's quality score: style findings (a hard
- * cap, never averaged away) plus per-axis stylometric distance and length
- * against the operator's own measured voice corpus. Pure and synchronous -
- * no model, no I/O - so it is reproducible across two runs on the same body
- * and the same corpus, and unit-testable without a database.
+ * cap, never averaged away), per-axis stylometric distance and length
+ * against the operator's own measured voice corpus, and - when the draft
+ * answers a source post - echo and language match against that post, plus
+ * a length comparison against the visible thread when one was supplied.
+ * Pure and synchronous - no model, no I/O - so it is reproducible across two
+ * runs on the same inputs, and unit-testable without a database.
  */
 export function computeDeterministicQuality(args: {
   body: string;
   styleFindings: StyleFinding[];
   corpus: OperatorCorpusProfile | null;
   rubric: QualityRubric;
+  /** The post/story/status this draft answers (LOR-251) - absent or empty
+   * for a proactive post, which has nothing to echo or match language
+   * against. */
+  post?: string | null;
+  /** Word counts of the visible thread's other comments (LOR-251), when a
+   * playbook supplied any - the length axis's preferred comparator over the
+   * operator's own corpus median. */
+  threadCommentWordCounts?: number[];
 }): DeterministicQualityDetail {
-  const { body, styleFindings, corpus, rubric } = args;
+  const { body, styleFindings, corpus, rubric, threadCommentWordCounts } = args;
+  const post = args.post && args.post.trim() !== '' ? args.post : null;
   const candidateM = measureOneText(body);
+  const postM = post !== null ? measureOneText(post) : null;
 
   // Rhythm/punctuation/shape/voiceMarkers all need the candidate to
   // individually clear register.ts's own floor - the same gate
@@ -194,6 +260,11 @@ export function computeDeterministicQuality(args: {
   // comparison, applied here to a candidate-vs-corpus one instead.
   const structuralMeasurable = corpus !== null && candidateM.register !== null;
   const lexiconMeasurable = corpus !== null && candidateM.wordCount >= AVOIDED_WORDS_MIN_WORDS;
+
+  const languageMatch =
+    postM !== null && candidateM.language !== 'unknown' && postM.language !== 'unknown'
+      ? candidateM.language === postM.language
+      : null;
 
   const distance: DeterministicQualityAxes = {
     rhythm: structuralMeasurable ? rhythmDistance(candidateM.rhythm, corpus.rhythm) : null,
@@ -206,13 +277,24 @@ export function computeDeterministicQuality(args: {
       : null,
     lexicon: lexiconMeasurable ? lexiconDistance(candidateM.lexicon, corpus!.lexicon) : null,
     length: null,
+    echo: postM !== null ? echoScore(body, post!) : null,
+    languageMatch: languageMatch === null ? null : languageMatch ? 0 : 1,
   };
 
   let lengthRatio: number | null = null;
-  if (corpus !== null && corpus.rhythm.medianItemWords > 0) {
-    lengthRatio = Math.round((candidateM.wordCount / corpus.rhythm.medianItemWords) * 100) / 100;
-    distance.length = Math.min(1, Math.abs(lengthRatio - 1));
+  let lengthComparisonBasis: 'thread-median' | 'operator-corpus' | null = null;
+  if (threadCommentWordCounts && threadCommentWordCounts.length > 0) {
+    const basis = median(threadCommentWordCounts);
+    if (basis > 0) {
+      lengthRatio = Math.round((candidateM.wordCount / basis) * 100) / 100;
+      lengthComparisonBasis = 'thread-median';
+    }
   }
+  if (lengthComparisonBasis === null && corpus !== null && corpus.rhythm.medianItemWords > 0) {
+    lengthRatio = Math.round((candidateM.wordCount / corpus.rhythm.medianItemWords) * 100) / 100;
+    lengthComparisonBasis = 'operator-corpus';
+  }
+  if (lengthRatio !== null) distance.length = Math.min(1, Math.abs(lengthRatio - 1));
 
   const measured = Object.values(distance).filter((d): d is number => d !== null);
   const axisScore =
@@ -236,9 +318,14 @@ export function computeDeterministicQuality(args: {
     styleFindingCount: styleFindings.length,
     distance,
     lengthRatio,
+    lengthComparisonBasis,
     candidateWordCount: candidateM.wordCount,
     measuredAxisCount: measured.length,
     corpusMeasured: corpus !== null,
+    sourceMeasured: postM !== null,
+    languageMatch,
+    candidateLanguage: candidateM.language,
+    postLanguage: postM !== null ? postM.language : null,
   };
 }
 
@@ -251,11 +338,28 @@ function describeDeterministic(d: DeterministicQualityDetail): string | null {
     );
   }
   if (d.lengthRatio != null) {
-    parts.push(`${d.lengthRatio}x the operator's typical length`);
+    const basisLabel =
+      d.lengthComparisonBasis === 'thread-median'
+        ? "the visible thread's length"
+        : "the operator's typical length";
+    parts.push(`${d.lengthRatio}x ${basisLabel}`);
   }
-  if (d.measuredAxisCount > 0) {
+  if (d.distance.echo != null) {
+    parts.push(`${Math.round(d.distance.echo * 100)}% echo of the source post`);
+  }
+  if (d.languageMatch === false) {
+    parts.push('answered in a different language than the source post');
+  }
+  const corpusAxisCount = [
+    d.distance.rhythm,
+    d.distance.punctuation,
+    d.distance.shape,
+    d.distance.voiceMarkers,
+    d.distance.lexicon,
+  ].filter((v) => v !== null).length;
+  if (corpusAxisCount > 0) {
     parts.push(
-      `${d.measuredAxisCount} voice ${d.measuredAxisCount === 1 ? 'axis' : 'axes'} measured against their own writing`,
+      `${corpusAxisCount} voice ${corpusAxisCount === 1 ? 'axis' : 'axes'} measured against their own writing`,
     );
   }
   return parts.length > 0 ? parts.join('; ') : 'No comparable operator voice profile yet.';
@@ -367,6 +471,8 @@ export async function scoreDraftQuality(
     styleFindings: StyleFinding[];
     corpus: OperatorCorpusProfile | null;
     rubric: QualityRubric;
+    post?: string | null;
+    threadCommentWordCounts?: number[];
   },
 ): Promise<DraftQualityResult> {
   const deterministic = computeDeterministicQuality({
@@ -374,6 +480,8 @@ export async function scoreDraftQuality(
     styleFindings: args.styleFindings,
     corpus: args.corpus,
     rubric: args.rubric,
+    post: args.post,
+    threadCommentWordCounts: args.threadCommentWordCounts,
   });
   const judged = await judgeQuality(db, {
     body: args.body,
@@ -386,6 +494,18 @@ export async function scoreDraftQuality(
     const cap = args.rubric.threshold_green - 1;
     qualityScore = qualityScore == null ? cap : Math.min(qualityScore, cap);
   }
+  // `drafts.quality_score` is a `smallint` column. `judged.score` is
+  // already a whole number (`judgeQuality` rounds it); the deterministic
+  // score keeps 2-decimal precision inside `qualityDetail.deterministic`
+  // for anything that wants the finer number, but LOR-251 is the first
+  // caller that regularly reaches this function with echo/language-match
+  // in the axis average and no style-finding cap to round it away for
+  // free (`computeDeterministicQuality`'s own axes needed a measured
+  // operator corpus before that; a source post alone is now enough) - a
+  // fractional value here fails the write outright rather than truncating,
+  // so round once, at the boundary, rather than changing what
+  // `deterministic.score` itself reports.
+  qualityScore = qualityScore == null ? null : Math.round(qualityScore);
 
   const qualityReason = judged ? judged.reason : describeDeterministic(deterministic);
   const qualityModel = judged

--- a/shared/src/voice-metrics.ts
+++ b/shared/src/voice-metrics.ts
@@ -266,6 +266,25 @@ function contentWords(text: string): Set<string> {
   return new Set(words);
 }
 
+/** How much of `candidate`'s own content words already appear in `post` -
+ * `0` means no shared wording, `1` means the candidate is built entirely
+ * out of the post's own words, `null` when the candidate has no content
+ * words of its own to measure. Exported (LOR-251) for the same reason the
+ * distance functions above are: `computeDeterministicQuality` (quality-
+ * judge.ts) needs this exact echo math for a campaign draft against the
+ * post it answers, and duplicating a Unicode-aware content-word extraction
+ * is exactly the kind of thing that drifts into two disagreeing copies. */
+export function echoScore(candidate: string, post: string): AxisScore {
+  const candidateContentWords = contentWords(candidate);
+  const postContentWords = contentWords(post);
+  return candidateContentWords.size > 0
+    ? round2(
+        [...candidateContentWords].filter((w) => postContentWords.has(w)).length /
+          candidateContentWords.size,
+      )
+    : null;
+}
+
 /**
  * Scores one candidate reply against the post it answers and the operator's
  * own real reply to that same post. Pure and synchronous - no model, no I/O.
@@ -290,15 +309,7 @@ export function scoreCandidate(args: ScoreCandidateArgs): VoiceCandidateScore {
     lengthComparisonBasis = 'actual-reply';
   }
 
-  const candidateContentWords = contentWords(candidate);
-  const postContentWords = contentWords(post);
-  const echo: AxisScore =
-    candidateContentWords.size > 0
-      ? round2(
-          [...candidateContentWords].filter((w) => postContentWords.has(w)).length /
-            candidateContentWords.size,
-        )
-      : null;
+  const echo = echoScore(candidate, post);
 
   const languageMatch =
     candidateM.language !== 'unknown' && postM.language !== 'unknown'

--- a/shared/tests/quality-judge.test.ts
+++ b/shared/tests/quality-judge.test.ts
@@ -194,6 +194,101 @@ describe('quality-judge', () => {
       const second = computeDeterministicQuality(args);
       expect(second).toEqual(first);
     });
+
+    it('measures echo against the source post the draft answers, null without one (LOR-251)', () => {
+      const post =
+        'We just shipped the new expense reconciliation workflow after months of testing.';
+      const withSource = computeDeterministicQuality({
+        body: 'Congrats on shipping the new expense reconciliation workflow!',
+        styleFindings: [],
+        corpus: null,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+        post,
+      });
+      expect(withSource.sourceMeasured).toBe(true);
+      expect(withSource.distance.echo).not.toBeNull();
+      expect(withSource.distance.echo!).toBeGreaterThan(0);
+
+      const withoutSource = computeDeterministicQuality({
+        body: 'Congrats on shipping the new expense reconciliation workflow!',
+        styleFindings: [],
+        corpus: null,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+      });
+      expect(withoutSource.sourceMeasured).toBe(false);
+      expect(withoutSource.distance.echo).toBeNull();
+      expect(withoutSource.languageMatch).toBeNull();
+      expect(withoutSource.distance.languageMatch).toBeNull();
+    });
+
+    it('measures language match against the source post, never a guessed true/false when either side is too short to classify (LOR-251)', () => {
+      const matching = computeDeterministicQuality({
+        body: 'This is a great update and I am glad the team shipped it this week.',
+        styleFindings: [],
+        corpus: null,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+        post: 'We shipped a big update to the product this week after a long sprint.',
+      });
+      expect(matching.languageMatch).toBe(true);
+      expect(matching.distance.languageMatch).toBe(0);
+
+      const mismatched = computeDeterministicQuality({
+        body: 'Questo aggiornamento e fantastico, complimenti a tutto il team per il lavoro.',
+        styleFindings: [],
+        corpus: null,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+        post: 'We shipped a big update to the product this week after a long sprint.',
+      });
+      expect(mismatched.languageMatch).toBe(false);
+      expect(mismatched.distance.languageMatch).toBe(1);
+
+      const unclassifiable = computeDeterministicQuality({
+        body: 'Grande!',
+        styleFindings: [],
+        corpus: null,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+        post: 'Ok.',
+      });
+      expect(unclassifiable.languageMatch).toBeNull();
+      expect(unclassifiable.distance.languageMatch).toBeNull();
+    });
+
+    it('prefers the visible thread median over the operator corpus median for the length axis (LOR-251)', () => {
+      const corpus = corpusFrom(LONG_OPERATOR_SAMPLE);
+      const body = 'One two three four five six seven eight nine ten.';
+      const withThread = computeDeterministicQuality({
+        body,
+        styleFindings: [],
+        corpus,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+        threadCommentWordCounts: [4, 5, 6],
+      });
+      expect(withThread.lengthComparisonBasis).toBe('thread-median');
+      expect(withThread.lengthRatio).toBe(2); // 10 candidate words / median 5
+
+      const withoutThread = computeDeterministicQuality({
+        body,
+        styleFindings: [],
+        corpus,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+      });
+      expect(withoutThread.lengthComparisonBasis).toBe('operator-corpus');
+    });
+
+    it('a proactive post with no source still scores from style and corpus alone, source axes null rather than a guessed zero (LOR-251)', () => {
+      const corpus = corpusFrom(LONG_OPERATOR_SAMPLE);
+      const result = computeDeterministicQuality({
+        body: LONG_OPERATOR_SAMPLE,
+        styleFindings: [],
+        corpus,
+        rubric: DEFAULT_QUALITY_RUBRIC,
+      });
+      expect(result.score).not.toBeNull();
+      expect(result.sourceMeasured).toBe(false);
+      expect(result.distance.echo).toBeNull();
+      expect(result.distance.languageMatch).toBeNull();
+      expect(result.languageMatch).toBeNull();
+    });
   });
 
   describe('DETERMINISTIC_QUALITY_MODEL', () => {

--- a/shared/tests/voice-metrics.test.ts
+++ b/shared/tests/voice-metrics.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { scoreCandidate, type ScoreCandidateArgs } from '../src/voice-metrics.js';
+import { scoreCandidate, echoScore, type ScoreCandidateArgs } from '../src/voice-metrics.js';
 import { loadVoiceEvalCases } from '../src/voice-eval-cases.js';
 
 // LOR-44: "sounds like him" is a product claim, not an opinion, and this is
@@ -161,6 +161,28 @@ describe('scoreCandidate', () => {
       actualReply: null,
     });
     expect(result.styleFindings.some((f) => f.ruleId === 'em-dash')).toBe(true);
+  });
+});
+
+describe('echoScore', () => {
+  // LOR-251: exported so quality-judge.ts's computeDeterministicQuality can
+  // reuse this exact math for a campaign draft against the post it
+  // answers, rather than a second copy - these defend the contract that
+  // caller now relies on directly, not just through scoreCandidate.
+  it("measures how much of the candidate is made of the post's own words", () => {
+    const post = 'We just shipped the new expense reconciliation workflow after months of testing.';
+    const copying = echoScore(
+      'Congrats on shipping the new expense reconciliation workflow!',
+      post,
+    );
+    const original = echoScore('Huge milestone, well deserved after all that effort.', post);
+    expect(copying).not.toBeNull();
+    expect(original).not.toBeNull();
+    expect(copying!).toBeGreaterThan(original!);
+  });
+
+  it('reports null when the candidate has no content words of its own', () => {
+    expect(echoScore('💪', 'A perfectly ordinary post about something.')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes LOR-251.

I closed the gap LOR-229 left open: `shared/src/voice-metrics.ts` scores a candidate on style findings, per-axis stylometric distance, length against the room, echo of the source text and language match, but `sourceRef` never carried the post body or its comments, only identifiers and a title. Echo and language-match were structurally dead on every real campaign draft.

## What changed

- **`sourceRef.sourceText` / `sourceRef.sourceComments`** are the new documented keys carrying the post and its visible comments, following the same "documented key, conditionally present" precedent `metadata.styleFindings` set in #593. No migration: `sourceRef` is already `jsonb`. `createDrafts` clamps both server-side to the assist plane's own `MAX_POST_CHARS`, `MAX_THREAD_COMMENTS`, `MAX_COMMENT_CHARS` and `MAX_THREAD_CHARS` (`assist/suggest-prompt.ts`), imported rather than re-chosen, before either the score computation or the persisted row ever sees them.
- **`shared/src/quality-judge.ts`'s `computeDeterministicQuality`** now takes an optional `post` and `threadCommentWordCounts`. Echo and language-match join the existing corpus-based axes in the same averaged score (I added `echoScore` to `voice-metrics.ts`, exported the same way the distance functions already are, so the math has one home). The length axis now prefers the visible thread's median over the operator's own corpus median when a playbook supplied one, the same preference order `voice-metrics.ts`'s own module header documents. Absent source text (a proactive post) leaves echo/languageMatch/thread-length `null`, never a guessed zero.
- **`draftRegenFinish`** reads the same `sourceText`/`sourceComments` back off the draft's own stored `sourceRef`. **`replyDraftFinish`** scores echo against the most recent inbound thread message (what a reply actually answers) and length against the visible conversation, via a new `loadReplyThread` helper shared with `replyDraftStart` so the two can never disagree about the thread.
- **Playbooks**: `reddit-commenter.md`, `hn-commenter.md`, `mastodon-commenter.md`, `linkedin-commenter.md` now send `sourceRef.sourceText` in their `drafts_create` examples, with a line telling the agent to send the real text, never a paraphrase. `reply-drafter.md` and `draft-regenerator.md` needed no playbook change: their source (the parent message, the existing draft's own `sourceRef`) already reaches the server through tools that existed before this issue.

## A bug found and fixed in the same commit (blocked verifying this issue otherwise)

`drafts.quality_score` is a `smallint` column, and `computeDeterministicQuality` had always been able to return a 2-decimal score - just never reached in practice, since every axis before this needed a measured operator corpus, and no existing test had ever persisted an uncapped, corpus-free score through the real DB write. Making echo/language-match/thread-length measurable *without* a corpus means this path is now the common case, not a rare one, and a fractional score crashed the write outright (`invalid input syntax for type smallint: "37.5"`). I round the persisted `qualityScore` to the nearest integer at the `scoreDraftQuality` boundary, without touching the 2-decimal detail still kept in `metadata.qualityDetail.deterministic.score`.

## Size impact (measured, not guessed)

Seeded three real drafts through the actual `createDrafts` path and read `pg_column_size` off the row (`docs/retention.md`'s default 90-day retention window is what this is bounded against):

| scenario | `source_ref` on disk | full row on disk |
|---|---|---|
| baseline (identifiers only, pre-LOR-251 shape) | 62 bytes | 804 bytes |
| realistic post (324 chars, no comments) | 452 bytes | 1,296 bytes |
| worst case (post clamped to `MAX_POST_CHARS`=4000; comments clamped by `MAX_THREAD_COMMENTS`/`MAX_COMMENT_CHARS`/`MAX_THREAD_CHARS` to 12 comments × 500 chars) | 1,143 bytes | 2,042 bytes |

The worst case's raw (uncompressed) JSON is ~10.1KB - that's the real ceiling, since a hostile or pathological input can't push it past the three clamps regardless of what a playbook sends. Postgres's own TOAST/pglz compression brought the *on-disk* worst case down to ~1.1KB for real (if repetitive, since my test corpus reused 8 sentences) English prose; less repetitive organic text would compress less, so the honest statement is "bounded at ~10KB raw, typically ~1-3KB on disk," not a single deceptively low number.

## Verified

- Seeded a `post_comment` draft through the real `createDrafts` path with `sourceRef.sourceText` present: `metadata.qualityDetail.deterministic` came back with `sourceMeasured: true`, `distance.echo` populated and greater than zero, and `languageMatch: true` - all previously always `null`/absent on a campaign draft.
- A proactive post with no source (mirroring `linkedin-poster`/`reddit-poster`) still scores from style findings and the operator corpus alone, with `sourceMeasured: false` and `distance.echo`/`distance.languageMatch`/top-level `languageMatch` all `null`, never a guessed zero.
- `draftRegenFinish` re-measures echo/language-match off the original draft's stored `sourceText`. `replyDraftFinish` measures echo against the most recent inbound thread message, not the parent draft.
- `pnpm -F @pitchbox/shared typecheck` and `pnpm -F @pitchbox/cli typecheck` clean. `npx eslint` / `npx prettier --check` clean on every changed file.
- Targeted tests green: `shared/tests/quality-judge.test.ts`, `shared/tests/voice-metrics.test.ts`, `cli/tests/commands/drafts-create.test.ts`, `cli/tests/commands/draft-regen.test.ts`, `cli/tests/commands/reply-draft.test.ts`, `cli/tests/commands/playbook-draft-payloads.test.ts`, `shared/tests/playbook-house-style.test.ts` (101 tests, 7 files).

## Could not verify

- The web Inbox's own rendering of the new axes - out of this issue's scope; the axes ship correctly shaped in `metadata.qualityDetail` for whichever surface reads it next.
- The deployed cloud edition's preview/prod behavior - AGENTS.md: neither reproduces locally.
- `preflight`'s full `pnpm test` run: it failed on 20 unrelated files (`skill-generate-e2e.test.ts`, `skill-generate-start.test.ts`, etc., all `Cannot read properties of undefined (reading 'id')` - an org-seeding race, not anything this diff touches) after a 543s run, matching LOR-220's documented cross-file flakiness on an unchanged tree. Pushed with `--no-verify` per AGENTS.md's own guidance that a full-suite failure here tells you nothing; the PR's required `ci` check only runs the scoped `quality` job (lint + typecheck + build), which I already verified locally.